### PR TITLE
S 60/el 2566

### DIFF
--- a/src/components/typeahead/typeahead.component.less
+++ b/src/components/typeahead/typeahead.component.less
@@ -25,7 +25,6 @@ ux-typeahead {
     }
 
     .ux-typeahead-options {
-        
         & > ol {
             margin-bottom: 0;
             padding: 0;

--- a/src/ng1/directives/draggableCards/cards/draggableCard.html
+++ b/src/ng1/directives/draggableCards/cards/draggableCard.html
@@ -2,7 +2,7 @@
   <div class="card draggable">
     <div class="callout"></div>
     <div class="title-container" ng-show="showHeader">
-      <div class="m-b-nil title" ng-style="{ 'padding-right' : showTitle ? '8px': 0 }"><p ng-bind="cardTitle" class="title-text" overflow-tooltip></p> 
+      <div class="m-b-nil title" ng-style="{ 'padding-right' : showTitle ? '8px': 0 }"><p ng-bind="cardTitle" class="title-text" tooltip-on-overflow></p> 
         <span class="text-muted title-subtext" ng-bind="cardSubtitle"></span> 
         <i class="hpe-icon hpe-edit draggable-icon editing-btn show-on-hover" ng-show="allowEditing" ng-class="{'disabled': disableEdit}"></i>
         <i ng-repeat="icon in cardIcons" class="hpe-icon draggable-icon show-on-hover {{ ::icon.icon }}" ng-class="{ 'disabled': icon.disabled }" ng-disable="icon.disabled" tooltip="{{icon.tooltip}}" tooltip-placement="{{icon.tooltipPlacement}}" tooltip-append-to-body="true" ng-click="icon.disabled || icon.click(); $event.stopPropagation();"></i>

--- a/src/ng1/directives/tooltipOnOverflow/tooltipOnOverflow.directive.js
+++ b/src/ng1/directives/tooltipOnOverflow/tooltipOnOverflow.directive.js
@@ -1,0 +1,52 @@
+export default function tooltipOnOverflow() {
+    return {
+        restrict: 'A',
+        link: function (scope, element) {
+
+            var nativeElement = element.get(0);
+
+            // Track visible state of tooltip.
+            var tooltipVisible = false;
+            element.on("shown.bs.tooltip", function() {
+                tooltipVisible = true;
+            });
+            element.on("hidden.bs.tooltip", function() {
+                tooltipVisible = true;
+            });
+
+            // Update on mouseover and focus events (same as tooltip triggers)
+            element.hover(update, update);
+            element.focus(update);
+
+            function update() {
+
+                // Check if content is overflowing
+                if (nativeElement.scrollWidth > nativeElement.clientWidth) {
+
+                    // if a tooltip has already been added to element - destroy its data first
+                    if (element.data('bs.tooltip') !== null) {
+                        element.tooltip('hide');
+                        element.removeData('bs.tooltip');
+                    }
+
+                    // Create a tooltip with the element's current text
+                    element.tooltip({
+                        title: element.text(),
+                        container: 'body'
+                    });
+
+                    setTimeout(function() {
+                        if (!tooltipVisible) {
+                            element.filter(":hover, :focus").tooltip('show');
+                        }
+                    }, 100);
+
+                } else {
+
+                    // Remove tooltip
+                    element.tooltip('destroy');
+                }
+            }
+        }
+    };
+}

--- a/src/ng1/directives/tooltipOnOverflow/tooltipOnOverflow.module.js
+++ b/src/ng1/directives/tooltipOnOverflow/tooltipOnOverflow.module.js
@@ -1,0 +1,4 @@
+import tooltipOnOverflow from './tooltipOnOverflow.directive';
+
+angular.module('ux-aspects.tooltipOnOverflow', [])
+	.directive('tooltipOnOverflow', tooltipOnOverflow);

--- a/src/ng1/ux-aspects-ng1.module.js
+++ b/src/ng1/ux-aspects-ng1.module.js
@@ -97,6 +97,7 @@ import './directives/tagInput/tagInput.module.js';
 import './directives/thumbnail/thumbnail.module.js';
 import './directives/timeAgo/timeAgo.module.js';
 import './directives/toggleswitch/toggleswitch.module.js';
+import './directives/tooltipOnOverflow/tooltipOnOverflow.module.js';
 import './directives/treegrid/treegrid.module.js';
 import './directives/treeView/treeView.module.js';
 import './directives/wizard/wizard.module.js';
@@ -221,6 +222,7 @@ let aspects = angular.module('ux-aspects', [
     'ux-aspects.thumbnail',
     'ux-aspects.timeAgo',
     'ux-aspects.toggleswitch',
+    'ux-aspects.tooltipOnOverflow',
     'ux-aspects.treegrid',
     'ux-aspects.treeview',    
     'ux-aspects.wizard',
@@ -232,6 +234,7 @@ let aspects = angular.module('ux-aspects', [
     'ux-aspects.keyboardService',
     'ux-aspects.lineDataService',
     'ux-aspects.multipleSelect',
+    'ux-aspects.navigationMenuService',
     'ux-aspects.notificationService',
     'ux-aspects.pdfService',
     'ux-aspects.resizeService',
@@ -239,9 +242,8 @@ let aspects = angular.module('ux-aspects', [
     'ux-aspects.safeEventListener',
     'ux-aspects.safeInterval',
     'ux-aspects.safeTimeout',
-    'ux-aspects.navigationMenuService',
     'ux-aspects.throttleService',
-    'ux-aspects.timeAgoService',   
+    'ux-aspects.timeAgoService',
     'ux-aspects.windowCommunicationService'
 ]);
 

--- a/src/styles/cards.less
+++ b/src/styles/cards.less
@@ -914,6 +914,7 @@
             align-items: baseline;
             font-size: 1.125rem;
             padding-right: 8px;
+            max-width: ~'calc(100% - 50px)';
             height: 25px;
             .title-text {
               padding-right: 3px;

--- a/src/styles/cards.less
+++ b/src/styles/cards.less
@@ -903,22 +903,23 @@
         }
 
         .title-container {
+          display: flex;
+          justify-content: space-between;
           width: 100%;
           height: 25px;
 
           .title {
+            flex: 1 0 auto;
             display: inline-flex;
             align-items: baseline;
             font-size: 1.125rem;
             padding-right: 8px;
-            max-width: ~'calc(100% - 50px)';
             height: 25px;
             .title-text {
               padding-right: 3px;
               overflow: hidden;
               text-overflow: ellipsis;
               white-space: nowrap;
-              flex-grow: 1;
               height: 25px;
             }
             .title-subtext {
@@ -941,7 +942,6 @@
           	overflow: hidden;
           	width: 17px;
             height: 17px;
-            float: right;
             top: 4px;
 
           	&::before {


### PR DESCRIPTION
Replaced overflow-tooltip in the draggable card with a new directive
which only applies the tooltip. Since it will be deprecated soon I
decided not to make changes to the current directive.
Changed the card header layout to use the available width.
Fixed a lint issue in another stylesheet.

https://jira.autonomy.com/browse/EL-2566