### PR TITLE
EL-3692 - Copy component/directive less files

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -21,7 +21,7 @@ module.exports = function (grunt) {
     // Register Tasks
     grunt.registerTask('cleanup', ['clean:library', 'clean:documentation', 'clean:ng1', 'clean:styles', 'clean:fonts', 'clean:images', 'clean:less', 'clean:licenses']);
     grunt.registerTask('lint', ['tslint:library', 'tslint:documentation', 'jshint:ng1', 'stylelint:components']);
-    grunt.registerTask('library', ['clean:library', 'webpack:library', 'webpack:ng1']);
+    grunt.registerTask('library', ['clean:library', 'webpack:library', 'webpack:ng1', 'copy:component_styles', 'copy:directive_styles']);
     grunt.registerTask('styles', ['clean:styles', 'less:styles']);
     grunt.registerTask('scripts', ['execute:iconset']);
     grunt.registerTask('assets', ['copy:fonts', 'copy:images', 'copy:less', 'copy:ng1', 'copy:styles']);

--- a/grunt/copy.js
+++ b/grunt/copy.js
@@ -19,6 +19,18 @@ module.exports = {
         dest: path.join(process.cwd(), 'dist', 'less'),
         expand: true
     },
+    component_styles: {
+        cwd: path.join(process.cwd(), 'src', 'components'),
+        src: '**/*.less',
+        dest: path.join(process.cwd(), 'dist', 'lib', 'components'),
+        expand: true
+    },
+    directive_styles: {
+        cwd: path.join(process.cwd(), 'src', 'directives'),
+        src: '**/*.less',
+        dest: path.join(process.cwd(), 'dist', 'lib', 'directives'),
+        expand: true
+    },
     ng1: {
         cwd: path.join(process.cwd(), 'dist', 'styles'),
         src: '**',


### PR DESCRIPTION
Component less files should now be copied into the dist folder as well. The will be in the lib folder under the corresponding component/directive folder.

Added as part of the grunt library task