### PR TITLE
Fixing webpack dev server issue

### DIFF
--- a/configs/webpack.docs.dev.config.js
+++ b/configs/webpack.docs.dev.config.js
@@ -3,7 +3,6 @@ const { join } = require('path');
 const webpack = require('webpack');
 const { NamedModulesPlugin, NoEmitOnErrorsPlugin } = webpack;
 const { CommonsChunkPlugin } = webpack.optimize;
-const { AngularCompilerPlugin } = require('@ngtools/webpack');
 const ProgressPlugin = require('webpack/lib/ProgressPlugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
@@ -65,7 +64,7 @@ module.exports = {
             {
                 test: /\.ts$/,
                 exclude: /snippets/,
-                use: '@ngtools/webpack'
+                use: ['awesome-typescript-loader', 'angular-router-loader', 'angular2-template-loader']
             },
             {
                 test: /\.less$/,
@@ -208,15 +207,10 @@ module.exports = {
 
         new NamedModulesPlugin({}),
 
-        new AngularCompilerPlugin({
-            mainPath: join(project_dir, 'docs', 'main.ts'),
-            tsConfigPath: join(project_dir, 'tsconfig.json'),
-            sourceMap: false,
-            skipCodeGeneration: true,
-            hostReplacementPaths: {
-                'environments\\environment.ts': 'environments\\environment.ts'
-            }
-        }),
+        new webpack.ContextReplacementPlugin(
+            /(.+)?angular(\\|\/)core(.+)?/,
+            join(project_dir, 'docs')
+        ),
 
         new ProgressPlugin(),
 

--- a/configs/webpack.docs.prod.config.js
+++ b/configs/webpack.docs.prod.config.js
@@ -255,7 +255,6 @@ module.exports = {
         new NoEmitOnErrorsPlugin(),
 
         new UglifyJsPlugin({
-            test: /(main|polyfills|vendor).js$/i,
             extractComments: false,
             sourceMap: false,
             cache: false,

--- a/configs/webpack.lib-assets.dev.config.js
+++ b/configs/webpack.lib-assets.dev.config.js
@@ -1,5 +1,5 @@
 const { join } = require('path');
-const { AngularCompilerPlugin } = require('@ngtools/webpack');
+const { ContextReplacementPlugin } = require('webpack');
 const project_dir = process.cwd();
 
 module.exports = {
@@ -27,7 +27,14 @@ module.exports = {
                 use: 'raw-loader'
             }, {
                 test: /\.ts$/,
-                use: '@ngtools/webpack'
+                use: [{
+                    loader: 'awesome-typescript-loader',
+                    options: {
+                        configFileName: join(project_dir, 'src', 'tsconfig-build.json')
+                    },
+                }, {
+                    loader: 'angular2-template-loader'
+                }]
             }, {
                 test: /\.less$/,
                 use: ['raw-loader', 'less-loader']
@@ -39,10 +46,9 @@ module.exports = {
     },
 
     plugins: [
-        new AngularCompilerPlugin({
-            tsConfigPath: join(project_dir, 'src', 'tsconfig-build.json'),
-            sourceMap: false,
-            skipCodeGeneration: true
-        }),
+        new ContextReplacementPlugin(
+            /(.+)?angular(\\|\/)core(.+)?/,
+            join(project_dir, 'docs')
+        ),
     ]
 };

--- a/docs/vendor.ts
+++ b/docs/vendor.ts
@@ -10,28 +10,13 @@ import 'jquery-ui/ui/position';
 import 'jquery-ui/ui/widgets/sortable';
 
 import 'bootstrap';
-
-/*
-  Import Angular 1 Components and their dependencies
-*/
-import 'angular';
+import * as angular from 'angular';
 
 /*
   Import Angular 1 Components and their dependencies
 */
 import '../src/ng1/ux-aspects-ng1.module';
 
-/*
-    Import Angular Libraries
-*/
-import '@angular/platform-browser';
-import '@angular/core';
-import '@angular/common';
-import '@angular/http';
-import '@angular/router';
-import '@angular/upgrade';
-
-import * as angular from 'angular';
 
 // create the AngularJS module
 angular.module('app', ['ux-aspects']);


### PR DESCRIPTION
For development mode reverting back to old webpack loaders as ngtools/webpack loader seems to be the cause of the HTTPS disconnect issue (possibly due to its high memory usage).

For production version, module chunks were not getting minified - now fixed. Still using ngtools in production build as it gives us AOT compilation and type checking in our views.

Removed angular imports from vendor.ts as CommonChunksPlugin will now optimise these for us without out having to explicitly put them here. In fact keeping them here was causing them to be included in some chunks, bloating their size unnecessarily.