### PR TITLE
Fixing date picker feedback

### DIFF
--- a/docs/app/pages/components/sections/date-time-picker/date-time-picker/date-time-picker.component.html
+++ b/docs/app/pages/components/sections/date-time-picker/date-time-picker/date-time-picker.component.html
@@ -4,7 +4,7 @@
             <span class="input-group-addon" tabindex="1" (click)="popover.show()">
                 <i class="hpe-icon hpe-calendar" aria-hidden="true"></i>
             </span>
-            <input type="text" #input #popover="bs-popover" [ngModel]="date | date:'dd MMMM yyyy HH:mm'" (keyup.enter)="parse(input.value)" [popover]="popoverTemplate" placement="bottom" [outsideClick]="true" containerClass="date-time-picker-popover" class="form-control" aria-label="Selected date">
+            <input type="text" #input #popover="bs-popover" [ngModel]="date | date:'dd MMMM yyyy HH:mm'" [popover]="popoverTemplate" placement="bottom" [outsideClick]="true" containerClass="date-time-picker-popover" class="form-control" aria-label="Selected date">
         </div>
 
         <p class="m-t">Selected date is:  <em>{{ date | date:'dd MMMM yyyy HH:mm' }} {{ timezone?.name }}</em></p>

--- a/docs/app/pages/components/sections/date-time-picker/date-time-picker/date-time-picker.component.ts
+++ b/docs/app/pages/components/sections/date-time-picker/date-time-picker/date-time-picker.component.ts
@@ -1,9 +1,13 @@
-import { Component, ViewEncapsulation } from '@angular/core';
+import { Component, ViewEncapsulation, ViewChild, ElementRef, AfterViewInit, OnDestroy } from '@angular/core';
 import { DocumentationSectionComponent } from '../../../../../decorators/documentation-section-component';
 import { BaseDocumentationSection } from '../../../../../components/base-documentation-section/base-documentation-section';
 import { DateTimePickerTimezone } from '../../../../../../../src/index';
 import { IPlunkProvider } from '../../../../../interfaces/IPlunkProvider';
 import { IPlunk } from '../../../../../interfaces/IPlunk';
+import { Observable } from 'rxjs/Observable';
+import { Subscription } from "rxjs/Subscription";
+import 'rxjs/add/observable/fromEvent';
+import 'rxjs/add/operator/debounceTime';
 
 @Component({
     selector: 'uxd-components-date-time-picker',
@@ -12,7 +16,9 @@ import { IPlunk } from '../../../../../interfaces/IPlunk';
     encapsulation: ViewEncapsulation.None
 })
 @DocumentationSectionComponent('ComponentsDateTimePickerComponent')
