### PR TITLE
EL-2369

### DIFF
--- a/docs/app/pages/charts/sections/spark-charts/spark-chart-ng1/snippets/chart.html
+++ b/docs/app/pages/charts/sections/spark-charts/spark-chart-ng1/snippets/chart.html
@@ -1,36 +1,44 @@
 <div class="row">
-    <spark type="vm.type" value="vm.percentComplete" fillheight="vm.fillheight" top-left-label="vm.label"
-           class="col-md-5 col-sm-5 col-xs-5" spark-tooltip="{{vm.tooltip}}"></spark>
+    <spark type="vm.charts[0].type" value="vm.charts[0].value" fillheight="vm.charts[0].fillHeight"
+        top-left-label="vm.charts[0].topLeftLabel" class="col-md-5 col-sm-5 col-xs-5"
+        spark-tooltip="{{vm.charts[0].tooltip}}"></spark>
     <div class="col-md-1 col-sm-1 col-xs-1"></div>
-    <spark type="vm.type2" value="30" fillheight="5" inline-label="'30%'" class="col-md-5 col-sm-5 col-xs-5 spark-chart1-demo"></spark>
+    <spark type="vm.charts[1].type" value="vm.charts[1].value" fillheight="vm.charts[1].fillHeight"
+        inline-label="vm.charts[1].inlineLabel" class="col-md-5 col-sm-5 col-xs-5 spark-chart1-demo"></spark>
 </div>
 
 <hr>
 
 <div class="row">
-    <spark type="vm.type1" value="vm.percentComplete" fillheight="vm.fillheight" top-left-label="vm.label" bottom-left-label="vm.label9"
-           class="col-md-5 col-sm-5 col-xs-5 " spark-tooltip="{{vm.tooltip}}"></spark>
+    <spark type="vm.charts[2].type" value="vm.charts[2].value" fillheight="vm.charts[2].fillHeight"
+        top-left-label="vm.charts[2].topLeftLabel" bottom-left-label="vm.charts[2].bottomLeftLabel"
+        class="col-md-5 col-sm-5 col-xs-5" spark-tooltip="{{vm.charts[2].tooltip}}"></spark>
     <div class="col-md-1 col-sm-1 col-xs-1"></div>
-    <spark type="vm.type2" value="30" fillheight="5" inline-label="vm.label8" class="col-md-5 col-sm-5 col-xs-5 spark-chart2-demo"
-           top-left-label="vm.label7"></spark>
+    <spark type="vm.charts[3].type" value="vm.charts[3].value" fillheight="vm.charts[3].fillHeight"
+        inline-label="vm.charts[3].inlineLabel" class="col-md-5 col-sm-5 col-xs-5 spark-chart2-demo"
+        top-left-label="vm.charts[3].topLeftLabel"></spark>
 </div>
 
 <hr>
 
 <div class="row">
-    <spark type="vm.type1" value="vm.percentComplete1" fillheight="10" top-left-label="vm.label1"
-           class="col-md-5 col-sm-5 col-xs-5 s" ></spark>
+    <spark type="vm.charts[4].type" value="vm.charts[4].value" fillheight="vm.charts[4].fillHeight"
+        top-left-label="vm.charts[4].topLeftLabel" class="col-md-5 col-sm-5 col-xs-5 s" ></spark>
     <div class="col-md-1 col-sm-1 col-xs-1"></div>
-    <spark type="vm.type2" value="30" fillheight="10" top-left-label="'30%'" bottom-left-label="vm.label10" top-right-label="vm.label5" bottom-right-label="vm.label6"
-           class="col-md-5 col-sm-5 col-xs-5"></spark>
+    <spark type="vm.charts[5].type" value="vm.charts[5].value" fillheight="vm.charts[5].fillHeight"
+        top-left-label="vm.charts[5].topLeftLabel" bottom-left-label="vm.charts[5].bottomLeftLabel"
+        top-right-label="vm.charts[5].topRightLabel" bottom-right-label="vm.charts[5].bottomRightLabel"
+        class="col-md-5 col-sm-5 col-xs-5"></spark>
 </div>
 
 <hr>
 
 <div class="row">
