### PR TITLE
S 69/el 2810

### DIFF
--- a/docs/app/data/components-page.json
+++ b/docs/app/data/components-page.json
@@ -836,16 +836,6 @@
                     "title": "Search Builder",
                     "component": "ComponentsSearchBuilderNg1Component",
                     "version": "AngularJS"
-                },
-                {
-                    "title": "Search History",
-                    "component": "ComponentsSearchHistoryNg1Component",
-                    "version": "AngularJS"
-                },
-                {
-                    "title": "Search Toolbar",
-                    "component": "ComponentsSearchToolbarNg1Component",
-                    "version": "AngularJS"
                 }
             ]
         },

--- a/docs/app/data/components-page.json
+++ b/docs/app/data/components-page.json
@@ -836,6 +836,16 @@
                     "title": "Search Builder",
                     "component": "ComponentsSearchBuilderNg1Component",
                     "version": "AngularJS"
+                },
+                {
+                    "title": "Search History",
+-                   "component": "ComponentsSearchHistoryNg1Component",
+                    "version": "AngularJS"
+-               },
+-               {
+                    "title": "Search Toolbar",
+-                   "component": "ComponentsSearchToolbarNg1Component",
+-                   "version": "AngularJS"
                 }
             ]
         },

--- a/docs/app/data/components-page.json
+++ b/docs/app/data/components-page.json
@@ -839,13 +839,13 @@
                 },
                 {
                     "title": "Search History",
--                   "component": "ComponentsSearchHistoryNg1Component",
+                    "component": "ComponentsSearchHistoryNg1Component",
                     "version": "AngularJS"
--               },
--               {
+                },
+                {
                     "title": "Search Toolbar",
--                   "component": "ComponentsSearchToolbarNg1Component",
--                   "version": "AngularJS"
+                    "component": "ComponentsSearchToolbarNg1Component",
+                    "version": "AngularJS"
                 }
             ]
         },

--- a/docs/app/pages/components/sections/scrollbar/custom-scrollbar-ng1/custom-scrollbar-ng1.component.html
+++ b/docs/app/pages/components/sections/scrollbar/custom-scrollbar-ng1/custom-scrollbar-ng1.component.html
@@ -49,6 +49,18 @@
         <td>number</td>
         <td>Margin in pixels to add around the scrollable area. The recommended margin as seen in the example above is 5. Default is 0.</td>
       </tr>
+      <tr>
+        <td class="attribute">contentUpdateSensor</td>
+        <td>boolean</td>
+        <td>This should be enabled if you have dropdowns within the scroll pane to allow the panel to resize when 
+          the dropdown is opened. It will be less performant with this enabled so should not be used unless needed.
+        </td>
+      </tr>
+      <tr>
+        <td class="attribute">contentUpdateSensorDelay</td>
+        <td>number</td>
+        <td>This will set the delay for the content update sensor. Lower numbers will have a greater impact to performance. By default this is set to 500ms.</td>
+      </tr>
     </tbody>
   </table>
 </div>

--- a/docs/app/pages/components/sections/search/search-builder-ng1/snippets/modalController.js
+++ b/docs/app/pages/components/sections/search/search-builder-ng1/snippets/modalController.js
@@ -11,7 +11,8 @@ function SearchBuilderDemoModalCtrl($modalInstance, $scope, searchBuilderPanel, 
     // scrollbar conguration
     vm.scrollBarConfig = {
         resizeSensor: true,
-        enableKeyboardNavigation: true
+        enableKeyboardNavigation: true,
+        contentUpdateSensor: true
     };
 
     //use a service to store these values - make them more accessible by all modal contents

--- a/docs/app/pages/components/sections/search/search-builder-ng1/wrapper/search-builder-wrapper.directive.js
+++ b/docs/app/pages/components/sections/search/search-builder-ng1/wrapper/search-builder-wrapper.directive.js
@@ -79,7 +79,8 @@ function SearchBuilderDemoModalCtrl($modalInstance, $scope, searchBuilderPanel, 
     // scrollbar conguration
     vm.scrollBarConfig = {
         resizeSensor: true,
-        enableKeyboardNavigation: true
+        enableKeyboardNavigation: true,
+        contentUpdateSensor: true
     };
 
     //use a service to store these values - make them more accessible by all modal contents

--- a/src/ng1/plugins/customscroll/jquery.jscrollpane.js
+++ b/src/ng1/plugins/customscroll/jquery.jscrollpane.js
@@ -94,7 +94,7 @@ LICENSE-END
 				wasAtTop = true, wasAtLeft = true, wasAtBottom = false, wasAtRight = false,
 				originalElement = elem.clone(false, false).empty(),
 				mwEvent = $.fn.mwheelIntent ? 'mwheelIntent.jsp' : 'mousewheel.jsp',
-				contentUpdateSensor, contentUpdateSensorDelay, timer, observer;;
+				contentUpdateSensor, contentUpdateSensorDelay, timer, observer;
 
 			// UX Aspects modification
 			var reinitialiseFn = function() {

--- a/src/ng1/plugins/customscroll/jquery.jscrollpane.js
+++ b/src/ng1/plugins/customscroll/jquery.jscrollpane.js
@@ -116,10 +116,10 @@ LICENSE-END
 				}
 				timer = setTimeout(function() {
 					if(settings) {
-						initialise(settings);
+						initialise(settings, true);
 					}
 					timer = null;	
-				}, 1000);
+				}, settings.autoReinitialiseDelay);
 			});
 			observer.observe(elem[0], {attributes: true, childList: true, subtree: true});
 
