### PR TITLE
EL-2608 - Marquee Modal fixed header table

### DIFF
--- a/src/ng1/external/angular-scrollable-table/angular-scrollable-table.js
+++ b/src/ng1/external/angular-scrollable-table/angular-scrollable-table.js
@@ -148,9 +148,10 @@ LICENSE-END
                 var width = parseInt(computedStyles.width);
                 // use offsetHeight as getting height from computed style is buggy in IE
                 var height = tableDisplayed.offsetHeight;
+                var overflow = computedStyles.overflowY === 'visible';
 
                 //check if a parent element has a display of none or a width of 0px and if so dont fix the header widths
-                if(display === 'none' || display === 'block' && height === 0 || width === 0){
+                if(display === 'none' || display === 'block' && (height === 0 && !overflow) || width === 0){
                   resolve = false;                 
                   break;
                 }


### PR DESCRIPTION
Before if a parent element had a height of 0 then the table would think it is hidden. Added a check to see if a parent element has a height of 0 but has overflow set to visible then still render the table.

Before:
[https://codepen.io/anon/pen/mwEdOb](https://codepen.io/anon/pen/mwEdOb)

After:
[https://codepen.io/ashh640/pen/dRRgqE](https://codepen.io/ashh640/pen/dRRgqE)