-    <spark type="vm.type3" value="vm.percentComplete1" fillheight="10" top-left-label="vm.label1"
-           class="col-md-5 col-sm-5 col-xs-5 s"></spark>
+    <spark type="vm.charts[6].type" value="vm.charts[6].value" fillheight="vm.charts[6].fillHeight"
+        top-left-label="vm.charts[6].topLeftLabel" class="col-md-5 col-sm-5 col-xs-5 s"></spark>
     <div class="col-md-1 col-sm-1 col-xs-1"></div>
-    <spark type="vm.type4" value="30" fillheight="10" top-left-label="'30%'" bottom-left-label="vm.label10" top-right-label="vm.label5" bottom-right-label="vm.label6"
-           class="col-md-5 col-sm-5 col-xs-5"></spark>
+    <spark type="vm.charts[7].type" value="vm.charts[7].value" fillheight="vm.charts[7].fillHeight"
+        top-left-label="vm.charts[7].topLeftLabel" bottom-left-label="vm.charts[7].bottomLeftLabel"
+        top-right-label="vm.charts[7].topRightLabel" bottom-right-label="vm.charts[7].bottomRightLabel"
+        class="col-md-5 col-sm-5 col-xs-5"></spark>
 </div>

--- a/docs/app/pages/charts/sections/spark-charts/spark-chart-ng1/snippets/chart.js
+++ b/docs/app/pages/charts/sections/spark-charts/spark-chart-ng1/snippets/chart.js
@@ -3,26 +3,64 @@ angular.module("app").controller("SparkChartCtrl", SparkChartCtrl);
 function SparkChartCtrl() {
     var vm = this;
 
-    vm.percentComplete = 35;
-    vm.type = "spark-chart1";
-    vm.label = "<span class='spark-label hidden-xxxs'><span class='large'>21.7</span><span class='medium light'>"
-                + " MB  Items  (" + vm.percentComplete + "%)</span></span>";
-    vm.fillheight = 10;
-
-    vm.percentComplete1 = 55;
-    vm.type1 = "spark-chart2";
-    vm.label1 = "<span class='spark-label hidden-xxs'><span class='large'>8.6</span><span class='medium light'>"
-                   + " GB Disk Space  (" + vm.percentComplete1 + "%)</span></span>";
-
-    vm.type2 = "spark-chart3";
-    vm.type3 = "spark-chart4";
-    vm.type4 = "spark-chart5";
-    vm.label5= "<span class='spark-label hidden-spark'><span class='medium light'>75.0M</span></span>";
-    vm.label6= "<span class='spark-label hidden-xxs'><span class='medium light'>TOTAL</span></span>";
-    vm.label7 = "<span class='spark-label-1 hidden-xxs'>STORAGE ON HOLD</span>";
-    vm.label8 = "<span class='spark-label hidden-spark'><span class='x-large'>30%</span></span>";
-    vm.label9 = "<span class='spark-label hidden-xxxs'><span class='medium light'>INDEX COVERAGE</span></span>";
-    vm.label10 = "<span class='spark-label hidden-xxxs'><span class='medium light'>ITEMS ON HOLD</span></span>";
-
-    vm.tooltip = "Spark Line indicator - 2.17MB of 8.2GB occupied (35%)";
+    vm.charts = [
+        {
+            type: 'spark-chart1',
+            value: 35,
+            fillHeight: 10,
+            topLeftLabel: "<span class='spark-label hidden-xxxs'><span class='large'>21.7</span><span class='medium light'>&nbsp;MB&nbsp;&nbsp;Items&nbsp;&nbsp;(35%)</span></span>",
+            tooltip: 'Spark Line indicator - 2.17MB of 8.2GB occupied (35%)'
+        },
+        {
+            type: 'spark-chart3',
+            value: 30,
+            fillHeight: 5,
+            inlineLabel: '30%'
+        },
+        {
+            type: 'spark-chart2',
+            value: 35,
+            fillHeight: 10,
+            topLeftLabel: "<span class='spark-label hidden-xxxs'><span class='large'>21.7</span><span class='medium light'>&nbsp;MB&nbsp;&nbsp;Items&nbsp;&nbsp;(35%)</span></span>",
+            bottomLeftLabel: "<span class='spark-label hidden-xxxs'><span class='medium light'>INDEX COVERAGE</span></span>",
+            tooltip: 'Spark Line indicator - 2.17MB of 8.2GB occupied (35%)'
+        },
+        {
+            type: 'spark-chart3',
+            value: 30,
+            fillHeight: 5,
+            inlineLabel: "<span class='spark-label hidden-spark'><span class='x-large'>30%</span></span>",
+            topLeftLabel: "<span class='spark-label hidden-xxs'><span class='small'>STORAGE ON HOLD</span></span>"
+        },
+        {
+            type: 'spark-chart4',
+            value: 55,
+            fillHeight: 10,
+            topLeftLabel: "<span class='spark-label hidden-xxs'><span class='large'>8.6</span><span class='medium light'>&nbsp;GB&nbsp;Disk Space&nbsp;&nbsp;(55%)</span></span>"
+        },
+        {
+            type: 'spark-chart5',
+            value: 30,
+            fillHeight: 10,
+            topLeftLabel: '30%',
+            topRightLabel: "<span class='spark-label hidden-spark'><span class='medium light'>75.0M</span></span>",
+            bottomLeftLabel: "<span class='spark-label hidden-xxxs'><span class='medium light'>ITEMS ON HOLD</span></span>",
+            bottomRightLabel: "<span class='spark-label hidden-xxs'><span class='medium light'>TOTAL</span></span>"
+        },
+        {
+            type: 'spark-vibrant1',
+            value: 55,
+            fillHeight: 10,
+            topLeftLabel: "<span class='spark-label hidden-xxs'><span class='large'>8.6</span><span class='medium light'>&nbsp;GB&nbsp;Disk Space&nbsp;&nbsp;(55%)</span></span>"
+        },
+        {
+            type: 'spark-vibrant2',
+            value: 30,
+            fillHeight: 10,
+            topLeftLabel: '30%',
+            bottomLeftLabel: "<span class='spark-label hidden-xxxs'><span class='medium light'>ITEMS ON HOLD</span></span>",
+            topRightLabel: "<span class='spark-label hidden-spark'><span class='medium light'>75.0M</span></span>",
+            bottomRightLabel: "<span class='spark-label hidden-xxs'><span class='medium light'>TOTAL</span></span>"
+        }
+    ];
 }

