### PR TITLE
EL-2441 - Navigation on small displays

### DIFF
--- a/docs/app/components/components.ts
+++ b/docs/app/components/components.ts
@@ -14,6 +14,7 @@ import { LandingPageFeatureComponent } from './landing-page-feature/landing-page
 import { ShowcaseCardComponent } from './showcase-card/showcase-card.component';
 import { ComponentSectionComponent } from './component-section/component-section.component';
 import { SnippetComponent } from './snippet/snippet.component';
+import { SectionSelectComponent } from './section-select/section-select.component';
 
 export const DOCUMENTATION_COMPONENTS = [
   EditExampleLinkComponent,
@@ -28,5 +29,6 @@ export const DOCUMENTATION_COMPONENTS = [
   LandingPageFeatureComponent,
   ShowcaseCardComponent,
   ComponentSectionComponent,
-  SnippetComponent
+  SnippetComponent,
+  SectionSelectComponent
 ];

--- a/docs/app/components/navigation-bar/navigation-bar.component.html
+++ b/docs/app/components/navigation-bar/navigation-bar.component.html
@@ -4,12 +4,34 @@
     <a class="navigation-bar-brand" routerLink="/landing">{{ brand.title }}</a>
 
     <div class="navigation-bar-items hidden-md hidden-sm hidden-xs">
-        
+
         <a class="navigation-bar-item" *ngFor="let link of links" [routerLink]="link.link" routerLinkActive="active">{{ link.title }}</a>
         <div class="navigation-bar-spacer"></div>
         <a class="navigation-bar-item" *ngFor="let link of social" [routerLink]="link.link" routerLinkActive="active">{{ link.title }}</a>
         <uxd-navigation-bar-search></uxd-navigation-bar-search>
 
     </div>
+
+    <div class="navigation-bar-hamburger-container hidden-lg">
+        <div class="navigation-bar-hamburger" [class.active]="expanded" (click)="expanded = !expanded">
+            <span class="hpe-icon hpe-menu"></span>
+        </div>
+    </div>
+
+</div>
+
+<div class="navigation-bar-dropdown hidden-lg" *ngIf="expanded">
+
+    <ul class="navigation-bar-dropdown-list">
+
+        <li class="navigation-bar-dropdown-list-item" *ngFor="let link of links">
+            <a class="navigation-bar-dropdown-list-item-link" [routerLink]="link.link" routerLinkActive="active" (click)="expanded = false">{{ link.title }}</a>
+        </li>
+
+        <li class="navigation-bar-dropdown-list-item" *ngFor="let link of social">
+            <a class="navigation-bar-dropdown-list-item-link" [routerLink]="link.link" routerLinkActive="active" (click)="expanded = false">{{ link.title }}</a>
+        </li>
+
+    </ul>
 
 </div>

--- a/docs/app/components/navigation-bar/navigation-bar.component.less
+++ b/docs/app/components/navigation-bar/navigation-bar.component.less
@@ -59,4 +59,65 @@
             flex: 1;
         }
     }
+
+    .navigation-bar-hamburger-container {
+        display: flex;
+        flex: 1;
+        height: 100%;
+        justify-content: flex-end;
+        align-items: center;
+
+        .navigation-bar-hamburger {
+            color: @nav-bar-item-color;
+            padding: 10px;
+            cursor: pointer;
+            transition: color 0.3s ease-in-out;
+
+            &:hover,
+            .active {
+                color: @nav-bar-item-active-color;
+            }
+        }
+    }
+}
+
+.navigation-bar-dropdown {
+    background-color: @nav-bar-bg;
+    width: 100%;
+    min-height: 100px;
+    margin-top: 3px;
+    box-shadow: 0px 3px 10px -3px @nav-bar-bg;
+
+    .navigation-bar-dropdown-list {
+        list-style-type: none;
+        margin: 0;
+        padding: 0;
+
+        .navigation-bar-dropdown-list-item {
+
+            .navigation-bar-dropdown-list-item-link {
+                display: block;
+                color: @nav-bar-item-color;
+                padding: 7px 30px;
+                transition: color 0.3s ease-in-out;
+
+                &:hover {
+                    color: @nav-bar-item-active-color;
+                }
+
+                &.active {
+                    background-color: @primary;
+                    color: @nav-bar-item-active-color;
+                }
+            }
+
+            &:first-of-type  {
+                padding-top: 7px;
+            }
+
+            &:last-of-type {
+                padding-bottom: 7px;
+            }
+        }
+    }
 }