-export class ComponentsDateTimePickerComponent extends BaseDocumentationSection implements IPlunkProvider {
+export class ComponentsDateTimePickerComponent extends BaseDocumentationSection implements IPlunkProvider, AfterViewInit, OnDestroy {
+
+    @ViewChild('input') dateInput: ElementRef;
 
     date: Date = new Date();
     timezone: DateTimePickerTimezone = { name: 'GMT', offset: 0 };
@@ -21,6 +27,7 @@ export class ComponentsDateTimePickerComponent extends BaseDocumentationSection 
     showTimezones: boolean = true;
     showMeridians: boolean = true;
     showSpinners: boolean = true;
+    subscription: Subscription;
 
     plunk: IPlunk = {
         files: {
@@ -48,6 +55,16 @@ export class ComponentsDateTimePickerComponent extends BaseDocumentationSection 
     
     constructor() {
         super(require.context('./snippets/', false, /\.(html|css|js|ts)$/));
+    }
+
+    ngAfterViewInit(): void {
+        this.subscription = Observable.fromEvent(this.dateInput.nativeElement, 'input')
+            .debounceTime(500)
+            .subscribe(event => this.parse(this.dateInput.nativeElement.value));
+    }
+
+    ngOnDestroy(): void {
+        this.subscription.unsubscribe();
     }
 
     parse(value: string): void {

--- a/docs/app/pages/components/sections/date-time-picker/date-time-picker/snippets/app.html
+++ b/docs/app/pages/components/sections/date-time-picker/date-time-picker/snippets/app.html
@@ -6,7 +6,6 @@
             </span>
             <input type="text" #input #popover="bs-popover" 
                 [ngModel]="date | date:'dd MMMM yyyy HH:mm'" 
-                (keyup.enter)="parse(input.value)"
                 [popover]="popoverTemplate" placement="bottom" 
                 [outsideClick]="true" 
                 containerClass="date-time-picker-popover"

--- a/docs/app/pages/components/sections/date-time-picker/date-time-picker/snippets/app.ts
+++ b/docs/app/pages/components/sections/date-time-picker/date-time-picker/snippets/app.ts
@@ -1,5 +1,9 @@
-import { Component, ViewEncapsulation } from '@angular/core';
+import { Component, ViewEncapsulation, ViewChild, ElementRef, AfterViewInit, OnDestroy } from '@angular/core';
 import { DateTimePickerTimezone } from '@ux-aspects/ux-aspects';
+import { Observable } from 'rxjs/Observable';
+import { Subscription } from "rxjs/Subscription";
+import 'rxjs/add/observable/fromEvent';
+import 'rxjs/add/operator/debounceTime';
 
 @Component({
     selector: 'app',
@@ -7,7 +11,9 @@ import { DateTimePickerTimezone } from '@ux-aspects/ux-aspects';
     styleUrls: ['./src/app.component.css'],
     encapsulation: ViewEncapsulation.None
 })
-export class AppComponent {
+export class AppComponent implements AfterViewInit, OnDestroy {
+
+    @ViewChild('input') dateInput: ElementRef;
 
     date: Date = new Date();
     timezone: DateTimePickerTimezone = { name: 'GMT', offset: 0 };
@@ -16,6 +22,17 @@ export class AppComponent {
     showTimezones: boolean = true;
     showMeridians: boolean = true;
     showSpinners: boolean = true;
+    subscription: Subscription;
+
+    ngAfterViewInit(): void {
+        this.subscription = Observable.fromEvent(this.dateInput.nativeElement, 'input')
+            .debounceTime(500)
+            .subscribe(event => this.parse(this.dateInput.nativeElement.value));
+    }
+
+    ngOnDestroy(): void {
+        this.subscription.unsubscribe();
+    }
 
     parse(value: string): void {
 

--- a/src/components/date-time-picker/time-view/time-view.component.html
+++ b/src/components/date-time-picker/time-view/time-view.component.html
@@ -1,6 +1,6 @@
 <div class="time-input-container">
   <timepicker [ngModel]="date" (ngModelChange)="update($event)" [minuteStep]="1" [hourStep]="1" [secondsStep]="1" [showSeconds]="showSeconds"
-    [showSpinners]="showSpinners"></timepicker>
+    [showSpinners]="showSpinners" [showMeridian]="showMeridian"></timepicker>
 
   <div class="btn-group meridian-picker" *ngIf="showMeridian">
     <button type="button" class="btn button-toggle-accent" [(ngModel)]="meridian" (ngModelChange)="setMeridian($event)" [btnRadio]="DatePickerMeridian.AM">AM</button>

--- a/src/components/date-time-picker/time-view/time-view.component.less
+++ b/src/components/date-time-picker/time-view/time-view.component.less
@@ -74,12 +74,12 @@ ux-date-time-picker-time-view {
                 font-weight: 900;
                 font-size: 14px;
 
-                &.glyphicon-chevron-up:before {
-                    content: "\F226";
+                &.glyphicon-chevron-up {
+                    .hpe-icon-up();
                 }
 
-                &.glyphicon-chevron-down:before {
-                    content: "\F176";
+                &.glyphicon-chevron-down {
+                    .hpe-icon-down();
                 }
             }
 

--- a/src/components/date-time-picker/time-view/time-view.component.ts
+++ b/src/components/date-time-picker/time-view/time-view.component.ts
@@ -66,7 +66,7 @@ export class DateTimePickerTimeViewComponent implements AfterViewInit {
 
         // update the meridian
         this.meridian = date.getHours() < 12 ? DatePickerMeridian.AM : DatePickerMeridian.PM;
-
+        
         // if the date has not changed then don't emit
         if (date.getTime() !== this.date.getTime()) {
             this.date = date;


### PR DESCRIPTION
Jira: https://jira.autonomy.com/browse/EL-2805

Fixing QA issues

1. Suggested rewording. Change "If not defined the users current timezone will try to be used. If their timezone is not available it will revert to GMT." to "If not defined the picker will try to use the user's timezone. If that is not available, it will revert to GMT."
**FIXED**

2. Update date and/or time in text box and the picker component is not updated. Should it be?
**FIXED**

3. Unexpected behaviour when showMeridian is Off.
UXAspects
Set time in picker to 23:57. Click down minutes. Time changes to 01:50. Should be 23:56?
Set time in picker to 23:59. Click up minutes. Time changes to 01:01. Should be 00:00?
Set time in picker to 00:00. Click down minutes. Time changes to 11:59. Should be 23:59?
Micro Focus
Set time in picker to 23:59. Click up minutes. Time changes to random values e.g. 11:16.
Set time in picker to 00:00. Click down minutes. Time changes to 11:59. Should be 23:59?
**FIXED**

4. Unexpected behaviour when showMeridian is On.
Can set time to 23:59.
**Part of ngx-bootstrap - can't fix**

5. Difference in displyed date/time between browsers
Selected date is: 08 November 2017 18:04 GMT (Chrome & Firefox)
Selected date is: 08 November 2017 13:00:11/8/2017 1:29:36 PM GMT (IE)
**Bug in Angular - Fixed in Angular 5**

6. Getting strange icons for spinners in UXAspects - see attached Spinners.png.
**FIXED**

7. Plunker crashes in IE when you try to open the picker (UXA and MF). No error logged.
**Bug in ngx-bootstrap - raised issue with them**