### PR TITLE
EL-2692 - Inlining Less files

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -21,10 +21,10 @@ module.exports = function (grunt) {
     // Register Tasks
     grunt.registerTask('cleanup', ['clean:library', 'clean:documentation', 'clean:ng1', 'clean:styles', 'clean:fonts', 'clean:images', 'clean:less', 'clean:licenses']);
     grunt.registerTask('lint', ['tslint:library', 'tslint:documentation', 'jshint:ng1', 'stylelint:components']);
-    grunt.registerTask('library', ['clean:library', 'webpack:library', 'webpack:ng1', 'copy:component_styles', 'copy:directive_styles']);
-    grunt.registerTask('styles', ['clean:styles', 'less:styles']);
+    grunt.registerTask('library', ['clean:library', 'webpack:library', 'webpack:ng1']);
+    grunt.registerTask('styles', ['clean:styles', 'execute:less']);
     grunt.registerTask('scripts', ['execute:iconset']);
-    grunt.registerTask('assets', ['copy:fonts', 'copy:images', 'copy:less', 'copy:ng1', 'copy:styles']);
+    grunt.registerTask('assets', ['copy:fonts', 'copy:images', 'copy:ng1', 'copy:styles']);
     grunt.registerTask('iconset', ['webfont:iconset']);
     grunt.registerTask('minify', ['uglify:ng1', 'cssmin:styles']);
     grunt.registerTask('licenses', ['execute:licenses', 'usebanner:ng1']);

--- a/grunt/copy.js
+++ b/grunt/copy.js
@@ -13,24 +13,6 @@ module.exports = {
         dest: path.join(process.cwd(), 'dist', 'img'),
         expand: true
     },
-    less: {
-        cwd: path.join(process.cwd(), 'src', 'styles'),
-        src: '**',
-        dest: path.join(process.cwd(), 'dist', 'less'),
-        expand: true
-    },
-    component_styles: {
-        cwd: path.join(process.cwd(), 'src', 'components'),
-        src: '**/*.less',
-        dest: path.join(process.cwd(), 'dist', 'lib', 'components'),
-        expand: true
-    },
-    directive_styles: {
-        cwd: path.join(process.cwd(), 'src', 'directives'),
-        src: '**/*.less',
-        dest: path.join(process.cwd(), 'dist', 'lib', 'directives'),
-        expand: true
-    },
     ng1: {
         cwd: path.join(process.cwd(), 'dist', 'styles'),
         src: '**',

--- a/grunt/execute.js
+++ b/grunt/execute.js
@@ -6,5 +6,8 @@ module.exports = {
     },
     licenses: {
         src: [ path.join(process.cwd(), 'scripts', 'licenses.js') ]
+    },
+    less: {
+        src: [ path.join(process.cwd(), 'scripts', 'inline-less.js') ]
     }
 };

--- a/grunt/less.js
+++ b/grunt/less.js
@@ -1,8 +1,0 @@
-const path = require('path');
-
-module.exports = {
-    styles: {
-        src: path.join(process.cwd(), 'src', 'styles', 'ux-aspects.less'),
-        dest: path.join(process.cwd(), 'dist', 'styles', 'ux-aspects.css')
-    }
-};

--- a/scripts/inline-less.js
+++ b/scripts/inline-less.js
@@ -1,0 +1,60 @@
+let fs = require('fs');
+let path = require('path');
+let less = require('less');
+
+// entry paths
+let rootPath = process.cwd();
+let stylesPath = path.join(rootPath, 'src', 'styles');
+let stylesheetPath = path.join(stylesPath, 'ux-aspects.less');
+
+// dist folder paths
+let lessDistPath = path.join(rootPath, 'dist', 'less');
+let cssDistPath = path.join(rootPath, 'dist', 'styles');
+
+// output file paths
+let lessDestinationPath = path.join(lessDistPath, 'ux-aspects.less');
+let cssDestinationPath = path.join(cssDistPath, 'ux-aspects.css');
+
+// load in the original less file
+let stylesheet = fs.readFileSync(stylesheetPath, 'utf8');
+
+// set up the less options
+let options = {
+    rootFileInfo: {
+        currentDirectory: stylesPath
+    }
+};
+
+// ensure output directories exists
+if (!fs.existsSync(lessDistPath)) {
+    fs.mkdirSync(lessDistPath);
+}
+
+if (!fs.existsSync(cssDistPath)) {
+    fs.mkdirSync(cssDistPath);
+}
+
+// parse the less file
+less.parse(stylesheet, options, (err, ruleset, imports, options) => {
+
+    // make all the import statements inline
+    let statements = ruleset.rules.filter(rule => rule.type === 'Import').map(rule => `@import (inline) "${ rule.path.value }";`).join('\n');
+
+    // produce the inline less file
+    less.render(statements, options, (err, output) => {
+
+        // output the less file
+        fs.writeFileSync(lessDestinationPath, output.css);
+
+        // convert to CSS
+        less.render(output.css, (err, output) => {
+
+            // output the css file
+            fs.writeFileSync(cssDestinationPath, output.css);
+
+            // end the script
+            process.exit();
+        });
+
+    });
+});

--- a/src/components/column-sorting/column-sorting.component.less
+++ b/src/components/column-sorting/column-sorting.component.less
@@ -1,5 +1,3 @@
-@import "../../styles/variables.less";
-
 ux-column-sorting {
     .ux-column-sorting {
         padding-left: 5px;

--- a/src/components/dashboard/dashboard.component.less
+++ b/src/components/dashboard/dashboard.component.less
@@ -1,5 +1,3 @@
-@import "../../styles/variables.less";
-
 ux-dashboard {
     position: relative;
     display: block;

--- a/src/components/page-header/navigation/navigation-item/navigation-item.component.less
+++ b/src/components/page-header/navigation/navigation-item/navigation-item.component.less
@@ -1,5 +1,3 @@
-@import "../../../../styles/variables.less";
-
 ux-page-header-horizontal-navigation-item {
     .horizontal-navigation-button {
         position: relative;

--- a/src/components/page-header/page-header.component.less
+++ b/src/components/page-header/page-header.component.less
@@ -1,5 +1,3 @@
-@import "../../styles/variables.less";
-
 ux-page-header {
     display: flex;
     flex-direction: column;

--- a/src/components/tag-input/tag-input.component.less
+++ b/src/components/tag-input/tag-input.component.less
@@ -1,5 +1,3 @@
-@import "../../styles/variables.less";
-
 ux-tag-input {
     display: inline-block;
     position: relative;

--- a/src/components/typeahead/typeahead.component.less
+++ b/src/components/typeahead/typeahead.component.less
@@ -1,5 +1,3 @@
-@import "../../styles/variables.less";
-
 ux-typeahead {
     display: none;
     position: absolute;


### PR DESCRIPTION
Tried the inlining approach which is exactly what we need but did cause a few problems with our current setup. When the import statements are marked as "inline" the less compiler outputs a less file rather than a CSS file, which breaks our webpack builds as it is expecting CSS from the less-loader.

An alternate would be to have a separate `ux-aspects-inline.less` file which would have all the imports marked as inline, however this would mean having to maintain two "entry" less files which will no doubt cause problems when someone forgets to update one.

The approach that was the easiest to get working was to write a node script that grunt runs as part of the build. The script converts all the imports to "inline" and then gets less to compile it. This produces the single less file with all styles in it. It then runs it through the less compiler again producing the css file.

Or if you have any other ideas i'm open to suggestions.