### PR TITLE
EL-2534 - Fixing library build

### DIFF
--- a/src/components/column-sorting/column-sorting.component.ts
+++ b/src/components/column-sorting/column-sorting.component.ts
@@ -1,4 +1,4 @@
-import { ColumnSortingDirective } from './column-sorting.directive';
+import { ColumnSortingDirective, ColumnSortingOrder } from './column-sorting.directive';
 import { Component, Input, Output, EventEmitter } from '@angular/core';
 
 @Component({
@@ -40,7 +40,7 @@ export class ColumnSortingComponent {
         });
     }
 
-    changeState() {
+    changeState(): ColumnSortingOrder[] {
 
         if (this.state === ColumnSortingState.Ascending) {
             this.state = ColumnSortingState.Descending;

--- a/src/components/slider/slider.component.ts
+++ b/src/components/slider/slider.component.ts
@@ -694,7 +694,7 @@ export enum SliderSnap {
     All
 }
 
-enum SliderTickType {
+export enum SliderTickType {
     Minor,
     Major
 }
@@ -724,14 +724,14 @@ export interface SliderTicksOptions {
     minor?: SliderTickOptions;
 }
 
-interface SliderTickOptions {
+export interface SliderTickOptions {
     show?: boolean;
     steps?: number | number[];
     labels?: boolean;
     formatter?: (value: number) => string | number;
 }
 
-interface SliderTick {
+export interface SliderTick {
     showTicks: boolean;
     showLabels: boolean;
     type: SliderTickType;
@@ -740,20 +740,20 @@ interface SliderTick {
     label: string | number;
 }
 
-interface SliderTrackColors {
+export interface SliderTrackColors {
     lower?: string | string[];
     range?: string | string[];
     higher?: string | string[];
 }
 
-interface SliderCallout {
+export interface SliderCallout {
     trigger?: SliderCalloutTrigger;
     background?: string;
     color?: string;
     formatter?: (value: number) => string | number;
 }
 
-enum SliderThumbEvent {
+export enum SliderThumbEvent {
     None,
     MouseOver,
     MouseLeave,
@@ -761,7 +761,7 @@ enum SliderThumbEvent {
     DragEnd
 }
 
-enum SliderThumb {
+export enum SliderThumb {
     Lower,
     Upper
 }

--- a/src/components/spark/spark.module.ts
+++ b/src/components/spark/spark.module.ts
@@ -2,7 +2,7 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 
 import { SparkComponent } from './spark.component';
-import { TooltipModule } from 'ngx-bootstrap';
+import { TooltipModule } from 'ngx-bootstrap/tooltip';
 
 @NgModule({
     imports: [


### PR DESCRIPTION
Spark module was import tooltip from 'ngx-bootsrap' rather than 'ngx-bootstrap/tooltip' adding ~800kb on to our library build output size.

Column sorting and Slider were using unexported enums & interfaces which preventing typescript from creating type definitions for them.