### PR TITLE
Build Output Optimization

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -25,7 +25,7 @@ module.exports = function (grunt) {
     grunt.registerTask('scripts', ['execute:iconset']);
     grunt.registerTask('assets', ['copy:fonts', 'copy:images', 'copy:less', 'copy:ng1', 'copy:styles']);
     grunt.registerTask('iconset', ['webfont:iconset']);
-    grunt.registerTask('minify', ['uglify:ng1', 'uglify:library', 'cssmin:styles']);
+    grunt.registerTask('minify', ['uglify:ng1', 'cssmin:styles']);
     grunt.registerTask('licenses', ['execute:licenses', 'usebanner:ng1']);
     grunt.registerTask('test', ['build', 'jasmine:ng1']);
     grunt.registerTask('server', ['documentation:build', 'connect:documentation']);

--- a/docs/app/app.component.ts
+++ b/docs/app/app.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, NgZone } from '@angular/core';
 import { Router, NavigationEnd } from '@angular/router';
 
 import { NavigationService } from './services/navigation/navigation.service';
@@ -11,7 +11,10 @@ import { NavigationService } from './services/navigation/navigation.service';
 export class AppComponent implements OnInit {
 
     constructor(private router: Router,
-        private navigation: NavigationService) {}
+        private navigation: NavigationService,
+        ngZone: NgZone) {
+            (<any>window).ngZone = ngZone;
+        }
 
     ngOnInit() {
 

--- a/docs/app/pages/components/sections/date-time-picker/date-range-picker-ng1/date-range-picker-ng1.component.html
+++ b/docs/app/pages/components/sections/date-time-picker/date-range-picker-ng1/date-range-picker-ng1.component.html
@@ -6,12 +6,12 @@
 
 <tabset>
     <tab heading="HTML">
-        <uxd-snippet [content]="snippets.compiled.sampleHtml"></uxd-snippet>
+        <uxd-snippet [code]="sampleHtml"></uxd-snippet>
     </tab>
     <tab heading="JavaScript">
-        <uxd-snippet [content]="snippets.compiled.sampleJs" language="javascript"></uxd-snippet>
+        <uxd-snippet [code]="sampleJs" language="javascript"></uxd-snippet>
     </tab>
     <tab heading="CSS">
-        <uxd-snippet [content]="snippets.compiled.sampleCss" language="css"></uxd-snippet>
+        <uxd-snippet [code]="sampleCss" language="css"></uxd-snippet>
     </tab>
 </tabset>

--- a/docs/app/pages/components/sections/date-time-picker/date-range-picker-ng1/date-range-picker-ng1.component.ts
+++ b/docs/app/pages/components/sections/date-time-picker/date-range-picker-ng1/date-range-picker-ng1.component.ts
@@ -2,7 +2,6 @@ import { Component, ChangeDetectionStrategy } from '@angular/core';
 import { DocumentationSectionComponent } from '../../../../../decorators/documentation-section-component';
 import { ICodePenProvider } from '../../../../../interfaces/ICodePenProvider';
 import { ICodePen } from '../../../../../interfaces/ICodePen';
-import { BaseDocumentationSection } from '../../../../../components/base-documentation-section/base-documentation-section';
 
 @Component({
     selector: 'uxd-components-date-range-picker-ng1',
@@ -10,25 +9,19 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
     changeDetection: ChangeDetectionStrategy.OnPush
 })
 @DocumentationSectionComponent('ComponentsDateRangePickerNg1Component')
-export class ComponentsDateRangePickerNg1Component extends BaseDocumentationSection implements ICodePenProvider {
+export class ComponentsDateRangePickerNg1Component implements ICodePenProvider {
 
-    constructor() {
-        super(
-            require.context('!!prismjs-loader?lang=html!./snippets/', false, /\.html$/),
-            require.context('!!prismjs-loader?lang=css!./snippets/', false, /\.css$/),
-            require.context('!!prismjs-loader?lang=javascript!./snippets/', false, /\.js$/),
-            require.context('!!prismjs-loader?lang=typescript!./snippets/', false, /\.ts$/),
-            require.context('./snippets/', false, /\.(html|css|js|ts)$/)
-        );
-    }
+    private sampleHtml = require('./snippets/sample.html');
+    private sampleJs = require('./snippets/sample.js');
+    private sampleCss = require('./snippets/sample.css');
 
     public codepen: ICodePen = {
-        html: this.snippets.raw.sampleHtml,
+        html: this.sampleHtml,
         htmlAttributes: {
             'ng-controller': 'DateRangePickerCtrl as vm'
         },
-        js: [this.snippets.raw.sampleJs],
-        css: [this.snippets.raw.sampleCss]
+        js: [this.sampleJs],
+        css: [this.sampleCss]
     };
 
 }

--- a/docs/app/pages/components/sections/date-time-picker/integrated-date-picker-ng1/integrated-date-picker-ng1.component.html
+++ b/docs/app/pages/components/sections/date-time-picker/integrated-date-picker-ng1/integrated-date-picker-ng1.component.html
@@ -93,9 +93,9 @@
 
 <tabset>
     <tab heading="HTML">
-        <uxd-snippet [content]="snippets.compiled.sampleHtml"></uxd-snippet>
+        <uxd-snippet [code]="sampleHtml"></uxd-snippet>
     </tab>
     <tab heading="JavaScript">
-        <uxd-snippet [content]="snippets.compiled.sampleJs" language="javascript"></uxd-snippet>
+        <uxd-snippet [code]="sampleJs" language="javascript"></uxd-snippet>
     </tab>
 </tabset>

--- a/docs/app/pages/components/sections/date-time-picker/integrated-date-picker-ng1/integrated-date-picker-ng1.component.ts
+++ b/docs/app/pages/components/sections/date-time-picker/integrated-date-picker-ng1/integrated-date-picker-ng1.component.ts
@@ -2,7 +2,6 @@ import { Component, ChangeDetectionStrategy } from '@angular/core';
 import { DocumentationSectionComponent } from '../../../../../decorators/documentation-section-component';
 import { ICodePenProvider } from '../../../../../interfaces/ICodePenProvider';
 import { ICodePen } from '../../../../../interfaces/ICodePen';
-import { BaseDocumentationSection } from '../../../../../components/base-documentation-section/base-documentation-section';
 
 @Component({
     selector: 'uxd-components-integrated-date-picker-ng1',
@@ -10,24 +9,17 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
     changeDetection: ChangeDetectionStrategy.OnPush
 })
 @DocumentationSectionComponent('ComponentsIntegratedDatePickerNg1Component')
-export class ComponentsIntegratedDatePickerNg1Component extends BaseDocumentationSection implements ICodePenProvider {
+export class ComponentsIntegratedDatePickerNg1Component implements ICodePenProvider {
 
-    constructor() {
-        super(
-            require.context('!!prismjs-loader?lang=html!./snippets/', false, /\.html$/),
-            require.context('!!prismjs-loader?lang=css!./snippets/', false, /\.css$/),
-            require.context('!!prismjs-loader?lang=javascript!./snippets/', false, /\.js$/),
-            require.context('!!prismjs-loader?lang=typescript!./snippets/', false, /\.ts$/),
-            require.context('./snippets/', false, /\.(html|css|js|ts)$/)
-        );
-    }
+    private sampleHtml = require('./snippets/sample.html');
+    private sampleJs = require('./snippets/sample.js');
 
     public codepen: ICodePen = {
-        html: this.snippets.raw.sampleHtml,
+        html: this.sampleHtml,
         htmlAttributes: {
             'ng-controller': 'IntegratedDatePickerCtrl as vm'
         },
-        js: [this.snippets.raw.sampleJs]
+        js: [this.sampleJs]
     };
 
 }

--- a/docs/app/pages/components/sections/input-controls/custom-dropdown-ng1/custom-dropdown-ng1.component.html
+++ b/docs/app/pages/components/sections/input-controls/custom-dropdown-ng1/custom-dropdown-ng1.component.html
@@ -10,15 +10,15 @@
 
 <tabset>
     <tab heading="HTML">
-        <uxd-snippet [content]="snippets.compiled.sampleHtml"></uxd-snippet>
+        <uxd-snippet [code]="sampleHtml"></uxd-snippet>
     </tab>
     <tab heading="Template HTML">
-        <uxd-snippet [content]="snippets.compiled.templateHtml"></uxd-snippet>
+        <uxd-snippet [code]="templateHtml"></uxd-snippet>
     </tab>
     <tab heading="JavaScript">
-        <uxd-snippet [content]="snippets.compiled.sampleJs" language="javascript"></uxd-snippet>
+        <uxd-snippet [code]="sampleJs" language="javascript"></uxd-snippet>
     </tab>
     <tab heading="CSS">
-        <uxd-snippet [content]="snippets.compiled.sampleCss" language="css"></uxd-snippet>
+        <uxd-snippet [code]="sampleCss" language="css"></uxd-snippet>
     </tab>
 </tabset>

--- a/docs/app/pages/components/sections/input-controls/custom-dropdown-ng1/custom-dropdown-ng1.component.ts
+++ b/docs/app/pages/components/sections/input-controls/custom-dropdown-ng1/custom-dropdown-ng1.component.ts
@@ -2,7 +2,6 @@ import { Component, ChangeDetectionStrategy } from '@angular/core';
 import { DocumentationSectionComponent } from '../../../../../decorators/documentation-section-component';
 import { ICodePenProvider } from '../../../../../interfaces/ICodePenProvider';
 import { ICodePen } from '../../../../../interfaces/ICodePen';
-import { BaseDocumentationSection } from '../../../../../components/base-documentation-section/base-documentation-section';
 
 @Component({
     selector: 'uxd-custom-dropdown-ng1',
@@ -10,26 +9,21 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
     changeDetection: ChangeDetectionStrategy.OnPush
 })
 @DocumentationSectionComponent('ComponentsCustomDropdownNg1Component')
-export class ComponentsCustomDropdownNg1Component extends BaseDocumentationSection implements ICodePenProvider {
-    
-    constructor() {
-        super(
-            require.context('!!prismjs-loader?lang=html!./snippets/', false, /\.html$/),
-            require.context('!!prismjs-loader?lang=css!./snippets/', false, /\.css$/),
-            require.context('!!prismjs-loader?lang=javascript!./snippets/', false, /\.js$/),
-            require.context('!!prismjs-loader?lang=typescript!./snippets/', false, /\.ts$/),
-            require.context('./snippets/', false, /\.(html|css|js|ts)$/)
-        );
-    }
+export class ComponentsCustomDropdownNg1Component implements ICodePenProvider {
+
+    private sampleHtml = require('./snippets/sample.html');
+    private templateHtml = require('./snippets/template.html');
+    private sampleCss = require('./snippets/sample.css');
+    private sampleJs = require('./snippets/sample.js');
 
     public codepen: ICodePen = {
-        html: this.snippets.raw.sampleHtml,
+        html: this.sampleHtml,
         htmlTemplates: [{
             id: 'template.html',
-            content: this.snippets.raw.templateHtml
+            content: this.templateHtml
         }],
-        css: [this.snippets.raw.sampleCss],
-        js: [this.snippets.raw.sampleJs]
+        css: [this.sampleCss],
+        js: [this.sampleJs]
     };
 
 }

--- a/docs/app/pages/components/sections/input-controls/slider-charts-ng1/slider-charts-ng1.component.html
+++ b/docs/app/pages/components/sections/input-controls/slider-charts-ng1/slider-charts-ng1.component.html
@@ -6,7 +6,7 @@
 
 <p>The component can be added to a page by using the following HTML:</p>
 
-<uxd-snippet [content]="snippets.compiled.sampleHtml"></uxd-snippet>
+<uxd-snippet [code]="sampleHtml"></uxd-snippet>
 
 <p>The slider chart has been primarily designed for use for filtering by date eg. within facets and should have the following
     attributes:</p>

--- a/docs/app/pages/components/sections/input-controls/slider-charts-ng1/slider-charts-ng1.component.ts
+++ b/docs/app/pages/components/sections/input-controls/slider-charts-ng1/slider-charts-ng1.component.ts
@@ -2,31 +2,24 @@ import { Component, ChangeDetectionStrategy } from '@angular/core';
 import { DocumentationSectionComponent } from '../../../../../decorators/documentation-section-component';
 import { ICodePenProvider } from '../../../../../interfaces/ICodePenProvider';
 import { ICodePen } from '../../../../../interfaces/ICodePen';
-import { BaseDocumentationSection } from '../../../../../components/base-documentation-section/base-documentation-section';
 
 @Component({
     selector: 'uxd-components-slider-charts-ng1',
     templateUrl: './slider-charts-ng1.component.html'
 })
 @DocumentationSectionComponent('ComponentsSliderChartsNg1Component')
-export class ComponentsSliderChartsNg1Component extends BaseDocumentationSection implements ICodePenProvider {
+export class ComponentsSliderChartsNg1Component implements ICodePenProvider {
 
-    constructor() {
-        super(
-            require.context('!!prismjs-loader?lang=html!./snippets/', false, /\.html$/),
-            require.context('!!prismjs-loader?lang=css!./snippets/', false, /\.css$/),
-            require.context('!!prismjs-loader?lang=javascript!./snippets/', false, /\.js$/),
-            require.context('!!prismjs-loader?lang=typescript!./snippets/', false, /\.ts$/),
-            require.context('./snippets/', false, /\.(html|css|js|ts)$/)
-        );
-    }
+    private sampleHtml = require('./snippets/sample.html');
+    private codepenHtml = require('./snippets/codepen.html');
+    private codepenJs = require('./snippets/codepen.js');
 
     public codepen: ICodePen = {
-        html: this.snippets.raw.codepenHtml,
+        html: this.codepenHtml,
         htmlAttributes: {
             'ng-controller': 'SlidersChartsCtrl as vm'
         },
-        js: [this.snippets.raw.codepenJs]
+        js: [this.codepenJs]
     };
 
 }

--- a/docs/app/pages/components/sections/input-controls/sliders-ng1/sliders-ng1.component.html
+++ b/docs/app/pages/components/sections/input-controls/sliders-ng1/sliders-ng1.component.html
@@ -9,7 +9,7 @@
 
 <p>The component can be added to a page by using the following HTML:</p>
 
-<uxd-snippet [content]="snippets.compiled.sample1Html"></uxd-snippet>
+<uxd-snippet [code]="sample1Html"></uxd-snippet>
 
 <blockquote>
     <p>Reference the CodePen for the code used in all examples above</p>
@@ -22,11 +22,11 @@
 
 <p>For single value selection, an example of the data in the controller may be:</p>
 
-<uxd-snippet [content]="snippets.compiled.sample1Js"></uxd-snippet>
+<uxd-snippet [code]="sample1Js" language="javascript"></uxd-snippet>
 
 <p>For range selection, an example of the data in the controller may be:</p>
 
-<uxd-snippet [content]="snippets.compiled.sample2Js"></uxd-snippet>
+<uxd-snippet [code]="sample2Js" language="javascript"></uxd-snippet>
 
 <p>The variable in the controller will be updated with the correct value, or values, when the slider is dragged.</p>
 
@@ -37,7 +37,7 @@
 
 <p>The default options for each chart are as follows:</p>
 
-<uxd-snippet [content]="snippets.compiled.sample3Js"></uxd-snippet>
+<uxd-snippet [code]="sample3Js" language="javascript"></uxd-snippet>
 
 <p>Full details on each property and the possible values for each can be found below. All properties are optional, if they are
     not specified the default value will be used.</p>
@@ -243,4 +243,4 @@
     will result in both controls displaying the same value, and if one is updated the other will update also. It may also
     be useful to debounce the update in text controls to allow users to finish typing before updating the slider. For example:</p>
 
-<uxd-snippet [content]="snippets.compiled.sample2Html"></uxd-snippet>
+<uxd-snippet [code]="sample2Html"></uxd-snippet>

--- a/docs/app/pages/components/sections/input-controls/sliders-ng1/sliders-ng1.component.ts
+++ b/docs/app/pages/components/sections/input-controls/sliders-ng1/sliders-ng1.component.ts
@@ -2,7 +2,6 @@ import { Component, ChangeDetectionStrategy } from '@angular/core';
 import { DocumentationSectionComponent } from '../../../../../decorators/documentation-section-component';
 import { ICodePenProvider } from '../../../../../interfaces/ICodePenProvider';
 import { ICodePen } from '../../../../../interfaces/ICodePen';
-import { BaseDocumentationSection } from '../../../../../components/base-documentation-section/base-documentation-section';
 
 @Component({
     selector: 'uxd-components-sliders-ng1',
@@ -10,24 +9,22 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
     changeDetection: ChangeDetectionStrategy.OnPush
 })
 @DocumentationSectionComponent('ComponentsSlidersNg1Component')
-export class ComponentsSlidersNg1Component extends BaseDocumentationSection implements ICodePenProvider {
+export class ComponentsSlidersNg1Component implements ICodePenProvider {
 
-    constructor() {
-        super(
-            require.context('!!prismjs-loader?lang=html!./snippets/', false, /\.html$/),
-            require.context('!!prismjs-loader?lang=css!./snippets/', false, /\.css$/),
-            require.context('!!prismjs-loader?lang=javascript!./snippets/', false, /\.js$/),
-            require.context('!!prismjs-loader?lang=typescript!./snippets/', false, /\.ts$/),
-            require.context('./snippets/', false, /\.(html|css|js|ts)$/)
-        );
-    }
+    private codepenHtml = require('./snippets/codepen.html');
+    private codepenJs = require('./snippets/codepen.js');
+    private sample1Html = require('./snippets/sample1.html');
+    private sample1Js = require('./snippets/sample1.js');
+    private sample2Html = require('./snippets/sample2.html');
+    private sample2Js = require('./snippets/sample2.js');
+    private sample3Js = require('./snippets/sample3.js');
 
     public codepen: ICodePen = {
-        html: this.snippets.raw.codepenHtml,
+        html: this.codepenHtml,
         htmlAttributes: {
             'ng-controller': 'SlidersCtrl as vm'
         },
-        js: [this.snippets.raw.codepenJs]
+        js: [this.codepenJs]
     };
 
 }

--- a/docs/app/pages/components/sections/input-controls/tags-ng1/tags-ng1.component.html
+++ b/docs/app/pages/components/sections/input-controls/tags-ng1/tags-ng1.component.html
@@ -213,10 +213,10 @@ All of these functions will be called with the tag available as <code class="hig
 
 <tabset>
     <tab heading="HTML">
-        <uxd-snippet [content]="snippets.compiled.sampleHtml"></uxd-snippet>
+        <uxd-snippet [code]="sampleHtml"></uxd-snippet>
     </tab>
     <tab heading="JavaScript">
-        <uxd-snippet [content]="snippets.compiled.sampleJs" language="javascript"></uxd-snippet>
+        <uxd-snippet [code]="sampleJs" language="javascript"></uxd-snippet>
     </tab>
 </tabset>
 
@@ -232,10 +232,10 @@ All of these functions will be called with the tag available as <code class="hig
 
 <tabset>
     <tab heading="HTML">
-        <uxd-snippet [content]="snippets.compiled.autocompleteHtml"></uxd-snippet>
+        <uxd-snippet [code]="autocompleteHtml"></uxd-snippet>
     </tab>
     <tab heading="JavaScript">
-        <uxd-snippet [content]="snippets.compiled.autocompleteJs" language="javascript"></uxd-snippet>
+        <uxd-snippet [code]="autocompleteJs" language="javascript"></uxd-snippet>
     </tab>
 </tabset>
 
@@ -247,9 +247,9 @@ All of these functions will be called with the tag available as <code class="hig
 
 <tabset>
     <tab heading="HTML">
-        <uxd-snippet [content]="snippets.compiled.customHtml"></uxd-snippet>
+        <uxd-snippet [code]="customHtml"></uxd-snippet>
     </tab>
     <tab heading="JavaScript">
-        <uxd-snippet [content]="snippets.compiled.customJs" language="javascript"></uxd-snippet>
+        <uxd-snippet [code]="customJs" language="javascript"></uxd-snippet>
     </tab>
 </tabset>

--- a/docs/app/pages/components/sections/input-controls/tags-ng1/tags-ng1.component.ts
+++ b/docs/app/pages/components/sections/input-controls/tags-ng1/tags-ng1.component.ts
@@ -2,7 +2,6 @@ import { Component, ChangeDetectionStrategy } from '@angular/core';
 import { DocumentationSectionComponent } from '../../../../../decorators/documentation-section-component';
 import { ICodePenProvider } from '../../../../../interfaces/ICodePenProvider';
 import { ICodePen } from '../../../../../interfaces/ICodePen';
-import { BaseDocumentationSection } from '../../../../../components/base-documentation-section/base-documentation-section';
 
 @Component({
     selector: 'uxd-components-tags-ng1',
@@ -10,24 +9,24 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
     changeDetection: ChangeDetectionStrategy.OnPush
 })
 @DocumentationSectionComponent('ComponentsTagsNg1Component')
-export class ComponentsTagsNg1Component extends BaseDocumentationSection implements ICodePenProvider {
+export class ComponentsTagsNg1Component implements ICodePenProvider {
 
-    constructor() {
-        super(
-            require.context('!!prismjs-loader?lang=html!./snippets/', false, /\.html$/),
-            require.context('!!prismjs-loader?lang=css!./snippets/', false, /\.css$/),
-            require.context('!!prismjs-loader?lang=javascript!./snippets/', false, /\.js$/),
-            require.context('!!prismjs-loader?lang=typescript!./snippets/', false, /\.ts$/),
-            require.context('./snippets/', false, /\.(html|css|js|ts)$/)
-        );
-    }
+    private sampleHtml = require('./snippets/sample.html');
+    private sampleJs = require('./snippets/sample.js');
+    private autocompleteHtml = require('./snippets/autocomplete.html');
+    private autocompleteJs = require('./snippets/autocomplete.js');
+    private customHtml = require('./snippets/custom.html');
+    private customJs = require('./snippets/custom.js');
+
+    private codepenHtml = require('./snippets/codepen.html');
+    private codepenJs = require('./snippets/codepen.js');
 
     public codepen: ICodePen = {
-        html: this.snippets.raw.codepenHtml,
+        html: this.codepenHtml,
         htmlAttributes: {
             'ng-controller': 'TagsCtrl as vm'
         },
-        js: [this.snippets.raw.codepenJs]
+        js: [this.codepenJs]
     };
 
 }

--- a/docs/app/pages/components/sections/notifications/notification-dropdown-ng1/notification-dropdown-ng1.component.html
+++ b/docs/app/pages/components/sections/notifications/notification-dropdown-ng1/notification-dropdown-ng1.component.html
@@ -10,19 +10,19 @@
 
 <tabset>
   <tab heading="HTML">
-    <uxd-snippet [content]="snippets.compiled.dropdownExampleHtml" language="html"></uxd-snippet>
+    <uxd-snippet [code]="dropdownExampleHtml" language="html"></uxd-snippet>
   </tab>
   <tab heading="JavaScript">
-    <uxd-snippet [content]="snippets.compiled.controllerJs" language="javascript"></uxd-snippet>
+    <uxd-snippet [code]="controllerJs" language="javascript"></uxd-snippet>
   </tab>
   <tab heading="CSS">
-    <uxd-snippet [content]="snippets.compiled.stylesCss" language="css"></uxd-snippet>
+    <uxd-snippet [code]="stylesCss" language="css"></uxd-snippet>
   </tab>
 </tabset>
 
 <p>The following code was used to add the button that will display notifications:</p>
 
-<uxd-snippet [content]="snippets.compiled.buttonExampleHtml" language="html"></uxd-snippet>
+<uxd-snippet [code]="buttonExampleHtml" language="html"></uxd-snippet>
 
 <blockquote>
   <p>Refer to the <a routerLink="/components/modals" fragment="side-modal-ng1">Side Modal</a> page for more information on how to use the side modal.</p>

--- a/docs/app/pages/components/sections/notifications/notification-dropdown-ng1/notification-dropdown-ng1.component.ts
+++ b/docs/app/pages/components/sections/notifications/notification-dropdown-ng1/notification-dropdown-ng1.component.ts
@@ -1,5 +1,4 @@
 import { Component, ViewEncapsulation, ChangeDetectionStrategy } from '@angular/core';
-import { BaseDocumentationSection } from '../../../../../components/base-documentation-section/base-documentation-section';
 import { ICodePenProvider } from '../../../../../interfaces/ICodePenProvider';
 import { ICodePen } from '../../../../../interfaces/ICodePen';
 import { DocumentationSectionComponent } from '../../../../../decorators/documentation-section-component';
@@ -10,30 +9,31 @@ import { DocumentationSectionComponent } from '../../../../../decorators/documen
     changeDetection: ChangeDetectionStrategy.OnPush
 })
 @DocumentationSectionComponent('ComponentsNotificationDropdownNg1Component')
-export class ComponentsNotificationDropdownNg1Component extends BaseDocumentationSection implements ICodePenProvider {
+export class ComponentsNotificationDropdownNg1Component implements ICodePenProvider {
+
+    private layoutHtml = require('./snippets/layout.html');
+    private controllerJs = require('./snippets/controller.js');
+    private modalLayoutHtml = require('./snippets/modalLayout.html');
+    private notificationHtml = require('./snippets/notification.html');
+    private stylesCss = require('./snippets/styles.css');
+    private modalControllerJs = require('./snippets/modalController.js');
+    private buttonExampleHtml = require('./snippets/button.example.html');
+    private dropdownExampleHtml = require('./snippets/dropdown.example.html');
+
     public codepen: ICodePen = {
-        html: this.snippets.raw.layoutHtml,
+        html: this.layoutHtml,
         htmlAttributes: {
             'ng-controller': 'NotificationDropdownDemoCtrl as vm'
         },
         htmlTemplates: [{
             id: 'modalLayout.html',
-            content: this.snippets.raw.modalLayoutHtml
+            content: this.modalLayoutHtml
         }, {
             id: 'notification.html',
-            content: this.snippets.raw.notificationHtml
+            content: this.notificationHtml
         }],
-        css: [this.snippets.raw.stylesCss],
-        js: [this.snippets.raw.controllerJs, this.snippets.raw.modalControllerJs]
+        css: [this.stylesCss],
+        js: [this.controllerJs, this.modalControllerJs]
     };
 
-    constructor() {
-        super(
-            require.context('!!prismjs-loader?lang=html!./snippets/', false, /\.html$/),
-            require.context('!!prismjs-loader?lang=css!./snippets/', false, /\.css$/),
-            require.context('!!prismjs-loader?lang=javascript!./snippets/', false, /\.js$/),
-            require.context('!!prismjs-loader?lang=typescript!./snippets/', false, /\.ts$/),
-            require.context('./snippets/', false, /\.(html|css|js|ts)$/)
-        );
-    }
 }

--- a/docs/app/pages/components/sections/notifications/notifications-ng1/notifications-ng1.component.html
+++ b/docs/app/pages/components/sections/notifications/notifications-ng1/notifications-ng1.component.html
@@ -96,12 +96,12 @@
 
 <tabset>
   <tab heading="HTML">
-    <uxd-snippet [content]="snippets.compiled.layoutExampleHtml" language="html"></uxd-snippet>
+    <uxd-snippet [code]="layoutExampleHtml" language="html"></uxd-snippet>
   </tab>
   <tab heading="JavaScript">
-    <uxd-snippet [content]="snippets.compiled.controllerExampleJs" language="javascript"></uxd-snippet>
+    <uxd-snippet [code]="controllerExampleJs" language="javascript"></uxd-snippet>
   </tab>
   <tab heading="CSS">
-    <uxd-snippet [content]="snippets.compiled.stylesCss" language="css"></uxd-snippet>
+    <uxd-snippet [code]="stylesCss" language="css"></uxd-snippet>
   </tab>
 </tabset>

--- a/docs/app/pages/components/sections/notifications/notifications-ng1/notifications-ng1.component.ts
+++ b/docs/app/pages/components/sections/notifications/notifications-ng1/notifications-ng1.component.ts
@@ -1,5 +1,4 @@
 import { Component, ViewEncapsulation, ChangeDetectionStrategy } from '@angular/core';
-import { BaseDocumentationSection } from '../../../../../components/base-documentation-section/base-documentation-section';
 import { ICodePenProvider } from '../../../../../interfaces/ICodePenProvider';
 import { ICodePen } from '../../../../../interfaces/ICodePen';
 import { DocumentationSectionComponent } from '../../../../../decorators/documentation-section-component';
@@ -12,23 +11,21 @@ import { DocumentationSectionComponent } from '../../../../../decorators/documen
     changeDetection: ChangeDetectionStrategy.OnPush
 })
 @DocumentationSectionComponent('ComponentsNotificationsNg1Component')
-export class ComponentsNotificationsNg1Component extends BaseDocumentationSection implements ICodePenProvider {
+export class ComponentsNotificationsNg1Component implements ICodePenProvider {
+
+    private layoutHtml = require('./snippets/layout.html');
+    private layoutExampleHtml = require('./snippets/layout.example.html');
+    private stylesCss = require('./snippets/styles.css');
+    private controllerJs = require('./snippets/controller.js');
+    private controllerExampleJs = require('./snippets/controller.example.js');
+
     public codepen: ICodePen = {
-        html: this.snippets.raw.layoutHtml,
+        html: this.layoutHtml,
         htmlAttributes: {
             'ng-controller': 'NotificationsDemoCtrl as vm'
         },
-        css: [this.snippets.raw.stylesCss],
-        js: [this.snippets.raw.controllerJs, this.snippets.raw.modalControllerJs]
+        css: [this.stylesCss],
+        js: [this.controllerJs]
     };
 
-    constructor() {
-        super(
-            require.context('!!prismjs-loader?lang=html!./snippets/', false, /\.html$/),
-            require.context('!!prismjs-loader?lang=css!./snippets/', false, /\.css$/),
-            require.context('!!prismjs-loader?lang=javascript!./snippets/', false, /\.js$/),
-            require.context('!!prismjs-loader?lang=typescript!./snippets/', false, /\.ts$/),
-            require.context('./snippets/', false, /\.(html|css|js|ts)$/)
-        );
-    }
 }

--- a/docs/app/pages/components/sections/panels/item-display-panel-ng1/item-display-panel-ng1.component.html
+++ b/docs/app/pages/components/sections/panels/item-display-panel-ng1/item-display-panel-ng1.component.html
@@ -54,10 +54,10 @@
 
 <tabset>
     <tab heading="HTML">
-        <uxd-snippet [content]="snippets.compiled.layoutHtml" language="html"></uxd-snippet>
+        <uxd-snippet [code]="layoutHtml" language="html"></uxd-snippet>
     </tab>
     <tab heading="JavaScript">
-        <uxd-snippet [content]="snippets.compiled.controllerExampleJs" language="javascript"></uxd-snippet>
+        <uxd-snippet [code]="controllerExampleJs" language="javascript"></uxd-snippet>
     </tab>
 </tabset>
 
@@ -65,4 +65,4 @@
 
 <p>The sample HTML for previous and next buttons in the modal footer is shown below:</p>
 
-<uxd-snippet [content]="snippets.compiled.modalFooterHtml" language="html"></uxd-snippet>
+<uxd-snippet [code]="modalFooterHtml" language="html"></uxd-snippet>

--- a/docs/app/pages/components/sections/panels/item-display-panel-ng1/item-display-panel-ng1.component.ts
+++ b/docs/app/pages/components/sections/panels/item-display-panel-ng1/item-display-panel-ng1.component.ts
@@ -10,36 +10,36 @@ import { DocumentationSectionComponent } from '../../../../../decorators/documen
     changeDetection: ChangeDetectionStrategy.OnPush
 })
 @DocumentationSectionComponent('ComponentsItemDisplayPanelNg1Component')
-export class ComponentsItemDisplayPanelNg1Component extends BaseDocumentationSection implements ICodePenProvider {
+export class ComponentsItemDisplayPanelNg1Component implements ICodePenProvider {
+
+    private layoutHtml = require('./snippets/layout.html');
+    private controllerExampleJs = require('./snippets/controller.example.js');
+    private modalFooterHtml = require('./snippets/modalFooter.html');
+    private modalDOCHtml = require('./snippets/modalDOC.html');
+    private modalPDFHtml = require('./snippets/modalPDF.html');
+    private modalPPTHtml = require('./snippets/modalPPT.html');
+    private controllerJs = require('./snippets/controller.js');
+    private stylesCss = require('./snippets/styles.css');
+
     public codepen: ICodePen = {
-        html: this.snippets.raw.layoutHtml,
+        html: this.layoutHtml,
         htmlAttributes: {
             'ng-controller': 'ItemDisplayPanelDemoCtrl as vm'
         },
         htmlTemplates: [{
             id: 'modalDOC.html',
-            content: this.snippets.raw.modalDOCHtml
+            content: this.modalDOCHtml
         }, {
             id: 'modalPDF.html',
-            content: this.snippets.raw.modalPDFHtml
+            content: this.modalPDFHtml
         }, {
             id: 'modalPPT.html',
-            content: this.snippets.raw.modalPPTHtml
+            content: this.modalPPTHtml
         }, {
             id: 'modalFooter.html',
-            content: this.snippets.raw.modalFooterHtml
+            content: this.modalFooterHtml
         }],
-        css: [this.snippets.raw.stylesCss],
-        js: [this.snippets.raw.controllerJs]
+        css: [this.stylesCss],
+        js: [this.controllerJs]
     };
-
-    constructor() {
-        super(
-            require.context('!!prismjs-loader?lang=html!./snippets/', false, /\.html$/),
-            require.context('!!prismjs-loader?lang=css!./snippets/', false, /\.css$/),
-            require.context('!!prismjs-loader?lang=javascript!./snippets/', false, /\.js$/),
-            require.context('!!prismjs-loader?lang=typescript!./snippets/', false, /\.ts$/),
-            require.context('./snippets/', false, /\.(html|css|js|ts)$/)
-        );
-    }
 }

--- a/docs/app/pages/components/sections/panels/side-inset-panel-ng1/side-inset-panel-ng1.component.html
+++ b/docs/app/pages/components/sections/panels/side-inset-panel-ng1/side-inset-panel-ng1.component.html
@@ -54,13 +54,13 @@
 
 <tabset>
     <tab heading="HTML">
-        <uxd-snippet [content]="snippets.compiled.layoutExampleHtml" language="html"></uxd-snippet>
+        <uxd-snippet [code]="layoutExampleHtml" language="html"></uxd-snippet>
     </tab>
     <tab heading="CSS">
-        <uxd-snippet [content]="snippets.compiled.stylesCss" language="css"></uxd-snippet>
+        <uxd-snippet [code]="stylesCss" language="css"></uxd-snippet>
     </tab>
     <tab heading="Side Panel HTML">
-        <uxd-snippet [content]="snippets.compiled.panelExampleHtml" language="html"></uxd-snippet>
+        <uxd-snippet [code]="panelExampleHtml" language="html"></uxd-snippet>
     </tab>
 </tabset>
 

--- a/docs/app/pages/components/sections/panels/side-inset-panel-ng1/side-inset-panel-ng1.component.ts
+++ b/docs/app/pages/components/sections/panels/side-inset-panel-ng1/side-inset-panel-ng1.component.ts
@@ -1,5 +1,4 @@
 import { Component, ViewEncapsulation, ChangeDetectionStrategy } from '@angular/core';
-import { BaseDocumentationSection } from '../../../../../components/base-documentation-section/base-documentation-section';
 import { ICodePenProvider } from '../../../../../interfaces/ICodePenProvider';
 import { ICodePen } from '../../../../../interfaces/ICodePen';
 import { DocumentationSectionComponent } from '../../../../../decorators/documentation-section-component';
@@ -10,22 +9,18 @@ import { DocumentationSectionComponent } from '../../../../../decorators/documen
     changeDetection: ChangeDetectionStrategy.OnPush
 })
 @DocumentationSectionComponent('ComponentsSideInsetPanelNg1Component')
-export class ComponentsSideInsetPanelNg1Component extends BaseDocumentationSection implements ICodePenProvider {
+export class ComponentsSideInsetPanelNg1Component implements ICodePenProvider {
+
+    private layoutHtml = require('./snippets/layout.html');
+    private stylesCss = require('./snippets/styles.css');
+    private layoutExampleHtml = require('./snippets/layout.example.html');
+    private panelExampleHtml = require('./snippets/panel.example.html');
+
     public codepen: ICodePen = {
-        html: this.snippets.raw.layoutHtml,
+        html: this.layoutHtml,
         htmlAttributes: {
             'id': 'ux-codepen-container-ns'
         },
-        css: [this.snippets.raw.stylesCss]
+        css: [this.stylesCss]
     };
-
-    constructor() {
-        super(
-            require.context('!!prismjs-loader?lang=html!./snippets/', false, /\.html$/),
-            require.context('!!prismjs-loader?lang=css!./snippets/', false, /\.css$/),
-            require.context('!!prismjs-loader?lang=javascript!./snippets/', false, /\.js$/),
-            require.context('!!prismjs-loader?lang=typescript!./snippets/', false, /\.ts$/),
-            require.context('./snippets/', false, /\.(html|css|js|ts)$/)
-        );
-    }
 }

--- a/docs/app/pages/components/sections/search/search-builder-ng1/search-builder-ng1.component.ts
+++ b/docs/app/pages/components/sections/search/search-builder-ng1/search-builder-ng1.component.ts
@@ -1,5 +1,4 @@
 import { Component, ViewEncapsulation, ChangeDetectionStrategy } from '@angular/core';
-import { BaseDocumentationSection } from '../../../../../components/base-documentation-section/base-documentation-section';
 import { ICodePenProvider } from '../../../../../interfaces/ICodePenProvider';
 import { ICodePen } from '../../../../../interfaces/ICodePen';
 import { DocumentationSectionComponent } from '../../../../../decorators/documentation-section-component';
@@ -12,14 +11,43 @@ import { DocumentationSectionComponent } from '../../../../../decorators/documen
     changeDetection: ChangeDetectionStrategy.OnPush
 })
 @DocumentationSectionComponent('ComponentsSearchBuilderNg1Component')
-export class ComponentsSearchBuilderNg1Component extends BaseDocumentationSection {
-    constructor() {
-        super(
-            require.context('!!prismjs-loader?lang=html!./snippets/', false, /\.html$/),
-            require.context('!!prismjs-loader?lang=css!./snippets/', false, /\.css$/),
-            require.context('!!prismjs-loader?lang=javascript!./snippets/', false, /\.js$/),
-            require.context('!!prismjs-loader?lang=typescript!./snippets/', false, /\.ts$/),
-            require.context('./snippets/', false, /\.(html|css|js|ts)$/)
-        );
-    }
+export class ComponentsSearchBuilderNg1Component {
+    
+    // simulate the structure of the base component - without loading the raw unprismified files
+    private snippets = {
+        compiled: {
+            addFieldPanelHtml: require('!!prismjs-loader?lang=html!./snippets/addFieldPanel.html'),
+            addFieldPanelJs: require('!!prismjs-loader?lang=javascript!./snippets/addFieldPanel.js'),
+            authorComponentHtml: require('!!prismjs-loader?lang=html!./snippets/authorComponent.html'),
+            componentArrayExampleJs: require('!!prismjs-loader?lang=javascript!./snippets/componentArray.example.js'),
+            controllerJs: require('!!prismjs-loader?lang=javascript!./snippets/controller.js'),
+            custodianComponentHtml: require('!!prismjs-loader?lang=html!./snippets/custodianComponent.html'),
+            custodianComponentJs: require('!!prismjs-loader?lang=javascript!./snippets/custodianComponent.js'),
+            custodianPanelHtml: require('!!prismjs-loader?lang=html!./snippets/custodianPanel.html'),
+            custodianPanelJs: require('!!prismjs-loader?lang=javascript!./snippets/custodianPanel.js'),
+            dateRangeComponentHtml: require('!!prismjs-loader?lang=html!./snippets/dateRangeComponent.html'),
+            dateRangeComponentJs: require('!!prismjs-loader?lang=javascript!./snippets/dateRangeComponent.js'),
+            fileNameComponentHtml: require('!!prismjs-loader?lang=html!./snippets/fileNameComponent.html'),
+            fileTypesComponentHtml: require('!!prismjs-loader?lang=html!./snippets/fileTypesComponent.html'),
+            fileTypesComponentJs: require('!!prismjs-loader?lang=javascript!./snippets/fileTypesComponent.js'),
+            fileTypesPanelHtml: require('!!prismjs-loader?lang=html!./snippets/fileTypesPanel.html'),
+            fileTypesPanelJs: require('!!prismjs-loader?lang=javascript!./snippets/fileTypesPanel.js'),
+            keywordComponentHtml: require('!!prismjs-loader?lang=html!./snippets/keywordComponent.html'),
+            layoutHtml: require('!!prismjs-loader?lang=html!./snippets/layout.html'),
+            modalControllerJs: require('!!prismjs-loader?lang=javascript!./snippets/modalController.js'),
+            modalLayoutExampleHtml: require('!!prismjs-loader?lang=html!./snippets/modalLayout.example.html'),
+            modalLayoutHtml: require('!!prismjs-loader?lang=html!./snippets/modalLayout.html'),
+            repositoryComponentHtml: require('!!prismjs-loader?lang=html!./snippets/repositoryComponent.html'),
+            repositoryComponentJs: require('!!prismjs-loader?lang=javascript!./snippets/repositoryComponent.js'),
+            repositoryPanelHtml: require('!!prismjs-loader?lang=html!./snippets/repositoryPanel.html'),
+            repositoryPanelJs: require('!!prismjs-loader?lang=javascript!./snippets/repositoryPanel.js'),
+            searchBuilderIdServiceJs: require('!!prismjs-loader?lang=javascript!./snippets/searchBuilderIdService.js'),      
+            searchBuilderPanelServiceJs: require('!!prismjs-loader?lang=javascript!./snippets/searchBuilderPanelService.js'),
+            searchGroupExampleHtml: require('!!prismjs-loader?lang=html!./snippets/searchGroup.example.html'),
+            searchQueryExampleJs: require('!!prismjs-loader?lang=javascript!./snippets/searchQuery.example.js'),
+            stylesCss: require('!!prismjs-loader?lang=css!./snippets/styles.css'),
+            textComponentHtml: require('!!prismjs-loader?lang=html!./snippets/textComponent.html'),
+        }
+    };
+
 }

--- a/docs/app/pages/components/sections/search/search-history-ng1/search-history-ng1.component.html
+++ b/docs/app/pages/components/sections/search/search-history-ng1/search-history-ng1.component.html
@@ -38,18 +38,18 @@
 
 <tabset>
   <tab heading="HTML">
-    <uxd-snippet [content]="snippets.compiled.layoutHtml" language="html"></uxd-snippet>
+    <uxd-snippet [code]="layoutHtml" language="html"></uxd-snippet>
   </tab>
   <tab heading="JavaScript">
-    <uxd-snippet [content]="snippets.compiled.controllerJs" language="javascript"></uxd-snippet>
+    <uxd-snippet [code]="controllerJs" language="javascript"></uxd-snippet>
   </tab>
   <tab heading="Modal HTML">
-    <uxd-snippet [content]="snippets.compiled.modalLayoutHtml" language="html"></uxd-snippet>
+    <uxd-snippet [code]="modalLayoutHtml" language="html"></uxd-snippet>
   </tab>
   <tab heading="Modal JavaScript">
-    <uxd-snippet [content]="snippets.compiled.modalControllerJs" language="javascript"></uxd-snippet>
+    <uxd-snippet [code]="modalControllerJs" language="javascript"></uxd-snippet>
   </tab>
   <tab heading="CSS">
-    <uxd-snippet [content]="snippets.compiled.stylesCss" language="css"></uxd-snippet>
+    <uxd-snippet [code]="stylesCss" language="css"></uxd-snippet>
   </tab>
 </tabset>

--- a/docs/app/pages/components/sections/search/search-history-ng1/search-history-ng1.component.ts
+++ b/docs/app/pages/components/sections/search/search-history-ng1/search-history-ng1.component.ts
@@ -1,5 +1,4 @@
 import { Component, ViewEncapsulation, ChangeDetectionStrategy } from '@angular/core';
-import { BaseDocumentationSection } from '../../../../../components/base-documentation-section/base-documentation-section';
 import { ICodePenProvider } from '../../../../../interfaces/ICodePenProvider';
 import { ICodePen } from '../../../../../interfaces/ICodePen';
 import { DocumentationSectionComponent } from '../../../../../decorators/documentation-section-component';
@@ -12,27 +11,25 @@ import { DocumentationSectionComponent } from '../../../../../decorators/documen
     changeDetection: ChangeDetectionStrategy.OnPush
 })
 @DocumentationSectionComponent('ComponentsSearchHistoryNg1Component')