--- a/docs/app/components/navigation-bar/navigation-bar.component.ts
+++ b/docs/app/components/navigation-bar/navigation-bar.component.ts
@@ -11,6 +11,7 @@ export class NavigationBarComponent {
     private brand: ILink;
     private links: ILink[];
     private social: ILink[];
+    private expanded: boolean = false;
 
     constructor() {
 

--- a/docs/app/components/section-select/section-select.component.html
+++ b/docs/app/components/section-select/section-select.component.html
@@ -1,0 +1,3 @@
+<select class="form-control" (change)="navigateToSection($event)" [(ngModel)]="section">
+    <option *ngFor="let section of navigation.categories" [ngValue]="section">{{ section.title }}</option>
+</select>

--- a/docs/app/components/section-select/section-select.component.ts
+++ b/docs/app/components/section-select/section-select.component.ts
@@ -1,0 +1,44 @@
+import { Component, Input, OnInit, OnDestroy } from '@angular/core';
+import { IDocumentationPage } from '../../interfaces/IDocumentationPage';
+import { Router, ActivatedRoute, NavigationEnd } from '@angular/router';
+import { Subscription } from 'rxjs/Subscription';
+
+@Component({
+    selector: 'uxd-section-select',
+    templateUrl: './section-select.component.html'
+})
+export class SectionSelectComponent implements OnInit, OnDestroy {
+
+    @Input() navigation: IDocumentationPage;
+
+    private section: any;
+    private path: string;
+    private routeSubscription: Subscription;
+
+    constructor(private router: Router, private activatedRoute: ActivatedRoute) { }
+
+    ngOnInit() {
+
+        this.routeSubscription = this.router.events.subscribe((event) => {
+            if (event instanceof NavigationEnd) {
+
+                // store the base path of the active url
+                this.activatedRoute.url.subscribe(urlSegment => {
+                    this.path = urlSegment[0].path;
+                });
+
+                this.activatedRoute.firstChild.url.subscribe(urlSegment => {
+                    this.section = this.navigation.categories.find(category => category.link === urlSegment[0].path);
+                });
+            }
+        });
+    }
+
+    ngOnDestroy() {
+        this.routeSubscription.unsubscribe();
+    }
+
+    navigateToSection(event: any) {
+        this.router.navigateByUrl(`${this.path}/${this.section.link}`);
+    }
+}

--- a/docs/app/components/side-navigation/side-navigation.component.ts
+++ b/docs/app/components/side-navigation/side-navigation.component.ts
@@ -1,9 +1,10 @@
-import { Component, Input, OnInit, HostListener, Inject, AfterViewInit, ViewEncapsulation } from '@angular/core';
+import { Component, Input, OnInit, HostListener, Inject, AfterViewInit, ViewEncapsulation, OnDestroy } from '@angular/core';
 import { DOCUMENT } from '@angular/platform-browser';
 import { ActivatedRoute, Router, NavigationEnd } from '@angular/router';
 
 import { IDocumentationPage } from '../../interfaces/IDocumentationPage';
 import { NavigationService } from '../../services/navigation/navigation.service';
+import { Subscription } from 'rxjs/Subscription';
 
 const BANNER_OFFSET = 172;
 const FOOTER_OFFSET = 162;
@@ -17,12 +18,13 @@ const FOOTER_OFFSET = 162;
         '[style.height.px]': 'height'
     }
 })
