### PR TITLE
Fixing search builder code samples

### DIFF
--- a/docs/app/pages/components/sections/search/search-builder-ng1/templates/insetPanels.html
+++ b/docs/app/pages/components/sections/search/search-builder-ng1/templates/insetPanels.html
@@ -4,28 +4,28 @@
 
 <h3 class="m-b-md">Add Field Panel</h3>
 <h4>HTML</h4>
-<pre class="language-html"><code ng-bind-html="snippets.compiled.addFieldPanelHtml"></code></pre>
+<pre class="language-html"><code ng-bind="snippets.compiled.addFieldPanelHtml"></code></pre>
 
 <h4>Controller</h4>
-<pre class="language-javascript"><code ng-bind-html="snippets.compiled.addFieldPanelJs"></code></pre>
+<pre class="language-javascript"><code ng-bind="snippets.compiled.addFieldPanelJs"></code></pre>
 
 <h3 class="m-b-md">Custodian Panel</h3>
 <h4>HTML</h4>
-<pre class="language-html"><code ng-bind-html="snippets.compiled.custodianPanelHtml"></code></pre>
+<pre class="language-html"><code ng-bind="snippets.compiled.custodianPanelHtml"></code></pre>
 
 <h4>Controller</h4>
-<pre class="language-javascript"><code ng-bind-html="snippets.compiled.custodianPanelJs"></code></pre>
+<pre class="language-javascript"><code ng-bind="snippets.compiled.custodianPanelJs"></code></pre>
 
 <h3 class="m-b-md">File Types Panel</h3>
 <h4>HTML</h4>
-<pre class="language-html"><code ng-bind-html="snippets.compiled.fileTypesPanelHtml"></code></pre>
+<pre class="language-html"><code ng-bind="snippets.compiled.fileTypesPanelHtml"></code></pre>
 
 <h4>Controller</h4>
-<pre class="language-javascript"><code ng-bind-html="snippets.compiled.fileTypesPanelJs"></code></pre>
+<pre class="language-javascript"><code ng-bind="snippets.compiled.fileTypesPanelJs"></code></pre>
 
 <h3 class="m-b-md">Repository Panel</h3>
 <h4>HTML</h4>
-<pre class="language-html"><code ng-bind-html="snippets.compiled.repositoryPanelHtml"></code></pre>
+<pre class="language-html"><code ng-bind="snippets.compiled.repositoryPanelHtml"></code></pre>
 
 <h4>Controller</h4>
-<pre class="language-javascript"><code ng-bind-html="snippets.compiled.repositoryPanelJs"></code></pre>
+<pre class="language-javascript"><code ng-bind="snippets.compiled.repositoryPanelJs"></code></pre>

--- a/docs/app/pages/components/sections/search/search-builder-ng1/templates/launchingModal.html
+++ b/docs/app/pages/components/sections/search/search-builder-ng1/templates/launchingModal.html
@@ -2,7 +2,7 @@
 <p>The Search Builder modal is launched using a button which calls a function in the controller which opens the modal.</p>
 <p>Use the following HTML to add a button to the page to launch the modal:</p>
 
-<pre class="language-html"><code ng-bind-html="snippets.compiled.layoutHtml"></code></pre>
+<pre class="language-html"><code ng-bind="snippets.compiled.layoutHtml"></code></pre>
 
 <h3 class="m-b-md">Controller</h3>
 
@@ -10,4 +10,4 @@
     the <code>searchQuery</code> an initial value for 'keyword' will allow focus to be set on the keyword element when the
     modal is opened.</p>
 
-<pre class="language-javascript"><code ng-bind-html="snippets.compiled.controllerJs"></code></pre>
+<pre class="language-javascript"><code ng-bind="snippets.compiled.controllerJs"></code></pre>

--- a/docs/app/pages/components/sections/search/search-builder-ng1/templates/searchBuilder.html
+++ b/docs/app/pages/components/sections/search/search-builder-ng1/templates/searchBuilder.html
@@ -13,7 +13,7 @@
 
 <p>The following HTML was used as the modal template:</p>
 
-<pre class="language-html"><code ng-bind-html="snippets.compiled.modalLayoutHtml"></code></pre>
+<pre class="language-html"><code ng-bind="snippets.compiled.modalLayoutHtml"></code></pre>
 
 <h3 class="m-b-md">Controller</h3>
 
@@ -41,11 +41,11 @@
 <br />
 <p>The following code is used for the modal controller: </p>
 
-<pre class="language-javascript"><code ng-bind-html="snippets.compiled.modalControllerJs"></code></pre>
+<pre class="language-javascript"><code ng-bind="snippets.compiled.modalControllerJs"></code></pre>
 
 <i>Note. This controller generates fake search result counts when the search query is changed based on the number of terms being searched for.</i>
 
 <h3 class="m-b-md">CSS</h3>
 <p>The following CSS was used to produce the styling in the example.</p>
 
-<pre class="language-css"><code ng-bind-html="snippets.compiled.stylesCss"></code></pre>
+<pre class="language-css"><code ng-bind="snippets.compiled.stylesCss"></code></pre>

