### PR TITLE
Disabled selectChildren when row selection is enabled

### DIFF
--- a/docs/app/pages/components/sections/tree-view/tree-grid-ng1/tree-grid-ng1.component.html
+++ b/docs/app/pages/components/sections/tree-view/tree-grid-ng1/tree-grid-ng1.component.html
@@ -315,7 +315,7 @@
         <ul>
           <li><code>row</code> (boolean) - when set to true, rows are selected by clicking anywhere on them. The selection can be extended by shift-clicking, and non-continuous rows can be added to the selection by control-clicking. Default is true.</li>
           <li><code>check</code> (boolean) - when set to true, rows can be selected by checkboxes. Default is false.</li>
-          <li><code>selectChildren</code> (boolean) - when set to true, selecting a row also selects its currently-loaded children.</li>
+          <li><code>selectChildren</code> (boolean) - when set to true, selecting a row also selects its currently-loaded children. This should be used in conjunction with the <code>check</code> option. Default is false.</li>
           <li><code>rowClass</code> (string) - the name of a class which will be applied to the row while it is selected. To remove the default appearance, set this to null or an empty string.</li>
         </ul>
       </td>

--- a/docs/app/pages/components/sections/tree-view/tree-grid-ng1/wrapper/tree-grid-wrapper.directive.html
+++ b/docs/app/pages/components/sections/tree-view/tree-grid-ng1/wrapper/tree-grid-wrapper.directive.html
@@ -19,7 +19,7 @@
                         <checkbox ng-model="vm.options.select.check">select.check</checkbox>
                     </div>
                     <div class="col-md-4 col-sm-12">
-                        <checkbox ng-model="vm.options.select.selectChildren">select.selectChildren</checkbox>
+                        <checkbox ng-model="vm.options.select.selectChildren" ng-disabled="vm.options.select.row">select.selectChildren</checkbox>
                     </div>
                 </div>
                 <div class="row uxd-customize-row">

--- a/docs/app/pages/components/sections/tree-view/tree-grid-ng1/wrapper/tree-grid-wrapper.directive.ts
+++ b/docs/app/pages/components/sections/tree-view/tree-grid-ng1/wrapper/tree-grid-wrapper.directive.ts
@@ -180,6 +180,13 @@ angular.module('app').controller('TreeGridDemoCtrl', ['$scope', '$displayPanel',
       }
     }
 
+    // Force selectChildren off if row selection is enabled
+    $scope.$watch('vm.options.select.row', function(nv: boolean) {
+      if (nv) {
+        vm.options.select.selectChildren = false;
+      }
+    });
+
   }
 
 angular.module('app').controller('TreeGridActionsCtrl', TreeGridActionsCtrl);


### PR DESCRIPTION
selectChildren is designed to work with the check option. Since there are issues with row selection and selectChildren I have disabled this combination for now.

https://jira.autonomy.com/browse/EL-2770