### PR TITLE
Fixing slider infinite loop

### DIFF
--- a/src/ng1/plugins/flot/jquery.flot.resize.js
+++ b/src/ng1/plugins/flot/jquery.flot.resize.js
@@ -51,7 +51,14 @@ LICENSE-END
             });
             if (i.length === 1) {
                 a = t;
-                h()
+
+                if(window.ngZone) {
+                    window.ngZone.runOutsideAngular(function() {
+                        h();
+                    });
+                } else {
+                    h()
+                }
             }
         },
         teardown: function () {


### PR DESCRIPTION
Improving slider component performance. The initial investigation was wrong, the slider was not in fact getting into an infinite loop, there was a jquery plugin that checked if flot charts needed resized and this was firing over and over again triggering change detection.

I have:
- Changed slider to use OnPush change detection
- Trigger change detection manually only when we know we need to
- Improved memory usage as the `clone` method seemed to be leaking memory, now releases the object once we no longer need it.
- Changed the flot plugin to check if NgZone is available and if so use it to run outside of angular preventing it from firing change detection.