### PR TITLE
EL-2471 - Fixing codepen issue

### DIFF
--- a/docs/app/pages/components/sections/tables/detail-row-header-ng1/wrapper/detail-row-header-wrapper.directive.ts
+++ b/docs/app/pages/components/sections/tables/detail-row-header-ng1/wrapper/detail-row-header-wrapper.directive.ts
@@ -75,7 +75,7 @@ class DetailRowHeaderPopoverCtrl {
 
     private scrollBarConfig = {
         autoReinitialise: true,
-        autoReinitialiseDelay: 50,
+        autoReinitialiseDelay: 500,
         enableKeyboardNavigation: true,
         scrollMargin: 5
     };

--- a/src/ng1/directives/sorters/detailRowHeader/detailRowHeaderPopover.directive.js
+++ b/src/ng1/directives/sorters/detailRowHeader/detailRowHeaderPopover.directive.js
@@ -48,7 +48,7 @@ export default function detailRowHeaderPopover($templateRequest, $compile, $root
 
             element.on("hidden.bs.popover", function(e) {
                 popoverOpen = false;
-                angular.element(e.target).data("bs.popover").inState.click = false;
+                angular.element(e.target).data("bs.popover").inState = { click: false };
                 popoverScope.$broadcast("detailRowHeaderPopoverClosed");
             });
 


### PR DESCRIPTION
The popovers were throwing errors in codepen, this solves fixes the errors allow the popover to be opened and closed correctly, autoReinitialize delay has been increased however the performance on IE is too poor to make much of an improvement, I have raised a ticket to migrate the fixed header table