### PR TITLE
EL-2641 - Hover Actions

### DIFF
--- a/docs/app/data/components-page.json
+++ b/docs/app/data/components-page.json
@@ -976,12 +976,27 @@
                 {
                     "title": "List Hover Actions",
                     "component": "ComponentsListHoverActionsNg1Component",
-                    "version": "AngularJS"
+                    "version": "AngularJS",
+                    "deprecated": true
                 },
                 {
                     "title": "Hover Actions",
                     "component": "ComponentsHoverActionsNg1Component",
-                    "version": "AngularJS"
+                    "version": "AngularJS",
+                    "deprecated": true
+                },
+                {
+                    "title": "Hover Actions",
+                    "component": "ComponentsHoverActionsComponent",
+                    "version": "Angular",
+                    "usage": [{
+                        "title": "Selectors",
+                        "content": "[uxHoverActionContainer], [uxHoverAction]"
+                    },
+                    {
+                        "title": "Module name",
+                        "content": "HoverActionModule"
+                    }]
                 },
                 {
                     "title": "Preview Pane",

--- a/docs/app/pages/components/sections/tables/hover-actions-ng1/hover-actions-ng1.component.ts
+++ b/docs/app/pages/components/sections/tables/hover-actions-ng1/hover-actions-ng1.component.ts
@@ -5,7 +5,7 @@ import { ICodePen } from '../../../../../interfaces/ICodePen';
 import { BaseDocumentationSection } from '../../../../../components/base-documentation-section/base-documentation-section';
 
 @Component({
-    selector: 'uxd-components-hover-actions',
+    selector: 'uxd-components-hover-actions-ng1',
     templateUrl: './hover-actions-ng1.component.html'
 })
 @DocumentationSectionComponent('ComponentsHoverActionsNg1Component')

--- a/docs/app/pages/components/sections/tables/hover-actions/hover-actions.component.html
+++ b/docs/app/pages/components/sections/tables/hover-actions/hover-actions.component.html
@@ -10,7 +10,7 @@
     </thead>
 
     <tbody>
-        <tr *ngFor="let document of documents" uxHoverActionContainer tabindex="0">
+        <tr class="hover-action-container" *ngFor="let document of documents" uxHoverActionContainer>
             <td class="text-black">{{ document.name }}</td>
             <td>{{ document.author }}</td>
             <td>{{ document.date.toLocaleDateString() }}</td>
@@ -27,3 +27,46 @@
 </table>
 
 <hr>
+
+<p>
+    Hover actions are a simple way to display additional controls on a component only on hover or when focused. It also provides
+    keyboard control for navigating through the hover actions. It is commonly used within table rows, however it can be used
+    within an element of any kind.
+</p>
+
+<p>
+    To add hover actions to an element add a <code>uxHoverActionContainer</code> directive to it. This will define the container
+    element that will contain hover actions. By default, container elements are given a <code>tabindex</code> of <code>0</code>.
+</p>
+
+<p>
+    Within the container you should add the <code>uxHoverAction</code> directive to any element that is a hover action.
+</p>
+
+<p>
+    When the hover action container is hovered or focused, or a hover action within it is focused, the container will receive
+    a <code>hover-action-container-active</code> class which can be used to apply additional styles when the container
+    is active.
+</p>
+
+<p>
+    Additionally, each hover action will receive a <code>hover-action-active</code> class when the container is hovered or
+    focused. A hover action will also receive a <code>hover-action-focused</code> class when that individual hover action
+    is focused.
+</p>
+
+<p>
+    The following code can be used to create the example shown above:
+</p>
+
+<tabset>
+    <tab heading="HTML">
+        <uxd-snippet [content]="snippets.compiled.appHtml"></uxd-snippet>
+    </tab>
+    <tab heading="TypeScript">
+        <uxd-snippet [content]="snippets.compiled.appTs"></uxd-snippet>
+    </tab>
+    <tab heading="CSS">
+        <uxd-snippet [content]="snippets.compiled.appCss"></uxd-snippet>
+    </tab>
+</tabset>

--- a/docs/app/pages/components/sections/tables/hover-actions/hover-actions.component.html
+++ b/docs/app/pages/components/sections/tables/hover-actions/hover-actions.component.html
@@ -1,0 +1,29 @@
+<table class="table table-hover">
+    <thead>
+        <tr class="table-header-dark">
+            <th>Name</th>
+            <th>Author</th>
+            <th>Date</th>
+            <th>Work Completed (%)</th>
+            <th></th>
+        </tr>
+    </thead>
+
+    <tbody>
+        <tr *ngFor="let document of documents" uxHoverActionContainer tabindex="0">
+            <td class="text-black">{{ document.name }}</td>
+            <td>{{ document.author }}</td>
+            <td>{{ document.date.toLocaleDateString() }}</td>
+            <td>
+                <ux-spark theme="chart2" [value]="document.complete" [inlineLabel]="document.complete" barHeight="3"></ux-spark>
+            </td>
+            <td>
+                <i class="hpe-icon hpe-view hover-action-icon" uxHoverAction></i>
+                <i class="hpe-icon hpe-share hover-action-icon" uxHoverAction></i>
+                <i class="hpe-icon hpe-trash hover-action-icon" uxHoverAction></i>
+            </td>
+        </tr>
+    </tbody>
+</table>
+
+<hr>

--- a/docs/app/pages/components/sections/tables/hover-actions/hover-actions.component.less
+++ b/docs/app/pages/components/sections/tables/hover-actions/hover-actions.component.less
@@ -1,0 +1,13 @@
+.hover-action-icon {
+    display: inline-block;
+    padding: 0 6px;
+    opacity: 0;
+
+    &.hover-action-hovered {
+        opacity: 0.5;
+    }
+
+    &.hover-action-active {
+        opacity: 1;
+    }
+}

--- a/docs/app/pages/components/sections/tables/hover-actions/hover-actions.component.less
+++ b/docs/app/pages/components/sections/tables/hover-actions/hover-actions.component.less
@@ -1,13 +1,14 @@
-.hover-action-icon {
-    display: inline-block;
-    padding: 0 6px;
-    opacity: 0;
+.hover-action-container {
+    outline: none;
 
-    &.hover-action-hovered {
-        opacity: 0.5;
+    &:focus,
+    &.hover-action-container-active {
+        background-color: #f5f5f5;
     }
 
-    &.hover-action-active {
-        opacity: 1;
+    .hover-action-icon {
+        display: inline-block;
+        padding: 3px 6px;
+        cursor: pointer;
     }
 }

--- a/docs/app/pages/components/sections/tables/hover-actions/hover-actions.component.ts
+++ b/docs/app/pages/components/sections/tables/hover-actions/hover-actions.component.ts
@@ -1,0 +1,37 @@
+import { Component } from '@angular/core';
+import { DocumentationSectionComponent } from '../../../../../decorators/documentation-section-component';
+import { ICodePenProvider } from '../../../../../interfaces/ICodePenProvider';
+import { ICodePen } from '../../../../../interfaces/ICodePen';
+import { BaseDocumentationSection } from '../../../../../components/base-documentation-section/base-documentation-section';
+import 'chance';
+
+@Component({
+    selector: 'uxd-components-hover-actions',
+    templateUrl: './hover-actions.component.html',
+    styleUrls: ['./hover-actions.component.less']
+})
+@DocumentationSectionComponent('ComponentsHoverActionsComponent')
+export class ComponentsHoverActionsComponent extends BaseDocumentationSection {
+
+    documents: HoverActionDocument[] = [];
+
+    constructor() {
+        super(require.context('./snippets/', false, /\.(html|css|js|ts)$/));
+
+        for (let idx = 1; idx < 6; idx++) {
+            this.documents.push({
+                name: `Document ${idx}`,
+                author: chance.name(),
+                date: chance.date({ year: 2017 }) as Date,
+                complete: chance.floating({ min: 0, max: 100, fixed: 2 })
+            });
+        }
+    }
+}
+
+interface HoverActionDocument {
+    name: string;
+    author: string;
+    date: Date;
+    complete: number;
+}

--- a/docs/app/pages/components/sections/tables/hover-actions/hover-actions.component.ts
+++ b/docs/app/pages/components/sections/tables/hover-actions/hover-actions.component.ts
@@ -1,9 +1,9 @@
 import { Component } from '@angular/core';
 import { DocumentationSectionComponent } from '../../../../../decorators/documentation-section-component';
-import { ICodePenProvider } from '../../../../../interfaces/ICodePenProvider';
-import { ICodePen } from '../../../../../interfaces/ICodePen';
 import { BaseDocumentationSection } from '../../../../../components/base-documentation-section/base-documentation-section';
 import 'chance';
+import { IPlunkProvider } from '../../../../../interfaces/IPlunkProvider';
+import { IPlunk } from '../../../../../interfaces/IPlunk';
 
 @Component({
     selector: 'uxd-components-hover-actions',
@@ -11,9 +11,26 @@ import 'chance';
     styleUrls: ['./hover-actions.component.less']
 })
 @DocumentationSectionComponent('ComponentsHoverActionsComponent')
-export class ComponentsHoverActionsComponent extends BaseDocumentationSection {
+export class ComponentsHoverActionsComponent extends BaseDocumentationSection implements IPlunkProvider {
 
     documents: HoverActionDocument[] = [];
+
+    plunk: IPlunk = {
+        files: {
+            'app.component.html': this.snippets.raw.appHtml,
+            'app.component.ts': this.snippets.raw.appTs,
+            'app.component.css': this.snippets.raw.appCss
+        },
+        modules: [
+            {
+                library: 'chance'
+            },
+            {
+                imports: ['HoverActionModule', 'SparkModule'],
+                library: 'ux-aspects'
+            }
+        ]
+    };
 
     constructor() {
         super(require.context('./snippets/', false, /\.(html|css|js|ts)$/));

--- a/docs/app/pages/components/sections/tables/hover-actions/snippets/app.css
+++ b/docs/app/pages/components/sections/tables/hover-actions/snippets/app.css
@@ -1,0 +1,14 @@
+.hover-action-container {
+    outline: none;
+}
+
+.hover-action-container:focus,
+.hover-action-container.hover-action-container-active {
+    background-color: #f5f5f5;
+}
+
+.hover-action-container .hover-action-icon {
+    display: inline-block;
+    padding: 3px 6px;
+    cursor: pointer;
+}

--- a/docs/app/pages/components/sections/tables/hover-actions/snippets/app.html
+++ b/docs/app/pages/components/sections/tables/hover-actions/snippets/app.html
@@ -1,0 +1,27 @@
+<table class="table table-hover">
+    <thead>
+        <tr class="table-header-dark">
+            <th>Name</th>
+            <th>Author</th>
+            <th>Date</th>
+            <th>Work Completed (%)</th>
+            <th></th>
+        </tr>
+    </thead>
+
+    <tbody>
+        <tr class="hover-action-container" *ngFor="let document of documents" uxHoverActionContainer>
+            <td class="text-black">{{ document.name }}</td>
+            <td>{{ document.author }}</td>
+            <td>{{ document.date.toLocaleDateString() }}</td>
+            <td>
+                <ux-spark theme="chart2" [value]="document.complete" [inlineLabel]="document.complete" barHeight="3"></ux-spark>
+            </td>
+            <td>
+                <i class="hpe-icon hpe-view hover-action-icon" uxHoverAction></i>
+                <i class="hpe-icon hpe-share hover-action-icon" uxHoverAction></i>
+                <i class="hpe-icon hpe-trash hover-action-icon" uxHoverAction></i>
+            </td>
+        </tr>
+    </tbody>
+</table>

--- a/docs/app/pages/components/sections/tables/hover-actions/snippets/app.ts
+++ b/docs/app/pages/components/sections/tables/hover-actions/snippets/app.ts
@@ -1,0 +1,31 @@
+import { Component } from '@angular/core';
+import 'chance';
+
+@Component({
+    selector: 'app',
+    templateUrl: './src/app.component.html',
+    styleUrls: ['./src/app.component.css']
+})
+export class AppComponent {
+
+    documents: HoverActionDocument[] = [];
+
+    constructor() {
+
+        for (let idx = 1; idx < 6; idx++) {
+            this.documents.push({
+                name: `Document ${idx}`,
+                author: chance.name(),
+                date: chance.date({ year: 2017 }) as Date,
+                complete: chance.floating({ min: 0, max: 100, fixed: 2 })
+            });
+        }
+    }
+}
+
+interface HoverActionDocument {
+    name: string;
+    author: string;
+    date: Date;
+    complete: number;
+}

--- a/docs/app/pages/components/sections/tables/tables.module.ts
+++ b/docs/app/pages/components/sections/tables/tables.module.ts
@@ -4,7 +4,7 @@ import { RouterModule } from '@angular/router';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { BsDropdownModule } from 'ngx-bootstrap/dropdown';
-import { CheckboxModule, RadioButtonModule, ColumnSortingModule, SparkModule, FilterModule, SliderModule } from '../../../../../../src/index';
+import { CheckboxModule, RadioButtonModule, ColumnSortingModule, SparkModule, FilterModule, SliderModule, HoverActionModule } from '../../../../../../src/index';
 import { DocumentationComponentsModule } from '../../../../components/components.module';
 import { ResolverService, DocumentationPage } from '../../../../services/resolver/resolver.service';
 import { DocumentationCategoryComponent } from '../../../../components/documentation-category/documentation-category.component';
@@ -40,6 +40,7 @@ import { ComponentsLayoutSwitchingComponent } from './layout-switching/layout-sw
 import { LayoutSwitcherModule } from '../../../../../../src/directives/layout-switcher/index';
 import { ButtonsModule } from 'ngx-bootstrap/buttons';
 import { AccordionModule } from 'ngx-bootstrap/accordion';
+import { ComponentsHoverActionsComponent } from './hover-actions/hover-actions.component';
 
 const SECTIONS = [
     ComponentsColumnSortingComponent,
@@ -68,7 +69,8 @@ const SECTIONS = [
     ComponentsColumnVisibilityNg1Component,
     ComponentsCustomResponsiveTableNg1Component,
     SampleFilterCustomComponent,
-    ComponentsLayoutSwitchingComponent
+    ComponentsLayoutSwitchingComponent,
+    ComponentsHoverActionsComponent
 ];
 
 const ROUTES = [
@@ -98,6 +100,7 @@ const ROUTES = [
         ButtonsModule.forRoot(),
         AccordionModule.forRoot(),
         SliderModule,
+        HoverActionModule,
         RouterModule.forChild(ROUTES)
     ],
     exports: SECTIONS,

--- a/src/components/spark/spark.module.ts
+++ b/src/components/spark/spark.module.ts
@@ -3,10 +3,12 @@ import { CommonModule } from '@angular/common';
 
 import { SparkComponent } from './spark.component';
 import { TooltipModule } from 'ngx-bootstrap/tooltip';
+import { ColorServiceModule } from '../../services/color/index';
 
 @NgModule({
     imports: [
         CommonModule,
+        ColorServiceModule,
         TooltipModule.forRoot()
     ],
     exports: [SparkComponent],

--- a/src/directives/hover-action/hover-action-container.directive.ts
+++ b/src/directives/hover-action/hover-action-container.directive.ts
@@ -1,0 +1,28 @@
+import { Directive, ContentChildren, QueryList, HostListener } from '@angular/core';
+import { HoverActionDirective } from './hover-action.directive';
+import { HoverActionService } from './hover-action.service';
+
+@Directive({
+    selector: '[uxHoverActionContainer]',
+    providers: [HoverActionService]
+})
+export class HoverActionContainerDirective {
+
+    @ContentChildren(HoverActionDirective) hoverActions: QueryList<HoverActionDirective>;
+
+    @HostListener('focus') focus(): void {
+        this.hoverActions.forEach(action => action.active = true);
+    }
+
+    @HostListener('blur') blur(): void {
+        this.hoverActions.forEach(action => action.active = false);
+    }
+
+    @HostListener('mouseenter') hover(): void {
+        this.hoverActions.forEach(action => action.hovered = true);
+    }
+
+    @HostListener('mouseleave') leave(): void {
+        this.hoverActions.forEach(action => action.hovered = false);
+    }
+}

--- a/src/directives/hover-action/hover-action.directive.less
+++ b/src/directives/hover-action/hover-action.directive.less
@@ -1,0 +1,15 @@
+[uxHoverActionContainer] {
+    [uxHoverAction] {
+        opacity: 0;
+
+        &.hover-action-active {
+            opacity: 0.5;
+        }
+
+        &.hover-action-focused,
+        &:hover,
+        &:focus {
+            opacity: 1;
+        }
+    }
+}

--- a/src/directives/hover-action/hover-action.directive.ts
+++ b/src/directives/hover-action/hover-action.directive.ts
@@ -1,0 +1,39 @@
+import { Directive, ElementRef, HostListener } from '@angular/core';
+import { HoverActionService } from './hover-action.service';
+
+@Directive({
+    selector: '[uxHoverAction]' ,
+    host: {
+        '[class.hover-action-active]': 'active',
+        '[class.hover-action-hovered]': 'hovered',
+        'tabindex': '0'
+    }
+})
+export class HoverActionDirective {
+
+    active: boolean = false;
+    hovered: boolean = false;
+    focused: boolean = false;
+
+    constructor(private _elementRef: ElementRef, private _hoverActionService: HoverActionService) {
+    }
+
+    focus(): void {
+        this.focused = true;
+        this._elementRef.nativeElement.focus();
+    }
+
+    @HostListener('blur') blur(): void {
+        this.focused = false;
+    }
+
+    @HostListener('keydown.arrowleft') focusPrevious(): void {
+        this._hoverActionService.focusPrevious();
+        debugger;
+    }
+
+    @HostListener('keydown.arrowright') focusNext(): void {
+        this._hoverActionService.focusNext();
+        debugger;
+    }
+}

--- a/src/directives/hover-action/hover-action.directive.ts
+++ b/src/directives/hover-action/hover-action.directive.ts
@@ -1,39 +1,58 @@
-import { Directive, ElementRef, HostListener } from '@angular/core';
+import { Directive, ElementRef, HostListener, OnDestroy, Input } from '@angular/core';
 import { HoverActionService } from './hover-action.service';
+import { Subscription } from 'rxjs/Subscription';
 
 @Directive({
-    selector: '[uxHoverAction]' ,
+    selector: '[uxHoverAction]',
     host: {
         '[class.hover-action-active]': 'active',
-        '[class.hover-action-hovered]': 'hovered',
-        'tabindex': '0'
+        '[class.hover-action-focused]': 'focused',
+        '[tabindex]': 'tabindex'
     }
 })
-export class HoverActionDirective {
+export class HoverActionDirective implements OnDestroy {
 
+    @Input() tabindex: number = -1;
     active: boolean = false;
-    hovered: boolean = false;
     focused: boolean = false;
 
+    private active$: Subscription;
+
     constructor(private _elementRef: ElementRef, private _hoverActionService: HoverActionService) {
+
+        // register the action
+        this._hoverActionService.register(this);
+
+        // watch for changes to the activeness of the container
+        this.active$ = this._hoverActionService.active.subscribe(active => this.active = active);
+    }
+
+    ngOnDestroy(): void {
+        this._hoverActionService.unregister(this);
+        this.active$.unsubscribe();
     }
 
     focus(): void {
-        this.focused = true;
         this._elementRef.nativeElement.focus();
     }
 
-    @HostListener('blur') blur(): void {
+    @HostListener('focus') onFocus(): void {
+        this.focused = true;
+        this._hoverActionService.updateVisibility();
+    }
+
+    @HostListener('blur') onBlur(): void {
         this.focused = false;
+        this._hoverActionService.updateVisibility();
     }
 
-    @HostListener('keydown.arrowleft') focusPrevious(): void {
-        this._hoverActionService.focusPrevious();
-        debugger;
+    @HostListener('keydown.arrowleft', ['$event']) previous(event: MouseEvent): void {
+        event.stopPropagation();        
+        this._hoverActionService.previous();
     }
 
-    @HostListener('keydown.arrowright') focusNext(): void {
-        this._hoverActionService.focusNext();
-        debugger;
+    @HostListener('keydown.arrowright', ['$event']) next(event: MouseEvent): void {
+        event.stopPropagation();
+        this._hoverActionService.next();
     }
 }

--- a/src/directives/hover-action/hover-action.module.ts
+++ b/src/directives/hover-action/hover-action.module.ts
@@ -1,0 +1,14 @@
+import { NgModule } from '@angular/core';
+import { HoverActionContainerDirective } from './hover-action-container.directive';
+import { HoverActionDirective } from './hover-action.directive';
+
+const DECLARATIONS = [
+    HoverActionDirective,
+    HoverActionContainerDirective
+];
+
+@NgModule({
+    exports: DECLARATIONS,
+    declarations: DECLARATIONS
+})
+export class HoverActionModule { }

--- a/src/directives/hover-action/hover-action.service.ts
+++ b/src/directives/hover-action/hover-action.service.ts
@@ -1,0 +1,21 @@
+import { Injectable } from '@angular/core';
+import { Subject } from 'rxjs/Subject';
+
+@Injectable()
+export class HoverActionService {
+
+    events: Subject<HoverActionEvent> = new Subject<HoverActionEvent>();
+
+    focusNext(): void {
+        this.events.next(new HoverActionNextEvent());
+    }
+    
+    focusPrevious(): void {
+        this.events.next(new HoverActionPreviousEvent());
+    }
+}
+
+export class HoverActionNextEvent { }
+export class HoverActionPreviousEvent { }
+
+export type HoverActionEvent = HoverActionNextEvent | HoverActionPreviousEvent;

--- a/src/directives/hover-action/hover-action.service.ts
+++ b/src/directives/hover-action/hover-action.service.ts
@@ -1,21 +1,95 @@
 import { Injectable } from '@angular/core';
 import { Subject } from 'rxjs/Subject';
+import { BehaviorSubject } from 'rxjs/BehaviorSubject';
+import { HoverActionDirective } from './hover-action.directive';
+import { HoverActionContainerDirective } from './hover-action-container.directive';
 
 @Injectable()
 export class HoverActionService {
 
-    events: Subject<HoverActionEvent> = new Subject<HoverActionEvent>();
+    active: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false);
 
-    focusNext(): void {
-        this.events.next(new HoverActionNextEvent());
+    private _container: HoverActionContainerDirective;
+    private _focused: boolean = false;
+    private _hovered: boolean = false;
+    private _actions: HoverActionDirective[] = [];
+
+    register(action: HoverActionDirective): void {
+        this._actions.push(action);
+    }
+
+    unregister(action: HoverActionDirective): void {
+        this._actions = this._actions.filter(actn => actn !== action);
     }
     
-    focusPrevious(): void {
-        this.events.next(new HoverActionPreviousEvent());
+    setContainer(container: HoverActionContainerDirective): void {
+        this._container = container;
+    }
+
+    setFocusState(focus: boolean): void {
+        this._focused = focus;
+        this.updateVisibility();
+    }
+
+    setHoverState(hover: boolean): void {
+        this._hovered = hover;
+        this.updateVisibility();
+    }
+
+    next(): void {
+
+        // if container has focus then focus the first hover action
+        if (this.containerHasFocus()) {
+            this.focusActionAtIndex(0);
+            return this.updateVisibility();
+        }
+
+        // if a hover action has focus then focus the next action
+        if (this.actionHasFocus()) {
+            let index = this.getFocusedActionIndex() + 1;
+            this.focusActionAtIndex(index);
+            this.updateVisibility();
+        }
+    }
+
+    previous(): void {
+        // if a hover action has focus then focus the previous action
+        if (this.actionHasFocus()) {
+            let index = this.getFocusedActionIndex() - 1;
+
+            if (index >= 0) {
+                this.focusActionAtIndex(index);
+            } else {
+                this._container.focus();
+            }
+        }
+
+        this.updateVisibility();
+    }
+    
+    updateVisibility(): void {
+        this.active.next(this._focused || this._hovered || this.actionHasFocus());
+    }
+
+    private focusActionAtIndex(index: number): void {
+        if (index >= 0 && index < this._actions.length) {
+            this._actions[index].focus();
+        }
+    }
+
+    private getFocusedActionIndex(): number {
+        return this._actions.findIndex(action => action === this.getFocusedAction());
+    }
+
+    private containerHasFocus(): boolean {
+        return this._focused;
+    }
+
+    private actionHasFocus(): boolean {
+        return !!this.getFocusedAction();
+    }
+
+    private getFocusedAction(): HoverActionDirective {
+        return this._actions.find(action => action.focused);
     }
 }
-
-export class HoverActionNextEvent { }
-export class HoverActionPreviousEvent { }
-
-export type HoverActionEvent = HoverActionNextEvent | HoverActionPreviousEvent;

--- a/src/directives/hover-action/index.ts
+++ b/src/directives/hover-action/index.ts
@@ -1,0 +1,3 @@
+export * from './hover-action.module';
+export * from './hover-action-container.directive';
+export * from './hover-action.directive';

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,7 @@ export * from './components/media-player/index';
   Export Directives
 */
 export * from './directives/focus-if/index';
+export * from './directives/hover-action/index';
 export * from './directives/infinite-scroll/index';
 export * from './directives/layout-switcher/index';
 export * from './directives/resize/index';

--- a/src/styles/ux-aspects.less
+++ b/src/styles/ux-aspects.less
@@ -77,3 +77,4 @@
 @import "../components/media-player/media-player.component.less";
 @import "../components/media-player/extensions/controls/controls.component.less";
 @import "../components/media-player/extensions/timeline/timeline.component.less";
+@import "../directives/hover-action/hover-action.directive.less";


### PR DESCRIPTION
Create hover action directives. I have deprecated both hover actions and list hover actions AngularJS components as these directives cover both use cases, no need for two separate components.