### PR TITLE
EL-2758 - Limiting files included

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,7 +125,15 @@
   },
   "files": [
     "configs/loaders",
-    "docs",
+    "docs/app/assets",
+    "docs/app/components",
+    "docs/app/data",
+    "docs/app/decorators",
+    "docs/app/directives",
+    "docs/app/interfaces",
+    "docs/app/pages",
+    "docs/app/services",
+    "docs/styles.less",
     "src",
     "LICENSE.md",
     "README.md"


### PR DESCRIPTION
Being more specific about which files are included in package. List only the required subdirectories in the docs/app folder. Didn't want to negate just the app.*.ts and wrapper.module.ts files as it mentions on the npm wiki:

"The consequences are undefined" if you try to negate any of the files entries (that is, "!foo.js"). Please don't. 