### PR TITLE
EL-2543 - Item display panel fix

### DIFF
--- a/src/ng1/directives/displayPanels/displayPanel/displayPanel.directive.js
+++ b/src/ng1/directives/displayPanels/displayPanel/displayPanel.directive.js
@@ -69,13 +69,18 @@ export default function displayPanel($templateRequest, $q, $compile, $timeout, $
 
                 if ($displayPanel.panelOpen() && !$displayPanel.panelHidden() && angular.element(target).closest(".display-panel").length < 1) {
 
+                    // if the target node is the HTML tag, then this was triggered by scrolling and we should not close the panel
+                    if (target.nodeName === 'HTML') {
+                        return;
+                    }
+
                     var closePanel = true;
-                    while (target.nodeName !== "BODY") {
+                    while (target && target.nodeName !== "BODY") {
                         if (isDisplayPanelItem(target)) {
                             closePanel = false;
                             break;
                         } else {
-                            target = target.parentNode;
+                            target = target.parentElement;
                         }
                     }
 


### PR DESCRIPTION
If the node is 'HTML' then it was triggered by scroll event and should not close panel. Also changed to use parent element instead of parent node and parent node will return a #document node above the HTML tag whereas parentElement will return null - due to trying to access attributes on the #document element which throws an error