### PR TITLE
EL-2377 - Allow Sorter Options to be Disabled

### DIFF
--- a/docs/app/pages/components/sections/tables/sorting-ng1/sorting-ng1.component.html
+++ b/docs/app/pages/components/sections/tables/sorting-ng1/sorting-ng1.component.html
@@ -33,6 +33,13 @@
                 <td>false</td>
             </tr>
             <tr>
+                <td class="attribute">disabled</td>
+                <td>boolean</td>
+                <td>variable</td>
+                <td>Allows a sorter option to be disabled. By default sorter options are enabled.</td>
+                <td>true</td>
+            </tr>
+            <tr>
                 <td class="attribute">default</td>
                 <td>boolean</td>
                 <td>variable</td>

--- a/src/ng1/directives/sorters/sorter/sorter.controller.js
+++ b/src/ng1/directives/sorters/sorter/sorter.controller.js
@@ -1,31 +1,35 @@
-SorterController.$inject = ["$scope"];
+export default class SorterController {
 
-export default function SorterController($scope) {
-    var vm = this;
-    vm.sorteroption = $scope;
-    vm.default = $scope.title;
-    vm.sorteroptions = $scope.sorteroptions = [];
-    vm.previousSorter = null;
-}
+    constructor($scope) {
+        this.sorteroption = $scope;
+        this.default = $scope.title;
+        this.sorteroptions = $scope.sorteroptions = [];
+        this.previousSorter = null;
+    }
 
-SorterController.prototype.setTitle = function(title, defaultval) {
+    setTitle(title, defaultVal) {
 
-    var sorterAlreadySelected = null;
-    this.sorteroption.name = title;
-    this.sorteroption.class = (!defaultval) ? 'sorter-selected' : '';
+        let sorterAlreadySelected = null;
 
-    if (this.previousSorter === this) {
+        this.sorteroption.name = title;
+        this.sorteroption.class = !defaultVal ? 'sorter-selected' : '';
 
-        if (defaultval) {
-            sorterAlreadySelected = true;
-            this.previousSorter = null;
-        } else {
-            sorterAlreadySelected = false;
-            this.previousSorter = this;
+        if (this.previousSorter === this) {
+
+            if (defaultVal) {
+                sorterAlreadySelected = true;
+                this.previousSorter = null;
+            } else {
+                sorterAlreadySelected = false;
+                this.previousSorter = this;
+            }
         }
     }
-};
 
-SorterController.prototype.addSorterOptions = function(val) {
-    this.sorteroptions.push(val);
-};
+    addSorterOptions(val) {
+        this.sorteroptions.push(val);
+    }
+
+}
+
+SorterController.$inject = ["$scope"];

--- a/src/ng1/directives/sorters/sorterOption/sorterOption.controller.js
+++ b/src/ng1/directives/sorters/sorterOption/sorterOption.controller.js
@@ -1,30 +1,43 @@
-SorterOptionCtrl.$inject = ["$scope", "previewPaneProvider"];
+export default class SorterOptionCtrl {
 
-export default function SorterOptionCtrl($scope, previewPaneProvider) {
-    var vm = this;
-    vm.selectCallback = $scope.select;
-    vm.name = $scope.name;
-    vm.default = $scope.default;
-    vm.sorterOption = $scope;
+    constructor($scope, previewPaneProvider) {
 
-    if (vm.default) {
-        vm.sorterOption.selectedClass = true;
+        this.selectCallback = $scope.select;
+        this.name = $scope.name;
+        this.default = $scope.default;
+        this.sorterOption = $scope;
+        this.disabled = $scope.disabled;
 
+        if (this.default) {
+            this.sorterOption.selectedClass = true;
+
+        }
+        this.sorterOption.provider = previewPaneProvider;
+
+        // watch for any changes to the disabled state
+        $scope.$watch('disabled', (newValue) => {
+            this.disabled = newValue;
+        });
     }
-    vm.sorterOption.provider = previewPaneProvider;
+
+    select() {
+
+        // if the sorter is disabled then prevent the click from doing anything
+        if (this.disabled) {
+            return;
+        }
+
+        this.sorter.setTitle(this.name, this.default);
+        this.sorter.sorteroptions.forEach(option => option.deselect());
+        this.sorterOption.selectedClass = true;
+        this.selectCallback();
+        this.sorterOption.provider.preview.previewFile = "";
+    }
+
+    deselect() {
+        this.sorterOption.selectedClass = false;
+    }
+
 }
 
-SorterOptionCtrl.prototype.select = function() {
-
-    this.sorter.setTitle(this.name, this.default);
-    for (var i = this.sorter.sorteroptions.length - 1; i >= 0; i--) {
-        this.sorter.sorteroptions[i].deselect();
-    }
-    this.sorterOption.selectedClass = true;
-    this.selectCallback();
-    this.sorterOption.provider.preview.previewFile = "";
-};
-
-SorterOptionCtrl.prototype.deselect = function() {
-    this.sorterOption.selectedClass = false;
-};
+SorterOptionCtrl.$inject = ['$scope', 'previewPaneProvider'];

--- a/src/ng1/directives/sorters/sorterOption/sorterOption.directive.js
+++ b/src/ng1/directives/sorters/sorterOption/sorterOption.directive.js
@@ -10,7 +10,8 @@ export default function sorterOption() {
             name: "=",
             select: "&",
             default: "=",
-            iconClass: "=?"
+            iconClass: "=?",
+            disabled: "=?"
         },
         link: function(scope, element, attrs, controller) {
 

--- a/src/ng1/directives/sorters/sorterOption/sorterOption.html
+++ b/src/ng1/directives/sorters/sorterOption/sorterOption.html
@@ -1,6 +1,6 @@
-<li>
+<li ng-class="{ 'sorter-option-disabled': soc.disabled }">
     <a href="" target="_blank" ng-click="soc.select()">
-        <i ng-class="{invisible: !selectedClass}" class="hpe-icon hpe-checkmark sorter-icon"></i>
+        <i ng-class="{ invisible: !selectedClass }" class="hpe-icon hpe-checkmark sorter-icon"></i>
         <p class="sorter-text"><span ng-bind="soc.name"></span></p>
         <i class="sorter-icon" ng-class="iconClass"></i>
     </a>

--- a/src/styles/filters.less
+++ b/src/styles/filters.less
@@ -113,11 +113,11 @@
 .sorter-title {
   vertical-align: middle;
 }
-.sorter-icon{
+.sorter-icon {
   display: inline-block;
   vertical-align: text-bottom;
 }
-.sorter-text{
+.sorter-text {
   margin: 0;
   display: inline-block;
   width: ~'calc(100% - 38px)';
@@ -125,6 +125,11 @@
 .sorter-text > span {
   margin-right: 10px;
 }
+
+.sorter-option-disabled {
+  opacity: 0.5;
+}
+
 .body-dark {
   .sorter-title {
     color: @filter-sorter-title-color-dark;

--- a/test/ng1-app/app/app.ts
+++ b/test/ng1-app/app/app.ts
@@ -1,0 +1,23 @@
+declare var angular: ng.IAngularStatic;
+
+// import required stylesheets
+import 'bootstrap/dist/css/bootstrap.min.css';
+import '../../../src/styles/ux-aspects.less';
+
+// import required scripts
+import * as jQuery from 'jquery';
+(<any>window).jQuery = jQuery;
+(<any>window).$ = jQuery;
+
+import 'jquery-ui/ui/unique-id';
+import 'jquery-ui/ui/position';
+import 'jquery-ui/ui/widgets/sortable';
+import 'bootstrap';
+import 'angular';
+import '../../../src/ng1/ux-aspects-ng1.module';
+
+// Import Controllers
+import { MainController } from './controller';
+
+angular.module('app', ['ux-aspects'])
+    .controller('MainController', MainController);

--- a/test/ng1-app/app/controller.ts
+++ b/test/ng1-app/app/controller.ts
@@ -1,0 +1,26 @@
+export class MainController {
+
+    sorters = {
+        title: 'Sort by',
+        options: [{
+            name: 'NAME',
+            sort: 'document',
+            default: false,
+            iconClass: 'hpe-icon hpe-actions',
+            disabled: true
+        }, {
+            name: 'DATE MODIFIED (earliest)',
+            sort: 'date',
+            default: false,
+            iconClass: 'hpe-icon hpe-manual',
+            disabled: false           
+        }, {
+            name: 'DATE MODIFIED (latest)',
+            sort: 'date',
+            orderDesc: true,
+            default: true,
+            iconClass: 'hpe-icon hpe-3d',
+            disabled: false            
+        }]
+    };
+}

--- a/test/ng1-app/index.html
+++ b/test/ng1-app/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html ng-app="app">
+
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <title>Testing Page</title>
+</head>
+
+<body ng-controller="MainController as vm">
+    <div class="wrapper">
+
+        <sorter sorter-title="vm.sorters.title">
+
+            <sorter-option ng-repeat="option in vm.sorters.options" name="option.name" select="option.select(option)" icon-class="option.iconClass"
+                default="option.default" disabled="option.disabled">
+            </sorter-option>
+
+        </sorter>
+
+    </div>
+</body>
+
+</html>

--- a/test/ng1-app/package.json
+++ b/test/ng1-app/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "ux-aspects-ng1-test-app",
+  "version": "1.0.0",
+  "description": "A sample app for testing Angular 1 components",
+  "main": "controller.js",
+  "scripts": {
+    "start": "webpack-dev-server"
+  },
+  "author": "Ashley Hunter",
+  "dependencies": {
+    "angular": "^1.3.16",
+    "bootstrap": "^3.3.7",
+    "jquery": "^3.2.1",
+    "jquery-ui": "^1.12.1"
+  },
+  "devDependencies": {
+    "@types/angular": "^1.3.2",
+    "awesome-typescript-loader": "^3.1.2",
+    "babel-core": "^6.24.1",
+    "babel-loader": "^7.0.0",
+    "babel-preset-env": "^1.4.0",
+    "babel-preset-es2015": "^6.24.1",
+    "css-loader": "^0.28.0",
+    "extract-text-webpack-plugin": "^2.1.0",
+    "file-loader": "^0.11.1",
+    "html-loader": "^0.4.5",
+    "html-webpack-plugin": "^2.28.0",
+    "less": "^2.7.2",
+    "less-loader": "^4.0.3",
+    "script-loader": "^0.7.0",
+    "typescript": "^2.2.2",
+    "webpack": "^2.4.1",
+    "webpack-dev-server": "^2.4.4"
+  }
+}

--- a/test/ng1-app/tsconfig.json
+++ b/test/ng1-app/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "sourceMap": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "lib": ["es2015", "dom"],
+    "noImplicitAny": true,
+    "declaration": false,
+    "suppressImplicitAnyIndexErrors": true
+  },
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/test/ng1-app/webpack.config.js
+++ b/test/ng1-app/webpack.config.js
@@ -1,0 +1,88 @@
+const path = require('path');
+const ExtractTextPlugin = require('extract-text-webpack-plugin');
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+
+module.exports = {
+
+    entry: './app/app.ts',
+
+    output: {
+        path: path.join(__dirname, 'dist'),
+        filename: 'app.js'
+    },
+
+    resolve: {
+        extensions: ['.ts', '.js']
+    },
+
+    module: {
+
+        rules: [{
+                test: /\.ts$/,
+                use: 'awesome-typescript-loader'
+            },
+            {
+                test: /\.html$/,
+                use: 'html-loader'
+            },
+            {
+                test: /\.css$/,
+                use: ExtractTextPlugin.extract({
+                    use: 'css-loader'
+                })
+            },
+            {
+                test: /\.less$/,
+                use: ExtractTextPlugin.extract({
+                    use: 'css-loader!less-loader'
+                })
+            },
+            {
+                test: /\.(png|jpe?g|gif|svg|woff|woff2|ttf|eot|ico|otf)$/,
+                use: 'file-loader?name=assets/[name].[ext]'
+            },
+            {
+                test: /\.js$/,
+                exclude: /(node_modules|bower_components)/,
+                use: {
+                    loader: 'babel-loader',
+                    query: {
+                        cacheDirectory: true,
+                        presets: [
+                            ["es2015", {
+                                "modules": false
+                            }]
+                        ]
+                    }
+                }
+            },
+            {
+                test: /(plugins|external)/,
+                exclude: /(node_modules|bower_components)/,
+                use: [{
+                    loader: 'script-loader'
+                }]
+            }
+        ]
+    },
+
+    plugins: [
+        new HtmlWebpackPlugin({
+            template: './index.html'
+        }),
+
+        new ExtractTextPlugin("styles.css"),
+    ],
+
+    devServer: {
+        historyApiFallback: true,
+        stats: {
+            colors: true,
+            reasons: true
+        },
+        headers: {
+            "Access-Control-Allow-Origin": "*"
+        }
+    }
+
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,7 @@
   },
   "exclude": [
     "node_modules",
-    "dist"
+    "dist",
+    "test"
   ]
 }


### PR DESCRIPTION
Added option to disable sorter option. Also added test page under "text/ng1-app" which allows us to test Angular 1 components again. To use the test page navigate to the folder in cmd and run `npm install` then `npm start` to launch local webserver. Output can be viewed at localhost:8080.

Also refactored sorter option code to make use of some of the newer ES6 syntax improving readability