### PR TITLE
EL-2814 - Maintaining backwards compatibility with file path changes

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -39,7 +39,7 @@ module.exports = function (grunt) {
     grunt.registerTask('e2e', ['tslint:e2e', 'clean:e2e', 'webpack:e2e', 'ts:e2e', 'run:e2e']);
 
     // Tasks with larger chains of events
-    grunt.registerTask('build', ['cleanup', 'lint', 'library', 'scripts', 'iconset', 'styles', 'documentation:build', 'minify', 'assets', 'licenses']);
+    grunt.registerTask('build', ['cleanup', 'lint', 'library', 'scripts', 'iconset', 'styles', 'documentation:build', 'minify', 'assets', 'licenses', 'execute:shim']);
 
     // default task will run dev environment
     grunt.registerTask('default', ['documentation:serve']);

--- a/grunt/execute.js
+++ b/grunt/execute.js
@@ -9,5 +9,8 @@ module.exports = {
     },
     less: {
         src: [ path.join(process.cwd(), 'scripts', 'inline-less.js') ]
+    },
+    shim: {
+        src: [ path.join(process.cwd(), 'scripts', 'shim.js') ]
     }
 };

--- a/scripts/shim.js
+++ b/scripts/shim.js
@@ -30,6 +30,12 @@ fs.writeFileSync(
     `@import url("../../styles/ux-aspects.css");`
 );
 
+fs.writeFileSync(
+   path.join(cssPath, 'ux-aspects.min.css'), 
+   `@import url("../../styles/ux-aspects.min.css");`
+);
+
+
 /**
  * Shim the Less Files
  */
@@ -60,6 +66,15 @@ let ng1FileContents = fs.readFileSync(path.join(buildPath, 'ng1', 'ux-aspects-ng
 fs.writeFileSync(
     path.join(ng1Path, 'ux-aspects-ng1.js'), 
     ng1FileContents
+);
+
+
+//  Duplicating this file as they may not be using a module loader if using ng1 only
+let ng1MinFileContents = fs.readFileSync(path.join(buildPath, 'ng1', 'ux-aspects-ng1.min.js'), 'utf8');
+
+fs.writeFileSync(
+    path.join(ng1Path, 'ux-aspects-ng1.min.js'), 
+    ng1MinFileContents
 );
 
 /**

--- a/scripts/shim.js
+++ b/scripts/shim.js
@@ -1,0 +1,74 @@
+/**
+ * This script is for adding references to files if they change location
+ * if the build output to prevent breaking references in existing projects
+ */
+const fs = require('fs');
+const path = require('path');
+
+const buildPath = path.join(process.cwd(), 'dist');
+const distPath = path.join(buildPath, 'dist');
+
+
+/**
+ * Create the dist directory
+ */
+if (!fs.existsSync(distPath)) {
+    fs.mkdirSync(distPath);
+}
+
+/**
+ * Shim the Stylesheet
+ */
+let cssPath = path.join(distPath, 'styles');
+
+if (!fs.existsSync(cssPath)) {
+    fs.mkdirSync(cssPath);
+}
+
+fs.writeFileSync(
+    path.join(cssPath, 'ux-aspects.css'), 
+    `@import url("../../styles/ux-aspects.css");`
+);
+
+/**
+ * Shim the Less Files
+ */
+let lessPath = path.join(distPath, 'less');
+
+if (!fs.existsSync(lessPath)) {
+    fs.mkdirSync(lessPath);
+}
+
+fs.writeFileSync(
+    path.join(lessPath, 'ux-aspects.less'), 
+    `@import "../../less/ux-aspects.less";`
+);
+
+/**
+ * Shim the Angular 1 components
+ */
+
+let ng1Path = path.join(distPath, 'ng1');
+
+if (!fs.existsSync(ng1Path)) {
+    fs.mkdirSync(ng1Path);
+}
+
+fs.writeFileSync(
+    path.join(ng1Path, 'ux-aspects-ng1.js'), 
+    `export * from '../../ng1/ux-aspects-ng1';`
+);
+
+/**
+ * Shim the Angular components
+ */
+let libPath = path.join(distPath, 'lib');
+
+if (!fs.existsSync(libPath)) {
+    fs.mkdirSync(libPath);
+}
+
+fs.writeFileSync(
+    path.join(libPath, 'index.js'), 
+    `export * from '../../bundles/ux-aspects.umd';`
+);

--- a/scripts/shim.js
+++ b/scripts/shim.js
@@ -54,9 +54,12 @@ if (!fs.existsSync(ng1Path)) {
     fs.mkdirSync(ng1Path);
 }
 
+//  Duplicating this file as they may not be using a module loader if using ng1 only
+let ng1FileContents = fs.readFileSync(path.join(buildPath, 'ng1', 'ux-aspects-ng1.js'), 'utf8');
+
 fs.writeFileSync(
     path.join(ng1Path, 'ux-aspects-ng1.js'), 
-    `export * from '../../ng1/ux-aspects-ng1';`
+    ng1FileContents
 );
 
 /**


### PR DESCRIPTION
Added a script to the grunt build task to place files in the locations before the package structure changed to import the new version of the file maintaining backwards compatibility