### PR TITLE
EL-2455 - Fixing checkbox alignment in Firefox

### DIFF
--- a/src/components/checkbox/checkbox.component.less
+++ b/src/components/checkbox/checkbox.component.less
@@ -4,6 +4,7 @@
     display: inline-block;
     margin-bottom: 5px;
     white-space: nowrap;
+    line-height: 0;
 }
 
 .ux-checkbox {

--- a/src/components/checkbox/checkbox.component.less
+++ b/src/components/checkbox/checkbox.component.less
@@ -111,7 +111,7 @@ input[type="checkbox"] {
     margin-left: 7px;
     margin-top: 1px;
     white-space: normal;
-    vertical-align: bottom;
+    vertical-align: top;
     height: 24px;
     cursor: default;
     line-height: 22px;

--- a/src/styles/input-controls.less
+++ b/src/styles/input-controls.less
@@ -5,6 +5,7 @@
 .el-checkbox-label, .el-radiobutton-label, .el-toggleswitch-label,  {
     margin-bottom: 5px;
     white-space: nowrap;
+    line-height: 0;
 
     .el-checkbox, .el-radiobutton {
         font-family: 'hpe-icons';
@@ -163,6 +164,7 @@
         margin-top: 1px;
         white-space: normal;
         vertical-align: top;
+        line-height: 22px;
     }
 }
 


### PR DESCRIPTION
Checked in Chrome Firefox and IE, the checkbox style is now consistent throughout