### PR TITLE
EL-2688 - Adding required slider class for Quantum mapping

### DIFF
--- a/src/components/slider/slider.component.html
+++ b/src/components/slider/slider.component.html
@@ -1,4 +1,4 @@
-<div class="track" #track [class.narrow]="options.track.height === sliderSize.Narrow" [class.wide]="options.track.height === sliderSize.Wide">
+<div class="track" #track [class.narrow]="options.track.height === sliderSize.Narrow" [class.wide]="options.track.height === sliderSize.Wide" [class.range]="options.type === sliderType.Range">
 
     <!-- Section Beneath Lower Thumb -->
     <div class="track-section track-lower" [style.flex-grow]="tracks.lower.size" [style.background]="tracks.lower.color"></div>


### PR DESCRIPTION
This is required so we can change the height of the active and inactive parts of the track, without this we cant style for both normal sliders and range sliders correctly 