@@ -136,7 +136,7 @@ LICENSE-END
 											(parseInt(elem.css('paddingRight'), 10) || 0);
 			}
 
-			function initialise(s)
+			function initialise(s, mutationObserved)
 			{
 
 				var /*firstChild, lastChild, */isMaintainingPositon, lastContentX, lastContentY,
@@ -199,9 +199,10 @@ LICENSE-END
 					maintainAtBottom = settings.stickToBottom && isCloseToBottom();
 					maintainAtRight  = settings.stickToRight  && isCloseToRight();
 
-					hasContainingSpaceChanged = elem.innerWidth() + originalPaddingTotalWidth != paneWidth || elem[0].outerHeight != paneHeight;
+					hasContainingSpaceChanged = elem.innerWidth() + originalPaddingTotalWidth != paneWidth || elem.outerHeight() != paneHeight || mutationObserved;
 
 					if (hasContainingSpaceChanged) {
+
 						// UX Aspects - modify width and height to account for scrollMargin setting
 						paneWidth = (elem.innerWidth() - (scrollMargin * 2)) + originalPaddingTotalWidth;
 						paneHeight = getContentHeightByMaxHeight(scrollMargin) || (elem.innerHeight() - (scrollMargin * 2));

--- a/src/ng1/plugins/customscroll/jquery.jscrollpane.js
+++ b/src/ng1/plugins/customscroll/jquery.jscrollpane.js
@@ -136,7 +136,7 @@ LICENSE-END
 											(parseInt(elem.css('paddingRight'), 10) || 0);
 			}
 
-			function initialise(s, mutationObserved)
+			function initialise(s, forceResize)
 			{
 
 				var /*firstChild, lastChild, */isMaintainingPositon, lastContentX, lastContentY,
@@ -199,7 +199,7 @@ LICENSE-END
 					maintainAtBottom = settings.stickToBottom && isCloseToBottom();
 					maintainAtRight  = settings.stickToRight  && isCloseToRight();
 
-					hasContainingSpaceChanged = elem.innerWidth() + originalPaddingTotalWidth != paneWidth || elem.outerHeight() != paneHeight || mutationObserved;
+					hasContainingSpaceChanged = elem.innerWidth() + originalPaddingTotalWidth != paneWidth || elem.outerHeight() != paneHeight || forceResize;
 
 					if (hasContainingSpaceChanged) {
 

--- a/src/ng1/plugins/customscroll/jquery.jscrollpane.js
+++ b/src/ng1/plugins/customscroll/jquery.jscrollpane.js
@@ -1411,6 +1411,12 @@ LICENSE-END
 
 				window.removeEventListener('resize', reinitialiseFn);
 
+				if(timer) {
+					clearTimeout(timer);
+				}
+
+				observer.disconnect();
+
 				if(retainDom !== true) {
 
 					var currentY = contentPositionY(),

--- a/src/ng1/plugins/customscroll/jquery.jscrollpane.js
+++ b/src/ng1/plugins/customscroll/jquery.jscrollpane.js
@@ -108,12 +108,21 @@ LICENSE-END
 				}
 			};
 
-			// UX Aspects modification to reinitialise when popovers are shown
-			elem.on('click', '*', function() {
-				if(settings) {
-					initialise(settings);
+			// UX Aspects modification to reinitialise when popovers are shown	
+			var timer = null;
+			var observer = new MutationObserver(function() {
+				if (timer !== null) {
+					return;
 				}
+				timer = setTimeout(function() {
+					if(settings) {
+						initialise(settings);
+					}
+					timer = null;	
+				}, 1000);
 			});
+			observer.observe(elem[0], {attributes: true, childList: true, subtree: true});
+
 
 			if (elem.css('box-sizing') === 'border-box') {
 				originalPadding = 0;
@@ -190,7 +199,7 @@ LICENSE-END
 					maintainAtBottom = settings.stickToBottom && isCloseToBottom();
 					maintainAtRight  = settings.stickToRight  && isCloseToRight();
 
-					hasContainingSpaceChanged = elem.innerWidth() + originalPaddingTotalWidth != paneWidth || elem.outerHeight() != paneHeight;
+					hasContainingSpaceChanged = elem.innerWidth() + originalPaddingTotalWidth != paneWidth || elem[0].outerHeight != paneHeight;
 
 					if (hasContainingSpaceChanged) {
 						// UX Aspects - modify width and height to account for scrollMargin setting

--- a/src/ng1/plugins/customscroll/jquery.jscrollpane.js
+++ b/src/ng1/plugins/customscroll/jquery.jscrollpane.js
@@ -93,7 +93,8 @@ LICENSE-END
 				reinitialiseInterval, resizeSensorDelay, resizeEventsAdded, originalPadding, originalPaddingTotalWidth, previousContentWidth,
 				wasAtTop = true, wasAtLeft = true, wasAtBottom = false, wasAtRight = false,
 				originalElement = elem.clone(false, false).empty(),
-				mwEvent = $.fn.mwheelIntent ? 'mwheelIntent.jsp' : 'mousewheel.jsp';
+				mwEvent = $.fn.mwheelIntent ? 'mwheelIntent.jsp' : 'mousewheel.jsp',
+				contentUpdateSensor, contentUpdateSensorDelay, timer, observer;;
 
 			// UX Aspects modification
 			var reinitialiseFn = function() {
@@ -107,22 +108,6 @@ LICENSE-END
 					initialise(settings);
 				}
 			};
-
-			// UX Aspects modification to reinitialise when popovers are shown	
-			var timer = null;
-			var observer = new MutationObserver(function() {
-				if (timer !== null) {
-					return;
-				}
-				timer = setTimeout(function() {
-					if(settings) {
-						initialise(settings, true);
-					}
-					timer = null;	
-				}, settings.autoReinitialiseDelay);
-			});
-			observer.observe(elem[0], {attributes: true, childList: true, subtree: true});
-
 
 			if (elem.css('box-sizing') === 'border-box') {
 				originalPadding = 0;
@@ -144,6 +129,24 @@ LICENSE-END
 						maintainAtBottom = false, maintainAtRight = false, scrollMargin;
 
 				settings = s;
+
+				// UX Aspects modification to reinitialise when popovers are shown
+				if (settings.contentUpdateSensor && !observer) {
+					timer = null;
+					observer = new MutationObserver(function() {
+						if (timer !== null) {
+							return;
+						}
+						timer = setTimeout(function() {
+							if(settings) {
+								initialise(settings, true);
+							}
+							timer = null;	
+						}, settings.contentUpdateSensorDelay);
+					});
+					observer.observe(elem[0], {attributes: true, childList: true, subtree: true});
+				}
+
 				// UX Aspects - scrollMargin setting
 				scrollMargin = parseInt(settings.scrollMargin || "0");
 				if (pane === undefined) {
@@ -1415,7 +1418,9 @@ LICENSE-END
 					clearTimeout(timer);
 				}
 
-				observer.disconnect();
+				if (observer) {
+					observer.disconnect();
+				}
 
 				if(retainDom !== true) {
 
@@ -1661,6 +1666,9 @@ LICENSE-END
 		// UX Aspects - Use resize Sensor instead
 		resizeSensor				: false,
 		resizeSensorDelay			: 0,
+		// UX Aspects mutation observer
+		contentUpdateSensor			:false,
+		contentUpdateSensorDelay	:500,
 		horizontalDragMinWidth		: 0,
 		horizontalDragMaxWidth		: 99999,
 		contentWidth				: undefined,

--- a/src/ng1/plugins/customscroll/jquery.jscrollpane.js
+++ b/src/ng1/plugins/customscroll/jquery.jscrollpane.js
@@ -108,6 +108,12 @@ LICENSE-END
 				}
 			};
 
+			// UX Aspects modification to reinitialise when popovers are shown
+			elem.on('click', '*', function() {
+				if(settings) {
+					initialise(settings);
+				}
+			});
 
 			if (elem.css('box-sizing') === 'border-box') {
 				originalPadding = 0;
@@ -123,7 +129,6 @@ LICENSE-END
 
 			function initialise(s)
 			{
-				
 
 				var /*firstChild, lastChild, */isMaintainingPositon, lastContentX, lastContentY,
 						hasContainingSpaceChanged, originalScrollTop, originalScrollLeft,
@@ -133,6 +138,7 @@ LICENSE-END
 				// UX Aspects - scrollMargin setting
 				scrollMargin = parseInt(settings.scrollMargin || "0");
 				if (pane === undefined) {
+
 					originalScrollTop = elem.scrollTop();
 					originalScrollLeft = elem.scrollLeft();
 
@@ -190,7 +196,7 @@ LICENSE-END
 						// UX Aspects - modify width and height to account for scrollMargin setting
 						paneWidth = (elem.innerWidth() - (scrollMargin * 2)) + originalPaddingTotalWidth;
 						paneHeight = getContentHeightByMaxHeight(scrollMargin) || (elem.innerHeight() - (scrollMargin * 2));
-						
+
 						container.css({
 							'width': paneWidth + 'px',
 							'height': paneHeight + 'px',
@@ -239,8 +245,6 @@ LICENSE-END
 				isScrollableV = percentInViewV > 1;
 
 				isScrollableH = s.isScrollableH && percentInViewH > 1;
-
-				//console.log(paneWidth, paneHeight, contentWidth, contentHeight, percentInViewH, percentInViewV, isScrollableH, isScrollableV);
 
 				if (!(isScrollableH || isScrollableV)) {
 					elem.removeClass('jspScrollable');


### PR DESCRIPTION
jscrollpane should now resize correctly when popovers and dropdowns are toggled. See the search builder, popovers would be cut off when added close to the bottom of the modal.

Jira: https://jira.autonomy.com/browse/EL-2810