### PR TITLE
EL-2507 - Adding close of click and close on escape

### DIFF
--- a/docs/app/components/usage-link/usage-link.component.html
+++ b/docs/app/components/usage-link/usage-link.component.html
@@ -14,7 +14,7 @@
     <p class="usage-tooltip">Copy to Clipboard</p>
 </ng-template>
 
-<a class="hyperlink-hover m-r-sm" tabindex="0" #pop="bs-popover" [popover]="popTemplate" triggers="" (click)="pop.toggle()" (keyup.enter)="pop.toggle()" container="body" placement="bottom" (onShown)="onShown(pop)"> 
+<a class="hyperlink-hover m-r-sm" tabindex="0" #pop="bs-popover" [popover]="popTemplate" triggers="" (click)="pop.toggle()" (keyup.enter)="pop.toggle()" container="body" placement="bottom" (onShown)="onShown($event, pop)"> 
     <i class="hpe-icon hpe-action p-r-xs"></i>
     Usage
 </a>

--- a/docs/app/components/usage-link/usage-link.component.html
+++ b/docs/app/components/usage-link/usage-link.component.html
@@ -14,7 +14,7 @@
     <p class="usage-tooltip">Copy to Clipboard</p>
 </ng-template>
 
-<a class="hyperlink-hover m-r-sm" tabindex="0" #pop="bs-popover" [popover]="popTemplate" triggers="" (click)="pop.toggle()" (keyup.enter)="pop.toggle()" container="body" placement="bottom" (onShown)="onShown($event, pop)"> 
+<a class="hyperlink-hover m-r-sm" tabindex="0" #pop="bs-popover" [popover]="popTemplate" triggers="" (click)="pop.toggle()" (keyup.enter)="pop.toggle()" container="body" placement="bottom" (onShown)="onShown()"> 
     <i class="hpe-icon hpe-action p-r-xs"></i>
     Usage
 </a>

