### PR TITLE
Added the option to create component-specific multiple select providers

### DIFF
--- a/src/ng1/directives/multipleSelect/multipleSelect.provider.js
+++ b/src/ng1/directives/multipleSelect/multipleSelect.provider.js
@@ -51,7 +51,22 @@ function MultipleSelect($timeout) {
     //used for us to keep track of total items selected.
     this.keyFn = null;
 
+    this.nextComponentId = 0;
+    this.componentInstances = {};
+
 }
+
+MultipleSelect.prototype.getNextComponentId = function() {
+    return this.nextComponentId++;
+};
+
+MultipleSelect.prototype.getComponentInstance = function(componentId) {
+    if (!this.componentInstances[componentId]) {
+        this.componentInstances[componentId] = new MultipleSelect(this.$timeout);
+    }
+
+    return this.componentInstances[componentId];
+};
 
 MultipleSelect.prototype.validateSelection = function() {
     if (this.state.selectAllMode === true && this.state.selecting === true) {

--- a/src/ng1/directives/treegrid/treegrid.controller.js
+++ b/src/ng1/directives/treegrid/treegrid.controller.js
@@ -2,6 +2,8 @@ TreegridCtrl.$inject = ["$scope", "$q", "multipleSelectProvider"];
 
 export default function TreegridCtrl($scope, $q, multipleSelectProvider) {
   var vm = this;
+  
+  var treegridId = multipleSelectProvider.getNextComponentId();
 
   var defaultOptions = {
     maxDepth: 5,
@@ -41,21 +43,21 @@ export default function TreegridCtrl($scope, $q, multipleSelectProvider) {
 
   vm.treeData = [];
 
-  vm.multipleSelectProvider = multipleSelectProvider;
+  vm.multipleSelectInstance = multipleSelectProvider.getComponentInstance(treegridId);
 
   vm.allSelected = false;
 
   // Set up multi select to work standalone
-  if (!vm.multipleSelectProvider.keyFn) {
-    vm.multipleSelectProvider.keyFn = function (e) {
+  if (!vm.multipleSelectInstance.keyFn) {
+    vm.multipleSelectInstance.keyFn = function (e) {
       return JSON.stringify(e.item);
     };
   }
-  if (!vm.multipleSelectProvider.onSelect) {
-    vm.multipleSelectProvider.onSelect = function () {};
+  if (!vm.multipleSelectInstance.onSelect) {
+    vm.multipleSelectInstance.onSelect = function () {};
   }
-  if (!vm.multipleSelectProvider.onDeselect) {
-    vm.multipleSelectProvider.onDeselect = function () {};
+  if (!vm.multipleSelectInstance.onDeselect) {
+    vm.multipleSelectInstance.onDeselect = function () {};
   }
 
   // Watch for changes to the tree data and update the view when it changes
@@ -63,7 +65,7 @@ export default function TreegridCtrl($scope, $q, multipleSelectProvider) {
     updateView();
   }, true);
 
-  $scope.$watch("vm.multipleSelectProvider.selectedItems", function (nv) {
+  $scope.$watch("vm.multipleSelectInstance.selectedItems", function (nv) {
     if (angular.isArray(nv)) {
       // selectedItems are JSON from keyFn above
       var selected = [];
@@ -80,7 +82,7 @@ export default function TreegridCtrl($scope, $q, multipleSelectProvider) {
   });
 
   $scope.$on("$destroy", function () {
-    vm.multipleSelectProvider.reset();
+    vm.multipleSelectInstance.reset();
   });
 
   // Retrieves array for ng-repeat of grid rows
@@ -195,6 +197,7 @@ export default function TreegridCtrl($scope, $q, multipleSelectProvider) {
       for (var i = 0; i < data.length; i += 1) {
         var canExpand = hasChildren(data[i]) && level < vm.allOptions.maxDepth;
         var row = {
+          treegridId: treegridId,
           level: level,
           levelClass: "treegrid-level-" + level,
           rowClass: getRowClass(data[i]),

--- a/src/ng1/directives/treegrid/treegridMultipleSelectItem.directive.js
+++ b/src/ng1/directives/treegrid/treegridMultipleSelectItem.directive.js
@@ -16,6 +16,8 @@ export default function treegridMultipleSelectItem(multipleSelectProvider) {
 
                 if (treeGridRow) {
 
+                    var multipleSelectInstance = multipleSelectProvider.getComponentInstance(treeGridRow.treegridId);
+
                     // Prevent text selection on shift-click
                     angular.element(element).children("*").css({
                         "user-select": "none",
@@ -65,8 +67,8 @@ export default function treegridMultipleSelectItem(multipleSelectProvider) {
                             }
                             else {
                                 // if shift key not held then dont select any
-                                multipleSelectProvider.selectNone();
-                                multipleSelectProvider.multipleRowSelectOriginIndex = scope.$index;
+                                multipleSelectInstance.selectNone();
+                                multipleSelectInstance.multipleRowSelectOriginIndex = scope.$index;
                             }
                         }
                         scope.$apply();
@@ -80,16 +82,16 @@ export default function treegridMultipleSelectItem(multipleSelectProvider) {
 
                     // Handler for row click, or external change to selection via multipleSelectProvider
                     scope.$watch(function () {
-                        return multipleSelectProvider.isSelected(treeGridRow.dataItem);
+                        return multipleSelectInstance.isSelected(treeGridRow.dataItem);
                     }, function (nv) {
                         setSelected(treeGridRow, nv);
                     });
 
                     // Handler for checkbox click, which uses ng-model="row.selected"
                     scope.$watch(attrs.treegridMultipleSelectItem + ".selected", function (nv) {
-                        var currentState = multipleSelectProvider.isSelected(treeGridRow.dataItem);
+                        var currentState = multipleSelectInstance.isSelected(treeGridRow.dataItem);
                         if (nv !== undefined && nv !== currentState) {
-                            currentState = multipleSelectProvider.itemClicked(treeGridRow.dataItem);
+                            currentState = multipleSelectInstance.itemClicked(treeGridRow.dataItem);
                         }
                     }, true);
 
@@ -104,29 +106,29 @@ export default function treegridMultipleSelectItem(multipleSelectProvider) {
 
             // Clear selection and select this row
             function startSelection() {
-                multipleSelectProvider.state.selecting = true;
-                if (multipleSelectProvider.state.selectedFromButton === false) {
-                    multipleSelectProvider.state.selectedFromCheckBox = true;
+                multipleSelectInstance.state.selecting = true;
+                if (multipleSelectInstance.state.selectedFromButton === false) {
+                    multipleSelectInstance.state.selectedFromCheckBox = true;
                 }
 
-                multipleSelectProvider.selectNone();
+                multipleSelectInstance.selectNone();
 
-                multipleSelectProvider.multipleRowSelectItemPreviousSelectionDirection = undefined;
-                if (multipleSelectProvider.itemClicked(treeGridRow.dataItem)) {
-                    multipleSelectProvider.multipleRowSelectOriginIndex = scope.$index;
+                multipleSelectInstance.multipleRowSelectItemPreviousSelectionDirection = undefined;
+                if (multipleSelectInstance.itemClicked(treeGridRow.dataItem)) {
+                    multipleSelectInstance.multipleRowSelectOriginIndex = scope.$index;
                     setSelected(treeGridRow, true);
                 }
             }
 
             // Add this row to the current selection
             function addToOrStartSelection() {
-                if (!multipleSelectProvider.state.selecting) {
+                if (!multipleSelectInstance.state.selecting) {
                     startSelection();
                 }
                 else {
-                    multipleSelectProvider.multipleRowSelectItemPreviousSelectionDirection = undefined;
-                    if (multipleSelectProvider.itemClicked(treeGridRow.dataItem)) {
-                        multipleSelectProvider.multipleRowSelectOriginIndex = scope.$index;
+                    multipleSelectInstance.multipleRowSelectItemPreviousSelectionDirection = undefined;
+                    if (multipleSelectInstance.itemClicked(treeGridRow.dataItem)) {
+                        multipleSelectInstance.multipleRowSelectOriginIndex = scope.$index;
                         setSelected(treeGridRow, true);
                     }
                     else {
@@ -137,7 +139,7 @@ export default function treegridMultipleSelectItem(multipleSelectProvider) {
 
             // Add this row and all intermediate rows to the current selection
             function extendOrStartSelection() {
-                if (!multipleSelectProvider.state.selecting) {
+                if (!multipleSelectInstance.state.selecting) {
                     startSelection();
                 }
                 else {
@@ -147,18 +149,18 @@ export default function treegridMultipleSelectItem(multipleSelectProvider) {
 
             // Select previous row, this row, and all intermediate rows
             function extendSelectionFromPrevious() {
-                multipleSelectProvider.state.selecting = true;
-                if (multipleSelectProvider.state.selectedFromButton === false) {
-                    multipleSelectProvider.state.selectedFromCheckBox = true;
+                multipleSelectInstance.state.selecting = true;
+                if (multipleSelectInstance.state.selectedFromButton === false) {
+                    multipleSelectInstance.state.selectedFromCheckBox = true;
                 }
-                multipleSelectProvider.multipleRowSelectItemPreviousSelectionDirection = undefined;
+                multipleSelectInstance.multipleRowSelectItemPreviousSelectionDirection = undefined;
                 extendSelection();
             }
 
             function extendSelection() {
-                var rows = getRowDataItemsToSelect(multipleSelectProvider.multipleRowSelectOriginIndex, scope.$index);
+                var rows = getRowDataItemsToSelect(multipleSelectInstance.multipleRowSelectOriginIndex, scope.$index);
                 var dataItems = rows.map(function(row) { return row.dataItem; });
-                var isSelected = multipleSelectProvider.rangeClicked(dataItems);
+                var isSelected = multipleSelectInstance.rangeClicked(dataItems);
                 for (var row of rows) {
                     setSelected(row, isSelected);
                 }


### PR DESCRIPTION
Switched tree grid to use separate multiple select instances per component. This solves the problems caused by multiple tree grids on a single page.

(Reported for the MF documentation but also applies to the two tree grid examples - previously selecting a row in one would clear the selection in the other.)

https://jira.autonomy.com/browse/EL-2871