### PR TITLE
EL-2524

### DIFF
--- a/configs/webpack.docs.dev.config.js
+++ b/configs/webpack.docs.dev.config.js
@@ -147,7 +147,7 @@ var docsConfig = {
         ),
 
         new HtmlWebpackPlugin({
-            template: './docs/index.html',
+            template: './docs/index.ejs',
             favicon: './docs/favicon.ico'
         }),
 

--- a/docs/app/showcase/charts/dist/index.html
+++ b/docs/app/showcase/charts/dist/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />
   <title page-title="UX Aspects"></title>
-
+  <link rel="shortcut icon" href="../../../favicon.ico" type="image/x-icon" />
   <link href="../bower_components/bootstrap/css/bootstrap.min.css" rel="stylesheet">
   <link href="../../../assets/css/ux-aspects.css" rel="stylesheet">
   <link href="../dist/css/site.css" rel="stylesheet">

--- a/docs/app/showcase/charts/src/index.html
+++ b/docs/app/showcase/charts/src/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />
   <title page-title="UX Aspects"></title>
-
+  <link rel="shortcut icon" href="../../../favicon.ico" type="image/x-icon" />
   <link href="../bower_components/bootstrap/css/bootstrap.min.css" rel="stylesheet">
   <link href="../../../assets/css/ux-aspects.css" rel="stylesheet">
   <link href="../dist/css/site.css" rel="stylesheet">

--- a/docs/app/showcase/list_view/dist/index.html
+++ b/docs/app/showcase/list_view/dist/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />
   <title page-title="UX Aspects"></title>
-
+  <link rel="shortcut icon" href="../../../favicon.ico" type="image/x-icon" />
   <link href="../bower_components/bootstrap/css/bootstrap.min.css" rel="stylesheet">
   <link href="../../../assets/css/ux-aspects.css" rel="stylesheet">
   <link href="../dist/css/site.css" rel="stylesheet">

--- a/docs/app/showcase/list_view/src/index.html
+++ b/docs/app/showcase/list_view/src/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />
   <title page-title="UX Aspects"></title>
-
+  <link rel="shortcut icon" href="../../../favicon.ico" type="image/x-icon" />
   <link href="../bower_components/bootstrap/css/bootstrap.min.css" rel="stylesheet">
   <link href="../../../assets/css/ux-aspects.css" rel="stylesheet">
   <link href="../dist/css/site.css" rel="stylesheet">

--- a/docs/index.ejs
+++ b/docs/index.ejs
@@ -1,4 +1,3 @@
-<DOCTYPE html>
 <html>
 <head>
     <meta charset="utf-8">


### PR DESCRIPTION
Removed <DOCTYPE html> and renamed template to .ejs as recommended in
the webpack HTML plugin docs.
Added shortcut icon link to showcase pages.

https://jira.autonomy.com/browse/EL-2524?focusedCommentId=1942236&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-1942236