### PR TITLE
Fixing issue with tooltip being left after element is removed

### DIFF
--- a/src/ng1/directives/overflowTooltip/singleLineOverflowTooltip.directive.js
+++ b/src/ng1/directives/overflowTooltip/singleLineOverflowTooltip.directive.js
@@ -40,7 +40,7 @@ export default function singleLineOverflowTooltip(safeTimeout, $window, $resize)
             //watch for changes to window size
             $window.addEventListener('resize', updateTooltipFn);
 
-            scope.$on('$destroy', function () {              
+            scope.$on('$destroy', function () {
                 element.tooltip('destroy');
                 $window.removeEventListener('resize', updateTooltipFn);
 

--- a/src/ng1/directives/overflowTooltip/singleLineOverflowTooltip.directive.js
+++ b/src/ng1/directives/overflowTooltip/singleLineOverflowTooltip.directive.js
@@ -40,9 +40,19 @@ export default function singleLineOverflowTooltip(safeTimeout, $window, $resize)
             //watch for changes to window size
             $window.addEventListener('resize', updateTooltipFn);
 
-            scope.$on('$destroy', function () {
+            scope.$on('$destroy', function () {              
                 element.tooltip('destroy');
                 $window.removeEventListener('resize', updateTooltipFn);
+
+                // check tooltip is removed
+                var remainingTooltipID = element.get(0).getAttribute('aria-describedBy');
+                if (remainingTooltipID) {
+                    var remainingTooltip = document.getElementById(remainingTooltipID);
+                    if (remainingTooltip) {
+                        remainingTooltip.remove();
+                    }
+                }
+
                 $resize.unbind(nativeElement, updateTooltip.bind(this));
             });
 

--- a/src/ng1/directives/overflowTooltip/singleLineOverflowTooltip.directive.js
+++ b/src/ng1/directives/overflowTooltip/singleLineOverflowTooltip.directive.js
@@ -40,7 +40,7 @@ export default function singleLineOverflowTooltip(safeTimeout, $window, $resize)
             //watch for changes to window size
             $window.addEventListener('resize', updateTooltipFn);
 
-            element.bind('$destroy', function () {
+            element.on('$destroy', function () {
                 element.tooltip('destroy');
                 $window.removeEventListener('resize', updateTooltipFn);
                 $resize.unbind(nativeElement, updateTooltip.bind(this));

--- a/src/ng1/directives/overflowTooltip/singleLineOverflowTooltip.directive.js
+++ b/src/ng1/directives/overflowTooltip/singleLineOverflowTooltip.directive.js
@@ -40,19 +40,9 @@ export default function singleLineOverflowTooltip(safeTimeout, $window, $resize)
             //watch for changes to window size
             $window.addEventListener('resize', updateTooltipFn);
 
-            scope.$on('$destroy', function () {
+            element.bind('$destroy', function () {
                 element.tooltip('destroy');
                 $window.removeEventListener('resize', updateTooltipFn);
-
-                // check tooltip is removed
-                var remainingTooltipID = element.get(0).getAttribute('aria-describedBy');
-                if (remainingTooltipID) {
-                    var remainingTooltip = document.getElementById(remainingTooltipID);
-                    if (remainingTooltip) {
-                        remainingTooltip.remove();
-                    }
-                }
-
                 $resize.unbind(nativeElement, updateTooltip.bind(this));
             });
 


### PR DESCRIPTION
This seems to be the only way we can reliably remove a specific tooltip. When the tooltip is applied to the body it gets an ID which matches the aria-describedBy attribute on the element so we can use this to remove the specific tooltip if it gets left behind.