### PR TITLE
EL-2660 - Improving examples and components

### DIFF
--- a/docs/app/components/base-documentation-section/base-documentation-section.ts
+++ b/docs/app/components/base-documentation-section/base-documentation-section.ts
@@ -2,7 +2,7 @@ import { ISnippets } from '../../interfaces/ISnippets';
 
 export abstract class BaseDocumentationSection {
 
-    protected snippets: ISnippets;
+    snippets: ISnippets;
 
     constructor(context?: __WebpackModuleApi.RequireContext) {
 

--- a/docs/app/components/component-section/component-section.component.ts
+++ b/docs/app/components/component-section/component-section.component.ts
@@ -24,8 +24,8 @@ export class ComponentSectionComponent implements OnInit {
 
     @ViewChild('container', { read: ViewContainerRef }) viewContainer: ViewContainerRef; 
     
-    private codepen: ICodePen;
-    private plunk: IPlunk;
+    codepen: ICodePen;
+    plunk: IPlunk;
     
     constructor(private resolverService: ResolverService) { }
 

--- a/docs/app/components/documentation-category/documentation-category.component.ts
+++ b/docs/app/components/documentation-category/documentation-category.component.ts
@@ -13,7 +13,7 @@ import { VersionService, Version } from '../../services/version/version.service'
 })
 export class DocumentationCategoryComponent implements OnInit, AfterViewInit {
 
-    private category: ICategory;
+    category: ICategory;
     private trackScroll: boolean = false;
     private versionSub: Subscription;
 

--- a/docs/app/components/edit-example-link/edit-example-link.component.html
+++ b/docs/app/components/edit-example-link/edit-example-link.component.html
@@ -1,1 +1,4 @@
-<a class="hyperlink-hover" tabindex="0" (keyup.enter)="linkClickHandler($event)" (click)="linkClickHandler($event)"><i class="hpe-icon hpe-edit p-r-xs"></i><ng-content></ng-content></a>
+<a class="hyperlink-hover" tabindex="0" (keyup.enter)="linkClick($event)" (click)="linkClick($event)">
+    <i class="hpe-icon hpe-edit p-r-xs"></i>
+    <ng-content></ng-content>
+</a>

--- a/docs/app/components/edit-example-link/edit-example-link.component.ts
+++ b/docs/app/components/edit-example-link/edit-example-link.component.ts
@@ -22,8 +22,6 @@ export class EditExampleLinkComponent {
     @Input() type: 'codepen' | 'plunker';
     @Input() version: 'Angular' | 'AngularJS' = 'Angular';
 
-    private linkClickHandler = this.linkClick.bind(this);
-
     constructor(private editExampleService: EditExampleService) {}
 
     linkClick(event: MouseEvent) {

--- a/docs/app/components/full-page-layout/full-page-layout.component.ts
+++ b/docs/app/components/full-page-layout/full-page-layout.component.ts
@@ -5,6 +5,4 @@ import { Component } from '@angular/core';
     templateUrl: './full-page-layout.component.html',
     styleUrls: ['./full-page-layout.component.less']
 })
-export class FullPageLayoutComponent {
-    constructor() {}
-}
+export class FullPageLayoutComponent { }

--- a/docs/app/components/landing-page-feature/landing-page-feature.component.ts
+++ b/docs/app/components/landing-page-feature/landing-page-feature.component.ts
@@ -1,5 +1,4 @@
 import { Component, Input } from '@angular/core';
-
 import { ILink } from '../../interfaces/ILink';
 
 @Component({

--- a/docs/app/components/navigation-bar-search/navigation-bar-search.component.ts
+++ b/docs/app/components/navigation-bar-search/navigation-bar-search.component.ts
@@ -26,10 +26,10 @@ export class NavigationBarSearchComponent {
 
     @ViewChildren('searchInput') searchInput: QueryList<ElementRef>;
 
-    protected searching: boolean;
-    protected query: BehaviorSubject<string>;
-    protected results: ISearchResult[];
-    protected activeIdx: number;
+    searching: boolean;
+    query: BehaviorSubject<string>;
+    results: ISearchResult[];
+    activeIdx: number;
 
     private data: ISearchResult[];
     private history: ISearchResult[] = [];

--- a/docs/app/components/navigation-bar/navigation-bar.component.ts
+++ b/docs/app/components/navigation-bar/navigation-bar.component.ts
@@ -8,10 +8,10 @@ import { ILink } from '../../interfaces/ILink';
 })
 export class NavigationBarComponent {
 
-    private brand: ILink;
-    private links: ILink[];
-    private social: ILink[];
-    private expanded: boolean = false;
+    brand: ILink;
+    links: ILink[];
+    social: ILink[];
+    expanded: boolean = false;
 
     constructor() {
 

--- a/docs/app/components/page-footer/page-footer.component.ts
+++ b/docs/app/components/page-footer/page-footer.component.ts
@@ -11,11 +11,11 @@ import { IFooter } from '../../interfaces/IFooter';
 })
 export class PageFooterComponent {
     
-    private copyright: string;
-    private logo: string;
-    private columns: IFooterColumn[];
-    private feedback: ILink;
-    private year: number;
+    copyright: string;
+    logo: string;
+    columns: IFooterColumn[];
+    feedback: ILink;
+    year: number;
 
     constructor() {
         // get the footer navigation data

--- a/docs/app/components/section-select/section-select.component.ts
+++ b/docs/app/components/section-select/section-select.component.ts
@@ -11,7 +11,7 @@ export class SectionSelectComponent implements OnInit, OnDestroy {
 
     @Input() navigation: IDocumentationPage;
 
-    private section: any;
+    section: any;
     private path: string;
     private routeSubscription: Subscription;
 

--- a/docs/app/components/showcase-card/showcase-card.component.html
+++ b/docs/app/components/showcase-card/showcase-card.component.html
@@ -1,4 +1,4 @@
-<a href="{{link}}">
+<a [href]="link">
 <div class="row">
     <div class="col-12 col-md-7">
         <img class="showcase-card-image" [src]="image">

--- a/docs/app/components/text-page-layout/text-page-layout.component.ts
+++ b/docs/app/components/text-page-layout/text-page-layout.component.ts
@@ -5,6 +5,4 @@ import { Component } from '@angular/core';
     templateUrl: './text-page-layout.component.html',
     styleUrls: ['./text-page-layout.component.less']
 })
-export class TextPageLayoutComponent {
-    constructor() {}
-}
+export class TextPageLayoutComponent { }

--- a/docs/app/directives/color-input/color-input.directive.ts
+++ b/docs/app/directives/color-input/color-input.directive.ts
@@ -11,7 +11,7 @@ export class ColorInputDirective implements OnChanges {
 
     @Input('uxd-color-input') value: string; 
 
-    private shadowStyle: SafeStyle;
+    shadowStyle: SafeStyle;
 
     constructor(private domSanitizer: DomSanitizer) { }
 

--- a/docs/app/interfaces/ISection.ts
+++ b/docs/app/interfaces/ISection.ts
@@ -6,4 +6,8 @@ export interface ISection {
     version: 'AngularJS' | 'Angular';
     deprecated?: boolean;
     externalUrl?: string;
+    usage: [{
+        title: string;
+        content: string;
+    }];
 }

--- a/docs/app/pages/blog/blog.component.ts
+++ b/docs/app/pages/blog/blog.component.ts
@@ -18,7 +18,7 @@ export class BlogPageComponent {
         allows us to convert markdown to html
         at compile time rather than run time.
     */
-    private posts: IBlogPost[];
+    posts: IBlogPost[];
 
     constructor(private domSanitizer: DomSanitizer) {
 

--- a/docs/app/pages/changelog/changelog.component.ts
+++ b/docs/app/pages/changelog/changelog.component.ts
@@ -9,7 +9,7 @@ import { DomSanitizer } from '@angular/platform-browser';
 })
 export class ChangeLogPageComponent {
 
-    private logs: IChangeLog[];
+    logs: IChangeLog[];
 
     constructor(private domSanitizer: DomSanitizer) {
 

--- a/docs/app/pages/charts/sections/bar-charts/bar-chart-ng1/bar-chart-ng1.component.ts
+++ b/docs/app/pages/charts/sections/bar-charts/bar-chart-ng1/bar-chart-ng1.component.ts
@@ -13,10 +13,10 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('ChartsBarChartNg1Component')
 export class ChartsBarChartNg1Component extends BaseDocumentationSection implements ICodePenProvider {
 
-    private data: any;
-    private options: any;
+    data: any;
+    options: any;
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.chartHtml,
         js: [this.snippets.raw.chartJs],
         htmlAttributes: {

--- a/docs/app/pages/charts/sections/bar-charts/horizontal-bar-chart-ng1/horizontal-bar-chart-ng1.component.ts
+++ b/docs/app/pages/charts/sections/bar-charts/horizontal-bar-chart-ng1/horizontal-bar-chart-ng1.component.ts
@@ -13,10 +13,10 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('ChartsHorizontalBarChartNg1Component')
 export class ChartsHorizontalBarChartNg1Component extends BaseDocumentationSection implements ICodePenProvider {
 
-    private data: any;
-    private options: any;
+    data: any;
+    options: any;
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.chartHtml,
         htmlAttributes: {
             'ng-controller': 'HorizontalBarChartCtrl as bc'

--- a/docs/app/pages/charts/sections/bar-charts/stacked-bar-chart-ng1/stacked-bar-chart-ng1.component.ts
+++ b/docs/app/pages/charts/sections/bar-charts/stacked-bar-chart-ng1/stacked-bar-chart-ng1.component.ts
@@ -13,10 +13,10 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('ChartsStackedBarChartNg1Component')
 export class ChartsStackedBarChartNg1Component extends BaseDocumentationSection implements ICodePenProvider {
 
-    private data: any;
-    private options: any;
+    data: any;
+    options: any;
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.chartHtml,
         htmlAttributes: {
             'ng-controller': 'StackedBarChartCtrl as bc'

--- a/docs/app/pages/charts/sections/donut-charts/donut-chart-ng1/donut-chart-ng1.component.ts
+++ b/docs/app/pages/charts/sections/donut-charts/donut-chart-ng1/donut-chart-ng1.component.ts
@@ -13,10 +13,10 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('ChartsDonutChartNg1Component')
 export class ChartsDonutChartNg1Component extends BaseDocumentationSection implements ICodePenProvider {
 
-    private data: any;
-    private options: any;
+    data: any;
+    options: any;
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.chartHtml,
         htmlAttributes: {
             'ng-controller': 'DonutChartCtrl as dc'

--- a/docs/app/pages/charts/sections/donut-charts/nested-donut-chart-ng1/nested-donut-chart-ng1.component.ts
+++ b/docs/app/pages/charts/sections/donut-charts/nested-donut-chart-ng1/nested-donut-chart-ng1.component.ts
@@ -13,10 +13,10 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('ChartsNestedDonutChartNg1Component')
 export class ChartsNestedDonutChartNg1Component extends BaseDocumentationSection implements ICodePenProvider {
 
-    private data: any[];
-    private options: any;
+    data: any[];
+    options: any;
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.chartHtml,
         js: [this.snippets.raw.chartJs],
         css: [this.snippets.raw.chartCss],

--- a/docs/app/pages/charts/sections/line-charts/line-chart-ng1/line-chart-ng1.component.ts
+++ b/docs/app/pages/charts/sections/line-charts/line-chart-ng1/line-chart-ng1.component.ts
@@ -13,10 +13,10 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('ChartsLineChartNg1Component')
 export class ChartsLineChartNg1Component extends BaseDocumentationSection implements ICodePenProvider {
 
-    private data: any;
-    private options: any;
+    data: any;
+    options: any;
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.chartHtml,
         htmlAttributes: {
             'ng-controller': 'LineChartCtrl as lc'

--- a/docs/app/pages/charts/sections/line-charts/multiple-axis-line-chart-ng1/multiple-axis-line-chart-ng1.component.ts
+++ b/docs/app/pages/charts/sections/line-charts/multiple-axis-line-chart-ng1/multiple-axis-line-chart-ng1.component.ts
@@ -13,10 +13,10 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('ChartsMultipleAxisLineChartNg1Component')
 export class ChartsMultipleAxisLineChartNg1Component extends BaseDocumentationSection implements ICodePenProvider {
 
-  private data: any[];
-  private options: any;
+  data: any[];
+  options: any;
 
-  public codepen: ICodePen = {
+  codepen: ICodePen = {
     html: this.snippets.raw.chartHtml,
     htmlAttributes: {
       'ng-controller': 'MultipleAxisLineChartCtrl as lc'

--- a/docs/app/pages/charts/sections/line-charts/stacked-line-chart-ng1/stacked-line-chart-ng1.component.ts
+++ b/docs/app/pages/charts/sections/line-charts/stacked-line-chart-ng1/stacked-line-chart-ng1.component.ts
@@ -13,10 +13,10 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('ChartsStackedLineChartNg1Component')
 export class ChartsStackedLineChartNg1Component extends BaseDocumentationSection implements ICodePenProvider {
 
-    private data: any[];
-    private options: any;
+    data: any[];
+    options: any;
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.chartHtml,
         htmlAttributes: {
             'ng-controller': 'StackedLineChartCtrl as lc'

--- a/docs/app/pages/charts/sections/live-charts/live-chart-ng1/live-chart-ng1.component.ts
+++ b/docs/app/pages/charts/sections/live-charts/live-chart-ng1/live-chart-ng1.component.ts
@@ -13,11 +13,11 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('ChartsLiveChartNg1Component')
 export class ChartsLiveChartNg1Component extends BaseDocumentationSection implements ICodePenProvider {
 
-    private series: any;
-    private options: any;
-    private livedata: any[] = [];
+    series: any;
+    options: any;
+    livedata: any[] = [];
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.chartHtml,
         htmlAttributes: {
             'ng-controller': 'LiveChartCtrl as lc'

--- a/docs/app/pages/charts/sections/live-charts/live-chart/live-chart.component.ts
+++ b/docs/app/pages/charts/sections/live-charts/live-chart/live-chart.component.ts
@@ -50,7 +50,7 @@ export class ChartsLiveChartComponent extends BaseDocumentationSection implement
     lineChartLegend: boolean = false;
     lineChartColors: any;
 
-    private livedata: number[] = [];
+    livedata: number[] = [];
 
     constructor(colorService: ColorService) {
         super(require.context('./snippets/', false, /(html|css|js|ts)$/));

--- a/docs/app/pages/charts/sections/live-charts/live-chart/snippets/live-chart.ts
+++ b/docs/app/pages/charts/sections/live-charts/live-chart/snippets/live-chart.ts
@@ -18,7 +18,7 @@ export class AppComponent {
     lineChartLegend: boolean = false;
     lineChartColors: any;
 
-    private livedata: number[] = [];
+    livedata: number[] = [];
 
     constructor(colorService: ColorService) {
 

--- a/docs/app/pages/charts/sections/organization-chart/organization-chart-ng1/organization-chart-ng1.component.ts
+++ b/docs/app/pages/charts/sections/organization-chart/organization-chart-ng1/organization-chart-ng1.component.ts
@@ -13,10 +13,10 @@ const chance = require('chance').Chance();
 @DocumentationSectionComponent('ChartsOrganizationChartNg1Component')
 export class ChartsOrganizationChartNg1Component extends BaseDocumentationSection implements ICodePenProvider {
 
-    private data: IOrganizationChartNode;
-    private options: any;
+    data: IOrganizationChartNode;
+    options: any;
     
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.chartHtml,
         htmlTemplates: [
             {

--- a/docs/app/pages/charts/sections/partition-map/partition-map-ng1/partition-map-ng1.component.ts
+++ b/docs/app/pages/charts/sections/partition-map/partition-map-ng1/partition-map-ng1.component.ts
@@ -15,11 +15,11 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('ChartsPartitionMapNg1Component')
 export class ChartsPartitionMapNg1Component extends BaseDocumentationSection implements ICodePenProvider {
 
-    private data: any;
-    private options: any;
-    private isLoading: boolean;
+    data: any;
+    options: any;
+    isLoading: boolean;
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.chartHtml,
         htmlAttributes: {
             'ng-controller': 'PartitionMapCtrl as vm'

--- a/docs/app/pages/charts/sections/partition-map/partition-map-ng1/popover/popover.controller.ts
+++ b/docs/app/pages/charts/sections/partition-map/partition-map-ng1/popover/popover.controller.ts
@@ -1,6 +1,6 @@
 class PartitionMapPopoverCtrl {
 
-    private lineChart: any;
+    lineChart: any;
 
     static $inject = ['$scope'];
 

--- a/docs/app/pages/charts/sections/peity-charts/peity-charts-ng1/peity-charts-ng1.component.ts
+++ b/docs/app/pages/charts/sections/peity-charts/peity-charts-ng1/peity-charts-ng1.component.ts
@@ -13,11 +13,11 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('ChartsPeityChartNg1Component')
 export class ChartsPeityChartNg1Component extends BaseDocumentationSection implements ICodePenProvider {
 
-    private lineChart: any;
-    private updatingLineChart: any;
-    private barChart: any;
+    lineChart: any;
+    updatingLineChart: any;
+    barChart: any;
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.chartHtml,
         htmlAttributes: {
             'ng-controller': 'PeityChartCtrl as pc'

--- a/docs/app/pages/charts/sections/sankey-chart/sankey-chart-ng1/sankey-chart-ng1.component.ts
+++ b/docs/app/pages/charts/sections/sankey-chart/sankey-chart-ng1/sankey-chart-ng1.component.ts
@@ -12,13 +12,13 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('ChartsSankeyChartNg1Component')
 export class ChartsSankeyChartNg1Component extends BaseDocumentationSection implements ICodePenProvider {
 
-  private resizeId: number = null;
-  private container: any = {};
-  private chart: any = {};
-  private data: any;
-  private options: any;
+  resizeId: number = null;
+  container: any = {};
+  chart: any = {};
+  data: any;
+  options: any;
   
-  public codepen: ICodePen = {
+  codepen: ICodePen = {
     html: this.snippets.raw.chartHtml,
     htmlAttributes: {
       'ng-controller': 'SankeyCtrl as vm'

--- a/docs/app/pages/charts/sections/scrollable-chart/scrollable-chart-ng1/scrollable-chart-ng1.component.ts
+++ b/docs/app/pages/charts/sections/scrollable-chart/scrollable-chart-ng1/scrollable-chart-ng1.component.ts
@@ -12,10 +12,11 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 })
 @DocumentationSectionComponent('ChartsScrollableChartNg1Component')
 export class ChartsScrollableChartNg1Component extends BaseDocumentationSection implements ICodePenProvider {
-    private data: any;
-    private options: any;
+    
+    data: any;
+    options: any;
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.chartHtml,
         htmlAttributes: {
             'ng-controller': 'ScrollableChartCtrl as sc'

--- a/docs/app/pages/charts/sections/scrollable-chart/scrollable-chart/scrollable-chart.component.ts
+++ b/docs/app/pages/charts/sections/scrollable-chart/scrollable-chart/scrollable-chart.component.ts
@@ -51,11 +51,11 @@ export class ChartsScrollableChartComponent extends BaseDocumentationSection imp
     barChartLegend: boolean = false;
     barChartColors: any;
 
-    private labels: string[] = ['.doc', '.ppt', '.pdf', '.xls', '.html', '.txt', '.png', '.bmp', '.gif', '.svg', '.ttf', '.wav'];
-    private data: number[] = [34, 25, 19, 34, 32, 44, 12, 27, 15, 48, 40, 36];
+    labels: string[] = ['.doc', '.ppt', '.pdf', '.xls', '.html', '.txt', '.png', '.bmp', '.gif', '.svg', '.ttf', '.wav'];
+    data: number[] = [34, 25, 19, 34, 32, 44, 12, 27, 15, 48, 40, 36];
 
-    private page: number = 0;
-    private pageSize: number = 4;
+    page: number = 0;
+    pageSize: number = 4;
 
     constructor(colorService: ColorService) {
         super(require.context('./snippets/', false, /(html|css|js|ts)$/));

--- a/docs/app/pages/charts/sections/scrollable-chart/scrollable-chart/snippets/scrollable-chart.ts
+++ b/docs/app/pages/charts/sections/scrollable-chart/scrollable-chart/snippets/scrollable-chart.ts
@@ -18,14 +18,14 @@ export class AppComponent {
     barChartLegend: boolean = false;
     barChartColors: any;
 
-    private labels: string[] = [
+    labels: string[] = [
         '.doc', '.ppt', '.pdf', '.xls', '.html', '.txt',
         '.png', '.bmp', '.gif', '.svg', '.ttf', '.wav'
     ];
-    private data: number[] = [34, 25, 19, 34, 32, 44, 12, 27, 15, 48, 40, 36];
+    data: number[] = [34, 25, 19, 34, 32, 44, 12, 27, 15, 48, 40, 36];
 
-    private page: number = 0;
-    private pageSize: number = 4;
+    page: number = 0;
+    pageSize: number = 4;
 
     constructor(colorService: ColorService) {
 

--- a/docs/app/pages/charts/sections/social-chart/social-chart-ng1/social-chart-ng1.component.ts
+++ b/docs/app/pages/charts/sections/social-chart/social-chart-ng1/social-chart-ng1.component.ts
@@ -13,20 +13,20 @@ const chance = require('chance').Chance();
 @DocumentationSectionComponent('ChartsSocialChartNg1Component')
 export class ChartsSocialChartNg1Component extends BaseDocumentationSection implements ICodePenProvider {
 
-    private minLabels: number;
-    private forceAtlasDuration: number;
-    private edgeWeightInfluence: boolean;
-    private options: any;
-    private detailStyle: any;
-    private communities: any;
-    private api: any;
-    private chartTitle: any;
-    private data: any;
-    private showMaximizeControl: boolean = false;
-    private startMaximized: boolean = false;
-    private templates: any;
+    minLabels: number;
+    forceAtlasDuration: number;
+    edgeWeightInfluence: boolean;
+    options: any;
+    detailStyle: any;
+    communities: any;
+    api: any;
+    chartTitle: any;
+    data: any;
+    showMaximizeControl: boolean = false;
+    startMaximized: boolean = false;
+    templates: any;
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.chartExampleHtml,
         htmlAttributes: {
             'ng-controller': 'SocialCtrl as vm'

--- a/docs/app/pages/charts/sections/spark-charts/spark-chart-ng1/spark-chart-ng1.component.ts
+++ b/docs/app/pages/charts/sections/spark-charts/spark-chart-ng1/spark-chart-ng1.component.ts
@@ -12,9 +12,9 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('ChartsSparkChartNg1Component')
 export class ChartsSparkChartNg1Component extends BaseDocumentationSection implements ICodePenProvider {
 
-    private charts: ISparkChart[];
+    charts: ISparkChart[];
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.chartHtml,
         htmlAttributes: {
             'ng-controller': 'SparkChartCtrl as vm'

--- a/docs/app/pages/charts/sections/timeline-chart/timeline-chart-ng1/timeline-chart-ng1.component.ts
+++ b/docs/app/pages/charts/sections/timeline-chart/timeline-chart-ng1/timeline-chart-ng1.component.ts
@@ -13,12 +13,12 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('ChartsTimelineChartNg1Component')
 export class ChartsTimelineChartNg1Component extends BaseDocumentationSection implements ICodePenProvider {
 
-    private timelineData: any;
-    private timelineOptions: any;
-    private detailedData: any;
-    private detailedOptions: any;
+    timelineData: any;
+    timelineOptions: any;
+    detailedData: any;
+    detailedOptions: any;
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.chartHtml,
         htmlAttributes: {
             'ng-controller': 'TimelineChartCtrl as tc'

--- a/docs/app/pages/components/sections/buttons/checkbox-buttons-ng1/checkbox-buttons-ng1.component.ts
+++ b/docs/app/pages/components/sections/buttons/checkbox-buttons-ng1/checkbox-buttons-ng1.component.ts
@@ -11,7 +11,7 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('ComponentsCheckboxButtonsNg1Component')
 export class ComponentsCheckboxButtonsNg1Component extends BaseDocumentationSection implements ICodePenProvider {
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.checkboxButtonsHtml,
         htmlAttributes: {
             'ng-controller': 'CheckboxButtonsCtrl as vm'

--- a/docs/app/pages/components/sections/buttons/dropdown-ng1/dropdown-ng1.component.ts
+++ b/docs/app/pages/components/sections/buttons/dropdown-ng1/dropdown-ng1.component.ts
@@ -13,7 +13,7 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('ComponentsDropdownNg1Component')
 export class ComponentsDropdownNg1Component extends BaseDocumentationSection implements ICodePenProvider {
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.dropdownHtml + '\n' + this.snippets.raw.dropdownMenuHtml,
         htmlAttributes: {
             'ng-controller': 'DropdownCtrl as vm'

--- a/docs/app/pages/components/sections/buttons/dropdowns/dropdowns.component.ts
+++ b/docs/app/pages/components/sections/buttons/dropdowns/dropdowns.component.ts
@@ -12,7 +12,7 @@ import { IPlunk, MAPPINGS } from '../../../../../interfaces/IPlunk';
 @DocumentationSectionComponent('ComponentsDropdownsComponent')
 export class ComponentsDropdownsComponent extends BaseDocumentationSection implements IPlunkProvider {
 
-    public cases = [
+    cases = [
         'Alpha',
         'Beta',
         'Gamma',
@@ -26,9 +26,9 @@ export class ComponentsDropdownsComponent extends BaseDocumentationSection imple
         'Alpha 2',
         'Alpha 3',
     ];
-    public caseFilter = '';
+    caseFilter = '';
 
-    public plunk: IPlunk = {
+    plunk: IPlunk = {
         files: {
             'app.component.html': this.snippets.raw.appHtml,
             'app.component.css': this.snippets.raw.appCss,

--- a/docs/app/pages/components/sections/buttons/dropdowns/snippets/app.ts
+++ b/docs/app/pages/components/sections/buttons/dropdowns/snippets/app.ts
@@ -5,7 +5,7 @@ import { Component } from '@angular/core';
     styleUrls: ['./src/app.component.css']
 })
 export class AppComponent {
-    public cases = [
+    cases = [
         'Alpha',
         'Beta',
         'Gamma',
@@ -19,5 +19,5 @@ export class AppComponent {
         'Alpha 2',
         'Alpha 3',
     ];
-    public caseFilter = '';
+    caseFilter = '';
 }

--- a/docs/app/pages/components/sections/buttons/floating-action-button-ng1/floating-action-button-ng1.component.ts
+++ b/docs/app/pages/components/sections/buttons/floating-action-button-ng1/floating-action-button-ng1.component.ts
@@ -11,7 +11,7 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('ComponentsFloatingActionButtonNg1Component')
 export class ComponentsFloatingActionButtonNg1Component extends BaseDocumentationSection implements ICodePenProvider {
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.floatingActionButtonHtml,
         htmlAttributes: {
             'ng-controller': 'FloatingActionButtonCtrl as vm'

--- a/docs/app/pages/components/sections/buttons/grouped-buttons-ng1/grouped-buttons-ng1.component.ts
+++ b/docs/app/pages/components/sections/buttons/grouped-buttons-ng1/grouped-buttons-ng1.component.ts
@@ -11,7 +11,7 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('ComponentsGroupedButtonsNg1Component')
 export class ComponentsGroupedButtonsNg1Component extends BaseDocumentationSection implements ICodePenProvider {
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.groupedButtonsTopHtml + '\n' + this.snippets.raw.groupedButtonsBottomHtml,
         htmlAttributes: {
             'ng-controller': 'GroupedButtonsCtrl as vm'

--- a/docs/app/pages/components/sections/buttons/pagination-ng1/pagination-ng1.component.ts
+++ b/docs/app/pages/components/sections/buttons/pagination-ng1/pagination-ng1.component.ts
@@ -11,7 +11,7 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('ComponentsPaginationNg1Component')
 export class ComponentsPaginationNg1Component extends BaseDocumentationSection implements ICodePenProvider {
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.paginationHtml,
         htmlAttributes: {
             'ng-controller': 'PaginationCtrl as vm'

--- a/docs/app/pages/components/sections/buttons/pagination/pagination.component.ts
+++ b/docs/app/pages/components/sections/buttons/pagination/pagination.component.ts
@@ -12,15 +12,15 @@ import { IPlunk, MAPPINGS } from '../../../../../interfaces/IPlunk';
 export class ComponentsPaginationComponent extends BaseDocumentationSection implements IPlunkProvider {
 
     // Pagination
-    public currentPage: number = 1;
-    public totalItems: number = 100;
-    public itemsPerPage: number = 10;
-    public totalPages: number;
-    public maxSize: number = 5;
-    public previousButton = `<i class="hpe-icon hpe-previous" aria-label="previous page"></i>`;
-    public nextButton = `<i class="hpe-icon hpe-next" aria-label="next page"></i>`;
+    currentPage: number = 1;
+    totalItems: number = 100;
+    itemsPerPage: number = 10;
+    totalPages: number;
+    maxSize: number = 5;
+    previousButton = `<i class="hpe-icon hpe-previous" aria-label="previous page"></i>`;
+    nextButton = `<i class="hpe-icon hpe-next" aria-label="next page"></i>`;
 
-    public plunk: IPlunk = {
+    plunk: IPlunk = {
         files: {
             'app.component.html': this.snippets.raw.appHtml,
             'app.component.ts': this.snippets.raw.appTs

--- a/docs/app/pages/components/sections/buttons/pagination/snippets/app.ts
+++ b/docs/app/pages/components/sections/buttons/pagination/snippets/app.ts
@@ -4,11 +4,11 @@ import { Component } from '@angular/core';
     templateUrl: './src/app.component.html'
 })
 export class AppComponent {
-    public currentPage: number = 1;
-    public totalItems: number = 100;
-    public itemsPerPage: number = 10;
-    public totalPages: number;
-    public maxSize: number = 5;
-    public previousButton = `<i class="hpe-icon hpe-previous" aria-label="previous page"></i>`;
-    public nextButton = `<i class="hpe-icon hpe-next" aria-label="next page"></i>`;
+    currentPage: number = 1;
+    totalItems: number = 100;
+    itemsPerPage: number = 10;
+    totalPages: number;
+    maxSize: number = 5;
+    previousButton = `<i class="hpe-icon hpe-previous" aria-label="previous page"></i>`;
+    nextButton = `<i class="hpe-icon hpe-next" aria-label="next page"></i>`;
 }

--- a/docs/app/pages/components/sections/buttons/radio-buttons-ng1/radio-buttons-ng1.component.ts
+++ b/docs/app/pages/components/sections/buttons/radio-buttons-ng1/radio-buttons-ng1.component.ts
@@ -11,7 +11,7 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('ComponentsRadioButtonsNg1Component')
 export class ComponentsRadioButtonsNg1Component extends BaseDocumentationSection implements ICodePenProvider {
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.radioButtonsHtml,
         htmlAttributes: {
             'ng-controller': 'RadioButtonsCtrl as vm'

--- a/docs/app/pages/components/sections/buttons/radio-buttons/radio-buttons.component.ts
+++ b/docs/app/pages/components/sections/buttons/radio-buttons/radio-buttons.component.ts
@@ -12,10 +12,10 @@ import { DocumentationSectionComponent } from '../../../../../decorators/documen
 export class ComponentsRadioButtonsComponent extends BaseDocumentationSection implements IPlunkProvider {
 
     // Radio model
-    public primaryRadioValue = 'left';
-    public accentRadioValue = 'left';
+    primaryRadioValue = 'left';
+    accentRadioValue = 'left';
 
-    public plunk: IPlunk = {
+    plunk: IPlunk = {
         files: {
             'app.component.html': this.snippets.raw.appHtml,
             'app.component.ts': this.snippets.raw.appTs

--- a/docs/app/pages/components/sections/buttons/radio-buttons/snippets/app.ts
+++ b/docs/app/pages/components/sections/buttons/radio-buttons/snippets/app.ts
@@ -5,6 +5,6 @@ import { Component } from '@angular/core';
 })
 export class AppComponent {
     // Radio model
-    public primaryRadioValue = 'left';
-    public accentRadioValue = 'left';
+    primaryRadioValue = 'left';
+    accentRadioValue = 'left';
 }

--- a/docs/app/pages/components/sections/buttons/single-toggle-button-ng1/single-toggle-button-ng1.component.ts
+++ b/docs/app/pages/components/sections/buttons/single-toggle-button-ng1/single-toggle-button-ng1.component.ts
@@ -11,7 +11,7 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('ComponentsSingleToggleButtonNg1Component')
 export class ComponentsSingleToggleButtonNg1Component extends BaseDocumentationSection implements ICodePenProvider {
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.singleToggleButtonHtml,
         htmlAttributes: {
             'ng-controller': 'SingleToggleButtonCtrl as vm'

--- a/docs/app/pages/components/sections/buttons/thumbnail-ng1/thumbnail-ng1.component.ts
+++ b/docs/app/pages/components/sections/buttons/thumbnail-ng1/thumbnail-ng1.component.ts
@@ -13,7 +13,7 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('ComponentsThumbnailNg1Component')
 export class ComponentsThumbnailNg1Component extends BaseDocumentationSection implements ICodePenProvider {
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.thumbnailHtml,
         htmlAttributes: {
             'ng-controller': 'ThumbnailDemoCtrl as vm'

--- a/docs/app/pages/components/sections/buttons/toggle-buttons-ng1/toggle-buttons-ng1.component.ts
+++ b/docs/app/pages/components/sections/buttons/toggle-buttons-ng1/toggle-buttons-ng1.component.ts
@@ -12,7 +12,7 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 export class ComponentsToggleButtonsNg1Component extends BaseDocumentationSection implements ICodePenProvider {
     
     
-    public codepen = {
+    codepen = {
         html: this.snippets.raw.toggleButtonsTopHtml + '\n' + this.snippets.raw.toggleButtonsBottomHtml
     };
 

--- a/docs/app/pages/components/sections/buttons/toggle-buttons/snippets/app.ts
+++ b/docs/app/pages/components/sections/buttons/toggle-buttons/snippets/app.ts
@@ -5,16 +5,17 @@ import { Component } from '@angular/core';
 })
 export class AppComponent {
     // Toggle model
-    public primaryToggleValue: number = 0;
-    public accentToggleValue: string = 'off';
+    primaryToggleValue: number = 0;
+    accentToggleValue: string = 'off';
 
     // Check model
-    public primaryCheckValue = {
+    primaryCheckValue = {
         bold: false,
         italic: true,
         underline: false
     };
-    public accentCheckValue = {
+    
+    accentCheckValue = {
         bold: false,
         italic: true,
         underline: false

--- a/docs/app/pages/components/sections/buttons/toggle-buttons/toggle-buttons.component.ts
+++ b/docs/app/pages/components/sections/buttons/toggle-buttons/toggle-buttons.component.ts
@@ -12,22 +12,23 @@ import { IPlunk, MAPPINGS } from '../../../../../interfaces/IPlunk';
 export class ComponentsToggleButtonsComponent extends BaseDocumentationSection implements IPlunkProvider {
 
     // Toggle model
-    public primaryToggleValue: number = 0;
-    public accentToggleValue: string = 'off';
+    primaryToggleValue: number = 0;
+    accentToggleValue: string = 'off';
 
     // Check model
-    public primaryCheckValue = {
+    primaryCheckValue = {
         bold: false,
         italic: true,
         underline: false
     };
-    public accentCheckValue = {
+    
+    accentCheckValue = {
         bold: false,
         italic: true,
         underline: false
     };
 
-    public plunk: IPlunk = {
+    plunk: IPlunk = {
         files: {
             'app.component.html': this.snippets.raw.toggleHtml + this.snippets.raw.checkHtml,
             'app.component.ts': this.snippets.raw.appTs

--- a/docs/app/pages/components/sections/component-list/component-list-ng1/component-list-ng1.component.ts
+++ b/docs/app/pages/components/sections/component-list/component-list-ng1/component-list-ng1.component.ts
@@ -11,7 +11,7 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('ComponentsComponentListNg1Component')
 export class ComponentsComponentListNg1Component extends BaseDocumentationSection implements ICodePenProvider {
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.componentListHtml,
         htmlAttributes: {
             'ng-controller': 'ComponentListDemoCtrl as vm'

--- a/docs/app/pages/components/sections/contacts/contacts-ng1/contacts-ng1.component.ts
+++ b/docs/app/pages/components/sections/contacts/contacts-ng1/contacts-ng1.component.ts
@@ -10,7 +10,7 @@ import { DocumentationSectionComponent } from '../../../../../decorators/documen
 })
 @DocumentationSectionComponent('ComponentsContactsNg1Component')
 export class ComponentsContactsNg1Component extends BaseDocumentationSection implements ICodePenProvider {
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.contactsHtml,
         htmlAttributes: {
             'ng-controller': 'ContactsDemoCtrl as vm'

--- a/docs/app/pages/components/sections/contacts/contacts-overflow-ng1/contacts-overflow-ng1.component.ts
+++ b/docs/app/pages/components/sections/contacts/contacts-overflow-ng1/contacts-overflow-ng1.component.ts
@@ -13,7 +13,7 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('ComponentsContactsOverflowNg1Component')
 export class ComponentsContactsOverflowNg1Component extends BaseDocumentationSection implements ICodePenProvider {
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.contactsOverflowHtml,
         htmlAttributes: {
             'ng-controller': 'ContactsOverflowDemoCtrl as vm'

--- a/docs/app/pages/components/sections/date-time-picker/date-picker-ng1/date-picker-ng1.component.ts
+++ b/docs/app/pages/components/sections/date-time-picker/date-picker-ng1/date-picker-ng1.component.ts
@@ -16,7 +16,7 @@ export class ComponentsDatePickerNg1Component extends BaseDocumentationSection i
         super(require.context('./snippets/', false, /\.(html|css|js|ts)$/));
     }
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.sampleHtml,
         htmlAttributes: {
             'ng-controller': 'DatePickerCtrl as vm'

--- a/docs/app/pages/components/sections/date-time-picker/date-range-picker-ng1/date-range-picker-ng1.component.ts
+++ b/docs/app/pages/components/sections/date-time-picker/date-range-picker-ng1/date-range-picker-ng1.component.ts
@@ -16,7 +16,7 @@ export class ComponentsDateRangePickerNg1Component extends BaseDocumentationSect
         super(require.context('./snippets/', false, /\.(html|css|js|ts)$/));
     }
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.sampleHtml,
         htmlAttributes: {
             'ng-controller': 'DateRangePickerCtrl as vm'

--- a/docs/app/pages/components/sections/date-time-picker/integrated-date-picker-ng1/integrated-date-picker-ng1.component.ts
+++ b/docs/app/pages/components/sections/date-time-picker/integrated-date-picker-ng1/integrated-date-picker-ng1.component.ts
@@ -16,7 +16,7 @@ export class ComponentsIntegratedDatePickerNg1Component extends BaseDocumentatio
         super(require.context('./snippets/', false, /\.(html|css|js|ts)$/));
     }
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.sampleHtml,
         htmlAttributes: {
             'ng-controller': 'IntegratedDatePickerCtrl as vm'

--- a/docs/app/pages/components/sections/date-time-picker/time-picker-ng1/time-picker-ng1.component.ts
+++ b/docs/app/pages/components/sections/date-time-picker/time-picker-ng1/time-picker-ng1.component.ts
@@ -16,7 +16,7 @@ export class ComponentsTimePickerNg1Component extends BaseDocumentationSection i
         super(require.context('./snippets/', false, /\.(html|css|js|ts)$/));
     }
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.sampleHtml,
         htmlAttributes: {
             'ng-controller': 'TimePickerCtrl as vm'

--- a/docs/app/pages/components/sections/draggable-cards/draggable-cards-list-view-ng1/draggable-cards-list-view-ng1.component.ts
+++ b/docs/app/pages/components/sections/draggable-cards/draggable-cards-list-view-ng1/draggable-cards-list-view-ng1.component.ts
@@ -13,7 +13,7 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('ComponentsDraggableCardsListViewNg1Component')
 export class ComponentsDraggableCardsListViewNg1Component extends BaseDocumentationSection implements ICodePenProvider {
     
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.draggableCardsListViewHtml,
         htmlAttributes: {
             'ng-controller': 'DraggableCardsListViewDemoCtrl as vm'

--- a/docs/app/pages/components/sections/draggable-cards/draggable-cards-ng1/draggable-cards-ng1.component.ts
+++ b/docs/app/pages/components/sections/draggable-cards/draggable-cards-ng1/draggable-cards-ng1.component.ts
@@ -13,7 +13,7 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('ComponentsDraggableCardsNg1Component')
 export class ComponentsDraggableCardsNg1Component extends BaseDocumentationSection implements ICodePenProvider {
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.draggableCardsHtml,
         htmlAttributes: {
             'ng-controller': 'DraggableCardsDemoCtrl as vm'

--- a/docs/app/pages/components/sections/draggable-panels/draggable-panels-ng1/draggable-panels-ng1.component.ts
+++ b/docs/app/pages/components/sections/draggable-panels/draggable-panels-ng1/draggable-panels-ng1.component.ts
@@ -11,7 +11,7 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('ComponentsDraggablePanelsNg1Component')
 export class ComponentsDraggablePanelsNg1Component extends BaseDocumentationSection implements ICodePenProvider {
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.draggablePanelsHtml
     };
     

--- a/docs/app/pages/components/sections/draggable-panels/draggable-panels-views-ng1/draggable-panels-views-ng1.component.ts
+++ b/docs/app/pages/components/sections/draggable-panels/draggable-panels-views-ng1/draggable-panels-views-ng1.component.ts
@@ -13,7 +13,7 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('ComponentsDraggablePanelsViewsNg1Component')
 export class ComponentsDraggablePanelsViewsNg1Component extends BaseDocumentationSection implements ICodePenProvider {
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.draggablePanelsViewsHtml,
         htmlAttributes: {
             'ng-controller': 'DraggablePanelsViewsDemoCtrl as vm'

--- a/docs/app/pages/components/sections/facets/facet-line-chart-ng1/facet-line-chart-ng1.component.ts
+++ b/docs/app/pages/components/sections/facets/facet-line-chart-ng1/facet-line-chart-ng1.component.ts
@@ -11,7 +11,7 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('ComponentsFacetLineChartNg1Component')
 export class ComponentsFacetLineChartNg1Component extends BaseDocumentationSection implements ICodePenProvider {
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.appHtml,
         js: [this.snippets.raw.appJs],
         css: [this.snippets.raw.appCss]

--- a/docs/app/pages/components/sections/facets/facet-typeahead-list/facet-typeahead-list.component.ts
+++ b/docs/app/pages/components/sections/facets/facet-typeahead-list/facet-typeahead-list.component.ts
@@ -18,7 +18,7 @@ export class ComponentsFacetTypeaheadListComponent extends BaseDocumentationSect
     facets: Observable<Facet[]>;
     suggestions: Facet[] = [];
 
-    private users: Facet[] = [];
+    users: Facet[] = [];
 
     plunk: IPlunk = {
         files: {

--- a/docs/app/pages/components/sections/facets/facet-typeahead-list/snippets/app.ts
+++ b/docs/app/pages/components/sections/facets/facet-typeahead-list/snippets/app.ts
@@ -13,7 +13,7 @@ export class AppComponent {
     facets: Observable<Facet[]>;
     suggestions: Facet[] = [];
 
-    private users: Facet[] = [];
+    users: Facet[] = [];
 
     constructor() {
 

--- a/docs/app/pages/components/sections/file-upload/file-upload-ng1/file-upload-ng1.component.ts
+++ b/docs/app/pages/components/sections/file-upload/file-upload-ng1/file-upload-ng1.component.ts
@@ -11,7 +11,7 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('ComponentsFileUploadNg1Component')
 export class ComponentsFileUploadNg1Component extends BaseDocumentationSection implements ICodePenProvider {
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.appHtml,
         js: [this.snippets.raw.appJs],
         css: [this.snippets.raw.appCss]

--- a/docs/app/pages/components/sections/flippable-cards/flippable-cards-ng1/flippable-cards-ng1.component.ts
+++ b/docs/app/pages/components/sections/flippable-cards/flippable-cards-ng1/flippable-cards-ng1.component.ts
@@ -11,7 +11,7 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('ComponentsFlippableCardsNg1Component')
 export class ComponentsFlippableCardsNg1Component extends BaseDocumentationSection implements ICodePenProvider {
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.appHtml,
         htmlAttributes: {
             'ng-controller': 'FlippableCardCtrl as vm'

--- a/docs/app/pages/components/sections/grid/grid-ng1/grid-ng1.component.ts
+++ b/docs/app/pages/components/sections/grid/grid-ng1/grid-ng1.component.ts
@@ -11,7 +11,7 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('ComponentsGridNg1Component')
 export class ComponentsGridNg1Component extends BaseDocumentationSection implements ICodePenProvider {
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.appHtml,
         htmlAttributes: {
             'ng-controller': 'GridDemoCtrl as vm'

--- a/docs/app/pages/components/sections/hierarchy-bar/hierarchy-bar-ng1/hierarchy-bar-ng1.component.ts
+++ b/docs/app/pages/components/sections/hierarchy-bar/hierarchy-bar-ng1/hierarchy-bar-ng1.component.ts
@@ -11,7 +11,7 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('ComponentsHierarchyBarNg1Component')
 export class ComponentsHierarchyBarNg1Component extends BaseDocumentationSection implements ICodePenProvider {
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.appHtml,
         htmlAttributes: {
             'ng-controller': 'HierarchyBarDemoCtrl as vm'

--- a/docs/app/pages/components/sections/input-controls/checkbox-ng1/checkbox-ng1.component.ts
+++ b/docs/app/pages/components/sections/input-controls/checkbox-ng1/checkbox-ng1.component.ts
@@ -16,7 +16,7 @@ export class ComponentsCheckboxNg1Component extends BaseDocumentationSection imp
         super(require.context('./snippets/', false, /\.(html|css|js|ts)$/));
     }
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.sampleHtml,
         htmlAttributes: {
             'ng-controller': 'CheckboxDemoCtrl as vm'

--- a/docs/app/pages/components/sections/input-controls/checkbox/checkbox.component.ts
+++ b/docs/app/pages/components/sections/input-controls/checkbox/checkbox.component.ts
@@ -11,13 +11,13 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('ComponentsCheckboxComponent')
 export class ComponentsCheckboxComponent extends BaseDocumentationSection implements IPlunkProvider {
 
-    public checkModel: any;
-    public simplified: boolean;
-    public indeterminateValue: number;
-    public disableCheck: boolean;
+    checkModel: any;
+    simplified: boolean;
+    indeterminateValue: number;
+    disableCheck: boolean;
 
-    public sliderValue: number = 50;
-    public sliderOptions: any = {
+    sliderValue: number = 50;
+    sliderOptions: any = {
         type: 'value',
         handles: {
             style: 'button',
@@ -61,7 +61,7 @@ export class ComponentsCheckboxComponent extends BaseDocumentationSection implem
         }
     };
 
-    public plunk: IPlunk = {
+    plunk: IPlunk = {
         files: {
             'app.component.ts': this.snippets.raw.appTs,
             'app.component.html': this.snippets.raw.appHtml

--- a/docs/app/pages/components/sections/input-controls/checkbox/snippets/app.ts
+++ b/docs/app/pages/components/sections/input-controls/checkbox/snippets/app.ts
@@ -5,14 +5,14 @@ import { Component } from '@angular/core';
     templateUrl: './src/app.component.html'
 })
 export class AppComponent {
-    private checkModel = {
+    checkModel = {
         option1: true,
         option2: false,
         option3: false,
         option4: false
     };
 
-    private simplified = false;
-    private indeterminateValue = -1;
-    private disableCheck = false;
+    simplified = false;
+    indeterminateValue = -1;
+    disableCheck = false;
 }

--- a/docs/app/pages/components/sections/input-controls/custom-dropdown-ng1/custom-dropdown-ng1.component.ts
+++ b/docs/app/pages/components/sections/input-controls/custom-dropdown-ng1/custom-dropdown-ng1.component.ts
@@ -16,7 +16,7 @@ export class ComponentsCustomDropdownNg1Component extends BaseDocumentationSecti
         super(require.context('./snippets/', false, /\.(html|css|js|ts)$/));
     }
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.sampleHtml,
         htmlTemplates: [{
             id: 'template.html',

--- a/docs/app/pages/components/sections/input-controls/expanding-text-area-ng1/expanding-text-area-ng1.component.ts
+++ b/docs/app/pages/components/sections/input-controls/expanding-text-area-ng1/expanding-text-area-ng1.component.ts
@@ -16,7 +16,7 @@ export class ComponentsExpandingTextAreaNg1Component extends BaseDocumentationSe
         super(require.context('./snippets/', false, /\.(html|css|js|ts)$/));
     }
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.sampleHtml
     };
 

--- a/docs/app/pages/components/sections/input-controls/inline-dropdown-ng1/inline-dropdown-ng1.component.ts
+++ b/docs/app/pages/components/sections/input-controls/inline-dropdown-ng1/inline-dropdown-ng1.component.ts
@@ -16,7 +16,7 @@ export class ComponentsInlineDropdownNg1Component extends BaseDocumentationSecti
         super(require.context('./snippets/', false, /\.(html|css|js|ts)$/));
     }
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.sampleHtml,
         htmlAttributes: {
             'ng-controller': 'InlineDropDownCtrl as vm'

--- a/docs/app/pages/components/sections/input-controls/input-expand-ng1/input-expand-ng1.component.ts
+++ b/docs/app/pages/components/sections/input-controls/input-expand-ng1/input-expand-ng1.component.ts
@@ -16,7 +16,7 @@ export class ComponentsInputExpandNg1Component extends BaseDocumentationSection 
         super(require.context('./snippets/', false, /\.(html|css|js|ts)$/));
     }
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.sampleHtml,
         htmlAttributes: {
             'ng-controller': 'InputExpandCtrl as vm'

--- a/docs/app/pages/components/sections/input-controls/input-mask-ng1/input-mask-ng1.component.ts
+++ b/docs/app/pages/components/sections/input-controls/input-mask-ng1/input-mask-ng1.component.ts
@@ -16,7 +16,7 @@ export class ComponentsInputMaskNg1Component extends BaseDocumentationSection im
         super(require.context('./snippets/', false, /\.(html|css|js|ts)$/));
     }
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.sampleHtml,
         htmlAttributes: {
             'ng-controller': 'InputMaskCtrl as vm'

--- a/docs/app/pages/components/sections/input-controls/number-picker-ng1/number-picker-ng1.component.ts
+++ b/docs/app/pages/components/sections/input-controls/number-picker-ng1/number-picker-ng1.component.ts
@@ -16,7 +16,7 @@ export class ComponentsNumberPickerNg1Component extends BaseDocumentationSection
         super(require.context('./snippets/', false, /\.(html|css|js|ts)$/));
     }
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.sampleHtml,
         htmlAttributes: {
             'ng-controller': 'NumberPickerCtrl as vm'

--- a/docs/app/pages/components/sections/input-controls/radio-button-ng1/radio-button-ng1.component.ts
+++ b/docs/app/pages/components/sections/input-controls/radio-button-ng1/radio-button-ng1.component.ts
@@ -16,7 +16,7 @@ export class ComponentsRadioButtonNg1Component extends BaseDocumentationSection 
         super(require.context('./snippets/', false, /\.(html|css|js|ts)$/));
     }
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.sampleHtml,
         htmlAttributes: {
             'ng-controller': 'RadioButtonCtrl as vm'

--- a/docs/app/pages/components/sections/input-controls/slider-charts-ng1/slider-charts-ng1.component.ts
+++ b/docs/app/pages/components/sections/input-controls/slider-charts-ng1/slider-charts-ng1.component.ts
@@ -15,7 +15,7 @@ export class ComponentsSliderChartsNg1Component extends BaseDocumentationSection
         super(require.context('./snippets/', false, /\.(html|css|js|ts)$/));
     }
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.codepenHtml,
         htmlAttributes: {
             'ng-controller': 'SlidersChartsCtrl as vm'

--- a/docs/app/pages/components/sections/input-controls/sliders-ng1/sliders-ng1.component.ts
+++ b/docs/app/pages/components/sections/input-controls/sliders-ng1/sliders-ng1.component.ts
@@ -16,7 +16,7 @@ export class ComponentsSlidersNg1Component extends BaseDocumentationSection impl
         super(require.context('./snippets/', false, /\.(html|css|js|ts)$/));
     }
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.codepenHtml,
         htmlAttributes: {
             'ng-controller': 'SlidersCtrl as vm'

--- a/docs/app/pages/components/sections/input-controls/tags-ng1/tags-ng1.component.ts
+++ b/docs/app/pages/components/sections/input-controls/tags-ng1/tags-ng1.component.ts
@@ -16,7 +16,7 @@ export class ComponentsTagsNg1Component extends BaseDocumentationSection impleme
         super(require.context('./snippets/', false, /\.(html|css|js|ts)$/));
     }
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.codepenHtml,
         htmlAttributes: {
             'ng-controller': 'TagsCtrl as vm'

--- a/docs/app/pages/components/sections/input-controls/tags/tags.component.ts
+++ b/docs/app/pages/components/sections/input-controls/tags/tags.component.ts
@@ -48,7 +48,7 @@ export class ComponentsTagsComponent extends BaseDocumentationSection implements
     dropDirection: 'up' | 'down' = 'down';
     showTypeaheadOnClick: boolean = false;
 
-    public plunk: IPlunk = {
+    plunk: IPlunk = {
         files: {
             'app.component.ts': this.snippets.raw.appTs,
             'app.component.html': this.snippets.raw.appHtml

--- a/docs/app/pages/components/sections/input-controls/toggle-switch-ng1/toggle-switch-ng1.component.ts
+++ b/docs/app/pages/components/sections/input-controls/toggle-switch-ng1/toggle-switch-ng1.component.ts
@@ -16,7 +16,7 @@ export class ComponentsToggleSwitchNg1Component extends BaseDocumentationSection
         super(require.context('./snippets/', false, /\.(html|css|js|ts)$/));
     }
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.sampleHtml,
         htmlAttributes: {
             'ng-controller': 'ToggleSwitchDemoCtrl as vm'

--- a/docs/app/pages/components/sections/input-controls/toggleswitch/snippets/app.ts
+++ b/docs/app/pages/components/sections/input-controls/toggleswitch/snippets/app.ts
@@ -5,16 +5,16 @@ import { Component } from '@angular/core';
     templateUrl: './src/app.component.html'
 })
 export class AppComponent {
-    public toggleSwitches: any;
-    public toggleSwitchDisable: boolean;
+    toggleSwitches: any;
+    toggleSwitchDisable: boolean;
 
     constructor() {
 
         this.toggleSwitches = {
-        option1: true,
-        option2: false,
-        option3: false,
-        option4: false
+            option1: true,
+            option2: false,
+            option3: false,
+            option4: false
         };
 
         this.toggleSwitchDisable = false;

--- a/docs/app/pages/components/sections/input-controls/toggleswitch/toggleswitch.component.ts
+++ b/docs/app/pages/components/sections/input-controls/toggleswitch/toggleswitch.component.ts
@@ -11,10 +11,10 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('ComponentsToggleSwitchComponent')
 export class ComponentsToggleSwitchComponent extends BaseDocumentationSection  implements IPlunkProvider {
 
-  public toggleSwitches: any;
-  public toggleSwitchDisable: boolean;
+  toggleSwitches: any;
+  toggleSwitchDisable: boolean;
 
-  public plunk: IPlunk = {
+  plunk: IPlunk = {
       files: {
           'app.component.ts': this.snippets.raw.appTs,
           'app.component.html': this.snippets.raw.appHtml

--- a/docs/app/pages/components/sections/keyboard/hotkeys-ng1/hotkeys-ng1.component.ts
+++ b/docs/app/pages/components/sections/keyboard/hotkeys-ng1/hotkeys-ng1.component.ts
@@ -13,7 +13,7 @@ import { DocumentationSectionComponent } from '../../../../../decorators/documen
 })
 @DocumentationSectionComponent('ComponentsHotkeysNg1Component')
 export class ComponentsHotkeysNg1Component extends BaseDocumentationSection implements ICodePenProvider {
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.layoutHtml,
         htmlAttributes: {
             'ng-controller': 'HotkeysDemoCtrl as vm'

--- a/docs/app/pages/components/sections/keyboard/keyboard-service-ng1/keyboard-service-ng1.component.ts
+++ b/docs/app/pages/components/sections/keyboard/keyboard-service-ng1/keyboard-service-ng1.component.ts
@@ -11,7 +11,7 @@ import { DocumentationSectionComponent } from '../../../../../decorators/documen
 })
 @DocumentationSectionComponent('ComponentsKeyboardServiceNg1Component')
 export class ComponentsKeyboardServiceNg1Component extends BaseDocumentationSection implements ICodePenProvider {
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.layoutHtml,
         htmlAttributes: {
             'ng-controller': 'KeyboardServiceDemoCtrl as vm'

--- a/docs/app/pages/components/sections/modals/marquee-modal-ng1/marquee-modal-ng1.component.ts
+++ b/docs/app/pages/components/sections/modals/marquee-modal-ng1/marquee-modal-ng1.component.ts
@@ -13,7 +13,7 @@ import { DocumentationSectionComponent } from '../../../../../decorators/documen
 })
 @DocumentationSectionComponent('ComponentsMarqueeModalNg1Component')
 export class ComponentsMarqueeModalNg1Component extends BaseDocumentationSection implements ICodePenProvider {
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.layoutHtml,
         htmlAttributes: {
             'ng-controller': 'MarqueeModalDemoCtrl as vm'

--- a/docs/app/pages/components/sections/modals/modal-ng1/modal-ng1.component.ts
+++ b/docs/app/pages/components/sections/modals/modal-ng1/modal-ng1.component.ts
@@ -11,7 +11,7 @@ import { DocumentationSectionComponent } from '../../../../../decorators/documen
 })
 @DocumentationSectionComponent('ComponentsModalNg1Component')
 export class ComponentsModalNg1Component extends BaseDocumentationSection implements ICodePenProvider {
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.layoutHtml,
         htmlAttributes: {
             'ng-controller': 'ModalDemoCtrl as vm'

--- a/docs/app/pages/components/sections/modals/side-modal-ng1/side-modal-ng1.component.ts
+++ b/docs/app/pages/components/sections/modals/side-modal-ng1/side-modal-ng1.component.ts
@@ -13,7 +13,7 @@ import { DocumentationSectionComponent } from '../../../../../decorators/documen
 })
 @DocumentationSectionComponent('ComponentsSideModalNg1Component')
 export class ComponentsSideModalNg1Component extends BaseDocumentationSection implements ICodePenProvider {
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.layoutHtml,
         htmlAttributes: {
             'ng-controller': 'SideModalDemoCtrl as vm'

--- a/docs/app/pages/components/sections/modals/square-modal-ng1/square-modal-ng1.component.ts
+++ b/docs/app/pages/components/sections/modals/square-modal-ng1/square-modal-ng1.component.ts
@@ -12,7 +12,7 @@ import { DocumentationSectionComponent } from '../../../../../decorators/documen
 })
 @DocumentationSectionComponent('ComponentsSquareModalNg1Component')
 export class ComponentsSquareModalNg1Component extends BaseDocumentationSection implements ICodePenProvider {
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.layoutHtml,
         htmlAttributes: {
             'ng-controller': 'SquareModalDemoCtrl as vm'

--- a/docs/app/pages/components/sections/notifications/alert-styles-ng1/alert-styles-ng1.component.ts
+++ b/docs/app/pages/components/sections/notifications/alert-styles-ng1/alert-styles-ng1.component.ts
@@ -11,7 +11,7 @@ import { DocumentationSectionComponent } from '../../../../../decorators/documen
 })
 @DocumentationSectionComponent('ComponentsAlertStylesNg1Component')
 export class ComponentsAlertStylesNg1Component extends BaseDocumentationSection implements ICodePenProvider {
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.layoutHtml,
         htmlAttributes: {
             'ng-controller': 'AlertStylesDemoCtrl as vm'

--- a/docs/app/pages/components/sections/notifications/dismissable-styles-ng1/dismissable-styles-ng1.component.ts
+++ b/docs/app/pages/components/sections/notifications/dismissable-styles-ng1/dismissable-styles-ng1.component.ts
@@ -11,7 +11,7 @@ import { DocumentationSectionComponent } from '../../../../../decorators/documen
 })
 @DocumentationSectionComponent('ComponentsDismissableStylesNg1Component')
 export class ComponentsDismissableStylesNg1Component extends BaseDocumentationSection implements ICodePenProvider {
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.layoutHtml,
         htmlAttributes: {
             'ng-controller': 'DismissableStylesDemoCtrl as vm'

--- a/docs/app/pages/components/sections/notifications/notification-dropdown-ng1/notification-dropdown-ng1.component.ts
+++ b/docs/app/pages/components/sections/notifications/notification-dropdown-ng1/notification-dropdown-ng1.component.ts
@@ -11,7 +11,7 @@ import { DocumentationSectionComponent } from '../../../../../decorators/documen
 })
 @DocumentationSectionComponent('ComponentsNotificationDropdownNg1Component')
 export class ComponentsNotificationDropdownNg1Component extends BaseDocumentationSection implements ICodePenProvider {
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.layoutHtml,
         htmlAttributes: {
             'ng-controller': 'NotificationDropdownDemoCtrl as vm'

--- a/docs/app/pages/components/sections/notifications/notification-list-ng1/notification-list-ng1.component.ts
+++ b/docs/app/pages/components/sections/notifications/notification-list-ng1/notification-list-ng1.component.ts
@@ -13,7 +13,7 @@ import { DocumentationSectionComponent } from '../../../../../decorators/documen
 })
 @DocumentationSectionComponent('ComponentsNotificationListNg1Component')
 export class ComponentsNotificationListNg1Component extends BaseDocumentationSection implements ICodePenProvider {
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.layoutHtml,
         htmlAttributes: {
             'ng-controller': 'NotificationListDemoCtrl as vm'

--- a/docs/app/pages/components/sections/notifications/notifications-ng1/notifications-ng1.component.ts
+++ b/docs/app/pages/components/sections/notifications/notifications-ng1/notifications-ng1.component.ts
@@ -13,7 +13,7 @@ import { DocumentationSectionComponent } from '../../../../../decorators/documen
 })
 @DocumentationSectionComponent('ComponentsNotificationsNg1Component')
 export class ComponentsNotificationsNg1Component extends BaseDocumentationSection implements ICodePenProvider {
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.layoutHtml,
         htmlAttributes: {
             'ng-controller': 'NotificationsDemoCtrl as vm'

--- a/docs/app/pages/components/sections/panels/collapsible-panels-ng1/collapsible-panels-ng1.component.ts
+++ b/docs/app/pages/components/sections/panels/collapsible-panels-ng1/collapsible-panels-ng1.component.ts
@@ -11,7 +11,7 @@ import { DocumentationSectionComponent } from '../../../../../decorators/documen
 })
 @DocumentationSectionComponent('ComponentsCollapsiblePanelsNg1Component')
 export class ComponentsCollapsiblePanelsNg1Component extends BaseDocumentationSection implements ICodePenProvider {
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.layoutHtml,
         htmlAttributes: {
             'ng-controller': 'CollapsiblePanelsDemoCtrl as vm'

--- a/docs/app/pages/components/sections/panels/item-display-panel-inline/item-display-panel-inline.component.ts
+++ b/docs/app/pages/components/sections/panels/item-display-panel-inline/item-display-panel-inline.component.ts
@@ -114,7 +114,7 @@ export class ComponentsItemDisplayPanelInlineComponent extends BaseDocumentation
         }
     }
 
-    public plunk: IPlunk = {
+    plunk: IPlunk = {
         files: {
             'app.component.ts': this.snippets.raw.appTs,
             'app.component.html': this.snippets.raw.appHtml,

--- a/docs/app/pages/components/sections/panels/item-display-panel-ng1/item-display-panel-ng1.component.ts
+++ b/docs/app/pages/components/sections/panels/item-display-panel-ng1/item-display-panel-ng1.component.ts
@@ -11,7 +11,7 @@ import { DocumentationSectionComponent } from '../../../../../decorators/documen
 })
 @DocumentationSectionComponent('ComponentsItemDisplayPanelNg1Component')
 export class ComponentsItemDisplayPanelNg1Component extends BaseDocumentationSection implements ICodePenProvider {
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.layoutHtml,
         htmlAttributes: {
             'ng-controller': 'ItemDisplayPanelDemoCtrl as vm'

--- a/docs/app/pages/components/sections/panels/item-display-panel/item-display-panel.component.ts
+++ b/docs/app/pages/components/sections/panels/item-display-panel/item-display-panel.component.ts
@@ -154,7 +154,7 @@ export class ComponentsItemDisplayPanelComponent extends BaseDocumentationSectio
         }
     }
 
-    public plunk: IPlunk = {
+    plunk: IPlunk = {
         files: {
             'app.component.ts': this.snippets.raw.appTs,
             'app.component.html': this.snippets.raw.appHtml

--- a/docs/app/pages/components/sections/panels/modal-inset-panel-ng1/item-display-panel-ng1.component.ts
+++ b/docs/app/pages/components/sections/panels/modal-inset-panel-ng1/item-display-panel-ng1.component.ts
@@ -13,7 +13,7 @@ import { DocumentationSectionComponent } from '../../../../../decorators/documen
 })
 @DocumentationSectionComponent('ComponentsModalInsetPanelNg1Component')
 export class ComponentsModalInsetPanelNg1Component extends BaseDocumentationSection implements ICodePenProvider {
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.layoutHtml,
         htmlAttributes: {
             'ng-controller': 'ModalInsetPanelDemoCtrl as vm'

--- a/docs/app/pages/components/sections/panels/side-inset-panel-ng1/side-inset-panel-ng1.component.ts
+++ b/docs/app/pages/components/sections/panels/side-inset-panel-ng1/side-inset-panel-ng1.component.ts
@@ -11,7 +11,7 @@ import { DocumentationSectionComponent } from '../../../../../decorators/documen
 })
 @DocumentationSectionComponent('ComponentsSideInsetPanelNg1Component')
 export class ComponentsSideInsetPanelNg1Component extends BaseDocumentationSection implements ICodePenProvider {
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.layoutHtml,
         htmlAttributes: {
             'id': 'ux-codepen-container-ns'

--- a/docs/app/pages/components/sections/popover/popover-ng1/popover-ng1.component.ts
+++ b/docs/app/pages/components/sections/popover/popover-ng1/popover-ng1.component.ts
@@ -13,7 +13,7 @@ import { DocumentationSectionComponent } from '../../../../../decorators/documen
 })
 @DocumentationSectionComponent('ComponentsPopoverNg1Component')
 export class ComponentsPopoverNg1Component extends BaseDocumentationSection implements ICodePenProvider {
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.layoutHtml,
         htmlAttributes: {
             'ng-controller': 'PopoverDemoCtrl as vm'

--- a/docs/app/pages/components/sections/progress/progress-bar-ng1/progress-bar-ng1.component.ts
+++ b/docs/app/pages/components/sections/progress/progress-bar-ng1/progress-bar-ng1.component.ts
@@ -11,7 +11,7 @@ import { DocumentationSectionComponent } from '../../../../../decorators/documen
 })
 @DocumentationSectionComponent('ComponentsProgressBarNg1Component')
 export class ComponentsProgressBarNg1Component extends BaseDocumentationSection implements ICodePenProvider {
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.layoutHtml,
         htmlAttributes: {
             'ng-controller': 'ProgressBarDemoCtrl as vm'

--- a/docs/app/pages/components/sections/scrollbar/custom-scrollbar-ng1/custom-scrollbar-ng1.component.ts
+++ b/docs/app/pages/components/sections/scrollbar/custom-scrollbar-ng1/custom-scrollbar-ng1.component.ts
@@ -13,7 +13,7 @@ import { DocumentationSectionComponent } from '../../../../../decorators/documen
 })
 @DocumentationSectionComponent('ComponentsCustomScrollbarNg1Component')
 export class ComponentsCustomScrollbarNg1Component extends BaseDocumentationSection implements ICodePenProvider {
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.layoutHtml,
         htmlAttributes: {
             'ng-controller': 'CustomScrollbarDemoCtrl as vm'

--- a/docs/app/pages/components/sections/scrollbar/infinite-scroll-load-more-ng1/infinite-scroll-load-more-ng1.component.ts
+++ b/docs/app/pages/components/sections/scrollbar/infinite-scroll-load-more-ng1/infinite-scroll-load-more-ng1.component.ts
@@ -13,7 +13,7 @@ import { DocumentationSectionComponent } from '../../../../../decorators/documen
 })
 @DocumentationSectionComponent('ComponentsInfiniteScrollLoadMoreNg1Component')
 export class ComponentsInfiniteScrollLoadMoreNg1Component extends BaseDocumentationSection implements ICodePenProvider {
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.layoutHtml,
         htmlAttributes: {
             'ng-controller': 'InfiniteScrollLoadMoreDemoCtrl as vm'

--- a/docs/app/pages/components/sections/scrollbar/infinite-scroll-ng1/infinite-scroll-ng1.component.ts
+++ b/docs/app/pages/components/sections/scrollbar/infinite-scroll-ng1/infinite-scroll-ng1.component.ts
@@ -14,7 +14,7 @@ import { DocumentationSectionComponent } from '../../../../../decorators/documen
 @DocumentationSectionComponent('ComponentsInfiniteScrollNg1Component')
 export class ComponentsInfiniteScrollNg1Component extends BaseDocumentationSection implements ICodePenProvider {
     
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.layoutHtml,
         htmlAttributes: {
             'ng-controller': 'InfiniteScrollDemoCtrl as vm'

--- a/docs/app/pages/components/sections/scrollbar/infinite-scroll/infinite-scroll.component.ts
+++ b/docs/app/pages/components/sections/scrollbar/infinite-scroll/infinite-scroll.component.ts
@@ -61,7 +61,7 @@ export class ComponentsInfiniteScrollComponent extends BaseDocumentationSection 
         return (e.name.toLowerCase().indexOf(normalisedFilter) >= 0);
     }
 
-    public plunk: IPlunk = {
+    plunk: IPlunk = {
         files: {
             'app.component.ts': this.snippets.raw.appTs,
             'app.component.html': this.snippets.raw.appHtml,

--- a/docs/app/pages/components/sections/scrollbar/virtual-scroll/snippets/app.ts
+++ b/docs/app/pages/components/sections/scrollbar/virtual-scroll/snippets/app.ts
@@ -1,6 +1,6 @@
-import 'chance';
-import { Component, ViewChild } from '@angular/core';
+import { Component } from '@angular/core';
 import { Subject } from 'rxjs/Subject';
+import 'chance';
 
 const DEPARTMENTS = ['Finance', 'Operations', 'Investor Relations', 'Technical', 'Auditing', 'Labs'];
 

--- a/docs/app/pages/components/sections/scrollbar/virtual-scroll/virtual-scroll.component.ts
+++ b/docs/app/pages/components/sections/scrollbar/virtual-scroll/virtual-scroll.component.ts
@@ -1,7 +1,7 @@
 import 'chance';
 import { BaseDocumentationSection} from '../../../../../components/base-documentation-section/base-documentation-section';
 import { DocumentationSectionComponent } from '../../../../../decorators/documentation-section-component';
-import { Component, ViewChild } from '@angular/core';
+import { Component } from '@angular/core';
 import { Subject } from 'rxjs/Subject';
 import { IPlunkProvider } from '../../../../../interfaces/IPlunkProvider';
 import { IPlunk } from '../../../../../interfaces/IPlunk';

--- a/docs/app/pages/components/sections/search/search-history-ng1/search-history-ng1.component.ts
+++ b/docs/app/pages/components/sections/search/search-history-ng1/search-history-ng1.component.ts
@@ -13,7 +13,7 @@ import { DocumentationSectionComponent } from '../../../../../decorators/documen
 })
 @DocumentationSectionComponent('ComponentsSearchHistoryNg1Component')
 export class ComponentsSearchHistoryNg1Component extends BaseDocumentationSection implements ICodePenProvider {
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.layoutHtml,
         htmlAttributes: {
             'ng-controller': 'SearchHistoryDemoCtrl as vm'

--- a/docs/app/pages/components/sections/search/search-toolbar-ng1/search-toolbar-ng1.component.ts
+++ b/docs/app/pages/components/sections/search/search-toolbar-ng1/search-toolbar-ng1.component.ts
@@ -11,7 +11,7 @@ import { DocumentationSectionComponent } from '../../../../../decorators/documen
 })
 @DocumentationSectionComponent('ComponentsSearchToolbarNg1Component')
 export class ComponentsSearchToolbarNg1Component extends BaseDocumentationSection implements ICodePenProvider {
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.layoutHtml,
         htmlAttributes: {
             'ng-controller': 'SearchToolbarDemoCtrl as vm'

--- a/docs/app/pages/components/sections/select/multiple-select-table-ng1/multiple-select-table-ng1.component.ts
+++ b/docs/app/pages/components/sections/select/multiple-select-table-ng1/multiple-select-table-ng1.component.ts
@@ -12,13 +12,13 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('ComponentsMultipleSelectTableNg1Component')
 export class ComponentsMultipleSelectTableNg1Component extends BaseDocumentationSection implements ICodePenProvider {
 
-    public codeSnippet = '{ id: 1, name: "Eric Carpenter" }';
+    codeSnippet = '{ id: 1, name: "Eric Carpenter" }';
 
     constructor() {
         super(require.context('./snippets/', false, /\.(html|css|js|ts)$/));
     }
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.sampleHtml,
         htmlAttributes: {
             'ng-controller': 'MultipleSelectTableCtrl as vm'

--- a/docs/app/pages/components/sections/select/select-ng1/select-ng1.component.ts
+++ b/docs/app/pages/components/sections/select/select-ng1/select-ng1.component.ts
@@ -16,7 +16,7 @@ export class ComponentsSelectNg1Component extends BaseDocumentationSection imple
         super(require.context('./snippets/', false, /\.(html|css|js|ts)$/));
     }
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.sampleHtml,
         htmlAttributes: {
             'ng-controller': 'SelectDemoCtrl as vm'

--- a/docs/app/pages/components/sections/select/select/select.component.ts
+++ b/docs/app/pages/components/sections/select/select/select.component.ts
@@ -39,38 +39,11 @@ export class ComponentsSelectComponent extends BaseDocumentationSection implemen
     // Customize settings
     pagingEnabled = new BehaviorSubject<boolean>(false);
     dataSet = new BehaviorSubject<string>('strings');
-
-    selectedDataSet(): any[] {
-        return this.dataSets[this.dataSet.getValue()];
-    }
-
-    loadOptions(pageNum: number, pageSize: number, filter: any): Promise<any[]> {
-        // Return a promise using setTimeout to simulate an HTTP request.
-        let promise = new Promise((resolve, reject) => {
-            setTimeout(() => {
-                const pageStart = pageNum * pageSize;
-                const newItems = this.selectedDataSet()
-                    .filter((option) => this.isFilterMatch(option, filter))
-                    .slice(pageStart, pageStart + pageSize);
-                resolve(newItems);
-            }, 2000);
-        });
-
-        return promise;
-    }
-
     loadOptionsCallback = this.loadOptions.bind(this);
 
-    isFilterMatch(option: string, filter: string): boolean {
-        if (!filter) {
-            return true;
-        }
-        return option.toLowerCase().indexOf(filter.toLowerCase()) >= 0;
-    }
+    dataSets: { strings?: any[], objects?: any[] } = {};
 
-    private dataSets: { strings?: any[], objects?: any[] } = {};
-
-    public plunk: IPlunk = {
+    plunk: IPlunk = {
         files: {
             'app.component.ts': this.snippets.raw.appTs,
             'app.component.html': this.snippets.raw.appHtml
@@ -127,5 +100,31 @@ export class ComponentsSelectComponent extends BaseDocumentationSection implemen
     
     ngOnInit() {
         this.options = this.selectedDataSet();
+    }
+
+    selectedDataSet(): any[] {
+        return this.dataSets[this.dataSet.getValue()];
+    }
+
+    loadOptions(pageNum: number, pageSize: number, filter: any): Promise<any[]> {
+        // Return a promise using setTimeout to simulate an HTTP request.
+        let promise = new Promise((resolve, reject) => {
+            setTimeout(() => {
+                const pageStart = pageNum * pageSize;
+                const newItems = this.selectedDataSet()
+                    .filter((option) => this.isFilterMatch(option, filter))
+                    .slice(pageStart, pageStart + pageSize);
+                resolve(newItems);
+            }, 2000);
+        });
+
+        return promise;
+    }
+
+    isFilterMatch(option: string, filter: string): boolean {
+        if (!filter) {
+            return true;
+        }
+        return option.toLowerCase().indexOf(filter.toLowerCase()) >= 0;
     }
 }

--- a/docs/app/pages/components/sections/select/select/snippets/app.snippet.ts
+++ b/docs/app/pages/components/sections/select/select/snippets/app.snippet.ts
@@ -31,36 +31,10 @@ export class AppComponent implements OnInit {
     // Customize settings
     pagingEnabled = new BehaviorSubject<boolean>(false);
     dataSet = new BehaviorSubject<string>('strings');
-
-    selectedDataSet(): any[] {
-        return this.dataSets[this.dataSet.getValue()];
-    }
-
-    loadOptions(pageNum: number, pageSize: number, filter: any): Promise<any[]> {
-        // Return a promise using setTimeout to simulate an HTTP request.
-        let promise = new Promise((resolve, reject) => {
-            setTimeout(() => {
-                const pageStart = pageNum * pageSize;
-                const newItems = this.selectedDataSet()
-                    .filter((option) => this.isFilterMatch(option, filter))
-                    .slice(pageStart, pageStart + pageSize);
-                resolve(newItems);
-            }, 2000);
-        });
-
-        return promise;
-    }
-
     loadOptionsCallback = this.loadOptions.bind(this);
 
-    isFilterMatch(option: string, filter: string): boolean {
-        if (!filter) {
-            return true;
-        }
-        return option.toLowerCase().indexOf(filter.toLowerCase()) >= 0;
-    }
 
-    private dataSets: { strings?: any[], objects?: any[] } = {};
+    dataSets: { strings?: any[], objects?: any[] } = {};
 
     constructor() {
 
@@ -101,5 +75,31 @@ export class AppComponent implements OnInit {
     
     ngOnInit() {
         this.options = this.selectedDataSet();
+    }
+
+    selectedDataSet(): any[] {
+        return this.dataSets[this.dataSet.getValue()];
+    }
+
+    loadOptions(pageNum: number, pageSize: number, filter: any): Promise<any[]> {
+        // Return a promise using setTimeout to simulate an HTTP request.
+        let promise = new Promise((resolve, reject) => {
+            setTimeout(() => {
+                const pageStart = pageNum * pageSize;
+                const newItems = this.selectedDataSet()
+                    .filter((option) => this.isFilterMatch(option, filter))
+                    .slice(pageStart, pageStart + pageSize);
+                resolve(newItems);
+            }, 2000);
+        });
+
+        return promise;
+    }
+
+    isFilterMatch(option: string, filter: string): boolean {
+        if (!filter) {
+            return true;
+        }
+        return option.toLowerCase().indexOf(filter.toLowerCase()) >= 0;
     }
 }

--- a/docs/app/pages/components/sections/select/select/snippets/app.ts
+++ b/docs/app/pages/components/sections/select/select/snippets/app.ts
@@ -32,36 +32,10 @@ export class AppComponent implements OnInit {
     // Customize settings
     pagingEnabled = new BehaviorSubject<boolean>(false);
     dataSet = new BehaviorSubject<string>('strings');
-
-    selectedDataSet(): any[] {
-        return this.dataSets[this.dataSet.getValue()];
-    }
-
-    loadOptions(pageNum: number, pageSize: number, filter: any): Promise<any[]> {
-        // Return a promise using setTimeout to simulate an HTTP request.
-        let promise = new Promise((resolve, reject) => {
-            setTimeout(() => {
-                const pageStart = pageNum * pageSize;
-                const newItems = this.selectedDataSet()
-                    .filter((option) => this.isFilterMatch(option, filter))
-                    .slice(pageStart, pageStart + pageSize);
-                resolve(newItems);
-            }, 2000);
-        });
-
-        return promise;
-    }
-
     loadOptionsCallback = this.loadOptions.bind(this);
 
-    isFilterMatch(option: string, filter: string): boolean {
-        if (!filter) {
-            return true;
-        }
-        return option.toLowerCase().indexOf(filter.toLowerCase()) >= 0;
-    }
 
-    private dataSets: { strings?: any[], objects?: any[] } = {};
+    dataSets: { strings?: any[], objects?: any[] } = {};
 
     constructor() {
 
@@ -102,5 +76,31 @@ export class AppComponent implements OnInit {
     
     ngOnInit() {
         this.options = this.selectedDataSet();
+    }
+
+    selectedDataSet(): any[] {
+        return this.dataSets[this.dataSet.getValue()];
+    }
+
+    loadOptions(pageNum: number, pageSize: number, filter: any): Promise<any[]> {
+        // Return a promise using setTimeout to simulate an HTTP request.
+        let promise = new Promise((resolve, reject) => {
+            setTimeout(() => {
+                const pageStart = pageNum * pageSize;
+                const newItems = this.selectedDataSet()
+                    .filter((option) => this.isFilterMatch(option, filter))
+                    .slice(pageStart, pageStart + pageSize);
+                resolve(newItems);
+            }, 2000);
+        });
+
+        return promise;
+    }
+    
+    isFilterMatch(option: string, filter: string): boolean {
+        if (!filter) {
+            return true;
+        }
+        return option.toLowerCase().indexOf(filter.toLowerCase()) >= 0;
     }
 }

--- a/docs/app/pages/components/sections/select/single-select-table-ng1/single-select-table-ng1.component.ts
+++ b/docs/app/pages/components/sections/select/single-select-table-ng1/single-select-table-ng1.component.ts
@@ -16,7 +16,7 @@ export class ComponentsSingleSelectTableNg1Component extends BaseDocumentationSe
         super(require.context('./snippets/', false, /\.(html|css|js|ts)$/));
     }
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.sampleHtml,
         htmlAttributes: {
             'ng-controller': 'SingleSelectTableCtrl as vm'

--- a/docs/app/pages/components/sections/side-navigation/app-navigator/app-navigator.component.ts
+++ b/docs/app/pages/components/sections/side-navigation/app-navigator/app-navigator.component.ts
@@ -12,7 +12,7 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('ComponentsAppNavigatorComponent')
 export class ComponentsAppNavigatorComponent extends BaseDocumentationSection implements ICodePenProvider {
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.appExampleHtml,
         htmlTemplates: [{
             id: 'app_navigator_popover.tmpl.html',

--- a/docs/app/pages/components/sections/side-navigation/navigation-menu-service-ng1/navigation-menu-service-ng1.component.ts
+++ b/docs/app/pages/components/sections/side-navigation/navigation-menu-service-ng1/navigation-menu-service-ng1.component.ts
@@ -12,7 +12,7 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('ComponentsNavigationMenuServiceNg1Component')
 export class ComponentsNavigationMenuServiceNg1Component extends BaseDocumentationSection implements ICodePenProvider {
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.layoutExampleHtml,
         css: [this.snippets.raw.stylesExampleCss],
         js: [this.snippets.raw.controllerJs]

--- a/docs/app/pages/components/sections/side-navigation/navigation/navigation.component.ts
+++ b/docs/app/pages/components/sections/side-navigation/navigation/navigation.component.ts
@@ -12,9 +12,9 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('ComponentsNavigationComponent')
 export class ComponentsNavigationComponent extends BaseDocumentationSection implements ICodePenProvider {
 
-    private noteCode = require('!!raw-loader!./snippets/ng-class.html');
+    noteCode = require('!!raw-loader!./snippets/ng-class.html');
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.sampleHtml,
         js: [this.snippets.raw.sampleJs]
     };

--- a/docs/app/pages/components/sections/splitter/layout-switching-splitter-ng1/layout-switching-splitter-ng1.component.ts
+++ b/docs/app/pages/components/sections/splitter/layout-switching-splitter-ng1/layout-switching-splitter-ng1.component.ts
@@ -13,7 +13,7 @@ import { DocumentationSectionComponent } from '../../../../../decorators/documen
 })
 @DocumentationSectionComponent('ComponentsLayoutSwitchingSplitterNg1Component')
 export class ComponentsLayoutSwitchingSplitterNg1Component extends BaseDocumentationSection implements ICodePenProvider {
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.layoutHtml,
         htmlAttributes: {
             'ng-controller': 'LayoutSwitchingSplitterDemoCtrl as vm'

--- a/docs/app/pages/components/sections/splitter/nested-splitter-ng1/nested-splitter-ng1.component.ts
+++ b/docs/app/pages/components/sections/splitter/nested-splitter-ng1/nested-splitter-ng1.component.ts
@@ -13,7 +13,7 @@ import { DocumentationSectionComponent } from '../../../../../decorators/documen
 })
 @DocumentationSectionComponent('ComponentsNestedSplitterNg1Component')
 export class ComponentsNestedSplitterNg1Component extends BaseDocumentationSection implements ICodePenProvider {
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.layoutHtml,
         css: [this.snippets.raw.stylesCss]
     };

--- a/docs/app/pages/components/sections/splitter/side-inset-panel-splitter-ng1/side-inset-panel-splitter-ng1.component.ts
+++ b/docs/app/pages/components/sections/splitter/side-inset-panel-splitter-ng1/side-inset-panel-splitter-ng1.component.ts
@@ -13,7 +13,7 @@ import { DocumentationSectionComponent } from '../../../../../decorators/documen
 })
 @DocumentationSectionComponent('ComponentsSideInsetPanelSplitterNg1Component')
 export class ComponentsSideInsetPanelSplitterNg1Component extends BaseDocumentationSection implements ICodePenProvider {
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.layoutHtml,
         htmlAttributes: {
             'ng-controller': 'SideInsetPanelSplitterDemoCtrl as vm'

--- a/docs/app/pages/components/sections/splitter/splitter-ng1/splitter-ng1.component.ts
+++ b/docs/app/pages/components/sections/splitter/splitter-ng1/splitter-ng1.component.ts
@@ -13,7 +13,7 @@ import { DocumentationSectionComponent } from '../../../../../decorators/documen
 })
 @DocumentationSectionComponent('ComponentsSplitterNg1Component')
 export class ComponentsSplitterNg1Component extends BaseDocumentationSection implements ICodePenProvider {
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.layoutHtml,
         htmlAttributes: {
             'ng-controller': 'SplitterDemoCtrl as vm'

--- a/docs/app/pages/components/sections/tables/column-sorting/column-sorting.component.ts
+++ b/docs/app/pages/components/sections/tables/column-sorting/column-sorting.component.ts
@@ -108,7 +108,7 @@ export class ComponentsColumnSortingComponent extends BaseDocumentationSection i
         });
     }
 
-    public plunk: IPlunk = {
+    plunk: IPlunk = {
         files: {
             'app.component.ts': this.snippets.raw.appTs,
             'app.component.html': this.snippets.raw.appHtml

--- a/docs/app/pages/components/sections/tables/column-visibility-ng1/column-visibility-ng1.component.ts
+++ b/docs/app/pages/components/sections/tables/column-visibility-ng1/column-visibility-ng1.component.ts
@@ -11,10 +11,10 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('ComponentsColumnVisibilityNg1Component')
 export class ComponentsColumnVisibilityNg1Component extends BaseDocumentationSection implements ICodePenProvider {
 
-    private columns: any;
-    private tableData: any[];
+    columns: any;
+    tableData: any[];
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.layoutHtml,
         htmlAttributes: {
             'ng-controller': 'ColumnVisibilityCtrl as vm'

--- a/docs/app/pages/components/sections/tables/custom-filters-component/custom-filters.component.ts
+++ b/docs/app/pages/components/sections/tables/custom-filters-component/custom-filters.component.ts
@@ -28,7 +28,7 @@ export class ComponentsCustomFiltersComponent extends BaseDocumentationSection i
         name: 'Inactive'
     }];
 
-    public plunk: IPlunk = {
+    plunk: IPlunk = {
         files: {
             'app.component.ts': this.snippets.raw.appTs,
             'app.component.html': this.snippets.raw.appHtml,

--- a/docs/app/pages/components/sections/tables/custom-responsive-table-ng1/custom-responsive-table-ng1.component.ts
+++ b/docs/app/pages/components/sections/tables/custom-responsive-table-ng1/custom-responsive-table-ng1.component.ts
@@ -11,7 +11,7 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('ComponentsCustomResponsiveTableNg1Component')
 export class ComponentsCustomResponsiveTableNg1Component extends BaseDocumentationSection implements ICodePenProvider {
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.sampleHtml,
         htmlAttributes: {
             'ng-controller': 'CustomResponsiveTableCtrl as vm'

--- a/docs/app/pages/components/sections/tables/detail-row-header-ng1/detail-row-header-ng1.component.ts
+++ b/docs/app/pages/components/sections/tables/detail-row-header-ng1/detail-row-header-ng1.component.ts
@@ -11,14 +11,14 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('ComponentsDetailRowHeaderNg1Component')
 export class ComponentsDetailRowHeaderNg1Component extends BaseDocumentationSection implements ICodePenProvider {
 
-    private htmlCode = this.snippets.compiled.layoutHtml;
-    private controllerCode = this.snippets.compiled.controllerJs;
-    private popoverHtmlCode = this.snippets.compiled.popoverHtml;
-    private popoverControllerCode = this.snippets.compiled.popoverControllerJs;
-    private styleCode = this.snippets.compiled.stylesCss;
-    private serviceCode = this.snippets.compiled.serviceJs;
+    htmlCode = this.snippets.compiled.layoutHtml;
+    controllerCode = this.snippets.compiled.controllerJs;
+    popoverHtmlCode = this.snippets.compiled.popoverHtml;
+    popoverControllerCode = this.snippets.compiled.popoverControllerJs;
+    styleCode = this.snippets.compiled.stylesCss;
+    serviceCode = this.snippets.compiled.serviceJs;
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.layoutHtml,
         htmlAttributes: {
             'ng-controller': 'DetailRowResponsiveTableCtrl as vm'

--- a/docs/app/pages/components/sections/tables/detail-row-header-ng1/wrapper/detail-row-header-wrapper.directive.ts
+++ b/docs/app/pages/components/sections/tables/detail-row-header-ng1/wrapper/detail-row-header-wrapper.directive.ts
@@ -73,16 +73,16 @@ angular.module('app').directive('uxdDetailRowHeaderWrapper', () => {
 
 class DetailRowHeaderPopoverCtrl {
 
-    private scrollBarConfig = {
+    scrollBarConfig = {
         autoReinitialise: true,
         autoReinitialiseDelay: 500,
         enableKeyboardNavigation: true,
         scrollMargin: 5
     };
 
-    public filterList: any[] = [];
-    public activeFilters: any[] = [];
-    public addresses: any[];
+    filterList: any[] = [];
+    activeFilters: any[] = [];
+    addresses: any[];
 
     static $inject = ['$scope', 'detailRowDataService'];
 

--- a/docs/app/pages/components/sections/tables/detail-row-responsive-ng1/detail-row-responsive-ng1.component.ts
+++ b/docs/app/pages/components/sections/tables/detail-row-responsive-ng1/detail-row-responsive-ng1.component.ts
@@ -11,11 +11,11 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('ComponentsDetailRowResponsiveNg1Component')
 export class ComponentsDetailRowResponsiveNg1Component extends BaseDocumentationSection implements ICodePenProvider {
 
-    public htmlCode = this.snippets.compiled.layoutHtml;
-    public jsCode = this.snippets.compiled.controllerJs;
-    public cssCode = this.snippets.compiled.stylesCss;
+    htmlCode = this.snippets.compiled.layoutHtml;
+    jsCode = this.snippets.compiled.controllerJs;
+    cssCode = this.snippets.compiled.stylesCss;
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.codepenHtml,
         htmlAttributes: {
             'ng-controller': 'DetailRowResponsiveTableCtrl as vm'

--- a/docs/app/pages/components/sections/tables/dynamic-filters-ng1/dynamic-filters-ng1.component.ts
+++ b/docs/app/pages/components/sections/tables/dynamic-filters-ng1/dynamic-filters-ng1.component.ts
@@ -9,10 +9,10 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('ComponentsDynamicFiltersNg1Component')
 export class ComponentsDynamicFiltersNg1Component extends BaseDocumentationSection {
     
-    private filterContainerCode = this.snippets.compiled.filterContainerHtml;
-    private filterControllerCode = this.snippets.compiled.filterContainerJs;
-    private filterOptionsCode = this.snippets.compiled.filterOptionsJs;
-    private filterCode = this.snippets.compiled.filterHtml;
+    filterContainerCode = this.snippets.compiled.filterContainerHtml;
+    filterControllerCode = this.snippets.compiled.filterContainerJs;
+    filterOptionsCode = this.snippets.compiled.filterOptionsJs;
+    filterCode = this.snippets.compiled.filterHtml;
     
     constructor() {
         super(require.context('./snippets/', false, /\.(html|css|js|ts)$/));

--- a/docs/app/pages/components/sections/tables/filters-ng1/filters-ng1.component.ts
+++ b/docs/app/pages/components/sections/tables/filters-ng1/filters-ng1.component.ts
@@ -9,9 +9,9 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('ComponentsFiltersNg1Component')
 export class ComponentsFiltersNg1Component extends BaseDocumentationSection {
     
-    private filterContainerCode = this.snippets.compiled.filterContainerHtml;
-    private filterCode = this.snippets.compiled.filterHtml;
-    private filterOptionsCode = this.snippets.compiled.filterOptionsHtml;
+    filterContainerCode = this.snippets.compiled.filterContainerHtml;
+    filterCode = this.snippets.compiled.filterHtml;
+    filterOptionsCode = this.snippets.compiled.filterOptionsHtml;
     
     constructor() {
         super(require.context('./snippets/', false, /\.(html|css|js|ts)$/));

--- a/docs/app/pages/components/sections/tables/filters/filters.component.ts
+++ b/docs/app/pages/components/sections/tables/filters/filters.component.ts
@@ -135,7 +135,7 @@ export class ComponentsFiltersComponent extends BaseDocumentationSection impleme
 
     filteredTable: FilterSampleItem[] = this.table;
 
-    public plunk: IPlunk = {
+    plunk: IPlunk = {
         files: {
             'app.component.ts': this.snippets.raw.appTs,
             'app.component.html': this.snippets.raw.appHtml

--- a/docs/app/pages/components/sections/tables/fixed-header-table-ng1/fixed-header-table-ng1.component.ts
+++ b/docs/app/pages/components/sections/tables/fixed-header-table-ng1/fixed-header-table-ng1.component.ts
@@ -11,10 +11,10 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('ComponentsFixedHeaderTableNg1Component')
 export class ComponentsFixedHeaderTableNg1Component extends BaseDocumentationSection implements ICodePenProvider {
     
-    private htmlCode = this.snippets.compiled.layoutHtml;
-    private jsCode = this.snippets.compiled.controllerJs;
+    htmlCode = this.snippets.compiled.layoutHtml;
+    jsCode = this.snippets.compiled.controllerJs;
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.layoutHtml,
         htmlAttributes: {
             'ng-controller': 'FixedHeaderCtrl'

--- a/docs/app/pages/components/sections/tables/grouping-ng1/grouping-ng1.component.ts
+++ b/docs/app/pages/components/sections/tables/grouping-ng1/grouping-ng1.component.ts
@@ -9,9 +9,9 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('ComponentsGroupingNg1Component')
 export class ComponentsGroupingNg1Component extends BaseDocumentationSection {
     
-    private idsCode = this.snippets.compiled.idsJs;
-    private rootCode = this.snippets.compiled.rootJs;
-    private hierarchyCode = this.snippets.compiled.hierarchyJs;
+    idsCode = this.snippets.compiled.idsJs;
+    rootCode = this.snippets.compiled.rootJs;
+    hierarchyCode = this.snippets.compiled.hierarchyJs;
     
     constructor() {
         super(require.context('./snippets/', false, /\.(html|css|js|ts)$/));

--- a/docs/app/pages/components/sections/tables/hover-actions-ng1/hover-actions-ng1.component.ts
+++ b/docs/app/pages/components/sections/tables/hover-actions-ng1/hover-actions-ng1.component.ts
@@ -11,11 +11,11 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('ComponentsHoverActionsNg1Component')
 export class ComponentsHoverActionsNg1Component extends BaseDocumentationSection implements ICodePenProvider {
     
-    private htmlCode = this.snippets.compiled.layoutHtml;
-    private jsCode = this.snippets.compiled.controllerJs;
-    private cssCode = this.snippets.compiled.stylesCss;
+    htmlCode = this.snippets.compiled.layoutHtml;
+    jsCode = this.snippets.compiled.controllerJs;
+    cssCode = this.snippets.compiled.stylesCss;
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.layoutHtml,
         htmlAttributes: {
             'ng-controller': 'HoverActionCtrl'

--- a/docs/app/pages/components/sections/tables/indices-ng1/indices-ng1.component.ts
+++ b/docs/app/pages/components/sections/tables/indices-ng1/indices-ng1.component.ts
@@ -9,7 +9,7 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('ComponentsIndicesNg1Component')
 export class ComponentsIndicesNg1Component extends BaseDocumentationSection {
     
-    private htmlCode = this.snippets.compiled.sampleHtml;
+    htmlCode = this.snippets.compiled.sampleHtml;
     
     constructor() {
         super(require.context('./snippets/', false, /\.(html|css|js|ts)$/));

--- a/docs/app/pages/components/sections/tables/layout-switching-ng1/layout-switching-ng1.component.ts
+++ b/docs/app/pages/components/sections/tables/layout-switching-ng1/layout-switching-ng1.component.ts
@@ -9,7 +9,7 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('ComponentsLayoutSwitchingNg1Component')
 export class ComponentsLayoutSwitchingNg1Component extends BaseDocumentationSection {
     
-    private htmlCode = this.snippets.compiled.sampleHtml;
+    htmlCode = this.snippets.compiled.sampleHtml;
     
     constructor() {
         super(require.context('./snippets/', false, /\.(html|css|js|ts)$/));

--- a/docs/app/pages/components/sections/tables/list-hover-actions-ng1/list-hover-actions-ng1.component.ts
+++ b/docs/app/pages/components/sections/tables/list-hover-actions-ng1/list-hover-actions-ng1.component.ts
@@ -9,7 +9,7 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('ComponentsListHoverActionsNg1Component')
 export class ComponentsListHoverActionsNg1Component extends BaseDocumentationSection {
     
-    private htmlCode = this.snippets.compiled.sampleHtml;
+    htmlCode = this.snippets.compiled.sampleHtml;
     
     constructor() {
         super(require.context('./snippets/', false, /\.(html|css|js|ts)$/));

--- a/docs/app/pages/components/sections/tables/multiple-column-sorting-ng1/multiple-column-sorting-ng1.component.ts
+++ b/docs/app/pages/components/sections/tables/multiple-column-sorting-ng1/multiple-column-sorting-ng1.component.ts
@@ -10,10 +10,11 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 })
 @DocumentationSectionComponent('ComponentsMultipleColumnSortingNg1Component')
 export class ComponentsMultipleColumnSortingNg1Component extends BaseDocumentationSection implements ICodePenProvider {
-    private htmlCode = this.snippets.compiled.sampleHtml;
-    private jsCode = this.snippets.compiled.sampleJs;
+    
+    htmlCode = this.snippets.compiled.sampleHtml;
+    jsCode = this.snippets.compiled.sampleJs;
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.sampleHtml,
         htmlAttributes: {
             'ng-controller': 'MultipleColumnSortingCtrl as vm'

--- a/docs/app/pages/components/sections/tables/multiple-column-sorting-ng1/wrapper/multi-column-sorting-wrapper.directive.ts
+++ b/docs/app/pages/components/sections/tables/multiple-column-sorting-ng1/wrapper/multi-column-sorting-wrapper.directive.ts
@@ -10,11 +10,11 @@ angular.module('app').directive('uxdMultiColumnSortingWrapper', () => {
 
 class MultiColumnSortingController {
 
-    private activeSorter = ['none', 'none', 'none'];
-    private orderDesc = ['none', 'none', 'none'];
+    activeSorter = ['none', 'none', 'none'];
+    orderDesc = ['none', 'none', 'none'];
 
-    private sorterHeaders: any[];
-    private sortableTable: any[];
+    sorterHeaders: any[];
+    sortableTable: any[];
 
     static $inject = ['$scope'];
 

--- a/docs/app/pages/components/sections/tables/multiple-select-actions-ng1/multiple-select-actions-ng1.component.ts
+++ b/docs/app/pages/components/sections/tables/multiple-select-actions-ng1/multiple-select-actions-ng1.component.ts
@@ -9,8 +9,8 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('ComponentsMultipleSelectActionsNg1Component')
 export class ComponentsMultipleSelectActionsNg1Component extends BaseDocumentationSection {
     
-    private htmlCode = this.snippets.compiled.layoutHtml;
-    private selectionCode = this.snippets.compiled.selectionHtml;
+    htmlCode = this.snippets.compiled.layoutHtml;
+    selectionCode = this.snippets.compiled.selectionHtml;
     
     constructor() {
         super(require.context('./snippets/', false, /\.(html|css|js|ts)$/));

--- a/docs/app/pages/components/sections/tables/multiple-selection-row-ng1/multiple-selection-row-ng1.component.ts
+++ b/docs/app/pages/components/sections/tables/multiple-selection-row-ng1/multiple-selection-row-ng1.component.ts
@@ -9,7 +9,7 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('ComponentsMultipleSelectionRowNg1Component')
 export class ComponentsMultipleSelectionRowNg1Component extends BaseDocumentationSection {
     
-    private htmlCode = this.snippets.compiled.layoutHtml;
+    htmlCode = this.snippets.compiled.layoutHtml;
     
     constructor() {
         super(require.context('./snippets/', false, /\.(html|css|js|ts)$/));

--- a/docs/app/pages/components/sections/tables/preview-pane-ng1/preview-pane-ng1.component.ts
+++ b/docs/app/pages/components/sections/tables/preview-pane-ng1/preview-pane-ng1.component.ts
@@ -9,8 +9,8 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('ComponentsPreviewPaneNg1Component')
 export class ComponentsPreviewPaneNg1Component extends BaseDocumentationSection {
     
-    private toggleCode = this.snippets.compiled.toggleHtml;
-    private previewItemCode = this.snippets.compiled.previewPaneItemHtml;
+    toggleCode = this.snippets.compiled.toggleHtml;
+    previewItemCode = this.snippets.compiled.previewPaneItemHtml;
     
     constructor() {
         super(require.context('./snippets/', false, /\.(html|css|js|ts)$/));

--- a/docs/app/pages/components/sections/tables/preview-pane-window-ng1/preview-pane-window-ng1.component.ts
+++ b/docs/app/pages/components/sections/tables/preview-pane-window-ng1/preview-pane-window-ng1.component.ts
@@ -11,13 +11,13 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('ComponentsPreviewPaneWindowNg1Component')
 export class ComponentsPreviewPaneWindowNg1Component extends BaseDocumentationSection implements ICodePenProvider {
     
-    private sampleCode = this.snippets.compiled.sampleHtml;
-    private htmlCode = this.snippets.compiled.layoutHtml;
-    private jsCode = this.snippets.compiled.controllerJs;
-    private cssCode = this.snippets.compiled.stylesCss;
-    private footerCode = this.snippets.compiled.footerHtml;
+    sampleCode = this.snippets.compiled.sampleHtml;
+    htmlCode = this.snippets.compiled.layoutHtml;
+    jsCode = this.snippets.compiled.controllerJs;
+    cssCode = this.snippets.compiled.stylesCss;
+    footerCode = this.snippets.compiled.footerHtml;
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.layoutHtml,
         htmlAttributes: {
             'ng-controller': 'PreviewPaneWindowCtrl as vm'

--- a/docs/app/pages/components/sections/tables/preview-pane-window-ng1/wrapper/preview-pane-window-wrapper.directive.ts
+++ b/docs/app/pages/components/sections/tables/preview-pane-window-ng1/wrapper/preview-pane-window-wrapper.directive.ts
@@ -11,27 +11,27 @@ angular.module('app').directive('uxdPreviewPaneWindowWrapper', () => {
 
 class PreviewPaneWindowController {
 
-    private sparklabel: any;
-    private previewFile: string;
-    private previewTitle: string;
-    private previewSubtitle: string;
-    private previewEmptyText = 'No document selected';
-    private previewName = 'preview-pane-example';
-    private selectedIndex = 0;
-    private reviewed = false;
-    private signed = '';
-    private items: any[];
-    private childScope: angular.IScope;
-    private bottomLeftLabel = "<span class='spark-bottom-label'>completed</span>";
+    sparklabel: any;
+    previewFile: string;
+    previewTitle: string;
+    previewSubtitle: string;
+    previewEmptyText = 'No document selected';
+    previewName = 'preview-pane-example';
+    selectedIndex = 0;
+    reviewed = false;
+    signed = '';
+    items: any[];
+    childScope: angular.IScope;
+    bottomLeftLabel = "<span class='spark-bottom-label'>completed</span>";
 
-    private scrollBarConfig = {
+    scrollBarConfig = {
         enableKeyboardNavigation: true,
         verticalGutter: -10,
         resizeSensor: true,
         isScrollableH: false
     };
 
-    private tooltip = {
+    tooltip = {
         content: 'Opens another window for a larger or full-screen preview',
         dismiss: 'HIDE TIP',
         direction: 'right',

--- a/docs/app/pages/components/sections/tables/reorderable-table-ng1/reorderable-table-ng1.component.ts
+++ b/docs/app/pages/components/sections/tables/reorderable-table-ng1/reorderable-table-ng1.component.ts
@@ -11,17 +11,17 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('ComponentsReorderableTableNg1Component')
 export class ComponentsReorderableTableNg1Component extends BaseDocumentationSection implements ICodePenProvider {
     
-    private htmlCode = this.snippets.compiled.layoutHtml;
-    private jsCode = this.snippets.compiled.controllerJs;
-    private cssCode = this.snippets.compiled.stylesCss;
+    htmlCode = this.snippets.compiled.layoutHtml;
+    jsCode = this.snippets.compiled.controllerJs;
+    cssCode = this.snippets.compiled.stylesCss;
 
-    private tableDataCode = this.snippets.compiled.tableDataHtml;
-    private controlsCode = this.snippets.compiled.controlsHtml;
+    tableDataCode = this.snippets.compiled.tableDataHtml;
+    controlsCode = this.snippets.compiled.controlsHtml;
 
-    private removeRowHtmlCode = this.snippets.compiled.removeRowHtml;
-    private removeRowJsCode = this.snippets.compiled.removeRowJs;
+    removeRowHtmlCode = this.snippets.compiled.removeRowHtml;
+    removeRowJsCode = this.snippets.compiled.removeRowJs;
     
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.layoutHtml,
         htmlAttributes: {
             'ng-controller': 'ReorderableCtrl as vm'

--- a/docs/app/pages/components/sections/tables/reorderable-table-ng1/wrapper/reorderable-table-wrapper.directive.ts
+++ b/docs/app/pages/components/sections/tables/reorderable-table-ng1/wrapper/reorderable-table-wrapper.directive.ts
@@ -11,7 +11,7 @@ angular.module('app').directive('uxdReorderableTableWrapper', () => {
 class ReorderableTableController {
 
     // create an array of documents
-    private documents: any[] = [];
+    documents: any[] = [];
 
     static $inject = ['$scope'];
 

--- a/docs/app/pages/components/sections/tables/single-column-sorting-ng1/single-column-sorting-ng1.component.ts
+++ b/docs/app/pages/components/sections/tables/single-column-sorting-ng1/single-column-sorting-ng1.component.ts
@@ -11,10 +11,10 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('ComponentsSingleColumnSortingNg1Component')
 export class ComponentsSingleColumnSortingNg1Component extends BaseDocumentationSection implements ICodePenProvider {
     
-    private htmlCode = this.snippets.compiled.sampleHtml;
-    private jsCode = this.snippets.compiled.sampleJs;
+    htmlCode = this.snippets.compiled.sampleHtml;
+    jsCode = this.snippets.compiled.sampleJs;
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.sampleHtml,
         htmlAttributes: {
             'ng-controller': 'SingleColumnSortingCtrl as vm'

--- a/docs/app/pages/components/sections/tables/single-column-sorting-ng1/wrapper/single-column-sorting-wrapper.directive.ts
+++ b/docs/app/pages/components/sections/tables/single-column-sorting-ng1/wrapper/single-column-sorting-wrapper.directive.ts
@@ -10,10 +10,10 @@ angular.module('app').directive('uxdSingleColumnSortingWrapper', () => {
 
 class SingleColumnSortingController {
 
-    private activeSorter: string = 'date';
-    private orderDesc: boolean = false;
-    private sorterHeaders: any[];
-    private sortableTable: any[];
+    activeSorter: string = 'date';
+    orderDesc: boolean = false;
+    sorterHeaders: any[];
+    sortableTable: any[];
 
     static $inject = ['$scope'];
 

--- a/docs/app/pages/components/sections/tables/sort-direction-toggle-ng1/sort-direction-toggle-ng1.component.ts
+++ b/docs/app/pages/components/sections/tables/sort-direction-toggle-ng1/sort-direction-toggle-ng1.component.ts
@@ -11,10 +11,10 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('ComponentsSortDirectionToggleNg1Component')
 export class ComponentsSortDirectionToggleNg1Component extends BaseDocumentationSection implements ICodePenProvider {
     
-    private htmlCode = this.snippets.compiled.sampleHtml;
-    private jsCode = this.snippets.compiled.sampleJs;
+    htmlCode = this.snippets.compiled.sampleHtml;
+    jsCode = this.snippets.compiled.sampleJs;
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.sampleHtml,
         htmlAttributes: {
             'ng-controller': 'SortToggleCtrl as vm'

--- a/docs/app/pages/components/sections/tables/sorting-ng1/sorting-ng1.component.ts
+++ b/docs/app/pages/components/sections/tables/sorting-ng1/sorting-ng1.component.ts
@@ -9,9 +9,9 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('ComponentsSortingNg1Component')
 export class ComponentsSortingNg1Component extends BaseDocumentationSection {
     
-    private sortingCode = this.snippets.compiled.layoutHtml;
-    private htmlCode = this.snippets.compiled.sampleHtml;
-    private jsCode = this.snippets.compiled.sampleJs;
+    sortingCode = this.snippets.compiled.layoutHtml;
+    htmlCode = this.snippets.compiled.sampleHtml;
+    jsCode = this.snippets.compiled.sampleJs;
     
     constructor() {
         super(require.context('./snippets/', false, /\.(html|css|js|ts)$/));

--- a/docs/app/pages/components/sections/tables/traditional-multiple-select-actions-ng1/traditional-multiple-select-actions-ng1.component.ts
+++ b/docs/app/pages/components/sections/tables/traditional-multiple-select-actions-ng1/traditional-multiple-select-actions-ng1.component.ts
@@ -9,8 +9,8 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('ComponentsTraditionalMultipleSelectActionsNg1Component')
 export class ComponentsTraditionalMultipleSelectActionsNg1Component extends BaseDocumentationSection {
     
-    private htmlCode = this.snippets.compiled.layoutHtml;
-    private selectionCode = this.snippets.compiled.selectionHtml;
+    htmlCode = this.snippets.compiled.layoutHtml;
+    selectionCode = this.snippets.compiled.selectionHtml;
     
     constructor() {
         super(require.context('./snippets/', false, /\.(html|css|js|ts)$/));

--- a/docs/app/pages/components/sections/tabs/card-tabs-ng1/card-tabs-ng1.component.ts
+++ b/docs/app/pages/components/sections/tabs/card-tabs-ng1/card-tabs-ng1.component.ts
@@ -12,7 +12,7 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('ComponentsCardTabsNg1Component')
 export class ComponentsCardTabsNg1Component extends BaseDocumentationSection implements ICodePenProvider {
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.sampleHtml,
         htmlAttributes: {
             'ng-controller': 'TabsCtrl as vm'

--- a/docs/app/pages/components/sections/tabs/detailed-tab-example-ng1/detailed-tab-example-ng1.component.ts
+++ b/docs/app/pages/components/sections/tabs/detailed-tab-example-ng1/detailed-tab-example-ng1.component.ts
@@ -12,11 +12,11 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('ComponentsDetailedTabExampleNg1Component')
 export class ComponentsDetailedTabExampleNg1Component extends BaseDocumentationSection implements ICodePenProvider {
 
-    private barHtml = require('./wrapper/tab-bar.html');
-    private sankeyHtml = require('./wrapper/tab-sankey.html');
-    private tableHtml = require('./wrapper/tab-table.html');
+    barHtml = require('./wrapper/tab-bar.html');
+    sankeyHtml = require('./wrapper/tab-sankey.html');
+    tableHtml = require('./wrapper/tab-table.html');
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.sampleHtml,
         htmlAttributes: {
             'ng-controller': 'TabsCtrl as vm'

--- a/docs/app/pages/components/sections/tabs/stacked-tabs-ng1/stacked-tabs-ng1-component.ts
+++ b/docs/app/pages/components/sections/tabs/stacked-tabs-ng1/stacked-tabs-ng1-component.ts
@@ -12,7 +12,7 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('ComponentsStackedTabsNg1Component')
 export class ComponentsStackedTabsNg1Component extends BaseDocumentationSection implements ICodePenProvider {
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.sampleHtml,
         htmlAttributes: {
             'ng-controller': 'TabsCtrl as vm'

--- a/docs/app/pages/components/sections/tabs/tabs-ng1/tabs-ng1.component.ts
+++ b/docs/app/pages/components/sections/tabs/tabs-ng1/tabs-ng1.component.ts
@@ -12,9 +12,9 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('ComponentsTabsNg1Component')
 export class ComponentsTabsNg1Component extends BaseDocumentationSection implements ICodePenProvider {
 
-    private tabContent = require('./wrapper/tab.html');
+    tabContent = require('./wrapper/tab.html');
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.sampleHtml,
         htmlAttributes: {
             'ng-controller': 'TabsCtrl as vm'

--- a/docs/app/pages/components/sections/timeline/timeline-ng1/timeline-ng1.component.ts
+++ b/docs/app/pages/components/sections/timeline/timeline-ng1/timeline-ng1.component.ts
@@ -12,7 +12,7 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('ComponentsTimelineNg1Component')
 export class ComponentsTimelineNg1Component extends BaseDocumentationSection implements ICodePenProvider {
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.sampleHtml,
         htmlAttributes: {
             'ng-controller': 'TimelineCtrl as vm'

--- a/docs/app/pages/components/sections/tooltips/overflow-tooltip-ng1/overflow-tooltip-ng1.component.ts
+++ b/docs/app/pages/components/sections/tooltips/overflow-tooltip-ng1/overflow-tooltip-ng1.component.ts
@@ -12,7 +12,7 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('ComponentsOverflowTooltipNg1Component')
 export class ComponentsOverflowTooltipNg1Component extends BaseDocumentationSection implements ICodePenProvider {
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.sampleHtml,
         css: [this.snippets.raw.sampleCss]
     };

--- a/docs/app/pages/components/sections/tooltips/single-line-overflow-tooltip-ng1/single-line-overflow-tooltip-ng1.component.ts
+++ b/docs/app/pages/components/sections/tooltips/single-line-overflow-tooltip-ng1/single-line-overflow-tooltip-ng1.component.ts
@@ -12,7 +12,7 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('ComponentsSingleLineOverflowTooltipNg1Component')
 export class ComponentsSingleLineOverflowTooltipNg1Component extends BaseDocumentationSection implements ICodePenProvider {
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.sampleHtml,
         css: [this.snippets.raw.sampleCss]
     };

--- a/docs/app/pages/components/sections/tooltips/static-tooltip-ng1/static-tooltip-ng1.component.ts
+++ b/docs/app/pages/components/sections/tooltips/static-tooltip-ng1/static-tooltip-ng1.component.ts
@@ -12,7 +12,7 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('ComponentsStaticTooltipNg1Component')
 export class ComponentsStaticTooltipNg1Component extends BaseDocumentationSection implements ICodePenProvider {
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.sampleHtml,
         htmlAttributes: {
             'ng-controller': 'StaticTooltipDemoCtrl as vm'

--- a/docs/app/pages/components/sections/tooltips/tooltips-ng1/tooltips-ng1.component.ts
+++ b/docs/app/pages/components/sections/tooltips/tooltips-ng1/tooltips-ng1.component.ts
@@ -12,7 +12,7 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('ComponentsTooltipsNg1Component')
 export class ComponentsTooltipsNg1Component extends BaseDocumentationSection implements ICodePenProvider {
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.sampleHtml,
         htmlAttributes: {
             'ng-controller': 'TooltipsCtrl as vm'

--- a/docs/app/pages/components/sections/tree-view/tree-grid-asynchronous-loading-ng1/tree-grid-asynchronous-loading-ng1.component.ts
+++ b/docs/app/pages/components/sections/tree-view/tree-grid-asynchronous-loading-ng1/tree-grid-asynchronous-loading-ng1.component.ts
@@ -12,7 +12,7 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('ComponentsTreeGridAsynchronousLoadingNg1Component')
 export class ComponentsTreeGridAsynchronousLoadingNg1Component extends BaseDocumentationSection implements ICodePenProvider {
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.sampleHtml,
         htmlAttributes: {
             'ng-controller': 'TreeGridAsyncDemoCtrl as vm'

--- a/docs/app/pages/components/sections/tree-view/tree-grid-ng1/tree-grid-ng1.component.ts
+++ b/docs/app/pages/components/sections/tree-view/tree-grid-ng1/tree-grid-ng1.component.ts
@@ -12,11 +12,11 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('ComponentsTreeGridNg1Component')
 export class ComponentsTreeGridNg1Component extends BaseDocumentationSection implements ICodePenProvider {
 
-    private actionsHtml = require('./wrapper/actions.html');
-    private displayPanel = require('./wrapper/displayPanel.html');
-    private displayPanelFooter = require('./wrapper/displayPanelFooter.html');
+    actionsHtml = require('./wrapper/actions.html');
+    displayPanel = require('./wrapper/displayPanel.html');
+    displayPanelFooter = require('./wrapper/displayPanelFooter.html');
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.sampleHtml,
         htmlAttributes: {
             'ng-controller': 'TreeGridCtrl as vm'

--- a/docs/app/pages/components/sections/tree-view/tree-view-companion-view-ng1/tree-view-companion-view-ng1.component.ts
+++ b/docs/app/pages/components/sections/tree-view/tree-view-companion-view-ng1/tree-view-companion-view-ng1.component.ts
@@ -12,7 +12,7 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('ComponentsTreeViewCompanionViewNg1Component')
 export class ComponentsTreeViewCompanionViewNg1Component extends BaseDocumentationSection implements ICodePenProvider {
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.sampleHtml,
         htmlAttributes: {
             'ng-controller': 'TreeViewCompanionViewCtrl as vm'

--- a/docs/app/pages/components/sections/tree-view/tree-view-ng1/tree-view-ng1.component.ts
+++ b/docs/app/pages/components/sections/tree-view/tree-view-ng1/tree-view-ng1.component.ts
@@ -12,7 +12,7 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('ComponentsTreeViewNg1Component')
 export class ComponentsTreeViewNg1Component extends BaseDocumentationSection implements ICodePenProvider {
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.sampleHtml,
         htmlAttributes: {
             'ng-controller': 'TreeViewDocumentationCtrl as vm'

--- a/docs/app/pages/components/sections/utilities/focus-on-show-ng1/focus-on-show-component.ts
+++ b/docs/app/pages/components/sections/utilities/focus-on-show-ng1/focus-on-show-component.ts
@@ -12,7 +12,7 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('ComponentsFocusOnShowNg1Component')
 export class ComponentsFocusOnShowNg1Component extends BaseDocumentationSection implements ICodePenProvider {
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.sampleExampleHtml
     };
 

--- a/docs/app/pages/components/sections/utilities/list-item-filter-ng1/list-item-filter-ng1.component.ts
+++ b/docs/app/pages/components/sections/utilities/list-item-filter-ng1/list-item-filter-ng1.component.ts
@@ -12,7 +12,7 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('ComponentsListItemFilterNg1Component')
 export class ComponentsListItemFilterNg1Component extends BaseDocumentationSection implements ICodePenProvider {
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.sampleHtml,
         htmlAttributes: {
             'ng-controller': 'ListItemFilterCtrl as vm'

--- a/docs/app/pages/components/sections/utilities/pdf-service-ng1/pdf-service-ng1.component.ts
+++ b/docs/app/pages/components/sections/utilities/pdf-service-ng1/pdf-service-ng1.component.ts
@@ -12,7 +12,7 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('ComponentsPdfServiceNg1Component')
 export class ComponentsPdfServiceNg1Component extends BaseDocumentationSection implements ICodePenProvider {
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.sampleHtml,
         htmlAttributes: {
             'ng-controller': 'PdfServiceCtrl as vm'

--- a/docs/app/pages/components/sections/utilities/time-ago-service-ng1/time-ago-service-ng1.component.ts
+++ b/docs/app/pages/components/sections/utilities/time-ago-service-ng1/time-ago-service-ng1.component.ts
@@ -12,7 +12,7 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('ComponentsTimeAgoServiceNg1Component')
 export class ComponentsTimeAgoServiceNg1Component extends BaseDocumentationSection implements ICodePenProvider {
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.sampleHtml,
         htmlAttributes: {
             'ng-controller': 'TimeAgoCtrl as vm'

--- a/docs/app/pages/components/sections/wizard/marquee-wizard-ng1/marquee-wizard-ng1.component.ts
+++ b/docs/app/pages/components/sections/wizard/marquee-wizard-ng1/marquee-wizard-ng1.component.ts
@@ -12,7 +12,7 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('ComponentsMarqueeWizardNg1Component')
 export class ComponentsMarqueeWizardNg1Component extends BaseDocumentationSection implements ICodePenProvider {
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.modalHtml,
         htmlAttributes: {
             'ng-controller': 'MarqueeModalCtrl as vm'

--- a/docs/app/pages/components/sections/wizard/vertical-wizard-ng1/vertical-wizard-ng1.component.ts
+++ b/docs/app/pages/components/sections/wizard/vertical-wizard-ng1/vertical-wizard-ng1.component.ts
@@ -12,7 +12,7 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('ComponentsVerticalWizardNg1Component')
 export class ComponentsVerticalWizardNg1Component extends BaseDocumentationSection implements ICodePenProvider {
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.sampleHtml,
         htmlAttributes: {
             'ng-controller': 'VerticalWizardCtrl as vm'

--- a/docs/app/pages/components/sections/wizard/wizard-ng1/wizard-ng1.component.ts
+++ b/docs/app/pages/components/sections/wizard/wizard-ng1/wizard-ng1.component.ts
@@ -12,7 +12,7 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('ComponentsWizardNg1Component')
 export class ComponentsWizardNg1Component extends BaseDocumentationSection implements ICodePenProvider {
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.sampleHtml,
         htmlAttributes: {
             'ng-controller': 'WizardCtrl as vm'

--- a/docs/app/pages/components/sections/wizard/wizard-validation-ng1/wizard-validation-ng1.component.ts
+++ b/docs/app/pages/components/sections/wizard/wizard-validation-ng1/wizard-validation-ng1.component.ts
@@ -12,7 +12,7 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('ComponentsWizardValidationNg1Component')
 export class ComponentsWizardValidationNg1Component extends BaseDocumentationSection implements ICodePenProvider {
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.sampleHtml,
         htmlAttributes: {
             'ng-controller': 'WizardValidationCtrl as vm'

--- a/docs/app/pages/css/sections/buttons/button-dropdowns/button-dropdowns.component.ts
+++ b/docs/app/pages/css/sections/buttons/button-dropdowns/button-dropdowns.component.ts
@@ -11,7 +11,7 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('CssButtonDropdownsComponent')
 export class CssButtonDropdownsComponent  extends BaseDocumentationSection implements ICodePenProvider {
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.sampleHtml
     };
 

--- a/docs/app/pages/css/sections/buttons/circular-icon-buttons/circular-icon-buttons.component.ts
+++ b/docs/app/pages/css/sections/buttons/circular-icon-buttons/circular-icon-buttons.component.ts
@@ -11,7 +11,7 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('CssCircularIconButtonsComponent')
 export class CssCircularIconButtonsComponent extends BaseDocumentationSection implements ICodePenProvider {
     
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.sampleHtml
     };
 

--- a/docs/app/pages/css/sections/buttons/colored-buttons/colored-buttons.component.ts
+++ b/docs/app/pages/css/sections/buttons/colored-buttons/colored-buttons.component.ts
@@ -11,7 +11,7 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('CssColoredButtonsComponent')
 export class CssColoredButtonsComponent extends BaseDocumentationSection implements ICodePenProvider {
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.sampleHtml
     };
 

--- a/docs/app/pages/css/sections/buttons/hyperlinks/hyperlinks.component.ts
+++ b/docs/app/pages/css/sections/buttons/hyperlinks/hyperlinks.component.ts
@@ -11,7 +11,7 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('CssHyperlinksComponent')
 export class CssHyperlinksComponent extends BaseDocumentationSection implements ICodePenProvider {
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.codepenExampleHtml
     };
 

--- a/docs/app/pages/css/sections/buttons/link-buttons/link-buttons.component.ts
+++ b/docs/app/pages/css/sections/buttons/link-buttons/link-buttons.component.ts
@@ -11,7 +11,7 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('CssLinkButtonsComponent')
 export class CssLinkButtonsComponent extends BaseDocumentationSection implements ICodePenProvider {
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.sampleHtml
     };
 

--- a/docs/app/pages/css/sections/buttons/size-variations/size-variations.component.ts
+++ b/docs/app/pages/css/sections/buttons/size-variations/size-variations.component.ts
@@ -11,7 +11,7 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('CssButtonsSizeVariationsComponent')
 export class CssButtonsSizeVariationsComponent extends BaseDocumentationSection implements ICodePenProvider {
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.codeExampleHtml
     };
 

--- a/docs/app/pages/css/sections/buttons/split-button-dropdowns/split-button-dropdowns.component.ts
+++ b/docs/app/pages/css/sections/buttons/split-button-dropdowns/split-button-dropdowns.component.ts
@@ -11,7 +11,7 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('CssSplitButtonDropdownsComponent')
 export class CssSplitButtonDropdownsComponent extends BaseDocumentationSection implements ICodePenProvider {
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.sampleHtml
     };
 

--- a/docs/app/pages/css/sections/color-palette/color-palette/color-palette.component.ts
+++ b/docs/app/pages/css/sections/color-palette/color-palette/color-palette.component.ts
@@ -9,7 +9,7 @@ import { DocumentationSectionComponent } from '../../../../../decorators/documen
 @DocumentationSectionComponent('CssColorPaletteComponent')
 export class CssColorPaletteComponent {
 
-    private colors: object;
+    colors: object;
 
     constructor(private colorService: ColorService) {
 

--- a/docs/app/pages/css/sections/forms/basic-form/basic-form.component.ts
+++ b/docs/app/pages/css/sections/forms/basic-form/basic-form.component.ts
@@ -13,7 +13,7 @@ export class CssBasicFormComponent extends BaseDocumentationSection implements I
 
     checked: boolean = false;
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.sampleHtml
     };
 

--- a/docs/app/pages/css/sections/forms/form-validation-field-by-field/form-validation-field-by-field.component.ts
+++ b/docs/app/pages/css/sections/forms/form-validation-field-by-field/form-validation-field-by-field.component.ts
@@ -11,7 +11,7 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('CssFormValidationFieldByFieldComponent')
 export class CssFormValidationFieldByFieldComponent extends BaseDocumentationSection implements ICodePenProvider {
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.sampleHtml
     };
 

--- a/docs/app/pages/css/sections/forms/form-validation-on-submit/form-validation-on-submit.component.ts
+++ b/docs/app/pages/css/sections/forms/form-validation-on-submit/form-validation-on-submit.component.ts
@@ -11,7 +11,7 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('CssFormValidationOnSubmitComponent')
 export class CssFormValidationOnSubmitComponent extends BaseDocumentationSection implements ICodePenProvider {
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.sampleHtml,
         js: [this.snippets.raw.sampleJs]
     };

--- a/docs/app/pages/css/sections/forms/horizontal-form/horizontal-form.component.ts
+++ b/docs/app/pages/css/sections/forms/horizontal-form/horizontal-form.component.ts
@@ -13,7 +13,7 @@ export class CssHorizontalFormComponent extends BaseDocumentationSection impleme
 
     checked: boolean = false;
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.codeExampleHtml
     };
 

--- a/docs/app/pages/css/sections/forms/inline-form/inline-form.component.ts
+++ b/docs/app/pages/css/sections/forms/inline-form/inline-form.component.ts
@@ -13,7 +13,7 @@ export class CssInlineFormComponent extends BaseDocumentationSection implements 
 
     checked: boolean = false;
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.codeExampleHtml
     };
 

--- a/docs/app/pages/css/sections/icons/basic-usage/basic-usage.component.ts
+++ b/docs/app/pages/css/sections/icons/basic-usage/basic-usage.component.ts
@@ -11,7 +11,7 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('CssBasicUsageComponent')
 export class CssBasicUsageComponent extends BaseDocumentationSection implements ICodePenProvider {
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.sampleHtml
     };
 

--- a/docs/app/pages/css/sections/icons/fixed-width/fixed-width.component.ts
+++ b/docs/app/pages/css/sections/icons/fixed-width/fixed-width.component.ts
@@ -11,7 +11,7 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('CssFixedWidthComponent')
 export class CssFixedWidthComponent extends BaseDocumentationSection implements ICodePenProvider {
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.sampleHtml
     };
 

--- a/docs/app/pages/css/sections/icons/icon-buttons/icon-buttons.component.ts
+++ b/docs/app/pages/css/sections/icons/icon-buttons/icon-buttons.component.ts
@@ -11,7 +11,7 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('CssIconButtonsComponent')
 export class CssIconButtonsComponent extends BaseDocumentationSection implements ICodePenProvider {
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.sampleHtml
     };
     

--- a/docs/app/pages/css/sections/icons/icon-colors/icon-colors.component.ts
+++ b/docs/app/pages/css/sections/icons/icon-colors/icon-colors.component.ts
@@ -11,7 +11,7 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('CssIconColorsComponent')
 export class CssIconColorsComponent extends BaseDocumentationSection implements ICodePenProvider {
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.sampleHtml
     };
 

--- a/docs/app/pages/css/sections/icons/icon-size/icon-size.component.ts
+++ b/docs/app/pages/css/sections/icons/icon-size/icon-size.component.ts
@@ -11,7 +11,7 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('CssIconSizeComponent')
 export class CssIconSizeComponent extends BaseDocumentationSection implements ICodePenProvider {
     
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.sampleHtml
     };
 

--- a/docs/app/pages/css/sections/icons/rotate-flip-icons/rotate-flip-icons.component.ts
+++ b/docs/app/pages/css/sections/icons/rotate-flip-icons/rotate-flip-icons.component.ts
@@ -11,7 +11,7 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('CssRotateFlipIconsComponent')
 export class CssRotateFlipIconsComponent extends BaseDocumentationSection implements ICodePenProvider {
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.sampleHtml
     };
 

--- a/docs/app/pages/css/sections/icons/ux-icons/ux-icons.component.ts
+++ b/docs/app/pages/css/sections/icons/ux-icons/ux-icons.component.ts
@@ -9,9 +9,9 @@ import { DocumentationSectionComponent } from '../../../../../decorators/documen
 @DocumentationSectionComponent('CssUxIconsComponent')
 export class CssUxIconsComponent {
 
-    private iconset: IIcons;
-    private iconlist: IIcon[]; 
-    private query: string;
+    iconset: IIcons;
+    iconlist: IIcon[]; 
+    query: string;
 
     constructor() {
 

--- a/docs/app/pages/css/sections/labels/labels/labels.component.ts
+++ b/docs/app/pages/css/sections/labels/labels/labels.component.ts
@@ -11,7 +11,7 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('CssLabelsComponent')
 export class CssLabelsComponent extends BaseDocumentationSection implements ICodePenProvider {
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.codeExampleHtml
     };
 

--- a/docs/app/pages/css/sections/labels/static-text/static-text.component.ts
+++ b/docs/app/pages/css/sections/labels/static-text/static-text.component.ts
@@ -11,7 +11,7 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('CssStaticTextComponent')
 export class CssStaticTextComponent extends BaseDocumentationSection implements ICodePenProvider {
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.sampleHtml
     };
     

--- a/docs/app/pages/css/sections/page-header/breadcrumb/breadcrumb.component.ts
+++ b/docs/app/pages/css/sections/page-header/breadcrumb/breadcrumb.component.ts
@@ -11,7 +11,7 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('CssBreadcrumbComponent')
 export class CssBreadcrumbComponent extends BaseDocumentationSection implements ICodePenProvider {
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.sampleHtml
     };
 

--- a/docs/app/pages/css/sections/page-header/page-header-example/page-header-example.component.ts
+++ b/docs/app/pages/css/sections/page-header/page-header-example/page-header-example.component.ts
@@ -11,7 +11,7 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('CssPageHeaderExampleComponent')
 export class CssPageHeaderExampleComponent extends BaseDocumentationSection implements ICodePenProvider {
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.sampleHtml,
         css: [this.snippets.raw.sampleCss],
         js: [this.snippets.raw.sampleJs]

--- a/docs/app/pages/css/sections/panels/basic-panel/basic-panel.component.ts
+++ b/docs/app/pages/css/sections/panels/basic-panel/basic-panel.component.ts
@@ -11,7 +11,7 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('CssBasicPanelComponent')
 export class CssBasicPanelComponent extends BaseDocumentationSection implements ICodePenProvider {
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.sampleHtml
     };
 

--- a/docs/app/pages/css/sections/panels/ebox-panel/ebox-panel.component.ts
+++ b/docs/app/pages/css/sections/panels/ebox-panel/ebox-panel.component.ts
@@ -11,7 +11,7 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('CssEboxPanelComponent')
 export class CssEboxPanelComponent extends BaseDocumentationSection implements ICodePenProvider {
     
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.sampleHtml
     };
 

--- a/docs/app/pages/css/sections/progress/activity-indicator-alternative/activity-indicator-alternative.component.ts
+++ b/docs/app/pages/css/sections/progress/activity-indicator-alternative/activity-indicator-alternative.component.ts
@@ -11,7 +11,7 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('CssActivityIndicatorAlternativeComponent')
 export class CssActivityIndicatorAlternativeComponent extends BaseDocumentationSection implements ICodePenProvider {
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.sampleHtml
     };
     

--- a/docs/app/pages/css/sections/progress/activity-indicator/activity-indicator.component.ts
+++ b/docs/app/pages/css/sections/progress/activity-indicator/activity-indicator.component.ts
@@ -11,7 +11,7 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('CssActivityIndicatorComponent')
 export class CssActivityIndicatorComponent extends BaseDocumentationSection implements ICodePenProvider {
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.sampleHtml
     };
     

--- a/docs/app/pages/css/sections/progress/mini-activity-indicator/mini-activity-indicator.component.ts
+++ b/docs/app/pages/css/sections/progress/mini-activity-indicator/mini-activity-indicator.component.ts
@@ -11,7 +11,7 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('CssMiniActivityIndicatorComponent')
 export class CssMiniActivityIndicatorComponent extends BaseDocumentationSection implements ICodePenProvider {
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: `${this.snippets.raw.sample1Html} ${this.snippets.raw.sample2Html} ${this.snippets.raw.sample3Html} ${this.snippets.raw.sample4Html}`
     };
 

--- a/docs/app/pages/css/sections/responsive-design/column-ordering/column-ordering.component.ts
+++ b/docs/app/pages/css/sections/responsive-design/column-ordering/column-ordering.component.ts
@@ -11,7 +11,7 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('CssColumnOrderingComponent')
 export class CssColumnOrderingComponent extends BaseDocumentationSection implements ICodePenProvider {
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.sampleHtml
     };
 

--- a/docs/app/pages/css/sections/responsive-design/mobile-desktop/mobile-desktop.component.ts
+++ b/docs/app/pages/css/sections/responsive-design/mobile-desktop/mobile-desktop.component.ts
@@ -11,7 +11,7 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('CssMobileDesktopComponent')
 export class CssMobileDesktopComponent extends BaseDocumentationSection implements ICodePenProvider {
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.sampleHtml
     };
 

--- a/docs/app/pages/css/sections/responsive-design/mobile-tablet-desktop/mobile-tablet-desktop.component.ts
+++ b/docs/app/pages/css/sections/responsive-design/mobile-tablet-desktop/mobile-tablet-desktop.component.ts
@@ -11,7 +11,7 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('CssMobileTabletDesktopComponent')
 export class CssMobileTabletDesktopComponent extends BaseDocumentationSection implements ICodePenProvider {
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.sampleHtml
     };
 

--- a/docs/app/pages/css/sections/responsive-design/nesting-columns/nesting-columns.component.ts
+++ b/docs/app/pages/css/sections/responsive-design/nesting-columns/nesting-columns.component.ts
@@ -11,7 +11,7 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('CssNestingColumnsComponent')
 export class CssNestingColumnsComponent extends BaseDocumentationSection implements ICodePenProvider {
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.sampleHtml
     };
 

--- a/docs/app/pages/css/sections/responsive-design/offsetting-columns/offsetting-columns.component.ts
+++ b/docs/app/pages/css/sections/responsive-design/offsetting-columns/offsetting-columns.component.ts
@@ -11,7 +11,7 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('CssOffsettingColumnsComponent')
 export class CssOffsettingColumnsComponent extends BaseDocumentationSection implements ICodePenProvider {
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.sampleHtml
     };
 

--- a/docs/app/pages/css/sections/responsive-design/responsive-column-resets/responsive-column-resets.component.ts
+++ b/docs/app/pages/css/sections/responsive-design/responsive-column-resets/responsive-column-resets.component.ts
@@ -11,7 +11,7 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('CssResponsiveColumnResetsComponent')
 export class CssResponsiveColumnResetsComponent extends BaseDocumentationSection implements ICodePenProvider {
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.sampleHtml
     };
 

--- a/docs/app/pages/css/sections/responsive-design/stacked-to-horizontal/stacked-to-horizontal.component.ts
+++ b/docs/app/pages/css/sections/responsive-design/stacked-to-horizontal/stacked-to-horizontal.component.ts
@@ -11,7 +11,7 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('CssStackedToHorizontalComponent')
 export class CssStackedToHorizontalComponent extends BaseDocumentationSection implements ICodePenProvider {
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.sampleHtml
     };
 

--- a/docs/app/pages/css/sections/structure/scroll-to-top-button/scroll-to-top-button.component.ts
+++ b/docs/app/pages/css/sections/structure/scroll-to-top-button/scroll-to-top-button.component.ts
@@ -11,7 +11,7 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('CssScrollToTopButtonComponent')
 export class CssScrollToTopButtonComponent extends BaseDocumentationSection implements ICodePenProvider {
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.codeExampleHtml
     };
 

--- a/docs/app/pages/css/sections/tables/cards/cards.component.ts
+++ b/docs/app/pages/css/sections/tables/cards/cards.component.ts
@@ -11,7 +11,7 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('CssCardsComponent')
 export class CssCardsComponent extends BaseDocumentationSection implements ICodePenProvider {
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.sampleHtml
     };
 

--- a/docs/app/pages/css/sections/tables/tables/tables.component.ts
+++ b/docs/app/pages/css/sections/tables/tables/tables.component.ts
@@ -11,7 +11,7 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('CssTablesComponent')
 export class CssTablesComponent extends BaseDocumentationSection implements ICodePenProvider {
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.sampleHtml
     };
 

--- a/docs/app/pages/css/sections/text-inputs/button-addons/button-addons.component.ts
+++ b/docs/app/pages/css/sections/text-inputs/button-addons/button-addons.component.ts
@@ -11,7 +11,7 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('CssButtonAddonsComponent')
 export class CssButtonAddonsComponent extends BaseDocumentationSection implements ICodePenProvider {
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.sampleHtml
     };
 

--- a/docs/app/pages/css/sections/text-inputs/disabled-inputs/disabled-inputs.component.ts
+++ b/docs/app/pages/css/sections/text-inputs/disabled-inputs/disabled-inputs.component.ts
@@ -11,7 +11,7 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('CssDisabledAreaComponent')
 export class CssDisabledAreaComponent extends BaseDocumentationSection implements ICodePenProvider {
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.sampleHtml
     };
 

--- a/docs/app/pages/css/sections/text-inputs/dropdown-addons/dropdown-addons.component.ts
+++ b/docs/app/pages/css/sections/text-inputs/dropdown-addons/dropdown-addons.component.ts
@@ -11,7 +11,7 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('CssDropdownAddonsComponent')
 export class CssDropdownAddonsComponent extends BaseDocumentationSection implements ICodePenProvider {
     
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.sampleHtml
     };
 

--- a/docs/app/pages/css/sections/text-inputs/float-labels/float-labels.component.ts
+++ b/docs/app/pages/css/sections/text-inputs/float-labels/float-labels.component.ts
@@ -11,7 +11,7 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('CssFloatLabelsComponent')
 export class CssFloatLabelsComponent extends BaseDocumentationSection implements ICodePenProvider {
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.sampleHtml
     };
 

--- a/docs/app/pages/css/sections/text-inputs/input-error/input-error.component.ts
+++ b/docs/app/pages/css/sections/text-inputs/input-error/input-error.component.ts
@@ -11,7 +11,7 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('CssInputErrorComponent')
 export class CssInputErrorComponent extends BaseDocumentationSection implements ICodePenProvider {
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.sampleHtml
     };
 

--- a/docs/app/pages/css/sections/text-inputs/input-groups/input-groups.component.ts
+++ b/docs/app/pages/css/sections/text-inputs/input-groups/input-groups.component.ts
@@ -11,7 +11,7 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('CssInputGroupsComponent')
 export class CssInputGroupsComponent extends BaseDocumentationSection implements ICodePenProvider {
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.sampleHtml
     };
 

--- a/docs/app/pages/css/sections/text-inputs/input-height/input-height.component.ts
+++ b/docs/app/pages/css/sections/text-inputs/input-height/input-height.component.ts
@@ -11,7 +11,7 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('CssInputHeightComponent')
 export class CssInputHeightComponent extends BaseDocumentationSection implements ICodePenProvider {
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.sampleHtml
     };
 

--- a/docs/app/pages/css/sections/text-inputs/input-required/input-required.component.ts
+++ b/docs/app/pages/css/sections/text-inputs/input-required/input-required.component.ts
@@ -11,7 +11,7 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('CssInputRequiredComponent')
 export class CssInputRequiredComponent extends BaseDocumentationSection implements ICodePenProvider {
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.sampleHtml
     };
 

--- a/docs/app/pages/css/sections/text-inputs/input-width/input-width.component.ts
+++ b/docs/app/pages/css/sections/text-inputs/input-width/input-width.component.ts
@@ -11,7 +11,7 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('CssInputWidthComponent')
 export class CssInputWidthComponent extends BaseDocumentationSection implements ICodePenProvider {
     
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.sampleHtml
     };
 

--- a/docs/app/pages/css/sections/text-inputs/inputs-help-text/inputs-help-text.component.ts
+++ b/docs/app/pages/css/sections/text-inputs/inputs-help-text/inputs-help-text.component.ts
@@ -12,7 +12,7 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('CssInputsHelpTextComponent')
 export class CssInputsHelpTextComponent extends BaseDocumentationSection implements ICodePenProvider {
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.codepenExampleHtml
     };
 

--- a/docs/app/pages/css/sections/text-inputs/segmented-addons/segmented-addons.component.ts
+++ b/docs/app/pages/css/sections/text-inputs/segmented-addons/segmented-addons.component.ts
@@ -11,7 +11,7 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('CssSegmentedAddonsComponent')
 export class CssSegmentedAddonsComponent extends BaseDocumentationSection implements ICodePenProvider {
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.sampleHtml
     };
 

--- a/docs/app/pages/css/sections/text-inputs/text-area/text-area.component.ts
+++ b/docs/app/pages/css/sections/text-inputs/text-area/text-area.component.ts
@@ -11,7 +11,7 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('CssTextAreaComponent')
 export class CssTextAreaComponent extends BaseDocumentationSection implements ICodePenProvider {
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.sampleHtml
     };
 

--- a/docs/app/pages/css/sections/text-inputs/text-inputs/text-inputs.component.ts
+++ b/docs/app/pages/css/sections/text-inputs/text-inputs/text-inputs.component.ts
@@ -11,7 +11,7 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('CssTextInputsComponent')
 export class CssTextInputsComponent extends BaseDocumentationSection implements ICodePenProvider {
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.sampleHtml
     };
 

--- a/docs/app/pages/css/sections/typography/blockquotes/blockquotes.component.ts
+++ b/docs/app/pages/css/sections/typography/blockquotes/blockquotes.component.ts
@@ -11,7 +11,7 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('CssBlockquotesComponent')
 export class CssBlockquotesComponent extends BaseDocumentationSection implements ICodePenProvider {
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.sampleHtml
     };
 

--- a/docs/app/pages/css/sections/typography/emphasis-classes/emphasis-classes.component.ts
+++ b/docs/app/pages/css/sections/typography/emphasis-classes/emphasis-classes.component.ts
@@ -11,7 +11,7 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('CssEmphasisClassesComponent')
 export class CssEmphasisClassesComponent extends BaseDocumentationSection implements ICodePenProvider {
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.sampleHtml
     };
     

--- a/docs/app/pages/css/sections/typography/headings/headings.component.ts
+++ b/docs/app/pages/css/sections/typography/headings/headings.component.ts
@@ -11,7 +11,7 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('CssHeadingsComponent')
 export class CssHeadingsComponent extends BaseDocumentationSection implements ICodePenProvider {
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.sampleHtml
     };
 

--- a/docs/app/pages/css/sections/typography/ordered-list/ordered-list.component.ts
+++ b/docs/app/pages/css/sections/typography/ordered-list/ordered-list.component.ts
@@ -11,7 +11,7 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('CssOrderedListComponent')
 export class CssOrderedListComponent extends BaseDocumentationSection implements ICodePenProvider {
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.codeExampleHtml
     };
 

--- a/docs/app/pages/css/sections/typography/paragraph-text/paragraph-text.component.ts
+++ b/docs/app/pages/css/sections/typography/paragraph-text/paragraph-text.component.ts
@@ -11,7 +11,7 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('CssParagraphTextComponent')
 export class CssParagraphTextComponent extends BaseDocumentationSection implements ICodePenProvider {
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.codeExampleHtml
     };
 

--- a/docs/app/pages/css/sections/typography/unordered-list/unordered-list.component.ts
+++ b/docs/app/pages/css/sections/typography/unordered-list/unordered-list.component.ts
@@ -11,7 +11,7 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('CssUnorderedListComponent')
 export class CssUnorderedListComponent extends BaseDocumentationSection implements ICodePenProvider {
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.codeExampleHtml
     };
 

--- a/docs/app/pages/css/sections/typography/unstyled-list/unstyled-list.component.ts
+++ b/docs/app/pages/css/sections/typography/unstyled-list/unstyled-list.component.ts
@@ -11,7 +11,7 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('CssUnstyledListComponent')
 export class CssUnstyledListComponent extends BaseDocumentationSection implements ICodePenProvider {
 
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.codeExampleHtml
     };
 

--- a/docs/app/pages/css/sections/typography/wells/wells.component.ts
+++ b/docs/app/pages/css/sections/typography/wells/wells.component.ts
@@ -11,7 +11,7 @@ import { BaseDocumentationSection } from '../../../../../components/base-documen
 @DocumentationSectionComponent('CssWellsComponent')
 export class CssWellsComponent extends BaseDocumentationSection implements ICodePenProvider {
     
-    public codepen: ICodePen = {
+    codepen: ICodePen = {
         html: this.snippets.raw.sampleHtml
     };
 

--- a/docs/app/pages/customize/customize.component.ts
+++ b/docs/app/pages/customize/customize.component.ts
@@ -8,8 +8,8 @@ import { ICustomisePage, ICustomisePageSection, ICustomisePageVariable } from '.
 })
 export class CustomizePageComponent {
 
-    private sections: ICustomisePageSection[];
-    private variables: any;
+    sections: ICustomisePageSection[];
+    variables: any;
 
     constructor(private lessService: LessService) {
 

--- a/docs/app/pages/landing/landing.component.ts
+++ b/docs/app/pages/landing/landing.component.ts
@@ -9,7 +9,7 @@ import { ILandingPage } from '../../interfaces/ILandingPage';
 })
 export class LandingPageComponent {
 
-    private landingPage: ILandingPage;
+    landingPage: ILandingPage;
 
     constructor() {
 

--- a/docs/app/pages/team/team.component.ts
+++ b/docs/app/pages/team/team.component.ts
@@ -9,7 +9,7 @@ import { ITeam } from '../../interfaces/ITeam';
 })
 export class TeamPageComponent {
 
-    private data: ITeam;
+    data: ITeam;
 
     constructor() {
         this.data = require('../../data/team-page.json');

--- a/src/components/checkbox/checkbox.component.ts
+++ b/src/components/checkbox/checkbox.component.ts
@@ -41,8 +41,8 @@ export class CheckboxComponent implements ControlValueAccessor {
 
     private _value: any = false;
 
-    private onTouchedCallback: () => void = () => { };
-    private onChangeCallback: (_: any) => void = () => { };
+    onTouchedCallback: () => void = () => { };
+    onChangeCallback: (_: any) => void = () => { };
 
     constructor() { }
 

--- a/src/components/column-sorting/column-sorting.component.html
+++ b/src/components/column-sorting/column-sorting.component.html
@@ -1,7 +1,7 @@
 <div class="ux-column-sorting">
     <i class="ux-column-sorting-icon hpe-icon" 
-        [class.hpe-ascend]="state===columnSortingState.Ascending" 
-        [class.hpe-descend]="state===columnSortingState.Descending" 
-        [class.column-sorting-icon-hidden]="state===columnSortingState.NoSort"></i>
+        [class.hpe-ascend]="state === columnSortingState.Ascending" 
+        [class.hpe-descend]="state === columnSortingState.Descending" 
+        [class.column-sorting-icon-hidden]="state === columnSortingState.NoSort"></i>
     <p class="ux-column-sorting-number">{{ orderNumber }}</p>
 </div>

--- a/src/components/column-sorting/column-sorting.component.ts
+++ b/src/components/column-sorting/column-sorting.component.ts
@@ -13,14 +13,14 @@ export class ColumnSortingComponent {
     @Input() orderNumber: number;
     @Output() stateChange: EventEmitter<ColumnSortingState> = new EventEmitter<ColumnSortingState>();
 
-    private parent: ColumnSortingDirective;
+    private _parent: ColumnSortingDirective;
     columnSortingState = ColumnSortingState;
 
     initParent(parent: ColumnSortingDirective) {
-        this.parent = parent;
+        this._parent = parent;
 
         // watch for any events
-        this.parent.events.subscribe(event => {
+        this._parent.events.subscribe(event => {
 
             let idx = event.findIndex(column => column.key === this.key);
 
@@ -51,7 +51,7 @@ export class ColumnSortingComponent {
         }
 
         // inform parent
-        return this.parent.toggleColumn(this.key, this.state);
+        return this._parent.toggleColumn(this.key, this.state);
 
     }
 }

--- a/src/components/facets/base/facet-base/facet-base.component.ts
+++ b/src/components/facets/base/facet-base/facet-base.component.ts
@@ -16,7 +16,7 @@ export class FacetBaseComponent implements OnInit {
 
     @Output() events: Subject<FacetEvent> = new Subject<FacetEvent>();
 
-    constructor( @Host() private facetContainer: FacetContainerComponent, protected _elementRef: ElementRef) {
+    constructor( @Host() private facetContainer: FacetContainerComponent, public _elementRef: ElementRef) {
 
         if (facetContainer) {
 

--- a/src/components/facets/facet-typeahead-list/facet-typeahead-list.component.ts
+++ b/src/components/facets/facet-typeahead-list/facet-typeahead-list.component.ts
@@ -24,8 +24,8 @@ export class FacetTypeaheadListComponent extends FacetBaseComponent implements O
     typeaheadOptions: Observable<Facet[]>;
     searchQuery: string;
 
-    private nativeElement: HTMLElement = this._elementRef.nativeElement as HTMLElement;
-    private defaultTypeaheadConfig: FacetTypeaheadListConfig = {
+    private _nativeElement: HTMLElement = this._elementRef.nativeElement as HTMLElement;
+    private _defaultTypeaheadConfig: FacetTypeaheadListConfig = {
         placeholder: '',
         maxResults: 50,
         minCharacters: 1
@@ -58,11 +58,11 @@ export class FacetTypeaheadListComponent extends FacetBaseComponent implements O
         }
 
         // provide default values for typeahead config
-        for (let prop in this.defaultTypeaheadConfig) {
+        for (let prop in this._defaultTypeaheadConfig) {
 
             // check if prop has been defined in the users typeahead config - if not set default value
             if (this.typeaheadConfig.hasOwnProperty(prop) === false) {
-                this.typeaheadConfig[prop] = this.defaultTypeaheadConfig[prop];
+                this.typeaheadConfig[prop] = this._defaultTypeaheadConfig[prop];
             }
         }
     }
@@ -83,7 +83,7 @@ export class FacetTypeaheadListComponent extends FacetBaseComponent implements O
 
     scrollToFocused(): void {
 
-        let dropdown = this.nativeElement.querySelector('.dropdown-menu');
+        let dropdown = this._nativeElement.querySelector('.dropdown-menu');
 
         // delay to allow the typeahead ui to update
         setTimeout(() => {

--- a/src/components/flippable-card/flippable-card.component.ts
+++ b/src/components/flippable-card/flippable-card.component.ts
@@ -27,8 +27,7 @@ export class FlippableCardComponent {
         this.setFlipped(!this.flipped);
     }
 
-    @HostListener('click')
-    private clickTrigger() {
+    @HostListener('click') clickTrigger() {
 
         // add or remove the class depending on whether or not the card has been flipped
         if (this.trigger === 'click') {
@@ -36,16 +35,14 @@ export class FlippableCardComponent {
         }
     }
 
-    @HostListener('mouseenter')
-    private hoverEnter() {
+    @HostListener('mouseenter') hoverEnter() {
         // if the trigger is hover then begin to flip
         if (this.trigger === 'hover') {
             this.setFlipped(true);
         }
     }
 
-    @HostListener('mouseleave')
-    private hoverExit() {
+    @HostListener('mouseleave') hoverExit() {
         if (this.trigger === 'hover') {
             this.setFlipped(false);
         }

--- a/src/components/page-header/navigation/navigation-dropdown-item/navigation-dropdown-item.component.ts
+++ b/src/components/page-header/navigation/navigation-dropdown-item/navigation-dropdown-item.component.ts
@@ -15,15 +15,12 @@ export class PageHeaderNavigationDropdownItemComponent {
 
     dropdownOpen: boolean = false;
 
-    private dropdownEvents: Subject<boolean>;
+    private _dropdownEvents: Subject<boolean> = new Subject<boolean>();
 
     constructor() {
 
-        // create a new subject observable
-        this.dropdownEvents = new Subject<boolean>();
-
         // subscribe to stream with a debounce (a small debounce is all that is required)
-        this.dropdownEvents.debounceTime(1).subscribe(visible => this.dropdownOpen = visible);
+        this._dropdownEvents.debounceTime(1).subscribe(visible => this.dropdownOpen = visible);
     }
 
     selectItem(item: PageHeaderNavigationDropdownItem, parentItem?: PageHeaderNavigationDropdownItem) {
@@ -46,11 +43,11 @@ export class PageHeaderNavigationDropdownItemComponent {
     }
 
     hoverStart() {
-        this.dropdownEvents.next(true);
+        this._dropdownEvents.next(true);
     }
 
     hoverLeave() {
-        this.dropdownEvents.next(false);
+        this._dropdownEvents.next(false);
     }
 
     close() {

--- a/src/components/radiobutton/radiobutton.component.ts
+++ b/src/components/radiobutton/radiobutton.component.ts
@@ -39,8 +39,8 @@ export class RadioButtonComponent implements ControlValueAccessor {
 
     private _value: any = false;
 
-    private onTouchedCallback: () => void = () => { };
-    private onChangeCallback: (_: any) => void = () => { };
+    onTouchedCallback: () => void = () => { };
+    onChangeCallback: (_: any) => void = () => { };
 
     @HostListener('click')
     checkItem() {

--- a/src/components/select/select.component.ts
+++ b/src/components/select/select.component.ts
@@ -84,13 +84,13 @@ export class SelectComponent implements OnInit, OnChanges, ControlValueAccessor 
     @Input() noOptionsTemplate: TemplateRef<any>;
     @Input() optionTemplate: TemplateRef<any>;
 
-    @ViewChild('singleInput') protected singleInput: ElementRef;
-    @ViewChild('multipleTypeahead') protected multipleTypeahead: TypeaheadComponent;
-    @ViewChild('singleTypeahead') protected singleTypeahead: TypeaheadComponent;
+    @ViewChild('singleInput') singleInput: ElementRef;
+    @ViewChild('multipleTypeahead') multipleTypeahead: TypeaheadComponent;
+    @ViewChild('singleTypeahead') singleTypeahead: TypeaheadComponent;
 
-    protected filter: Observable<string>;
+    filter: Observable<string>;
 
-    private propagateChange = (_: any) => { };
+    propagateChange = (_: any) => { };
 
     constructor(
         private _element: ElementRef,
@@ -155,12 +155,12 @@ export class SelectComponent implements OnInit, OnChanges, ControlValueAccessor 
         this.disabled = isDisabled;
     }
 
-    protected inputClickHandler(event: MouseEvent) {
+    inputClickHandler(event: MouseEvent) {
         this.selectInputText();
         this.dropdownOpen = true;
     }
 
-    protected inputBlurHandler(event: Event) {
+    inputBlurHandler(event: Event) {
         // Close dropdown and reset text input if focus is lost
         setTimeout(() => {
             if (!this._element.nativeElement.contains(this._document.activeElement)) {
@@ -175,7 +175,7 @@ export class SelectComponent implements OnInit, OnChanges, ControlValueAccessor 
     /**
      * Key handler for single select only. Multiple select key handling is in TagInputComponent.
      */
-    protected inputKeyHandler(event: KeyboardEvent) {
+    inputKeyHandler(event: KeyboardEvent) {
 
         // Standard keys for typeahead (up/down/esc)
         this._typeaheadKeyService.handleKey(event, this.singleTypeahead);
@@ -195,7 +195,7 @@ export class SelectComponent implements OnInit, OnChanges, ControlValueAccessor 
         }
     }
 
-    protected singleOptionSelected(event: TypeaheadOptionEvent) {
+    singleOptionSelected(event: TypeaheadOptionEvent) {
         if (event.option) {
             this.value = event.option;
             this.dropdownOpen = false;
@@ -205,7 +205,7 @@ export class SelectComponent implements OnInit, OnChanges, ControlValueAccessor 
     /**
      * Returns the display value of the given option.
      */
-    protected getDisplay(option: any): string {
+    getDisplay(option: any): string {
         if (option === null || option === undefined) {
             return '';
         }

--- a/src/components/slider/slider.component.ts
+++ b/src/components/slider/slider.component.ts
@@ -83,12 +83,12 @@ export class SliderComponent implements OnInit, AfterViewInit, DoCheck, OnDestro
     defaultOptions: SliderOptions;
 
     // observables for capturing movement
-    private lowerThumbDown: Observable<MouseEvent>;
-    private upperThumbDown: Observable<MouseEvent>;
-    private mouseMove: Observable<MouseEvent> = Observable.fromEvent(document, 'mousemove');
-    private mouseUp: Observable<MouseEvent> = Observable.fromEvent(document, 'mouseup');
-    private lowerDrag: Subscription;
-    private upperDrag: Subscription;
+    private _lowerThumbDown: Observable<MouseEvent>;
+    private _upperThumbDown: Observable<MouseEvent>;
+    private _mouseMove: Observable<MouseEvent> = Observable.fromEvent(document, 'mousemove');
+    private _mouseUp: Observable<MouseEvent> = Observable.fromEvent(document, 'mouseup');
+    private _lowerDrag: Subscription;
+    private _upperDrag: Subscription;
 
     constructor(colorService: ColorService) {
 
@@ -162,8 +162,8 @@ export class SliderComponent implements OnInit, AfterViewInit, DoCheck, OnDestro
     }
 
     ngOnDestroy() {
-        this.lowerDrag.unsubscribe();
-        this.upperDrag.unsubscribe();
+        this._lowerDrag.unsubscribe();
+        this._upperDrag.unsubscribe();
     }
 
     getFormattedValue(thumb: SliderThumb): string | number {
@@ -173,21 +173,21 @@ export class SliderComponent implements OnInit, AfterViewInit, DoCheck, OnDestro
     private initObservables(): void {
 
         // when a user begins to drag lower thumb - subscribe to mouse move events until the mouse is lifted
-        this.lowerThumbDown = Observable.fromEvent(this.lowerThumb.nativeElement, 'mousedown');
+        this._lowerThumbDown = Observable.fromEvent(this.lowerThumb.nativeElement, 'mousedown');
 
-        this.lowerDrag = this.lowerThumbDown.switchMap(event => {
+        this._lowerDrag = this._lowerThumbDown.switchMap(event => {
             event.preventDefault();
-            return this.mouseMove.takeUntil(this.mouseUp);
+            return this._mouseMove.takeUntil(this._mouseUp);
         }).subscribe(event => {
             event.preventDefault();
             this.updateThumbPosition(event, SliderThumb.Lower);
         });
 
         // when a user begins to drag upper thumb - subscribe to mouse move events until the mouse is lifted
-        this.upperThumbDown = Observable.fromEvent(this.upperThumb.nativeElement, 'mousedown');
-        this.upperDrag = this.upperThumbDown.switchMap(event => {
+        this._upperThumbDown = Observable.fromEvent(this.upperThumb.nativeElement, 'mousedown');
+        this._upperDrag = this._upperThumbDown.switchMap(event => {
             event.preventDefault();
-            return this.mouseMove.takeUntil(this.mouseUp);
+            return this._mouseMove.takeUntil(this._mouseUp);
         }).subscribe(event => {
             event.preventDefault();
             this.updateThumbPosition(event, SliderThumb.Upper);

--- a/src/components/tag-input/tag-input-event.ts
+++ b/src/components/tag-input/tag-input-event.ts
@@ -4,11 +4,11 @@ export class TagInputEvent {
 
     constructor(public tag: any) {}
 
-    public preventDefault() {
+    preventDefault() {
         this._defaultPrevented = true;
     }
 
-    public defaultPrevented(): boolean {
+    defaultPrevented(): boolean {
         return this._defaultPrevented;
     }
 }

--- a/src/components/toggleswitch/toggleswitch.component.ts
+++ b/src/components/toggleswitch/toggleswitch.component.ts
@@ -38,8 +38,8 @@ export class ToggleSwitchComponent implements ControlValueAccessor {
 
     private _value: boolean = false;
 
-    private onTouchedCallback: () => void = () => { };
-    private onChangeCallback: (_: any) => void = () => { };
+    onTouchedCallback: () => void = () => { };
+    onChangeCallback: (_: any) => void = () => { };
 
     toggleChecked() {
         if (!this.disabled && this.clickable) {

--- a/src/components/typeahead/typeahead-key.service.ts
+++ b/src/components/typeahead/typeahead-key.service.ts
@@ -6,7 +6,7 @@ export class TypeaheadKeyService {
 
     constructor() { }
 
-    public handleKey(event: KeyboardEvent, typeahead: TypeaheadComponent) {
+    handleKey(event: KeyboardEvent, typeahead: TypeaheadComponent) {
         if (typeahead) {
             switch (event.key) {
                 case 'ArrowUp':

--- a/src/components/typeahead/typeahead.component.ts
+++ b/src/components/typeahead/typeahead.component.ts
@@ -72,9 +72,9 @@ export class TypeaheadComponent implements OnInit, OnChanges {
     @ViewChild('defaultOptionTemplate') private _defaultOptionTemplate: TemplateRef<any>;
     @ViewChild('defaultNoOptionsTemplate') private _defaultNoOptionsTemplate: TemplateRef<any>;
 
-    protected loadOptionsCallback: InfiniteScrollLoadFunction;
-    protected visibleOptions: any[] = [];
-    protected loading = false;
+    loadOptionsCallback: InfiniteScrollLoadFunction;
+    visibleOptions: any[] = [];
+    loading = false;
 
     optionApi: TypeaheadOptionApi = {
         getKey: this.getKey.bind(this),
@@ -121,19 +121,19 @@ export class TypeaheadComponent implements OnInit, OnChanges {
         this.updateOptions();
     }
 
-    protected optionMousedownHandler(event: MouseEvent) {
+    optionMousedownHandler(event: MouseEvent) {
         // Workaround to prevent focus changing when an option is clicked
         event.preventDefault();
     }
 
-    protected optionClickHandler(event: MouseEvent, option: any) {
+    optionClickHandler(event: MouseEvent, option: any) {
         this.select(option);
     }
 
     /**
      * Returns the unique key value of the given option.
      */
-    protected getKey(option: any): string {
+    getKey(option: any): string {
         if (typeof this.key === 'function') {
             return this.key(option);
         }
@@ -146,7 +146,7 @@ export class TypeaheadComponent implements OnInit, OnChanges {
     /**
      * Returns the display value of the given option.
      */
-    protected getDisplay(option: any): string {
+    getDisplay(option: any): string {
         if (typeof this.display === 'function') {
             return this.display(option);
         }
@@ -160,7 +160,7 @@ export class TypeaheadComponent implements OnInit, OnChanges {
      * Returns the display value of the given option with HTML markup added to highlight the part which matches the current filter value.
      * @param option 
      */
-    protected getDisplayHtml(option: any) {
+    getDisplayHtml(option: any) {
         const displayText = this.getDisplay(option).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
         let displayHtml = displayText;
         if (this.filter) {
@@ -177,14 +177,14 @@ export class TypeaheadComponent implements OnInit, OnChanges {
     /**
      * Returns true if the infinite scroll component should load 
      */
-    protected isInfiniteScroll() {
+    isInfiniteScroll() {
         return typeof this.options === 'function';
     }
 
     /**
      * Selects the given option, emitting the optionSelected event and closing the dropdown.
      */
-    protected select(option: any) {
+    select(option: any) {
         if (!this.isDisabled(option)) {
             this.optionSelected.emit(new TypeaheadOptionEvent(option));
             this._highlighted.next(null);
@@ -195,7 +195,7 @@ export class TypeaheadComponent implements OnInit, OnChanges {
     /**
      * Returns true if the given option is part of the disabledOptions array.
      */
-    protected isDisabled(option: any): boolean {
+    isDisabled(option: any): boolean {
         if (this.disabledOptions) {
             const optionKey = this.getKey(option);
             const result = this.disabledOptions.find((selectedOption) => {
@@ -209,7 +209,7 @@ export class TypeaheadComponent implements OnInit, OnChanges {
     /**
      * Set the given option as the current highlighted option, available in the highlightedOption parameter.
      */
-    protected highlight(option: any) {
+    highlight(option: any) {
         if (!this.isDisabled(option)) {
             this._highlighted.next(option);
         }
@@ -219,7 +219,7 @@ export class TypeaheadComponent implements OnInit, OnChanges {
      * Increment or decrement the highlighted option in the list. Disabled options are skipped.
      * @param d Value to be added to the index of the highlighted option, i.e. -1 to move backwards, +1 to move forwards.
      */
-    public moveHighlight(d: number): any {
+    moveHighlight(d: number): any {
         const highlightIndex = this.indexOfVisibleOption(this.highlighted);
         let newIndex = highlightIndex;
         let disabled = true;
@@ -241,14 +241,14 @@ export class TypeaheadComponent implements OnInit, OnChanges {
     /**
      * Returns true if the given option is the highlighted option.
      */
-    protected isHighlighted(option: any): boolean {
+    isHighlighted(option: any): boolean {
         return this.getKey(option) === this.getKey(this.highlighted);
     }
 
     /**
      * Set up the options before the dropdown is displayed.
      */
-    private initOptions() {
+    initOptions() {
         // Clear previous highlight
         this._highlighted.next(null);
         if (this.selectFirst) {
@@ -260,7 +260,7 @@ export class TypeaheadComponent implements OnInit, OnChanges {
     /**
      * Update the visibleOptions array with the current filter.
      */
-    private updateOptions() {
+    updateOptions() {
         if (typeof this.options === 'object') {
             const normalisedInput = (this.filter || '').toLowerCase();
             this.visibleOptions = this.options.filter((option) => {

--- a/src/directives/infinite-scroll/infinite-scroll.directive.ts
+++ b/src/directives/infinite-scroll/infinite-scroll.directive.ts
@@ -380,10 +380,10 @@ export class InfiniteScrollDirective implements OnInit, AfterContentInit, OnChan
  * The internal data associated with a load/check request.
  */
 class InfiniteScrollRequest {
-    public check: boolean;
-    public pageNumber: number;
-    public pageSize: number;
-    public filter: any;
+    check: boolean;
+    pageNumber: number;
+    pageSize: number;
+    filter: any;
 }
 
 export type InfiniteScrollLoadFunction = (pageNum: number, pageSize: number, filter: any) => any | Promise<any>;
@@ -412,11 +412,11 @@ export class InfiniteScrollLoadingEvent {
     /**
      * Prevents the default behaviour of the `loading` event (loading function will not be called).
      */
-    public preventDefault() {
+    preventDefault() {
         this._defaultPrevented = true;
     }
 
-    public defaultPrevented(): boolean {
+    defaultPrevented(): boolean {
         return this._defaultPrevented;
     }
 }

--- a/src/directives/resize/resize.directive.ts
+++ b/src/directives/resize/resize.directive.ts
@@ -10,10 +10,10 @@ export class ResizeDirective {
     @Input() throttle: number = 0;
     @Output('uxResize') resize: EventEmitter<any> = new EventEmitter<any>();
 
-    constructor(private elementRef: ElementRef, private resizeService: ResizeService, private renderer: Renderer2) { }
+    constructor(private _elementRef: ElementRef, private _resizeService: ResizeService, private _renderer: Renderer2) { }
 
     ngOnInit(): void {
-        this.resizeService.addResizeListener(this.elementRef.nativeElement, this.renderer).debounceTime(this.throttle).subscribe(event => {
+        this._resizeService.addResizeListener(this._elementRef.nativeElement, this._renderer).debounceTime(this.throttle).subscribe(event => {
             this.resize.emit(event);
         });
     }

--- a/src/services/color/color.service.ts
+++ b/src/services/color/color.service.ts
@@ -8,7 +8,7 @@ import {
 
 export class ColorService {
 
-    private html = '<div class="primary-color"></div>' +
+    private _html = '<div class="primary-color"></div>' +
     '<div class="accent-color"></div>' +
     '<div class="secondary-color"></div>' +
     '<div class="alternate1-color"></div>' +
@@ -34,17 +34,17 @@ export class ColorService {
     '<div class="warning-color"></div>' +
     '<div class="critical-color"></div>';
 
-    private element: HTMLElement;
-    private colors: any;
+    private _element: HTMLElement;
+    private _colors: any;
 
     constructor( @Inject(DOCUMENT) document: any) {
-        this.element = document.createElement('div');
-        this.element.className = 'color-chart';
-        this.element.innerHTML = this.html;
+        this._element = document.createElement('div');
+        this._element.className = 'color-chart';
+        this._element.innerHTML = this._html;
 
-        document.body.appendChild(this.element);
+        document.body.appendChild(this._element);
 
-        this.colors = {
+        this._colors = {
             primary: this.getColorValue('primary'),
             accent: this.getColorValue('accent'),
             secondary: this.getColorValue('secondary'),
@@ -72,12 +72,12 @@ export class ColorService {
             critical: this.getColorValue('critical')
         };
 
-        this.element.parentNode.removeChild(this.element);
+        this._element.parentNode.removeChild(this._element);
     }
 
     private getColorValue(color: ColorIdentifier): ThemeColor {
 
-        let target = this.element.querySelector('.' + color + '-color');
+        let target = this._element.querySelector('.' + color + '-color');
 
         if (!target) {
             throw new Error('Invalid color');
@@ -91,29 +91,29 @@ export class ColorService {
     }
 
     getColor(color: ColorIdentifier): ThemeColor {
-        return this.colors[color];
+        return this._colors[color];
     }
 
 }
 
 export class ThemeColor {
 
-    private r: string;
-    private g: string;
-    private b: string;
-    private a: string;
+    private _r: string;
+    private _g: string;
+    private _b: string;
+    private _a: string;
 
     constructor(r: string, g: string, b: string, a: string) {
-        this.r = r;
-        this.g = g;
-        this.b = b;
-        this.a = a === undefined ? '1' : a;
+        this._r = r;
+        this._g = g;
+        this._b = b;
+        this._a = a === undefined ? '1' : a;
     }
 
     toHex() {
-        var red = parseInt(this.r).toString(16);
-        var green = parseInt(this.g).toString(16);
-        var blue = parseInt(this.b).toString(16);
+        var red = parseInt(this._r).toString(16);
+        var green = parseInt(this._g).toString(16);
+        var blue = parseInt(this._b).toString(16);
 
         if (red.length < 2) {
             red = '0' + red;
@@ -129,30 +129,30 @@ export class ThemeColor {
     }
 
     toRgb() {
-        return 'rgb(' + this.r + ', ' + this.g + ', ' + this.b + ')';
+        return 'rgb(' + this._r + ', ' + this._g + ', ' + this._b + ')';
     }
 
     toRgba() {
-        return 'rgba(' + this.r + ', ' + this.g + ', ' + this.b + ', ' + this.a + ')';
+        return 'rgba(' + this._r + ', ' + this._g + ', ' + this._b + ', ' + this._a + ')';
     }
 
     setRed(red: string) {
-        this.r = red;
+        this._r = red;
         return this;
     }
 
     setGreen(green: string) {
-        this.g = green;
+        this._g = green;
         return this;
     }
 
     setBlue(blue: string) {
-        this.b = blue;
+        this._b = blue;
         return this;
     }
 
     setAlpha(alpha: string | number) {
-        this.a = alpha.toString();
+        this._a = alpha.toString();
         return this;
     }
 }


### PR DESCRIPTION
Removing uses of private and protected when the variable is referenced in the view. Also removing uses of 'public' (except in constructor parameters) as by default all variables are public so having the keyword is not necessary.

Also renaming some private instance variables to have the _ prefix to conform to coding standards