### PR TITLE
Build Improvements - Less Tilde Support

### DIFF
--- a/src/styles/ux-aspects.less
+++ b/src/styles/ux-aspects.less
@@ -1,5 +1,5 @@
 // Third Party Imports
-@import '../../node_modules/angular-tree-component/dist/angular-tree-component.css';
+@import '~angular-tree-component/dist/angular-tree-component.css';
 
 // UX Aspects Imports
 @import "variables.less";


### PR DESCRIPTION
Discovered one potential issue with including styles from a third party library in our stylesheet. Before it was a relative path, however if a team tried to import our less file (instead of the css file), the relative path would no longer be correct due to NPM flattening the folder structure and cause a compilation error.

Webpack supports the tilde to resolve this issue, but less.js which we use doesn't support that, so I have added a function to resolve the tilde for the less.js bit, this way anyone import the less directly will get the benefit of the tilde path resolution.