### PR TITLE
EL-2373

### DIFF
--- a/docs/app/pages/charts/sections/social-chart/social-chart-ng1/snippets/edge-detail.html
+++ b/docs/app/pages/charts/sections/social-chart/social-chart-ng1/snippets/edge-detail.html
@@ -2,7 +2,7 @@
 
 <div class="left-node social-edge-layout-demo social-edge-demo-clickable" ng-click="sc.selectedEdge.sourceNode.goTo()">
 	<div class="social-edge-demo-inner">
-		<i class="hpe-icon hpe-user" style="color:#2ad2c9; font-size:20px;"></i>
+		<i class="hpe-icon hpe-user text-vibrant1" style="font-size:20px;"></i>
 		<h3 class="selectednode-label" style="margin-bottom:0px;">{{sc.selectedEdge.sourceNode.label}}</h3>
 		<div class="selectednode-additional-label">{{sc.selectedEdge.sourceNode.additional.fullName}}</div>
 	</div>
@@ -20,7 +20,7 @@
 
 <div class="right-node social-edge-layout-demo social-edge-demo-clickable" ng-click="sc.selectedEdge.targetNode.goTo()">
 	<div class="social-edge-demo-inner">
-		<i class="hpe-icon hpe-user" style="color:#2ad2c9; font-size:20px;"></i>
+		<i class="hpe-icon hpe-user text-vibrant1" style="font-size:20px;"></i>
 		<h3 class="selectededge-targetnode-label" style="margin-bottom:0px;">{{sc.selectedEdge.targetNode.label}}</h3>
 		<div class="selectededge-targetnode-label-full">{{sc.selectedEdge.targetNode.additional.fullName}}</div>
 	</div>

--- a/docs/app/pages/charts/sections/social-chart/social-chart-ng1/snippets/edge-popover.html
+++ b/docs/app/pages/charts/sections/social-chart/social-chart-ng1/snippets/edge-popover.html
@@ -1,7 +1,7 @@
 <div class="edge-popover-demo social-demo">
 
 <div class="left-node-e social-edge-layout-demo">
-	<i class="hpe-icon hpe-user" style="color:#2ad2c9; font-size:20px;"></i>
+	<i class="hpe-icon hpe-user text-vibrant1" style="font-size:20px;"></i>
 	<h3 class="selectednode-label">{{sc.hoveredItem.sourceNode.label}}</h3>
 	<div class="selectednode-additional-label">{{sc.hoveredItem.sourceNode.additional.fullName}}</div>
 </div>
@@ -17,7 +17,7 @@
 </div>
 
 <div class="right-node-e social-edge-layout-demo">
-	<i class="hpe-icon hpe-user" style="color:#2ad2c9; font-size:20px;"></i>
+	<i class="hpe-icon hpe-user text-vibrant1" style="font-size:20px;"></i>
 	<h3 class="selectededge-targetnode-label">{{sc.hoveredItem.targetNode.label}}</h3>
 	<div class="selectededge-targetnode-label-full">{{sc.hoveredItem.targetNode.additional.fullName}}</div>
 </div>

--- a/docs/app/pages/charts/sections/social-chart/social-chart-ng1/snippets/node-detail.html
+++ b/docs/app/pages/charts/sections/social-chart/social-chart-ng1/snippets/node-detail.html
@@ -1,7 +1,7 @@
 <div style="padding:10px;color:#fff;" class="social-demo node-details-demo">
 
 <div class="id-holder">
-	<i class="hpe-icon hpe-user black-tooltip" style="color:#2ad2c9; font-size:45px;"
+	<i class="hpe-icon hpe-user black-tooltip text-vibrant1" style="font-size:45px;"
 	tooltip="Custodian" tooltip-placement="bottom"></i>
 	<h3 class="selectednode-label">{{sc.selectedNode.label}}</h3>
 	<h4 class="selectednode-additional-label">{{sc.selectedNode.additional.fullName}}</h4>
@@ -23,12 +23,12 @@
 
 
 			<div class="ndp-icon">
-				<i class="hpe-icon hpe-user neighbour-icon black-tooltip"></i>
+				<i class="hpe-icon hpe-user text-vibrant1 neighbour-icon black-tooltip"></i>
 			</div>
 			<div class="ndp-text-spark">
 				<span class="neighbor-label-details">{{neighbour.label}}</span>
 				<span class="volume-label">&nbsp;({{sc.selectedNode.additional.sent[neighbour.id] + sc.selectedNode.additional.received[neighbour.id]}})</span>
-				<spark class="col-lg-12 p-r-nil p-l-nil" type="'spark-chart1'" value="neighbour.setInExternal.ratio" fillheight="5" inline="false"></spark>
+				<spark class="col-lg-12 p-r-nil p-l-nil" type="'spark-vibrant1'" value="neighbour.setInExternal.ratio" fillheight="5" inline="false"></spark>
 			</div>
 
 		</li>
@@ -97,7 +97,6 @@
 		display: inline-block;
 	}
 	.neighbour-icon{
-		color:#2ad2c9;
 		font-size:16px;
 		position: relative;
 		top: -2px;

--- a/docs/app/pages/charts/sections/social-chart/social-chart-ng1/snippets/node-popover.html
+++ b/docs/app/pages/charts/sections/social-chart/social-chart-ng1/snippets/node-popover.html
@@ -1,7 +1,7 @@
 <div style="padding:5px;color:#fff;" class="social-demo node-popover-demo">
 
 <div class="node-popover-id-holder">
-	<i class="hpe-icon hpe-user" style="color:#2ad2c9; font-size:35px;"></i>
+	<i class="hpe-icon hpe-user text-vibrant1" style="font-size:35px;"></i>
 	<h3 class="selectednode-label">{{sc.hoveredItem.label}}</h3>
 	<h4 class="selectednode-additional-label">{{sc.hoveredItem.additional.fullName}}</h4>
 	<div class="m-b-sm">
@@ -19,7 +19,7 @@
 		<li class="neighbor-label-popover" ng-repeat="neighbour in sc.hoveredItem.neighborNodes" style="list-style:none;" ng-click="neighbour.setInExternal.goToEdge()"
       tooltip="{{::neighbour.additional.fullName}}" tooltip-placement="{{::($last && !$first) ? 'top' : 'bottom'}}" tooltip-append-to-body="false">
 			<span >{{::neighbour.label}}</span>
-			<spark class="col-lg-12 p-r-nil p-l-nil" type="'spark-chart1'" value="neighbour.setInExternal.ratio" fillheight="5" inline="false"></spark>
+			<spark class="col-lg-12 p-r-nil p-l-nil" type="'spark-vibrant1'" value="neighbour.setInExternal.ratio" fillheight="5" inline="false"></spark>
 		</li>
 	</ul>
 </div>

--- a/src/styles/typography.less
+++ b/src/styles/typography.less
@@ -206,6 +206,26 @@ b {
   color: @accent;
 }
 
+.text-alternate1 {
+  color: @alternate1;
+}
+
+.text-alternate2 {
+  color: @alternate2;
+}
+
+.text-alternate3 {
+  color: @alternate3;
+}
+
+.text-vibrant1 {
+  color: @vibrant1;
+}
+
+.text-vibrant2 {
+  color: @vibrant2;
+}
+
 .text-alert, .text-error, .text-warning {
   color: @critical;
 }


### PR DESCRIPTION
Added .text-vibrant1 and a few others to allow examples to use
additional standard colors in icons.
Updated social chart example templates with the new class.

https://jira.autonomy.com/browse/EL-2373