-export class ComponentsSearchHistoryNg1Component extends BaseDocumentationSection implements ICodePenProvider {
+export class ComponentsSearchHistoryNg1Component implements ICodePenProvider {
+
+    private layoutHtml = require('./snippets/layout.html');
+    private modalLayoutHtml = require('./snippets/modalLayout.html');
+    private stylesCss = require('./snippets/styles.css');
+    private controllerJs = require('./snippets/controller.js');
+    private modalControllerJs = require('./snippets/modalController.js');
+
     public codepen: ICodePen = {
-        html: this.snippets.raw.layoutHtml,
+        html: this.layoutHtml,
         htmlAttributes: {
             'ng-controller': 'SearchHistoryDemoCtrl as vm'
         },
         htmlTemplates: [{
             id: 'modalLayout.html',
-            content: this.snippets.raw.modalLayoutHtml
+            content: this.modalLayoutHtml
         }],
-        css: [this.snippets.raw.stylesCss],
-        js: [this.snippets.raw.controllerJs, this.snippets.raw.modalControllerJs]
+        css: [this.stylesCss],
+        js: [this.controllerJs, this.modalControllerJs]
     };
 
-    constructor() {
-        super(
-            require.context('!!prismjs-loader?lang=html!./snippets/', false, /\.html$/),
-            require.context('!!prismjs-loader?lang=css!./snippets/', false, /\.css$/),
-            require.context('!!prismjs-loader?lang=javascript!./snippets/', false, /\.js$/),
-            require.context('!!prismjs-loader?lang=typescript!./snippets/', false, /\.ts$/),
-            require.context('./snippets/', false, /\.(html|css|js|ts)$/)
-        );
-    }
 }

--- a/docs/app/pages/components/sections/select/select-ng1/select-ng1.component.html
+++ b/docs/app/pages/components/sections/select/select-ng1/select-ng1.component.html
@@ -14,10 +14,10 @@
 
 <tabset>
     <tab heading="HTML">
-        <uxd-snippet [content]="snippets.compiled.sampleHtml"></uxd-snippet>
+        <uxd-snippet [code]="sampleHtml"></uxd-snippet>
     </tab>
     <tab heading="JavaScript">
-        <uxd-snippet [content]="snippets.compiled.sampleJs" language="javascript"></uxd-snippet>
+        <uxd-snippet [code]="sampleJs" language="javascript"></uxd-snippet>
     </tab>
 </tabset>
 

--- a/docs/app/pages/components/sections/select/select-ng1/select-ng1.component.ts
+++ b/docs/app/pages/components/sections/select/select-ng1/select-ng1.component.ts
@@ -2,7 +2,6 @@ import { Component, ChangeDetectionStrategy } from '@angular/core';
 import { DocumentationSectionComponent } from '../../../../../decorators/documentation-section-component';
 import { ICodePenProvider } from '../../../../../interfaces/ICodePenProvider';
 import { ICodePen } from '../../../../../interfaces/ICodePen';
-import { BaseDocumentationSection } from '../../../../../components/base-documentation-section/base-documentation-section';
 
 @Component({
     selector: 'uxd-components-select-ng1',
@@ -10,24 +9,18 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
     changeDetection: ChangeDetectionStrategy.OnPush
 })
 @DocumentationSectionComponent('ComponentsSelectNg1Component')
-export class ComponentsSelectNg1Component extends BaseDocumentationSection implements ICodePenProvider {
+export class ComponentsSelectNg1Component implements ICodePenProvider {
 
-    constructor() {
-        super(
-            require.context('!!prismjs-loader?lang=html!./snippets/', false, /\.html$/),
-            require.context('!!prismjs-loader?lang=css!./snippets/', false, /\.css$/),
-            require.context('!!prismjs-loader?lang=javascript!./snippets/', false, /\.js$/),
-            require.context('!!prismjs-loader?lang=typescript!./snippets/', false, /\.ts$/),
-            require.context('./snippets/', false, /\.(html|css|js|ts)$/)
-        );
-    }
+    private sampleHtml = require('./snippets/sample.html');
+    private sampleJs = require('./snippets/sample.js');
+    private sampleFullJs = require('./snippets/sampleFull.js');
 
     public codepen: ICodePen = {
-        html: this.snippets.raw.sampleHtml,
+        html: this.sampleHtml,
         htmlAttributes: {
             'ng-controller': 'SelectDemoCtrl as vm'
         },
-        js: [this.snippets.raw.sampleFullJs]
+        js: [this.sampleFullJs]
     };
 
 }

--- a/docs/app/pages/components/sections/tables/custom-responsive-table-ng1/custom-responsive-table-ng1.component.html
+++ b/docs/app/pages/components/sections/tables/custom-responsive-table-ng1/custom-responsive-table-ng1.component.html
@@ -7,14 +7,15 @@
 <tabset>
 
     <tab heading="HTML">
-        <uxd-snippet language="html" [content]="snippets.compiled.sampleHtml"></uxd-snippet>
+        <uxd-snippet language="html" [code]="htmlCode"></uxd-snippet>
     </tab>
     
     <tab heading="Javascript">
-        <uxd-snippet language="javascript"  [content]="snippets.compiled.sampleJs"></uxd-snippet>
+        <uxd-snippet language="javascript"  [code]="jsCode"></uxd-snippet>
     </tab>
     
     <tab heading="CSS">
-        <uxd-snippet language="css" [content]="snippets.compiled.sampleCss"></uxd-snippet>
+        <uxd-snippet language="css" [code]="cssCode"></uxd-snippet>
     </tab>
+    
 </tabset>

--- a/docs/app/pages/components/sections/tables/custom-responsive-table-ng1/custom-responsive-table-ng1.component.ts
+++ b/docs/app/pages/components/sections/tables/custom-responsive-table-ng1/custom-responsive-table-ng1.component.ts
@@ -2,31 +2,24 @@ import { Component } from '@angular/core';
 import { DocumentationSectionComponent } from '../../../../../decorators/documentation-section-component';
 import { ICodePenProvider } from './../../../../../interfaces/ICodePenProvider';
 import { ICodePen } from './../../../../../interfaces/ICodePen';
-import { BaseDocumentationSection } from '../../../../../components/base-documentation-section/base-documentation-section';
 
 @Component({
     selector: 'uxd-components-custom-reposonsive-table',
     templateUrl: './custom-responsive-table-ng1.component.html'
 })
 @DocumentationSectionComponent('ComponentsCustomResponsiveTableNg1Component')
-export class ComponentsCustomResponsiveTableNg1Component extends BaseDocumentationSection implements ICodePenProvider {
+export class ComponentsCustomResponsiveTableNg1Component implements ICodePenProvider {
+
+    private htmlCode = require('./snippets/sample.html');
+    private jsCode = require('./snippets/sample.js');
+    private cssCode = require('./snippets/sample.css');
 
     public codepen: ICodePen = {
-        html: this.snippets.raw.sampleHtml,
+        html: this.htmlCode,
         htmlAttributes: {
             'ng-controller': 'CustomResponsiveTableCtrl as vm'
         },
-        js: [this.snippets.raw.sampleJs],
-        css: [this.snippets.raw.sampleCss]
+        js: [this.jsCode],
+        css: [this.cssCode]
     };
-    
-    constructor() {
-        super(
-            require.context('!!prismjs-loader?lang=html!./snippets/', false, /\.html$/),
-            require.context('!!prismjs-loader?lang=css!./snippets/', false, /\.css$/),
-            require.context('!!prismjs-loader?lang=javascript!./snippets/', false, /\.js$/),
-            require.context('!!prismjs-loader?lang=typescript!./snippets/', false, /\.ts$/),
-            require.context('./snippets/', false, /\.(html|css|js|ts)$/)
-        );
-    }
 }

--- a/docs/app/pages/components/sections/tables/detail-row-header-ng1/detail-row-header-ng1.component.html
+++ b/docs/app/pages/components/sections/tables/detail-row-header-ng1/detail-row-header-ng1.component.html
@@ -56,27 +56,27 @@
 <tabset>
 
     <tab heading="HTML">
-        <uxd-snippet language="html" [content]="htmlCode"></uxd-snippet>
+        <uxd-snippet language="html" [code]="htmlCode"></uxd-snippet>
     </tab>
 
     <tab heading="Controller">
-        <uxd-snippet language="javascript" [content]="controllerCode"></uxd-snippet>
+        <uxd-snippet language="javascript" [code]="controllerCode"></uxd-snippet>
     </tab>
 
     <tab heading="Popover HTML">
-        <uxd-snippet language="html" [content]="popoverHtmlCode"></uxd-snippet>
+        <uxd-snippet language="html" [code]="popoverHtmlCode"></uxd-snippet>
     </tab>
 
     <tab heading="Popover Controller">
-        <uxd-snippet language="javascript" [content]="popoverControllerCode"></uxd-snippet>
+        <uxd-snippet language="javascript" [code]="popoverControllerCode"></uxd-snippet>
     </tab>
 
     <tab heading="CSS">
-        <uxd-snippet language="css" [content]="styleCode"></uxd-snippet>
+        <uxd-snippet language="css" [code]="styleCode"></uxd-snippet>
     </tab>
 
     <tab heading="Data Service">
-        <uxd-snippet language="javascript" [content]="serviceCode"></uxd-snippet>
+        <uxd-snippet language="javascript" [code]="serviceCode"></uxd-snippet>
     </tab>
 
 </tabset>

--- a/docs/app/pages/components/sections/tables/detail-row-header-ng1/detail-row-header-ng1.component.ts
+++ b/docs/app/pages/components/sections/tables/detail-row-header-ng1/detail-row-header-ng1.component.ts
@@ -2,50 +2,39 @@ import { Component } from '@angular/core';
 import { DocumentationSectionComponent } from '../../../../../decorators/documentation-section-component';
 import { ICodePenProvider } from '../../../../../interfaces/ICodePenProvider';
 import { ICodePen } from '../../../../../interfaces/ICodePen';
-import { BaseDocumentationSection } from '../../../../../components/base-documentation-section/base-documentation-section';
 
 @Component({
     selector: 'uxd-components-detail-row-header',
     templateUrl: './detail-row-header-ng1.component.html'
 })
 @DocumentationSectionComponent('ComponentsDetailRowHeaderNg1Component')
-export class ComponentsDetailRowHeaderNg1Component extends BaseDocumentationSection implements ICodePenProvider {
+export class ComponentsDetailRowHeaderNg1Component implements ICodePenProvider {
 
-    private htmlCode = this.snippets.compiled.layoutHtml;
-    private controllerCode = this.snippets.compiled.controllerJs;
-    private popoverHtmlCode = this.snippets.compiled.popoverHtml;
-    private popoverControllerCode = this.snippets.compiled.popoverControllerJs;
-    private styleCode = this.snippets.compiled.stylesCss;
-    private serviceCode = this.snippets.compiled.serviceJs;
+    private htmlCode = require('./snippets/layout.html');
+    private controllerCode = require('./snippets/controller.js');
+    private popoverHtmlCode = require('./snippets/popover.html');
+    private popoverControllerCode = require('./snippets/popover.controller.js');
+    private styleCode = require('./snippets/styles.css');
+    private serviceCode = require('./snippets/service.js');
 
     public codepen: ICodePen = {
-        html: this.snippets.raw.layoutHtml,
+        html: this.htmlCode,
         htmlAttributes: {
             'ng-controller': 'DetailRowResponsiveTableCtrl as vm'
         },
         htmlTemplates: [
             {
                 id: 'detailRowHeaderPopover.html',
-                content: this.snippets.raw.popoverHtml
+                content: this.popoverHtmlCode
             }
         ],
         js: [
-            this.snippets.raw.controllerJs,
-            this.snippets.raw.popoverControllerJs,
-            this.snippets.raw.serviceJs
+            this.controllerCode,
+            this.popoverControllerCode,
+            this.serviceCode
         ],
         css: [
-            this.snippets.raw.styleCss
+            this.styleCode
         ]
     };
-    
-    constructor() {
-        super(
-            require.context('!!prismjs-loader?lang=html!./snippets/', false, /\.html$/),
-            require.context('!!prismjs-loader?lang=css!./snippets/', false, /\.css$/),
-            require.context('!!prismjs-loader?lang=javascript!./snippets/', false, /\.js$/),
-            require.context('!!prismjs-loader?lang=typescript!./snippets/', false, /\.ts$/),
-            require.context('./snippets/', false, /\.(html|css|js|ts)$/)
-        );
-    }
 }

--- a/docs/app/pages/components/sections/tables/detail-row-responsive-ng1/detail-row-responsive-ng1.component.html
+++ b/docs/app/pages/components/sections/tables/detail-row-responsive-ng1/detail-row-responsive-ng1.component.html
@@ -21,15 +21,15 @@
 <tabset>
 
     <tab heading="HTML">
-        <uxd-snippet language="html" [content]="htmlCode"></uxd-snippet>
+        <uxd-snippet language="html" [code]="htmlCode"></uxd-snippet>
     </tab>
 
     <tab heading="Controller">
-        <uxd-snippet language="javascript" [content]="jsCode"></uxd-snippet>
+        <uxd-snippet language="javascript" [code]="jsCode"></uxd-snippet>
     </tab>
 
     <tab heading="CSS">
-        <uxd-snippet language="css" [content]="cssCode"></uxd-snippet>
+        <uxd-snippet language="css" [code]="cssCode"></uxd-snippet>
     </tab>
 
 </tabset>

--- a/docs/app/pages/components/sections/tables/detail-row-responsive-ng1/detail-row-responsive-ng1.component.ts
+++ b/docs/app/pages/components/sections/tables/detail-row-responsive-ng1/detail-row-responsive-ng1.component.ts
@@ -2,35 +2,24 @@ import { Component } from '@angular/core';
 import { DocumentationSectionComponent } from '../../../../../decorators/documentation-section-component';
 import { ICodePenProvider } from '../../../../../interfaces/ICodePenProvider';
 import { ICodePen } from '../../../../../interfaces/ICodePen';
-import { BaseDocumentationSection } from '../../../../../components/base-documentation-section/base-documentation-section';
 
 @Component({
     selector: 'uxd-components-detail-row-responsive',
     templateUrl: './detail-row-responsive-ng1.component.html'
 })
 @DocumentationSectionComponent('ComponentsDetailRowResponsiveNg1Component')
-export class ComponentsDetailRowResponsiveNg1Component extends BaseDocumentationSection implements ICodePenProvider {
+export class ComponentsDetailRowResponsiveNg1Component implements ICodePenProvider {
 
-    public htmlCode = this.snippets.compiled.layoutHtml;
-    public jsCode = this.snippets.compiled.controllerJs;
-    public cssCode = this.snippets.compiled.stylesCss;
+    public htmlCode = require('./snippets/layout.html');
+    public jsCode = require('./snippets/controller.js');
+    public cssCode = require('./snippets/styles.css');
 
     public codepen: ICodePen = {
-        html: this.snippets.raw.codepenHtml,
+        html: require('./snippets/codepen.html'),
         htmlAttributes: {
             'ng-controller': 'DetailRowResponsiveTableCtrl as vm'
         },
-        js: [this.snippets.raw.codepenJs],
-        css: [this.snippets.raw.stylesCss]
+        js: [require('./snippets/codepen.js')],
+        css: [this.cssCode]
     };
-    
-    constructor() {
-        super(
-            require.context('!!prismjs-loader?lang=html!./snippets/', false, /\.html$/),
-            require.context('!!prismjs-loader?lang=css!./snippets/', false, /\.css$/),
-            require.context('!!prismjs-loader?lang=javascript!./snippets/', false, /\.js$/),
-            require.context('!!prismjs-loader?lang=typescript!./snippets/', false, /\.ts$/),
-            require.context('./snippets/', false, /\.(html|css|js|ts)$/)
-        );
-    }
 }

--- a/docs/app/pages/components/sections/tables/dynamic-filters-ng1/dynamic-filters-ng1.component.html
+++ b/docs/app/pages/components/sections/tables/dynamic-filters-ng1/dynamic-filters-ng1.component.html
@@ -63,11 +63,11 @@
 <tabset>
 
     <tab heading="HTML">
-        <uxd-snippet language="html" [content]="filterContainerCode"></uxd-snippet>
+        <uxd-snippet language="html" [code]="filterContainerCode"></uxd-snippet>
     </tab>
 
     <tab heading="Javascript">
-        <uxd-snippet language="javascript" [content]="filterControllerCode"></uxd-snippet>
+        <uxd-snippet language="javascript" [code]="filterControllerCode"></uxd-snippet>
     </tab>
 
 </tabset>
@@ -81,8 +81,8 @@
     of <code>fixedOptions</code>. An example is shown below:
 </p>
 
-<uxd-snippet language="javascript" [content]="filterOptionsCode"></uxd-snippet>
+<uxd-snippet language="javascript" [code]="filterOptionsCode"></uxd-snippet>
 
 <p>Passed to the directive as shown:</p>
 
-<uxd-snippet language="html" [content]="filterCode"></uxd-snippet>
+<uxd-snippet language="html" [code]="filterCode"></uxd-snippet>

--- a/docs/app/pages/components/sections/tables/dynamic-filters-ng1/dynamic-filters-ng1.component.ts
+++ b/docs/app/pages/components/sections/tables/dynamic-filters-ng1/dynamic-filters-ng1.component.ts
@@ -1,26 +1,16 @@
 import { Component } from '@angular/core';
 import { DocumentationSectionComponent } from '../../../../../decorators/documentation-section-component';
-import { BaseDocumentationSection } from '../../../../../components/base-documentation-section/base-documentation-section';
 
 @Component({
     selector: 'uxd-components-dynamic-filters',
     templateUrl: './dynamic-filters-ng1.component.html'
 })
 @DocumentationSectionComponent('ComponentsDynamicFiltersNg1Component')
-export class ComponentsDynamicFiltersNg1Component extends BaseDocumentationSection {
+export class ComponentsDynamicFiltersNg1Component {
     
-    private filterContainerCode = this.snippets.compiled.filterContainerHtml;
-    private filterControllerCode = this.snippets.compiled.filterContainerJs;
-    private filterOptionsCode = this.snippets.compiled.filterOptionsJs;
-    private filterCode = this.snippets.compiled.filterHtml;
-    
-    constructor() {
-        super(
-            require.context('!!prismjs-loader?lang=html!./snippets/', false, /\.html$/),
-            require.context('!!prismjs-loader?lang=css!./snippets/', false, /\.css$/),
-            require.context('!!prismjs-loader?lang=javascript!./snippets/', false, /\.js$/),
-            require.context('!!prismjs-loader?lang=typescript!./snippets/', false, /\.ts$/)
-        );
-    }
+    private filterContainerCode = require('./snippets/filter-container.html');
+    private filterControllerCode = require('./snippets/filter-container.js');
+    private filterOptionsCode = require('./snippets/filter-options.js');
+    private filterCode = require('./snippets/filter.html');
 
 }

--- a/docs/app/pages/components/sections/tables/multiple-column-sorting-ng1/multiple-column-sorting-ng1.component.html
+++ b/docs/app/pages/components/sections/tables/multiple-column-sorting-ng1/multiple-column-sorting-ng1.component.html
@@ -25,11 +25,11 @@
 <tabset>
 
     <tab heading="HTML">
-        <uxd-snippet language="html" [content]="htmlCode"></uxd-snippet>
+        <uxd-snippet language="html" [code]="htmlCode"></uxd-snippet>
     </tab>
 
     <tab heading="Javascript">
-        <uxd-snippet language="javascript" [content]="jsCode"></uxd-snippet>
+        <uxd-snippet language="javascript" [code]="jsCode"></uxd-snippet>
     </tab>
 
 </tabset>

--- a/docs/app/pages/components/sections/tables/multiple-column-sorting-ng1/multiple-column-sorting-ng1.component.ts
+++ b/docs/app/pages/components/sections/tables/multiple-column-sorting-ng1/multiple-column-sorting-ng1.component.ts
@@ -2,32 +2,22 @@ import { Component } from '@angular/core';
 import { DocumentationSectionComponent } from '../../../../../decorators/documentation-section-component';
 import { ICodePenProvider } from '../../../../../interfaces/ICodePenProvider';
 import { ICodePen } from '../../../../../interfaces/ICodePen';
-import { BaseDocumentationSection } from '../../../../../components/base-documentation-section/base-documentation-section';
 
 @Component({
     selector: 'uxd-components-multiple-column-sorting',
     templateUrl: './multiple-column-sorting-ng1.component.html'
 })
 @DocumentationSectionComponent('ComponentsMultipleColumnSortingNg1Component')
-export class ComponentsMultipleColumnSortingNg1Component extends BaseDocumentationSection implements ICodePenProvider {
-    private htmlCode = this.snippets.compiled.sampleHtml;
-    private jsCode = this.snippets.compiled.sampleJs;
+export class ComponentsMultipleColumnSortingNg1Component implements ICodePenProvider {
+
+    private htmlCode = require('./snippets/sample.html');
+    private jsCode = require('./snippets/sample.js');
 
     public codepen: ICodePen = {
-        html: this.snippets.raw.sampleHtml,
+        html: this.htmlCode,
         htmlAttributes: {
             'ng-controller': 'MultipleColumnSortingCtrl as vm'
         },
-        js: [this.snippets.raw.sampleJs]
+        js: [this.jsCode]
     };
-    
-    constructor() {
-        super(
-            require.context('!!prismjs-loader?lang=html!./snippets/', false, /\.html$/),
-            require.context('!!prismjs-loader?lang=css!./snippets/', false, /\.css$/),
-            require.context('!!prismjs-loader?lang=javascript!./snippets/', false, /\.js$/),
-            require.context('!!prismjs-loader?lang=typescript!./snippets/', false, /\.ts$/),
-            require.context('./snippets/', false, /\.(html|css|js|ts)$/)
-        );
-    }
 }

--- a/docs/app/pages/components/sections/tables/preview-pane-window-ng1/preview-pane-window-ng1.component.html
+++ b/docs/app/pages/components/sections/tables/preview-pane-window-ng1/preview-pane-window-ng1.component.html
@@ -40,7 +40,7 @@
     set which will be the same value as the attribute you set in the <code>preview-pane-window</code> directive.
 </p>
 
-<uxd-snippet language="html" [content]="sampleCode"></uxd-snippet>
+<uxd-snippet language="html" [code]="sampleCode"></uxd-snippet>
 
 <blockquote>
     <p>
@@ -53,15 +53,15 @@
 
 <tabset>
     <tab heading="HTML">
-        <uxd-snippet language="html" [content]="htmlCode"></uxd-snippet>
+        <uxd-snippet language="html" [code]="htmlCode"></uxd-snippet>
     </tab>
     
     <tab heading="Javascript">
-        <uxd-snippet language="javascript" [content]="jsCode"></uxd-snippet>
+        <uxd-snippet language="javascript" [code]="jsCode"></uxd-snippet>
     </tab>
     
     <tab heading="CSS">
-        <uxd-snippet language="css" [content]="cssCode"></uxd-snippet>
+        <uxd-snippet language="css" [code]="cssCode"></uxd-snippet>
     </tab>
 </tabset>
 
@@ -71,4 +71,4 @@
     visible when in the window. An example of a preview pane footer can be found below:
 </p>
 
-<uxd-snippet language="html" [content]="footerCode"></uxd-snippet>
+<uxd-snippet language="html" [code]="footerCode"></uxd-snippet>

--- a/docs/app/pages/components/sections/tables/preview-pane-window-ng1/preview-pane-window-ng1.component.ts
+++ b/docs/app/pages/components/sections/tables/preview-pane-window-ng1/preview-pane-window-ng1.component.ts
@@ -2,23 +2,22 @@ import { Component } from '@angular/core';
 import { DocumentationSectionComponent } from '../../../../../decorators/documentation-section-component';
 import { ICodePenProvider } from '../../../../../interfaces/ICodePenProvider';
 import { ICodePen } from '../../../../../interfaces/ICodePen';
-import { BaseDocumentationSection } from '../../../../../components/base-documentation-section/base-documentation-section';
 
 @Component({
     selector: 'uxd-components-preview-pane-window',
     templateUrl: './preview-pane-window-ng1.component.html'
 })
 @DocumentationSectionComponent('ComponentsPreviewPaneWindowNg1Component')
-export class ComponentsPreviewPaneWindowNg1Component extends BaseDocumentationSection implements ICodePenProvider {
+export class ComponentsPreviewPaneWindowNg1Component implements ICodePenProvider {
     
-    private sampleCode = this.snippets.compiled.sampleHtml;
-    private htmlCode = this.snippets.compiled.layoutHtml;
-    private jsCode = this.snippets.compiled.controllerJs;
-    private cssCode = this.snippets.compiled.stylesCss;
-    private footerCode = this.snippets.compiled.footerHtml;
+    private sampleCode = require('./snippets/sample.html');
+    private htmlCode = require('./snippets/layout.html');
+    private jsCode = require('./snippets/controller.js');
+    private cssCode = require('./snippets/styles.css');
+    private footerCode = require('./snippets/footer.html');
 
     public codepen: ICodePen = {
-        html: this.snippets.raw.layoutHtml,
+        html: this.htmlCode,
         htmlAttributes: {
             'ng-controller': 'PreviewPaneWindowCtrl as vm'
         },
@@ -45,19 +44,8 @@ export class ComponentsPreviewPaneWindowNg1Component extends BaseDocumentationSe
             }
         ],
         js: [ 
-            this.snippets.raw.controllerJs
+            this.jsCode
         ],
-        css: [this.snippets.raw.stylesCss]
+        css: [this.cssCode]
     };
-    
-    constructor() {
-        super(
-            require.context('!!prismjs-loader?lang=html!./snippets/', false, /\.html$/),
-            require.context('!!prismjs-loader?lang=css!./snippets/', false, /\.css$/),
-            require.context('!!prismjs-loader?lang=javascript!./snippets/', false, /\.js$/),
-            require.context('!!prismjs-loader?lang=typescript!./snippets/', false, /\.ts$/),
-            require.context('./snippets/', false, /\.(html|css|js|ts)$/)
-        );
-    }
-
 }

--- a/docs/app/pages/components/sections/tables/reorderable-table-ng1/reorderable-table-ng1.component.ts
+++ b/docs/app/pages/components/sections/tables/reorderable-table-ng1/reorderable-table-ng1.component.ts
@@ -2,41 +2,30 @@ import { Component } from '@angular/core';
 import { DocumentationSectionComponent } from '../../../../../decorators/documentation-section-component';
 import { ICodePenProvider } from '../../../../../interfaces/ICodePenProvider';
 import { ICodePen } from '../../../../../interfaces/ICodePen';
-import { BaseDocumentationSection } from '../../../../../components/base-documentation-section/base-documentation-section';
 
 @Component({
     selector: 'uxd-components-reorderable-table',
     templateUrl: './reorderable-table-ng1.component.html'
 })
 @DocumentationSectionComponent('ComponentsReorderableTableNg1Component')
-export class ComponentsReorderableTableNg1Component extends BaseDocumentationSection implements ICodePenProvider {
+export class ComponentsReorderableTableNg1Component implements ICodePenProvider {
     
-    private htmlCode = this.snippets.compiled.layoutHtml;
-    private jsCode = this.snippets.compiled.controllerJs;
-    private cssCode = this.snippets.compiled.stylesCss;
+    private htmlCode = require('./snippets/layout.html');
+    private jsCode = require('./snippets/controller.js');
+    private cssCode =  require('./snippets/styles.css');
 
-    private tableDataCode = this.snippets.compiled.tableDataHtml;
-    private controlsCode = this.snippets.compiled.controlsHtml;
+    private tableDataCode =  require('./snippets/table-data.html');
+    private controlsCode =  require('./snippets/controls.html');
 
-    private removeRowHtmlCode = this.snippets.compiled.removeRowHtml;
-    private removeRowJsCode = this.snippets.compiled.removeRowJs;
+    private removeRowHtmlCode = require('./snippets/remove-row.html');
+    private removeRowJsCode = require('./snippets/remove-row.js');
     
     public codepen: ICodePen = {
-        html: this.snippets.raw.layoutHtml,
+        html: this.htmlCode,
         htmlAttributes: {
             'ng-controller': 'ReorderableCtrl as vm'
         },
-        js: [this.snippets.raw.controllerJs],
-        css: [this.snippets.raw.stylesCss]
+        js: [this.jsCode],
+        css: [this.cssCode]
     };
-    
-    constructor() {
-        super(
-            require.context('!!prismjs-loader?lang=html!./snippets/', false, /\.html$/),
-            require.context('!!prismjs-loader?lang=css!./snippets/', false, /\.css$/),
-            require.context('!!prismjs-loader?lang=javascript!./snippets/', false, /\.js$/),
-            require.context('!!prismjs-loader?lang=typescript!./snippets/', false, /\.ts$/),
-            require.context('./snippets/', false, /\.(html|css|js|ts)$/)
-        );
-    }
 }

--- a/docs/app/pages/components/sections/tables/single-column-sorting-ng1/single-column-sorting-ng1.component.html
+++ b/docs/app/pages/components/sections/tables/single-column-sorting-ng1/single-column-sorting-ng1.component.html
@@ -24,11 +24,11 @@
 <tabset>
 
     <tab heading="HTML">
-        <uxd-snippet language="html" [content]="htmlCode"></uxd-snippet>
+        <uxd-snippet language="html" [code]="htmlCode"></uxd-snippet>
     </tab>
 
     <tab heading="Javascript">
-        <uxd-snippet language="javascript" [content]="jsCode"></uxd-snippet>
+        <uxd-snippet language="javascript" [code]="jsCode"></uxd-snippet>
     </tab>
 </tabset>
 

--- a/docs/app/pages/components/sections/tables/single-column-sorting-ng1/single-column-sorting-ng1.component.ts
+++ b/docs/app/pages/components/sections/tables/single-column-sorting-ng1/single-column-sorting-ng1.component.ts
@@ -2,33 +2,22 @@ import { Component } from '@angular/core';
 import { DocumentationSectionComponent } from '../../../../../decorators/documentation-section-component';
 import { ICodePenProvider } from '../../../../../interfaces/ICodePenProvider';
 import { ICodePen } from '../../../../../interfaces/ICodePen';
-import { BaseDocumentationSection } from '../../../../../components/base-documentation-section/base-documentation-section';
 
 @Component({
     selector: 'uxd-components-single-column-sorting',
     templateUrl: './single-column-sorting-ng1.component.html'
 })
 @DocumentationSectionComponent('ComponentsSingleColumnSortingNg1Component')
-export class ComponentsSingleColumnSortingNg1Component extends BaseDocumentationSection implements ICodePenProvider {
+export class ComponentsSingleColumnSortingNg1Component implements ICodePenProvider {
     
-    private htmlCode = this.snippets.compiled.sampleHtml;
-    private jsCode = this.snippets.compiled.sampleJs;
+    private htmlCode = require('./snippets/sample.html');
+    private jsCode = require('./snippets/sample.js');
 
     public codepen: ICodePen = {
-        html: this.snippets.raw.sampleHtml,
+        html: this.htmlCode,
         htmlAttributes: {
             'ng-controller': 'SingleColumnSortingCtrl as vm'
         },
-        js: [this.snippets.raw.sampleJs]
+        js: [this.jsCode]
     };
-    
-    constructor() {
-        super(
-            require.context('!!prismjs-loader?lang=html!./snippets/', false, /\.html$/),
-            require.context('!!prismjs-loader?lang=css!./snippets/', false, /\.css$/),
-            require.context('!!prismjs-loader?lang=javascript!./snippets/', false, /\.js$/),
-            require.context('!!prismjs-loader?lang=typescript!./snippets/', false, /\.ts$/),
-            require.context('./snippets/', false, /\.(html|css|js|ts)$/)
-        );
-    }
 }

--- a/docs/app/pages/components/sections/tables/traditional-multiple-select-actions-ng1/traditional-multiple-select-actions-ng1.component.html
+++ b/docs/app/pages/components/sections/tables/traditional-multiple-select-actions-ng1/traditional-multiple-select-actions-ng1.component.html
@@ -101,7 +101,7 @@
     The <code>display-select-options</code> will display the Select All/None options and count of selected items. The <code>display-cancel-option</code>    will show the cancel button which will discard the selection mode on click.
 </p>
 
-<uxd-snippet language="html" [content]="htmlCode"></uxd-snippet>
+<uxd-snippet language="html" [code]="htmlCode"></uxd-snippet>
 
 <p>
     To get the check box, you must use the <code>.multi-select-checkbox</code> class. Also, <code>multiple-list-select-item="item"</code>    attribute should be set to the specified item you want to select. Note the value specified for the attribute is evaluated
@@ -109,7 +109,7 @@
     When using a <code>table</code> the <code>extended-checkbox-hit</code> attribute can be added to the <code>td</code>    element that encloses <code>multiple-list-select-item</code> to extend the hit area to the space around the checkbox.
 </p>
 
-<uxd-snippet language="html" [content]="selectionCode"></uxd-snippet>
+<uxd-snippet language="html" [code]="selectionCode"></uxd-snippet>
 
 <p>
     A selection can be made invalid by changing the items in the grid. A selection can only be made invalid if “Select All” was

--- a/docs/app/pages/components/sections/tables/traditional-multiple-select-actions-ng1/traditional-multiple-select-actions-ng1.component.ts
+++ b/docs/app/pages/components/sections/tables/traditional-multiple-select-actions-ng1/traditional-multiple-select-actions-ng1.component.ts
@@ -1,23 +1,14 @@
 import { Component } from '@angular/core';
 import { DocumentationSectionComponent } from '../../../../../decorators/documentation-section-component';
-import { BaseDocumentationSection } from '../../../../../components/base-documentation-section/base-documentation-section';
 
 @Component({
     selector: 'uxd-components-traditional-multiple-select-actions',
     templateUrl: './traditional-multiple-select-actions-ng1.component.html'
 })
 @DocumentationSectionComponent('ComponentsTraditionalMultipleSelectActionsNg1Component')
-export class ComponentsTraditionalMultipleSelectActionsNg1Component extends BaseDocumentationSection {
+export class ComponentsTraditionalMultipleSelectActionsNg1Component {
     
-    private htmlCode = this.snippets.compiled.layoutHtml;
-    private selectionCode = this.snippets.compiled.selectionHtml;
-    
-    constructor() {
-        super(
-            require.context('!!prismjs-loader?lang=html!./snippets/', false, /\.html$/),
-            require.context('!!prismjs-loader?lang=css!./snippets/', false, /\.css$/),
-            require.context('!!prismjs-loader?lang=javascript!./snippets/', false, /\.js$/),
-            require.context('!!prismjs-loader?lang=typescript!./snippets/', false, /\.ts$/)
-        );
-    }
+    private htmlCode = require('./snippets/layout.html');
+    private selectionCode = require('./snippets/selection.html');
+
 }

--- a/grunt/uglify.js
+++ b/grunt/uglify.js
@@ -9,15 +9,6 @@ module.exports = {
         },
         src: path.join(process.cwd(), 'dist', 'ng1', 'ux-aspects-ng1.js'),
         dest: path.join(process.cwd(), 'dist', 'ng1', 'ux-aspects-ng1.min.js')
-    },
-
-    library: {
-        options: {
-            preserveComments: /(?:^!|@(?:license|preserve|cc_on))/,
-            maxLineLen: 0
-        },
-        src: path.join(process.cwd(), 'dist', 'lib', 'ux-aspects.js'),
-        dest: path.join(process.cwd(), 'dist', 'lib', 'ux-aspects.min.js')
     }
 
 };


### PR DESCRIPTION
Removing use of prism loader in some of our sections. While we will likely move back to use this once each category has it's own module, for the time removing these from these sections reduces build output ~1.3mb.

Also remove uglify step from grunt task for Angular 4 library as this is no longer needed - the consuming module loader should take care of this now