### PR TITLE
Fixing index file

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -17,10 +17,6 @@ export * from './components/slider/index';
 export * from './components/spark/index';
 export * from './components/tag-input/index';
 export * from './components/toggleswitch/index';
-export * from './components/facets/index';
-export * from './components/breadcrumbs/index';
-export * from './components/page-header/index';
-export * from './components/slider/index';
 export * from './components/typeahead/index';
 
 /*


### PR DESCRIPTION
There were a few duplicate entries in the index.ts file which caused exporting of duplicated components to fail