-export class SideNavigationComponent implements OnInit, AfterViewInit {
+export class SideNavigationComponent implements OnInit, AfterViewInit, OnDestroy {
     @Input() navigation: IDocumentationPage;
 
     private top: number;
     private height: number;
     private scrollApi: any = {};
+    private routeSubscription: Subscription;
 
     constructor(@Inject(DOCUMENT) private document: Document,
         private router: Router,
@@ -36,7 +38,7 @@ export class SideNavigationComponent implements OnInit, AfterViewInit {
         }
 
         // Fix nav position on navigate
-        this.router.events.subscribe((event) => {
+        this.routeSubscription = this.router.events.subscribe((event) => {
             if (event instanceof NavigationEnd) {
                 this.updatePosition();
             }
@@ -48,6 +50,10 @@ export class SideNavigationComponent implements OnInit, AfterViewInit {
         setTimeout(() => {
             this.updatePosition();
         }, 100);
+    }
+
+    ngOnDestroy() {
+        this.routeSubscription.unsubscribe();
     }
 
     isActive(section: string) {

--- a/docs/app/pages/charts/charts.component.html
+++ b/docs/app/pages/charts/charts.component.html
@@ -1,15 +1,25 @@
 <uxd-page-header header="Charts" description="Components for displaying analytics"></uxd-page-header>
 
 <div class="container p-t">
+
+    <div class="row hidden-md hidden-lg">
+
+        <div class="col-sm-12 m-b-lg">
+            <h3 class="m-t-sm">Sections</h3>
+            <uxd-section-select [navigation]="navigation"></uxd-section-select>
+        </div>
+
+    </div>
+
     <div class="row">
 
         <!-- Page Content -->
-        <div class="col-md-9 pull-md-3">
+        <div class="col-md-9 pull-md-3 col-sm-12">
             <router-outlet></router-outlet>
         </div>
 
         <!-- Side Navigation -->
-        <div class="col-md-3 push-md-9">
+        <div class="col-md-3 push-md-9 hidden-sm hidden-xs">
             <uxd-side-navigation [navigation]="navigation"></uxd-side-navigation>
         </div>
         

--- a/docs/app/pages/components/components.component.html
+++ b/docs/app/pages/components/components.component.html
@@ -1,15 +1,25 @@
 <uxd-page-header header="Components" description="Angular components to quickly build an application"></uxd-page-header>
 
 <div class="container p-t">
+
+    <div class="row hidden-md hidden-lg">
+
+        <div class="col-sm-12 m-b-lg">
+            <h3 class="m-t-sm">Sections</h3>
+            <uxd-section-select [navigation]="navigation"></uxd-section-select>
+        </div>
+
+    </div>
+
     <div class="row">
 
         <!-- Page Content -->
-        <div class="col-md-9 pull-md-3">
+        <div class="col-md-9 pull-md-3 col-sm-12">
             <router-outlet></router-outlet>
         </div>
 
         <!-- Side Navigation -->
-        <div class="col-md-3 push-md-9">
+        <div class="col-md-3 push-md-9 hidden-sm hidden-xs">
             <uxd-side-navigation [navigation]="navigation"></uxd-side-navigation>
         </div>
         

--- a/docs/app/pages/css/css.component.html
+++ b/docs/app/pages/css/css.component.html
@@ -1,15 +1,25 @@
 <uxd-page-header header="CSS" description="Styled controls to quickly build an application"></uxd-page-header>
 
 <div class="container p-t">
+
+    <div class="row hidden-md hidden-lg">
+
+        <div class="col-sm-12 m-b-lg">
+            <h3 class="m-t-sm">Sections</h3>
+            <uxd-section-select [navigation]="navigation"></uxd-section-select>
+        </div>
+
+    </div>
+    
     <div class="row">
 
         <!-- Page Content -->
-        <div class="col-md-9 pull-md-3">
+        <div class="col-md-9 pull-md-3 col-sm-12">
             <router-outlet></router-outlet>
         </div>
 
         <!-- Side Navigation -->
-        <div class="col-md-3 push-md-9">
+        <div class="col-md-3 push-md-9 hidden-sm hidden-xs">
             <uxd-side-navigation [navigation]="navigation"></uxd-side-navigation>
         </div>
         

--- a/docs/styles.less
+++ b/docs/styles.less
@@ -16,6 +16,12 @@ html, body {
     min-height: 100%;
 }
 
+@media (max-width: 991px) {
+    .app-page-content {
+        padding-bottom: 50px;
+    }
+}
+
 .uxd-component-section-content > * > h4 {
     margin-top: 2rem;
 }
@@ -50,12 +56,18 @@ pre[class*="language-"] code {
             color: #008080;
         }
 
-        &.attr-value {
+        &.attr-value,
+        &.string {
             color: #c7254e;
         }
 
         &.tag {
             color: #4472c4;
+        }
+
+        &.boolean,
+        &.number {
+            color: #195f91;
         }
     }
 }


### PR DESCRIPTION
Adding navigation menu on small displays and adding section dropdown on the top of css, components and charts pages on small displays

Note: The select control to select sections does not use the dynamic select component on purpose, as the native browser select control is specifically supported on mobile devices and will provide a better user experience on these devices