--- a/docs/app/pages/components/sections/search/search-builder-ng1/templates/searchComponents.html
+++ b/docs/app/pages/components/sections/search/search-builder-ng1/templates/searchComponents.html
@@ -4,44 +4,44 @@
 
 <h3 class="m-b-md">Author Component</h3>
 <h4>HTML</h4>
-<pre class="language-html"><code ng-bind-html="snippets.compiled.authorComponentHtml"></code></pre>
+<pre class="language-html"><code ng-bind="snippets.compiled.authorComponentHtml"></code></pre>
 
 <h3 class="m-b-md">Custodian Component</h3>
 <h4>HTML</h4>
-<pre class="language-html"><code ng-bind-html="snippets.compiled.custodianComponentHtml"></code></pre>
+<pre class="language-html"><code ng-bind="snippets.compiled.custodianComponentHtml"></code></pre>
 
 <h4>Controller</h4>
-<pre class="language-javascript"><code ng-bind-html="snippets.compiled.custodianComponentJs"></code></pre>
+<pre class="language-javascript"><code ng-bind="snippets.compiled.custodianComponentJs"></code></pre>
 
 <h3 class="m-b-md">Date Range Component</h3>
 <h4>HTML</h4>
-<pre class="language-html"><code ng-bind-html="snippets.compiled.dateRangeComponentHtml"></code></pre>
+<pre class="language-html"><code ng-bind="snippets.compiled.dateRangeComponentHtml"></code></pre>
 
 <h4>Controller</h4>
-<pre class="language-javascript"><code ng-bind-html="snippets.compiled.dateRangeComponentJs"></code></pre>
+<pre class="language-javascript"><code ng-bind="snippets.compiled.dateRangeComponentJs"></code></pre>
 
 <h3 class="m-b-md">File Name Component</h3>
 <h4>HTML</h4>
-<pre class="language-html"><code ng-bind-html="snippets.compiled.fileNameComponentHtml"></code></pre>
+<pre class="language-html"><code ng-bind="snippets.compiled.fileNameComponentHtml"></code></pre>
 
 <h3 class="m-b-md">File Types Component</h3>
 <h4>HTML</h4>
-<pre class="language-html"><code ng-bind-html="snippets.compiled.fileTypesComponentHtml"></code></pre>
+<pre class="language-html"><code ng-bind="snippets.compiled.fileTypesComponentHtml"></code></pre>
 
 <h4>Controller</h4>
-<pre class="language-javascript"><code ng-bind-html="snippets.compiled.fileTypesComponentJs"></code></pre>
+<pre class="language-javascript"><code ng-bind="snippets.compiled.fileTypesComponentJs"></code></pre>
 
 <h3 class="m-b-md">Keyword Component</h3>
 <h4>HTML</h4>
-<pre class="language-html"><code ng-bind-html="snippets.compiled.keywordComponentHtml"></code></pre>
+<pre class="language-html"><code ng-bind="snippets.compiled.keywordComponentHtml"></code></pre>
 
 <h3 class="m-b-md">Repository Component</h3>
 <h4>HTML</h4>
-<pre class="language-html"><code ng-bind-html="snippets.compiled.repositoryComponentHtml"></code></pre>
+<pre class="language-html"><code ng-bind="snippets.compiled.repositoryComponentHtml"></code></pre>
 
 <h4>Controller</h4>
-<pre class="language-javascript"><code ng-bind-html="snippets.compiled.repositoryComponentJs"></code></pre>
+<pre class="language-javascript"><code ng-bind="snippets.compiled.repositoryComponentJs"></code></pre>
 
 <h3 class="m-b-md">Text Component</h3>
 <h4>HTML</h4>
-<pre class="language-html"><code ng-bind-html="snippets.compiled.textComponentHtml"></code></pre>
+<pre class="language-html"><code ng-bind="snippets.compiled.textComponentHtml"></code></pre>

--- a/docs/app/pages/components/sections/search/search-builder-ng1/templates/services.html
+++ b/docs/app/pages/components/sections/search/search-builder-ng1/templates/services.html
@@ -6,7 +6,7 @@
   handled in a service it can simply be injected into any component that wants to control the panel.</p>
 
 <p>The following code is used to create the service:</p>
-<pre class="language-javascript"><code ng-bind-html="snippets.compiled.searchBuilderPanelServiceJs"></code></pre>
+<pre class="language-javascript"><code ng-bind="snippets.compiled.searchBuilderPanelServiceJs"></code></pre>
 
 <h3 class="m-b-md">SearchBuilderId Service</h3>
 
@@ -15,4 +15,4 @@
 
 <p>The following code is used to create the service:</p>
 
-<pre class="language-javascript"><code ng-bind-html="snippets.compiled.searchBuilderIdServiceJs"></code></pre>
+<pre class="language-javascript"><code ng-bind="snippets.compiled.searchBuilderIdServiceJs"></code></pre>


### PR DESCRIPTION
They were binding to html so they were rendering the contents of the code sample rather than displaying the code