### PR TITLE
EL-2385 - Fixing firefox date picker size

### DIFF
--- a/src/styles/controls.less
+++ b/src/styles/controls.less
@@ -525,7 +525,7 @@ select {
     tr {
       th, td {
         text-align: center;
-        width: 30px;
+        width: auto;
         height: 30px;
         border-radius: 4px;
         border: none;


### PR DESCRIPTION
On firefox the date picker was alot wider than on the other browers, this makes them consistent