--- a/docs/app/pages/charts/sections/spark-charts/spark-chart-ng1/spark-chart-ng1.component.ts
+++ b/docs/app/pages/charts/sections/spark-charts/spark-chart-ng1/spark-chart-ng1.component.ts
@@ -44,7 +44,7 @@ export class ChartsSparkChartNg1Component implements ICodePenProvider {
                 inlineLabel: '30%'
             },
             {
-                type: 'spark-chart1',
+                type: 'spark-chart2',
                 value: 35,
                 fillHeight: 10,
                 topLeftLabel: `<span class='spark-label hidden-xxxs'><span class='large'>21.7</span><span class='medium light'>&nbsp;MB&nbsp;&nbsp;Items&nbsp;&nbsp;(35%)</span></span>`,
@@ -53,25 +53,10 @@ export class ChartsSparkChartNg1Component implements ICodePenProvider {
             },
             {
                 type: 'spark-chart3',
-                value: 55,
+                value: 30,
                 fillHeight: 5,
                 inlineLabel: '<span class="spark-label hidden-spark"><span class="x-large">30%</span></span>',
-                topLeftLabel: '<span class="spark-label-1 hidden-xxs">STORAGE ON HOLD</span>'
-            },
-            {
-                type: 'spark-chart2',
-                value: 55,
-                fillHeight: 10,
-                topLeftLabel: "<span class='spark-label hidden-xxs'><span class='large'>8.6</span><span class='medium light'>&nbsp;GB&nbsp;Disk Space&nbsp;&nbsp;(55%)</span></span>"
-            },
-            {
-                type: 'spark-chart3',
-                value: 30,
-                fillHeight: 10,
-                topLeftLabel: '30%',
-                topRightLabel: '<span class="spark-label hidden-spark"><span class="medium light">75.0M</span></span>',
-                bottomLeftLabel: '<span class="spark-label hidden-xxxs"><span class="medium light">ITEMS ON HOLD</span></span>',
-                bottomRightLabel: '<span class="spark-label hidden-xxs"><span class="medium light">TOTAL</span></span>'
+                topLeftLabel: '<span class="spark-label hidden-xxs"><span class="small">STORAGE ON HOLD</span></span>'
             },
             {
                 type: 'spark-chart4',
@@ -81,6 +66,21 @@ export class ChartsSparkChartNg1Component implements ICodePenProvider {
             },
             {
                 type: 'spark-chart5',
+                value: 30,
+                fillHeight: 10,
+                topLeftLabel: '30%',
+                topRightLabel: '<span class="spark-label hidden-spark"><span class="medium light">75.0M</span></span>',
+                bottomLeftLabel: '<span class="spark-label hidden-xxxs"><span class="medium light">ITEMS ON HOLD</span></span>',
+                bottomRightLabel: '<span class="spark-label hidden-xxs"><span class="medium light">TOTAL</span></span>'
+            },
+            {
+                type: 'spark-vibrant1',
+                value: 55,
+                fillHeight: 10,
+                topLeftLabel: "<span class='spark-label hidden-xxs'><span class='large'>8.6</span><span class='medium light'>&nbsp;GB&nbsp;Disk Space&nbsp;&nbsp;(55%)</span></span>"
+            },
+            {
+                type: 'spark-vibrant2',
                 value: 30,
                 fillHeight: 10,
                 topLeftLabel: '30%',

--- a/docs/styles.less
+++ b/docs/styles.less
@@ -847,33 +847,6 @@ tr.dragging .reorderable-controls .reorder-drag {
 }
 
 /*
-    Spark Charts
-*/
-.spark-label .x-large {
-  font-size: 24px; 
-}
-
-.spark-label .large {
-  font-size: 16px;
-}
-
-.spark-label .medium {
-  font-size: 14px; 
-}
-
-.spark-label .small {
-  font-size: 10px; 
-}
-
-.spark-label .light {
-  opacity: 0.6; 
-}
-
-.spark-label-1 {
-    font-size: 11px;
-}
-
-/*
     Card Tabs
 */
 .cardTab {

--- a/src/styles/charts.less
+++ b/src/styles/charts.less
@@ -94,6 +94,26 @@
   }
 }
 
+.spark-label .x-large {
+  font-size: 24px; 
+}
+
+.spark-label .large {
+  font-size: 16px;
+}
+
+.spark-label .medium {
+  font-size: 14px; 
+}
+
+.spark-label .small {
+  font-size: 11px; 
+}
+
+.spark-label .light {
+  opacity: 0.6; 
+}
+
 .spark-chart1 {
   background-color: @spark-chart1-track;
   .fill {


### PR DESCRIPTION
Updated spark chart examples per Roland's mockup.
Updated codepen and example code to be more organised.
Moved the label size styles from documentation into the library so that
they can be used anywhere, including the CodePen.

https://jira.autonomy.com/browse/EL-2369