### PR TITLE
EL-2471 - Fixing detail row header popover issue

### DIFF
--- a/src/ng1/directives/sorters/detailRowHeader/detailRowHeaderPopover.directive.js
+++ b/src/ng1/directives/sorters/detailRowHeader/detailRowHeaderPopover.directive.js
@@ -46,8 +46,9 @@ export default function detailRowHeaderPopover($templateRequest, $compile, $root
                 popoverScope.$broadcast("detailRowHeaderPopoverOpened");
             });
 
-            element.on("hidden.bs.popover", function() {
+            element.on("hidden.bs.popover", function(e) {
                 popoverOpen = false;
+                angular.element(e.target).data("bs.popover").inState.click = false;
                 popoverScope.$broadcast("detailRowHeaderPopoverClosed");
             });
 


### PR DESCRIPTION
This line resets the 'inState.click' variable for the popover which the hide method isn't doing. This fixes the double click required to open the popover after we manually hide it.