### PR TITLE
Added reset event handler to ng1 infinite scroll

### DIFF
--- a/docs/app/pages/components/sections/scrollbar/infinite-scroll-ng1/infinite-scroll-ng1.component.html
+++ b/docs/app/pages/components/sections/scrollbar/infinite-scroll-ng1/infinite-scroll-ng1.component.html
@@ -109,6 +109,11 @@
     </tbody>
   </table>
 </div>
+
+<p>Additionally, the <code>infiniteScroll.reset</code> event can be broadcast on the controller. This will clear the list and load the first page again, which may be useful in case the external data source changes.</p>
+
+<uxd-snippet [content]="snippets.compiled.resetJs" language="javascript"></uxd-snippet>
+
 <p>The following code was used to create the example above:</p>
 
 <tabset>

--- a/docs/app/pages/components/sections/scrollbar/infinite-scroll-ng1/snippets/reset.js
+++ b/docs/app/pages/components/sections/scrollbar/infinite-scroll-ng1/snippets/reset.js
@@ -1,0 +1,1 @@
+$scope.$broadcast('infiniteScroll.reset');

--- a/docs/app/pages/components/sections/scrollbar/infinite-scroll/infinite-scroll.component.ts
+++ b/docs/app/pages/components/sections/scrollbar/infinite-scroll/infinite-scroll.component.ts
@@ -43,7 +43,7 @@ export class ComponentsInfiniteScrollComponent extends BaseDocumentationSection 
     exhausted: boolean = false;
 
     load(pageNum: number, pageSize: number, filter: any): Promise<any[]> {
-        let promise = new Promise((resolve, reject) => {
+        let promise = new Promise<any[]>((resolve, reject) => {
             setTimeout(() => {
                 const pageStart = pageNum * pageSize;
                 const newItems = this.allEmployees

--- a/src/ng1/directives/infiniteScroll/infiniteScroll.directive.js
+++ b/src/ng1/directives/infiniteScroll/infiniteScroll.directive.js
@@ -67,20 +67,30 @@ export default function infiniteScroll($parse, $templateRequest, $compile, $time
                     //store the new search query
                     searchQuery = nv;
 
-                    //remove all previous list items
-                    getContainer().empty();
-
-                    //set the page back to zero
-                    currentPage = 0;
-                    isLoading = false;
-
-                    //load the next page
-                    loadPage();
+                    // Clear the container and start from the first page
+                    reset();
                 }
+            });
+
+            // Reset on external event, e.g. if dataset changes
+            scope.$on('infiniteScroll.reset', function () {
+                reset();
             });
 
             //allow jScrollPane to initialise
             $timeout(bindToScroll);
+
+            function reset() {
+                //remove all previous list items
+                getContainer().empty();
+
+                //set the page back to zero
+                currentPage = 0;
+                isLoading = false;
+
+                //load the next page
+                loadPage();
+            }
 
             function showLoadingIndicator() {
 
@@ -196,8 +206,8 @@ export default function infiniteScroll($parse, $templateRequest, $compile, $time
                 //ensure enough items are visible to show a scrollbar
 
                 // if we are running in Angular 2 and ngZone is globally available then run outside of ngZone
-                if(window.ngZone) {
-                    window.ngZone.runOutsideAngular(function() {
+                if (window.ngZone) {
+                    window.ngZone.runOutsideAngular(function () {
                         ensureScrollable();
                     });
                 } else {
@@ -313,7 +323,7 @@ export default function infiniteScroll($parse, $templateRequest, $compile, $time
                 // jspInitialised is true only when the element is visible and jsp init is complete
                 var jspInitialised;
                 if (jScrollPane) {
-                    element.bind("jsp-initialised", function() {
+                    element.bind("jsp-initialised", function () {
                         jspInitialised = true;
                     });
                 }


### PR DESCRIPTION
Added the event `infiniteScroll.reset` which clears the list and starts from page 0 again. This avoids the need to use the query string as a hack to reload the list.
(This is already available on the Angular 4 equivalent via exporting the directive.)

https://jira.autonomy.com/browse/EL-2726