### PR TITLE
EL-2462 - Bower Dependencies

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -20,7 +20,7 @@
     "url": "https://github.com/UXAspects/UXAspects"
   },
   "main": [
-    "dist/lib/ux-aspects.js",
+    "dist/lib/index.js",
     "dist/ng1/ux-aspects-ng1.js",
     "dist/styles/ux-aspects.css"
   ],

--- a/configs/webpack.library.config.js
+++ b/configs/webpack.library.config.js
@@ -7,7 +7,7 @@ module.exports = {
 
     output: {
         path: path.join(process.cwd(), 'dist', 'lib'),
-        filename: 'ux-aspects.js',
+        filename: 'index.js',
         libraryTarget: 'umd'
     },
 
@@ -21,14 +21,20 @@ module.exports = {
     ],
 
     module: {
-        rules: [
-            {
+        rules: [{
                 test: /\.html$/,
                 use: 'raw-loader'
             },
             {
                 test: /\.ts$/,
-                use: ['awesome-typescript-loader', 'angular2-template-loader']
+                use: [{
+                    loader: 'awesome-typescript-loader',
+                    options: {
+                        configFileName: path.join(process.cwd(), 'src', 'tsconfig-build.json')
+                    },
+                }, {
+                    loader: 'angular2-template-loader'
+                }]
             },
             {
                 test: /\.less$/,

--- a/docs/app/app.module.ts
+++ b/docs/app/app.module.ts
@@ -15,7 +15,16 @@ import { UpgradeAdapter } from '@angular/upgrade';
 import { TabsModule } from 'ng2-bootstrap/tabs';
 
 // Import UX Aspects
-import { UxAspectsModule } from '../../src/index';
+import { 
+  CheckboxModule, 
+  ColorServiceModule, 
+  EboxModule, 
+  FlippableCardModule, 
+  ProgressBarModule, 
+  RadioButtonModule, 
+  SparkModule, 
+  ToggleSwitchModule 
+} from '../../src/index';
 
 // Import Child Modules
 import { DOCUMENTATION_COMPONENTS } from './components/components';
@@ -247,7 +256,14 @@ const DECLARATIONS = [
     TabsModule.forRoot(),
 
     // Library Module
-    UxAspectsModule,
+    CheckboxModule, 
+    ColorServiceModule, 
+    EboxModule, 
+    FlippableCardModule, 
+    ProgressBarModule, 
+    RadioButtonModule, 
+    SparkModule, 
+    ToggleSwitchModule,
 
     // Routing Module
     RouterModule.forRoot(appRoutes, { useHash: true, initialNavigation: false })

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,44 +1,16 @@
-import { NgModule, NgZone } from '@angular/core';
+/*
+  Export Modules
+*/
+export * from './components/checkbox/checkbox.module';
+export * from './components/ebox/ebox.module';
+export * from './components/flippable-card/flippable-card.module';
+export * from './components/progressbar/progressbar.module';
+export * from './components/radiobutton/radiobutton.module';
+export * from './components/spark/spark.module';
+export * from './components/toggleswitch/toggleswitch.module';
+export * from './services/color/color.module';
 
-import { EboxModule } from './components/ebox/ebox.module';
-import { CheckboxModule } from './components/checkbox/checkbox.module';
-import { RadioButtonModule } from './components/radiobutton/radiobutton.module';
-import { SparkModule } from './components/spark/spark.module';
-import { ProgressBarModule } from './components/progressbar/progressbar.module';
-import { FlippableCardModule } from './components/flippable-card/flippable-card.module';
-import { ToggleSwitchModule } from './components/toggleswitch/toggleswitch.module';
-
-import { ColorService } from './services/color/color.service';
-
-const UX_ASPECTS_MODULES = [ 
-  EboxModule, 
-  CheckboxModule, 
-  SparkModule, 
-  ProgressBarModule, 
-  RadioButtonModule, 
-  FlippableCardModule,
-  ToggleSwitchModule
-];
-
-@NgModule({
-  imports: UX_ASPECTS_MODULES,
-  exports: UX_ASPECTS_MODULES,
-  providers: [
-    ColorService
-  ]
-})
-export class UxAspectsModule {
-    constructor( private ngZone: NgZone) {
-      // make ngzone global
-      (<any>window).ngZone = ngZone;
-    }
- }
-
-export * from './components/checkbox/checkbox.component';
-export * from './components/ebox/ebox.component';
-export * from './components/flippable-card/flippable-card.component';
-export * from './components/progressbar/progressbar.component';
-export * from './components/radiobutton/radiobutton.component';
-export * from './components/spark/spark.component';
-export * from './components/toggleswitch/toggleswitch.component';
+/*
+  Export Services
+*/
 export * from './services/color/color.service';

--- a/src/services/color/color.module.ts
+++ b/src/services/color/color.module.ts
@@ -1,0 +1,11 @@
+import { NgModule } from '@angular/core';
+
+import { ColorService } from './color.service';
+
+@NgModule({
+    imports: [],
+    exports: [],
+    declarations: [],
+    providers: [ColorService],
+})
+export class ColorServiceModule { }

--- a/src/services/color/color.service.ts
+++ b/src/services/color/color.service.ts
@@ -37,7 +37,7 @@ export class ColorService {
     private element: HTMLElement;
     private colors: any;
 
-    constructor(@Inject(DOCUMENT) document: Document) {
+    constructor(@Inject(DOCUMENT) document: any) {
         this.element = document.createElement('div');
         this.element.className = 'color-chart';
         this.element.innerHTML = this.html;

--- a/src/tsconfig-build.json
+++ b/src/tsconfig-build.json
@@ -1,0 +1,30 @@
+{
+    "compilerOptions": {
+        "declaration": true,
+        "target": "es5",
+        "module": "es2015",
+        "baseUrl": ".",
+        "stripInternal": true,
+        "experimentalDecorators": true,
+        "moduleResolution": "node",
+        "outDir": "../dist/lib",
+        "rootDir": ".",
+        "lib": ["es2015", "dom"],
+        "skipLibCheck": true,
+        "suppressImplicitAnyIndexErrors": true,
+        "typeRoots": [
+            "../node_modules/@types"
+        ]
+    },
+    "angularCompilerOptions": {
+        "strictMetadataEmit": true,
+        "skipTemplateCodegen": true
+    },
+    "files": [
+        "./index.ts"
+    ],
+    "exclude": [
+        "node_modules",
+        "dist"
+    ]
+}


### PR DESCRIPTION
Outputting type definitions and updating bower.json with new output file. Also removing main ux-aspects module as this is now considered bad practice as it can break tree shaking.

No bower dependencies to be updated, Angular 4 doesnt have a bower package, nor does ngx-bootstrap. I have raised a jira to public an NPM package where we can specify these dependencies