### PR TITLE
EL-2841 - Scrolling to a subsection breaks in MF site

### DIFF
--- a/docs/app/services/navigation/navigation.service.ts
+++ b/docs/app/services/navigation/navigation.service.ts
@@ -25,12 +25,17 @@ export class NavigationService {
         private router: Router,
         private versionService: VersionService) { }
 
+    getScrollTop(): number {
+        // support all browsers
+        return window.pageYOffset || document.documentElement.scrollTop || document.body.scrollTop || 0;
+    }
+
     getTopOffset() {
         return NAVIGATION_TOP_OFFSET;
     }
 
     isScrolledToBottom() {
-        return (this.document.body.scrollTop + window.innerHeight) >= this.document.body.offsetHeight;
+        return (this.getScrollTop() + window.innerHeight) >= this.document.body.offsetHeight;
     }
 
     isFragmentActive(id: string) {
@@ -66,7 +71,8 @@ export class NavigationService {
         if (element) {
             element.scrollIntoView(true);
             // Offset for fixed header unless scrolled to the bottom
-            if ((this.document.body.scrollTop + this.document.body.clientHeight) < this.document.body.offsetHeight) {
+
+            if (!this.isScrolledToBottom()) {
                 window.scrollBy(0, -this.getTopOffset());
             }
         }


### PR DESCRIPTION
Click items on the right navigation in the MF site cut off the section header.

Updated this section to use non deprecated apis for getting scroll position. To test simply copy this navigation service file into the @ux-aspects/ux-aspects-docs folder so that it overrides the one there. You should now see the functionality works as expected in both the regular & MF docs sites