### PR TITLE
Fixing typos and IE issue

### DIFF
--- a/docs/app/pages/components/sections/help-center/help-center/snippets/app.html
+++ b/docs/app/pages/components/sections/help-center/help-center/snippets/app.html
@@ -1,7 +1,8 @@
 <ux-page-header [crumbs]="crumbs" header="Repositories" [iconMenus]="menus"></ux-page-header>
 
 <div class="help-center-toolbar">
-    <button class="btn button-primary" [disabled]="loading" (click)="loadData()" [uxHelpCenterItem]="refreshHelpCenterItem">
+    <button class="btn button-primary" [disabled]="loading" 
+            (click)="loadData()" [uxHelpCenterItem]="refreshHelpCenterItem">
         <i class="hpe-icon hpe-refresh p-r-xs"></i> Refresh
     </button>
 </div>

--- a/docs/app/pages/components/sections/help-center/help-center/snippets/app.ts
+++ b/docs/app/pages/components/sections/help-center/help-center/snippets/app.ts
@@ -32,7 +32,8 @@ export class AppComponent implements OnDestroy {
     constructor(private _helpCenterService: HelpCenterService) {
 
         // update the menu items when new ones are added
-        this._helpCenter$ = this._helpCenterService.items.subscribe(items => this.menus[0].dropdown = items);
+        this._helpCenter$ = this._helpCenterService.items
+            .subscribe(items => this.menus[0].dropdown = items);
 
         // load table data
         this.loadData();

--- a/docs/app/pages/components/sections/tables/layout-switching/layout-switching.component.html
+++ b/docs/app/pages/components/sections/tables/layout-switching/layout-switching.component.html
@@ -90,7 +90,7 @@
 
 <p>
     To use the layout switcher add the <code>uxLayoutSwitcher</code> directive to the container element. The size of this
-    element will be monitored and the appropriate layout will be displayed based on the containers dimensions. The following attribute 
+    element will be monitored and the appropriate layout will be displayed based on the container's dimensions. The following attribute 
     can be used to configure the directive:
 </p>
 

--- a/docs/app/pages/components/sections/tables/layout-switching/snippets/app.html
+++ b/docs/app/pages/components/sections/tables/layout-switching/snippets/app.html
@@ -79,7 +79,8 @@
                             Use the slider above to change the width of the container element. 
                             When displaying the <b>table</b> group the layout will simply resize, 
                             however when displaying the <b>card</b> group it will
-                            switch between a grid and stacked layout depending on the size of the container.
+                            switch between a grid and stacked layout depending on the 
+                            size of the container.
                         </i>
                     </div>
                 </div>

--- a/docs/app/pages/components/sections/tables/layout-switching/snippets/app.ts
+++ b/docs/app/pages/components/sections/tables/layout-switching/snippets/app.ts
@@ -49,7 +49,11 @@ export class AppComponent {
     constructor() {
         // create some sample data
         for (let idx = 1; idx < 10; idx++) {
-            this.documents.push({ name: `Document ${idx}`, author: chance.name(), date: chance.date({ year: 2017 }) as Date });
+            this.documents.push({
+                name: `Document ${idx}`,
+                author: chance.name(),
+                date: chance.date({ year: 2017 }) as Date
+            });
         }
     }
 }

--- a/src/components/page-header/navigation/navigation.component.ts
+++ b/src/components/page-header/navigation/navigation.component.ts
@@ -9,7 +9,7 @@ export class PageHeaderNavigationComponent {
     
     @ViewChildren(PageHeaderNavigationItemComponent) menuItems: QueryList<PageHeaderNavigationItemComponent>;
      
-    @Input() items: PageHeaderNavigationItem[];
+    @Input() items: PageHeaderNavigationItem[] = [];
 
     onSelect(item: PageHeaderNavigationItem) {
         

--- a/src/components/page-header/page-header.component.html
+++ b/src/components/page-header/page-header.component.html
@@ -5,13 +5,13 @@
         <img [attr.src]="logo" class="page-header-logo">
     </div>
 
-    <div class="page-header-navigation" [ngClass]="alignment" *ngIf="items">
+    <div class="page-header-navigation" [ngClass]="alignment">
 
         <!-- The Top Navigation Options -->
         <ux-page-header-horizontal-navigation [items]="items"></ux-page-header-horizontal-navigation>
     </div>
 
-    <div class="page-header-icon-menus" *ngIf="iconMenus">
+    <div class="page-header-icon-menus">
         <ux-page-header-icon-menu *ngFor="let menu of iconMenus" [menu]="menu"></ux-page-header-icon-menu>
     </div>
 </div>

--- a/src/components/page-header/page-header.component.html
+++ b/src/components/page-header/page-header.component.html
@@ -1,17 +1,17 @@
 <!-- Display Upper Section when not condensed -->
 <div class="page-header-actions" *ngIf="!condensed">
 
-    <div class="page-header-logo-container" *ngIf="logo">
+    <div class="page-header-logo-container" [hidden]="!logo">
         <img [attr.src]="logo" class="page-header-logo">
     </div>
 
-    <div class="page-header-navigation" [ngClass]="alignment">
+    <div class="page-header-navigation" [ngClass]="alignment" *ngIf="items">
 
         <!-- The Top Navigation Options -->
         <ux-page-header-horizontal-navigation [items]="items"></ux-page-header-horizontal-navigation>
     </div>
 
-    <div class="page-header-icon-menus">
+    <div class="page-header-icon-menus" *ngIf="iconMenus">
         <ux-page-header-icon-menu *ngFor="let menu of iconMenus" [menu]="menu"></ux-page-header-icon-menu>
     </div>
 </div>

--- a/src/components/page-header/page-header.component.less
+++ b/src/components/page-header/page-header.component.less
@@ -26,6 +26,10 @@ ux-page-header {
             .page-header-logo {
                 max-height: 100%;
             }
+
+            &[hidden] {
+                display: none;
+            }
         }
 
         .page-header-navigation {


### PR DESCRIPTION
Fixing typos and line lengths for layout switcher and help center. Also fixing some weird IE issue where ngIf wouldn't work in help center plunker. Used hidden attribute instead, no idea what caused this.