### PR TITLE
EL-2652 - Fixing media player icon positioning

### DIFF
--- a/src/components/media-player/extensions/controls/controls.component.less
+++ b/src/components/media-player/extensions/controls/controls.component.less
@@ -11,6 +11,10 @@ ux-media-player-controls {
         font-weight: 600;
         transition: color 0.3s ease-in-out;
 
+        &.hpe-volume-low {
+            padding-left: 4px;
+        }
+
         &:hover {
             color: @mediaplayer-controls-btn-hover-color;
         }


### PR DESCRIPTION
Repositioning volume low icon so it doesn't shift when it changes to mute or high volume