--- a/docs/app/components/usage-link/usage-link.component.ts
+++ b/docs/app/components/usage-link/usage-link.component.ts
@@ -4,25 +4,54 @@ import { Input, Renderer2, Component } from '@angular/core';
 @Component({
     selector: 'uxd-usage-link',
     templateUrl: './usage-link.component.html',
-    styleUrls: ['./usage-link.component.less']
+    styleUrls: ['./usage-link.component.less'],
+    host: {
+        '(document:click)': 'onClick($event, pop)',
+        '(document:keyup.escape)': 'closePopover()'
+    }
 })
 export class UsageLinkComponent {
 
     @Input() usage: Usage;
     @Input() pop: string;
 
+    private popover: any;
     private popoverElement: any;
+    private usageElement: any;
+
 
     constructor(private renderer: Renderer2) {}
 
-    onShown(popover: any) {
-
+    onShown(event: any, popover: any) {
+        this.usageElement = event.content.elementRef.nativeElement.parentElement;
+        this.popover = popover;
         this.popoverElement = popover._popover._componentRef.location.nativeElement;
 
         this.renderer.setStyle(this.popoverElement, 'style', '300px');
         this.renderer.setStyle(this.popoverElement, 'maxWidth', '300px');
         this.renderer.setStyle(this.popoverElement, 'borderRadius', '0');
         this.renderer.setStyle(this.popoverElement, 'zIndex', '1');
+    }
+
+    closePopover () {
+        if (this.popover) {
+            this.popover.hide();
+        }
+    }
+
+    onClick(event: any){
+        if (!this.popover) {
+            return;
+        }
+        let target = event.target;
+        while (target.parentNode) {
+            if(target !== this.popoverElement && target !== this.usageElement) {
+                target = target.parentNode
+            } else {
+                return;
+            }
+        }
+        this.popover.hide();
     }
 
     // copy to clipboard button

--- a/docs/app/components/usage-link/usage-link.component.ts
+++ b/docs/app/components/usage-link/usage-link.component.ts
@@ -1,5 +1,6 @@
 import { Usage } from './../../interfaces/Usage';
-import { Input, Renderer2, Component } from '@angular/core';
+import { Input, Renderer2, Component, ElementRef, ViewChild } from '@angular/core';
+import { PopoverDirective, PopoverContainerComponent } from 'ngx-bootstrap/popover';
 
 @Component({
     selector: 'uxd-usage-link',
@@ -13,19 +14,16 @@ import { Input, Renderer2, Component } from '@angular/core';
 export class UsageLinkComponent {
 
     @Input() usage: Usage;
-    @Input() pop: string;
 
-    private popover: any;
-    private popoverElement: any;
-    private usageElement: any;
+    // private popover: PopoverDirective;
+    @ViewChild(PopoverDirective) popover: PopoverDirective;
 
+    private popoverElement: HTMLElement;
 
-    constructor(private renderer: Renderer2) {}
+    constructor(private renderer: Renderer2, private elementRef: ElementRef) {}
 
-    onShown(event: any, popover: any) {
-        this.usageElement = event.content.elementRef.nativeElement.parentElement;
-        this.popover = popover;
-        this.popoverElement = popover._popover._componentRef.location.nativeElement;
+    onShown() {
+        this.popoverElement = (<any>this.popover)._popover._componentRef.location.nativeElement;
 
         this.renderer.setStyle(this.popoverElement, 'style', '300px');
         this.renderer.setStyle(this.popoverElement, 'maxWidth', '300px');
@@ -34,19 +32,14 @@ export class UsageLinkComponent {
     }
 
     closePopover () {
-        if (this.popover) {
-            this.popover.hide();
-        }
+        this.popover.hide();
     }
 
-    onClick(event: any){
-        if (!this.popover) {
-            return;
-        }
-        let target = event.target;
+    onClick(event: MouseEvent) {
+        let target = event.target as HTMLElement;
         while (target.parentNode) {
-            if(target !== this.popoverElement && target !== this.usageElement) {
-                target = target.parentNode
+            if (target !== this.popoverElement && target !== this.elementRef.nativeElement) {
+                target = target.parentNode as HTMLElement;
             } else {
                 return;
             }

--- a/docs/app/components/usage-link/usage-link.component.ts
+++ b/docs/app/components/usage-link/usage-link.component.ts
@@ -1,13 +1,13 @@
 import { Usage } from './../../interfaces/Usage';
 import { Input, Renderer2, Component, ElementRef, ViewChild } from '@angular/core';
-import { PopoverDirective, PopoverContainerComponent } from 'ngx-bootstrap/popover';
+import { PopoverDirective } from 'ngx-bootstrap/popover';
 
 @Component({
     selector: 'uxd-usage-link',
     templateUrl: './usage-link.component.html',
     styleUrls: ['./usage-link.component.less'],
     host: {
-        '(document:click)': 'onClick($event, pop)',
+        '(document:click)': 'onClick($event)',
         '(document:keyup.escape)': 'closePopover()'
     }
 })
@@ -15,7 +15,6 @@ export class UsageLinkComponent {
 
     @Input() usage: Usage;
 
-    // private popover: PopoverDirective;
     @ViewChild(PopoverDirective) popover: PopoverDirective;
 
     private popoverElement: HTMLElement;
@@ -36,15 +35,11 @@ export class UsageLinkComponent {
     }
 
     onClick(event: MouseEvent) {
-        let target = event.target as HTMLElement;
-        while (target.parentNode) {
-            if (target !== this.popoverElement && target !== this.elementRef.nativeElement) {
-                target = target.parentNode as HTMLElement;
-            } else {
-                return;
-            }
+        if (!this.popoverElement || !this.popoverElement.contains(event.target as HTMLElement) &&
+            !this.elementRef.nativeElement.contains(event.target)) {
+
+            this.popover.hide();
         }
-        this.popover.hide();
     }
 
     // copy to clipboard button


### PR DESCRIPTION
Popover now closes when you click elsewhere on the page and when you press escape. Tabbing onto copy buttons has been left out as it will come with a performance hit and is not required