### PR TITLE
Fixing environment property

### DIFF
--- a/configs/webpack.docs.dev.config.js
+++ b/configs/webpack.docs.dev.config.js
@@ -217,7 +217,8 @@ module.exports = {
         new NoEmitOnErrorsPlugin(),
 
         new webpack.DefinePlugin({
-            VERSION: JSON.stringify(require('../src/package.json').version)
+            VERSION: JSON.stringify(require('../src/package.json').version),
+            PRODUCTION: false
         }),
     ],
 

--- a/configs/webpack.docs.prod.config.js
+++ b/configs/webpack.docs.prod.config.js
@@ -274,14 +274,12 @@ module.exports = {
         new AngularCompilerPlugin({
             entryModule: './docs/app/app.module#AppModule',
             tsConfigPath: join(project_dir, 'tsconfig.json'),
-            sourceMap: false,
-            hostReplacementPaths: {
-                'environments\\environment.ts': 'environments\\environment.prod.ts'
-            }
+            sourceMap: false
         }),
         
         new webpack.DefinePlugin({
-            VERSION: JSON.stringify(require('../src/package.json').version)
+            VERSION: JSON.stringify(require('../src/package.json').version),
+            PRODUCTION: true
         }),
     ]
 };

--- a/docs/environments/environment.prod.ts
+++ b/docs/environments/environment.prod.ts
@@ -1,3 +1,0 @@
-export const environment = {
-  production: true
-};

--- a/docs/environments/environment.ts
+++ b/docs/environments/environment.ts
@@ -1,3 +1,5 @@
+declare const PRODUCTION: boolean;
+
 export const environment = {
-  production: false
+  production: PRODUCTION
 };


### PR DESCRIPTION
Angular compiler plugin for some reason wasn't setting the environment property correctly in production build. Changed to use webpack DefinePlugin to set the production value