### PR TITLE
EL-2467 - Added replace true back into help center menu

### DIFF
--- a/src/ng1/directives/helpCenter/helpCenter.spec.js
+++ b/src/ng1/directives/helpCenter/helpCenter.spec.js
@@ -21,8 +21,8 @@ describe('help center directive', function () {
       $scope.$digest();
     });
     it("replaces content with help center menu list", function () {
-      expect((element.find("li:first-child>a")[0].innerText)).toBe(helpText);
-      expect((element.find("li:first-child>a").attr('href'))).toBe(parenturl);
+      expect((element.find("ul>li:first-child>a")[0].innerText)).toBe(helpText);
+      expect((element.find("ul>li:first-child>a").attr('href'))).toBe(parenturl);
     });
   });
 });

--- a/src/ng1/directives/helpCenter/helpCenterMenu.directive.js
+++ b/src/ng1/directives/helpCenter/helpCenterMenu.directive.js
@@ -11,6 +11,7 @@ export default function helpCenterMenu($timeout, $rootScope) {
             sortFn: "=?"
         },
         template: require('./helpCenterMenu.html'),
+        replace: "true",
         link: function (scope) {
             if (!scope.target) scope.target = '_self';
             scope.iconBase = scope.icon && scope.icon.indexOf('hp-') === -1 ? 'hpe-icon' : 'hp-icon';

--- a/src/ng1/directives/helpCenter/helpCenterMenu.directive.js
+++ b/src/ng1/directives/helpCenter/helpCenterMenu.directive.js
@@ -11,7 +11,6 @@ export default function helpCenterMenu($timeout, $rootScope) {
             sortFn: "=?"
         },
         template: require('./helpCenterMenu.html'),
-        replace: "true",
         link: function (scope) {
             if (!scope.target) scope.target = '_self';
             scope.iconBase = scope.icon && scope.icon.indexOf('hp-') === -1 ? 'hpe-icon' : 'hp-icon';

--- a/src/styles/theme.less
+++ b/src/styles/theme.less
@@ -288,6 +288,24 @@
       color: @grey2;
     }
   }
+  .navbar-top-links {
+      .navbar-top-link {
+        &.help {
+          margin-right: 0;
+          .count-info {
+            padding: 20px 10px;
+            height: 57px;
+            &:hover, &:focus {
+              cursor: pointer;
+              background-color: darken(@navbar-bg-light, 3%);
+            }
+          }
+        }
+        .helpCenter {
+          margin-top: 25px;
+        }
+      }
+    }
   }
 }
 


### PR DESCRIPTION
Removing replace true caused some issues with the help center menu, I will raise a ticket to add a wrapper for this instead.