### PR TITLE
EL-2904 - Infinite Scroll Refresh

### DIFF
--- a/docs/app/pages/components/components-sections/scrollbar/infinite-scroll-ng1/infinite-scroll-ng1.component.html
+++ b/docs/app/pages/components/components-sections/scrollbar/infinite-scroll-ng1/infinite-scroll-ng1.component.html
@@ -59,9 +59,19 @@
     </tr>
 </uxd-api-properties>
 
-<p>Additionally, the <code>infiniteScroll.reset</code> event can be broadcast on the controller. This will clear the list and load the first page again, which may be useful in case the external data source changes.</p>
+<p>Additionally, there are several events which can be broadcast to allow further interaction with the directive.</p>
 
-<uxd-snippet [content]="snippets.compiled.resetJs" language="javascript"></uxd-snippet>
+<uxd-api-properties>
+  <tr uxd-api-property name="infiniteScroll.reset" type="void">
+    This will reset the infinite scroll directive. It will clear all items and start loading the first page.
+  </tr>
+  <tr uxd-api-property name="infiniteScroll.reload" type="void">
+    This will call the paging function for each loaded page and update any changed data. The current page and scroll position will be retained.
+  </tr>
+  <tr uxd-api-property name="infiniteScroll.reloadPage" type="number">
+    This will call the paging function for the specified page. It will then update the data for that page while retaining scroll position.
+  </tr>
+</uxd-api-properties>
 
 <p>The following code was used to create the example above:</p>
 

--- a/docs/app/pages/components/components-sections/scrollbar/infinite-scroll-ng1/snippets/reset.js
+++ b/docs/app/pages/components/components-sections/scrollbar/infinite-scroll-ng1/snippets/reset.js
@@ -1,1 +1,0 @@
-$scope.$broadcast('infiniteScroll.reset');

--- a/src/ng1/directives/infiniteScroll/adapters/element-scroll.adapter.js
+++ b/src/ng1/directives/infiniteScroll/adapters/element-scroll.adapter.js
@@ -1,0 +1,33 @@
+import { ScrollAdapter } from './scroll.adapter';
+
+export class ElementScrollAdapter extends ScrollAdapter {
+
+    constructor(element) {
+        super(element);
+
+        // bind to the scroll event
+        this.element.on('scroll', this.scroll.bind(this));
+
+        // inform the consumer that the scrollbar is initialised
+        this.notify('initialised');
+    }
+
+    getScrollbarVisible() {
+        return this.element.get(0).clientHeight !== 0 && 
+               this.element.get(0).scrollHeight <= this.element.get(0).clientHeight;
+    }
+
+    scroll() {
+        const position = this.element.scrollTop() + this.element.innerHeight();
+        const height = this.element.get(0).scrollHeight;
+        const percentage = (position / height) * 100;
+
+        this.notify('scroll', percentage);
+    }
+
+    destroy() {
+        this.element.off('scroll', this.scroll);
+        super.destroy();
+    }
+
+}

--- a/src/ng1/directives/infiniteScroll/adapters/scroll-pane.adapter.js
+++ b/src/ng1/directives/infiniteScroll/adapters/scroll-pane.adapter.js
@@ -1,0 +1,39 @@
+import { ScrollAdapter } from './scroll.adapter';
+
+export class ScrollPaneAdapter extends ScrollAdapter {
+
+    constructor(element) {
+        super(element);
+
+        this.initialised = false;
+
+        // listen for scroll events
+        this.element.on('jsp-scroll-y', this.scroll.bind(this));
+
+        // wait for scrollbar to be ready
+        this.element.on('jsp-initialised', () => {
+            this.initialised = true;
+            this.notify('initialised');
+        });
+    }
+
+    getScrollbarVisible() {
+        return !this.initialised ? false : this.element.data('jsp').getIsScrollableV();
+    }
+
+    scroll() {
+
+        if (!this.initialised) {
+            return;
+        }
+
+        const percentage = this.element.data('jsp').getPercentScrolledY() * 100;
+        this.notify('scroll', percentage);
+    }
+
+    destroy() {
+        this.element.off('jsp-scroll-y', this.scroll);
+        super.destroy();
+    }
+
+}

--- a/src/ng1/directives/infiniteScroll/adapters/scroll.adapter.js
+++ b/src/ng1/directives/infiniteScroll/adapters/scroll.adapter.js
@@ -1,0 +1,35 @@
+export class ScrollAdapter {
+
+    constructor(element) {
+        this.element = element ? angular.element(element) : null;
+        this.subscribers = [];
+    }
+
+    /**
+     * Subscribe to events
+     */
+    subscribe(event, callback) {
+        this.subscribers.push({
+            event: event,
+            callback: callback
+        });
+    }
+
+    /**
+     * Notify subscribers about an event
+     */
+    notify(event, value) {
+
+        this.subscribers
+            .filter(subscriber => subscriber.event === event)
+            .forEach(subscriber => subscriber.callback(value));
+    }
+
+    /**
+     * Tear down the scroll adapter
+     */
+    destroy() {
+        this.element = null;
+        this.subscribers = [];
+    }
+}

--- a/src/ng1/directives/infiniteScroll/adapters/window-scroll.adapter.js
+++ b/src/ng1/directives/infiniteScroll/adapters/window-scroll.adapter.js
@@ -1,0 +1,42 @@
+import { ScrollAdapter } from './scroll.adapter';
+
+export class WindowScrollAdapter extends ScrollAdapter {
+
+    constructor() {
+        super();
+
+        // store references to the elements
+        this.window = angular.element(window);
+        this.body = angular.element(document.body);
+
+        // bind to the scroll event
+        this.window.on('scroll', this.scroll.bind(this));
+
+        // inform the consumer than the listener is ready
+        this.notify('initialised');
+    }
+
+    getScrollbarVisible() {
+        return this.body.height() <= this.window.height();
+    }
+
+    /**
+     * When scrolled calulcate the percentage we have scrolled
+     */
+    scroll() {
+        const position = this.element.scrollTop() + this.element.height();
+        const height = angular.innerHeight();
+        const percentage = (position / height) * 100;
+
+        // notify all the subscribers
+        this.notify('scroll', percentage);
+    }
+
+    /**
+     * Clean up after ourselves
+     */
+    destroy() {
+        this.window.off('scroll', this.scroll);
+        super.destroy();
+    }
+}

--- a/src/ng1/directives/infiniteScroll/infiniteScroll.controller.js
+++ b/src/ng1/directives/infiniteScroll/infiniteScroll.controller.js
@@ -1,0 +1,194 @@
+import { ScrollPaneAdapter } from "./adapters/scroll-pane.adapter";
+import { WindowScrollAdapter } from "./adapters/window-scroll.adapter";
+import { ElementScrollAdapter } from "./adapters/element-scroll.adapter";
+import { Observable } from 'rxjs/Observable';
+
+export class InfiniteScrollController {
+
+    get searchQuery() {
+        return this._query;
+    }
+
+    set searchQuery(value) {
+        if (value !== this._query) {
+            this._query = value;
+            this.reset();
+        }
+    }
+
+    constructor($attrs, $templateRequest, $scope, $element, safeInterval, $timeout) {
+        this.page = 0;
+        this.items = [];
+        this.pages = [];
+        this.template = null;
+        this.loading = false;
+        this.complete = false;
+        this.$element = $element;
+        this.$interval = safeInterval.create($scope);
+        this.buttonOptions = { show: false, text: 'Load More', class: '' };
+
+        // private variables
+        this._query = null;
+        this._subscription = null;
+
+        // set some default values if required
+        this.pagePosition = this.pagePosition || 85;
+        this.windowScroll = this.windowScroll || false;
+        this.showLoading = this.showLoading !== false;
+        this.buttonOptions = angular.extend(this.buttonOptions, this.loadMoreButton);
+
+        // determine the type of scrolling to use
+        this.scrollbar = angular.isUndefined($attrs.scrollPane) ? ScrollType.Standard : ScrollType.JScrollPane;
+
+        // watch for broadcasted events
+        $scope.$on('infiniteScroll.reset', () => this.reset());
+        $scope.$on('infiniteScroll.reload', () => this.reload());        
+        $scope.$on('infiniteScroll.reloadPage', (event, page) => this.getPage(page));
+
+        // get the appropriate scrollbar adapter
+        this.scrollbarAdapter = this.getScrollbarAdapter();
+
+        // we want to ensure that the container is scrollable
+        this.scrollbarAdapter.subscribe('initialised', () => $timeout(this.ensureScrollable.bind(this)));
+
+        // bind to any scroll events
+        this.scrollbarAdapter.subscribe('scroll', this.onScroll.bind(this));
+
+        // load the first page
+        this.getPage(0);
+    }
+
+    /**
+     * Ensure that there are enough items to scroll
+     */
+    ensureScrollable() {
+
+        //if we are using a load more button this is also not required
+        if (this.buttonOptions && this.buttonOptions.show) return;
+
+        // repeat until we have enough items
+        this.$interval.interval(() => {
+
+            // if we are currently loading or have loaded all pages then do nothing
+            if (this.loading || this.complete) {
+                return;
+            }
+
+            // check if scrollbar is visible
+            if (!this.scrollbarAdapter.getScrollbarVisible()) {
+                this.getNextPage();
+            }
+
+        }, 250, 0, false);
+    }
+
+    /**
+     * Handle scroll events
+     */
+    onScroll(position) {
+
+        // if we are using the load more button 
+        // or we are currently loading then stop here
+        if (this.loading || this.buttonOptions.show) {
+            return;
+        }
+
+        // otherwise check if the position is greater than the loading position
+        if (position >= this.pagePosition) {
+            this.getNextPage();
+        }
+    }
+
+    /**
+     * Get the items for a specific page
+     */
+    getPage(page) {
+
+        // update the loading state
+        this.loading = true;
+
+        // call the specified paging function
+        let results = this.pageFn(page, this.pageSize, this.searchQuery);
+        
+        // convert to an observable
+        const observable = angular.isArray(results) ? Observable.of(results) : Observable.from(results);
+
+        // store the subscription - now it is cancellable unlike a promise
+        this._subscription = observable.subscribe(items => this.setPageItems(page, items));
+    }
+
+    /**
+     * Load the next page
+     */
+    getNextPage() {
+        this.getPage(++this.page);
+    }
+
+    /**
+     * Define the items associated with each page
+     */
+    setPageItems(page, items) {
+
+        // if no items are returned then we have loaded all pages
+        if (items.length === 0) {
+            this.complete = true;
+        }
+
+        // store the data for the relevant page
+        this.pages[page] = items;
+
+        // flatten the array
+        this.items = this.pages.reduce((previous, current) => previous.concat(current), []);
+
+        // update the loading state
+        this.loading = false;
+    }
+
+    reset() {
+        // remove all current data
+        this.page = 0;
+        this.items = [];
+        this.pages = [];
+
+        // reset the loading state and cancel any pending requests
+        this.loading = false;
+
+        if (this._subscription) {
+            this._subscription.unsubscribe();
+        }
+
+        // reset back to page one
+        this.getPage(0);
+    }
+
+    /**
+     * Reload all pages that have already been loaded
+     */
+    reload() {
+        this.pages.forEach((page, idx) => this.getPage(idx));
+    }
+
+    /**
+     * Allows us to abstract the different event bindings
+     */
+    getScrollbarAdapter() {
+
+        if (this.scrollbar === ScrollType.JScrollPane) {
+            return new ScrollPaneAdapter(this.$element);
+        }
+
+        if (this.scrollbar === ScrollType.Standard && this.windowScroll) {
+            return new WindowScrollAdapter();
+        }
+
+        return new ElementScrollAdapter(this.$element);
+    }
+
+}
+
+const ScrollType = {
+    JScrollPane: 0,
+    Standard: 1
+};
+
+InfiniteScrollController.$inject = ['$attrs', '$templateRequest', '$scope', '$element', 'safeInterval', '$timeout'];

--- a/src/ng1/directives/infiniteScroll/infiniteScroll.controller.js
+++ b/src/ng1/directives/infiniteScroll/infiniteScroll.controller.js
@@ -25,7 +25,6 @@ export class InfiniteScrollController {
         this.complete = false;
         this.$element = $element;
         this.$interval = safeInterval.create($scope);
-        this.buttonOptions = { show: false, text: 'Load More', class: '' };
 
         // private variables
         this._query = null;
@@ -35,7 +34,7 @@ export class InfiniteScrollController {
         this.pagePosition = this.pagePosition || 85;
         this.windowScroll = this.windowScroll || false;
         this.showLoading = this.showLoading !== false;
-        this.buttonOptions = angular.extend(this.buttonOptions, this.loadMoreButton);
+        this.buttonOptions = angular.extend({ show: false, text: 'Load More' }, this.loadMoreButton);
 
         // determine the type of scrolling to use
         this.scrollbar = angular.isUndefined($attrs.scrollPane) ? ScrollType.Standard : ScrollType.JScrollPane;
@@ -70,7 +69,7 @@ export class InfiniteScrollController {
         this.$interval.interval(() => {
 
             // if we are currently loading or have loaded all pages then do nothing
-            if (this.loading || this.complete) {
+            if (this.loading || this.complete || document.hidden) {
                 return;
             }
 

--- a/src/ng1/directives/infiniteScroll/infiniteScroll.controller.js
+++ b/src/ng1/directives/infiniteScroll/infiniteScroll.controller.js
@@ -44,6 +44,9 @@ export class InfiniteScrollController {
         $scope.$on('infiniteScroll.reload', () => this.reload());        
         $scope.$on('infiniteScroll.reloadPage', (event, page) => this.getPage(page));
 
+        // cleanup after ourselves
+        $scope.$on('$destroy', () => this.scrollbarAdapter.destroy());
+
         // get the appropriate scrollbar adapter
         this.scrollbarAdapter = this.getScrollbarAdapter();
 

--- a/src/ng1/directives/infiniteScroll/infiniteScroll.controller.js
+++ b/src/ng1/directives/infiniteScroll/infiniteScroll.controller.js
@@ -1,7 +1,8 @@
 import { ScrollPaneAdapter } from "./adapters/scroll-pane.adapter";
 import { WindowScrollAdapter } from "./adapters/window-scroll.adapter";
 import { ElementScrollAdapter } from "./adapters/element-scroll.adapter";
-import { Observable } from 'rxjs/Observable';
+import { of } from 'rxjs/observable/of';
+import { from } from 'rxjs/observable/from';
 
 export class InfiniteScrollController {
 
@@ -113,7 +114,7 @@ export class InfiniteScrollController {
         let results = this.pageFn(page, this.pageSize, this.searchQuery);
         
         // convert to an observable
-        const observable = angular.isArray(results) ? Observable.of(results) : Observable.from(results);
+        const observable = angular.isArray(results) ? of(results) : from(results);
 
         // store the subscription - now it is cancellable unlike a promise
         this._subscription = observable.subscribe(items => this.setPageItems(page, items));

--- a/src/ng1/directives/infiniteScroll/infiniteScroll.directive.js
+++ b/src/ng1/directives/infiniteScroll/infiniteScroll.directive.js
@@ -1,363 +1,69 @@
-infiniteScroll.$inject = ['$parse', '$templateRequest', '$compile', '$timeout', 'safeTimeout', 'safeInterval'];
+import { InfiniteScrollController } from './infiniteScroll.controller';
 
-export default function infiniteScroll($parse, $templateRequest, $compile, $timeout, safeTimeout, safeInterval) {
+infiniteScroll.$inject = ['$compile', '$templateRequest'];
+
+export default function infiniteScroll($compile, $templateRequest) {
     return {
         restrict: 'A',
-        link: function (scope, element, attrs) {
+        controller: InfiniteScrollController,
+        controllerAs: '$ctrl',
+        bindToController: true,
+        scope: {
+            pageSize: '=',
+            pageFn: '=',
+            pagePosition: '=?',
+            containerId: '=?',
+            itemTemplate: '=',
+            itemApi: '=',
+            showLoading: '=?',
+            searchQuery: '=?',
+            scrollConfig: '=',
+            windowScroll: '=?',
+            loadMoreButton: '=?'
+        },
+        link: function (scope, element, attrs, controller) {
 
-            //initialise properties
-            var currentPage = 0;
-            var items = [];
-            var itemTemplate = null;
-            var lastPage = false;
-            var loadingIndicator = null,
-                loadButton = null;
-            var isLoading = false;
-            var isInitialised = false;
-            var safeIntervalInstance = safeInterval.create(scope);
-            var body = angular.element('body');
-            var win = angular.element(window);
+            // create our insertion point
+            $templateRequest(controller.itemTemplate).then(template => {
 
-            //get the evaluated attributes from the element - prevent isolating scope
-            var pageSize = +$parse(attrs.pageSize)(scope);
-            var pageFn = $parse(attrs.pageFn)(scope);
-            var pagePosition = attrs.pagePosition ? +$parse(attrs.pagePosition)(scope) : 85;
-            var containerId = attrs.containerId ? $parse(attrs.containerId)(scope) : null;
-            var itemTemplateUrl = $parse(attrs.itemTemplate)(scope);
-            var itemApi = attrs.itemApi ? $parse(attrs.itemApi)(scope) : null;
-            var showLoading = attrs.showLoading ? $parse(attrs.showLoading)(scope) : true;
-            var searchQuery = $parse(attrs.searchQuery)(scope);
-            var scrollBarConfig = $parse(attrs.scrollConfig)(scope);
+                // create an element from the template and add repeater
+                const templateElement = angular.element(template);
+                templateElement.attr('ng-repeat', 'data in $ctrl.items');
+                templateElement.attr('ng-init', 'api = $ctrl.itemApi');
 
-            //allow option to use window scroll rather than div
-            var windowScroll = attrs.windowScroll ? $parse(attrs.windowScroll)(scope) : false;
-
-            //load more button
-            var defaultLoadButtonOptions = {
-                show: false,
-                text: 'Load More',
-                class: ''
-            };
-
-            var loadButtonOptions = defaultLoadButtonOptions;
-
-            if (attrs.loadMoreButton) {
-                var value = $parse(attrs.loadMoreButton)(scope);
-                loadButtonOptions = angular.extend(defaultLoadButtonOptions, value);
-            }
-
-            //detect whether this is on a normal scrollbar or a jscrollpane
-            var jScrollPane = attrs.scrollPane === '';
-
-            //load the template
-            var templateLoaded = $templateRequest(itemTemplateUrl);
-
-            //wait for promise to be resolved (template has been loaded)
-            templateLoaded.then(function (template) {
-                //store the item template
-                itemTemplate = template;
-
-                //load the first page
-                loadPage();
+                // compile and add element
+                getContainer().prepend($compile(templateElement)(scope));
             });
 
-            //perform search when search query changes
-            scope.$watch(attrs.searchQuery, function (nv, ov) {
-                if (nv !== ov) {
-                    //store the new search query
-                    searchQuery = nv;
+            // if we need a load more button then create one
+            if (controller.buttonOptions && controller.buttonOptions.show) {
 
-                    // Clear the container and start from the first page
-                    reset();
-                }
-            });
+                // create the button element
+                let button = angular.element(`
+                    <div class="infinite-scroll-load-button {{ $ctrl.buttonOptions.class }}" ng-click="$ctrl.getNextPage()" ng-show="!$ctrl.loading">
+                        <p class="load-button-text">{{ $ctrl.buttonOptions.text }}</p>
+                    </div>
+                `);
 
-            // Reset on external event, e.g. if dataset changes
-            scope.$on('infiniteScroll.reset', function () {
-                reset();
-            });
-
-            //allow jScrollPane to initialise
-            $timeout(bindToScroll);
-
-            function reset() {
-                //remove all previous list items
-                getContainer().empty();
-
-                //set the page back to zero
-                currentPage = 0;
-                isLoading = false;
-
-                //load the next page
-                loadPage();
+                // add the element to the dom
+                getContainer().append($compile(button)(scope));
             }
 
-            function showLoadingIndicator() {
+            // add a loading indicator if required
+            if (controller.showLoading) {
 
-                //if option specified not to show indicator then stop here
-                if (!showLoading) return;
+                const indicator = angular.element(`
+                    <div class="infinite-scroll-loading" ng-show="$ctrl.loading">
+                        <div class="spinner spinner-accent spinner-bounce-middle"></div>
+                        <span class="spinner-text">Loading...</span>
+                    </div>
+                `);
 
-                //if no loading indicator has been created then make one
-                if (!loadingIndicator) {
-                    //create spinner container
-                    loadingIndicator = document.createElement('div');
-                    loadingIndicator.className = 'infinite-scroll-loading';
-
-                    //create spinner
-                    var spinner = document.createElement('div');
-                    spinner.className = 'spinner spinner-accent spinner-bounce-middle';
-
-                    var spinnerText = document.createElement('span');
-                    spinnerText.className = 'spinner-text';
-                    spinnerText.innerHTML = "Loading...";
-
-                    //add spinner to container
-                    loadingIndicator.appendChild(spinner);
-                    loadingIndicator.appendChild(spinnerText);
-                }
-
-                //add loading indicator to bottom of container
-                getContainer().append(loadingIndicator);
-            }
-
-            function showLoadingButton() {
-                //if no button should be shown then stop here - or if we are on the last page then no more to load
-                if (!loadButtonOptions || !loadButtonOptions.show || lastPage) return;
-
-                //create element if one does not already exist
-                if (!loadButton) {
-                    //create the element
-                    loadButton = angular.element('<div class="infinite-scroll-load-button ' + loadButtonOptions.class + '"><p class="load-button-text">' + loadButtonOptions.text + '</p></div>');
-
-                    //add click event - use angular as it is easier to unit test
-                    loadButton.click(function () {
-                        //remove the button from the dom
-                        loadButton.remove();
-
-                        //remove any references to load button
-                        loadButton = null;
-
-                        //load the next page
-                        loadNextPage();
-
-                        //scrol to bottom of the div
-                        scrollToBottom();
-                    });
-                }
-
-                //add button to container
-                getContainer().append(loadButton);
-            }
-
-            function hideLoadingIndicator() {
-                //remove loading indicator from the container
-                getContainer().find('.infinite-scroll-loading').remove();
-            }
-
-            function bindToScroll() {
-
-                //if we want to use a loading button instead we dont need to bind to scroll
-                if (loadButtonOptions && loadButtonOptions.show) return;
-
-                //if we are should use window scrolling
-                if (windowScroll === true) {
-
-                    win.scroll(function () {
-                        //dont do anything if we are loading
-                        if (isLoading) return;
-
-                        //calculate the percentage value from scrolled
-                        var scrollPosition = win.scrollTop() + win.height();
-                        var scrollHeight = body.innerHeight();
-                        var scrolledPercentage = (scrollPosition / scrollHeight) * 100;
-
-                        //we we are near the bottom of the list then begin loading the next page
-                        if (scrolledPercentage > pagePosition) loadNextPage();
-                    });
-
-                } else if (jScrollPane) {
-
-                    element.on('jsp-scroll-y', function () {
-                        //dont do anything if we are loading
-                        if (isLoading) return;
-
-                        //get the jscrollpane data
-                        var scrolledPercentage = element.data('jsp').getPercentScrolledY() * 100;
-
-                        //we we are near the bottom of the list then begin loading the next page
-                        if (scrolledPercentage > pagePosition) loadNextPage();
-                    });
-                } else {
-                    element.scroll(function () {
-                        //dont do anything if we are loading
-                        if (isLoading) return;
-
-                        //calculate the percentage value from scrolled
-                        var scrollPosition = element.scrollTop() + element.innerHeight();
-                        var scrollHeight = element.get(0).scrollHeight;
-                        var scrolledPercentage = (scrollPosition / scrollHeight) * 100;
-
-                        //we we are near the bottom of the list then begin loading the next page
-                        if (scrolledPercentage > pagePosition) loadNextPage();
-
-                    });
-                }
-
-                //ensure enough items are visible to show a scrollbar
-
-                // if we are running in Angular 2 and ngZone is globally available then run outside of ngZone
-                if (window.ngZone) {
-                    window.ngZone.runOutsideAngular(function () {
-                        ensureScrollable();
-                    });
-                } else {
-                    ensureScrollable();
-                }
-            }
-
-            function loadNextPage() {
-                currentPage++;
-                loadPage();
-            }
-
-            function loadPage() {
-
-                //store loading state
-                isLoading = true;
-
-                //show loading indicator
-                showLoadingIndicator();
-
-                //Save the search query for this request to make sure that only the active query response is loaded
-                var thisSearchQuery = searchQuery;
-
-                //call the specified paging function
-                var results = pageFn(currentPage, pageSize, thisSearchQuery);
-
-                //if results is a promise wait until it is solved
-                if (results.then) {
-                    results.then(
-                        function (newItems) {
-                            // Only load the active query
-                            // (Multiple requests may be active at once so avoid combining them)
-                            if (searchQuery === thisSearchQuery) {
-                                processItems(newItems);
-                            }
-                        },
-                        function () {
-                            //if request fails reset properties
-                            isLoading = false;
-                            hideLoadingIndicator();
-                            lastPage = true;
-                        });
-                } else
-                    processItems(results);
-            }
-
-            function processItems(newItems) {
-                //hide loading indicator if there was one
-                hideLoadingIndicator();
-
-                //check if the number of items returned is less than expected - if so then it is the last page
-                if (!newItems || newItems.length < pageSize) lastPage = true;
-
-                //if the items was null or empty dont render new results
-                if (!newItems || newItems.length === 0) return;
-
-                //append the new items to the list
-                for (var i = 0; i < newItems.length; i++) items.push(newItems[i]);
-
-                //render the new items
-                renderItems(newItems);
-
-                // Mark that it's run at least once
-                isInitialised = true;
-            }
-
-            function renderItems(newItems) {
-
-                //get the container element
-                var container = getContainer();
-
-                for (var i = 0; i < newItems.length; i++) {
-                    var item = newItems[i];
-
-                    //create new scope with data as item data
-                    var itemScope = scope.$new();
-                    itemScope.data = item;
-                    itemScope.api = itemApi;
-
-                    //compile and append item
-                    var compiledItem = $compile(itemTemplate)(itemScope);
-                    container.append(compiledItem);
-                }
-
-                //depending on when the rendering is occuring we likely need to manually start a digest
-                if (scope.$root.$$phase === null) scope.$digest();
-
-                // if the scroll is a jScrollPane, then timeout for longer than the autoReinitialiseDelay to ensure the paging isn't done twice
-                if (jScrollPane) {
-                    var safeTimeoutInstance = safeTimeout.create(scope);
-
-                    var delay = angular.isDefined(scrollBarConfig.autoReinitialiseDelay) ? scrollBarConfig.autoReinitialiseDelay + 10 : 1000;
-                    safeTimeoutInstance.timeout(function () {
-                        isLoading = false;
-                    }, delay);
-                } else
-                    isLoading = false;
-
-                //show load more button (if required)
-                showLoadingButton();
+                getContainer().append($compile(indicator)(scope));
             }
 
             function getContainer() {
-
-                //if no container was specified then just return the element
-                if (containerId === null) return element;
-
-                return angular.element(element.find('[infinite-scroll-container="' + containerId + '"]').get(0));
-            }
-
-            function ensureScrollable() {
-                // Checking for a scrollbar should only happen when the jscrollpane is visible and initialised
-                // jspInitialised is true only when the element is visible and jsp init is complete
-                var jspInitialised;
-                if (jScrollPane) {
-                    element.bind("jsp-initialised", function () {
-                        jspInitialised = true;
-                    });
-                }
-
-                //if we are using a load more button this is also not required
-                if (loadButtonOptions && loadButtonOptions.show) return;
-
-                //we need to constantly check that a scrollbar is visible and if not then load more until there is
-                safeIntervalInstance.interval(function () {
-                    //if we are currently loading then we should wait until we arent - if last page then no more to load
-                    if (!isInitialised || isLoading || lastPage) return;
-
-                    if (windowScroll) {
-                        //if a window scrollbar is not visible then load the next page
-                        if (body.height() <= win.height()) loadNextPage();
-                    } else if (jScrollPane) {
-                        // If the element has lost visibility then wait for it to become initialised again
-                        if (!element.is(":visible")) jspInitialised = false;
-                        if (jspInitialised) {
-                            var scrollbarVisible = element.data('jsp').getIsScrollableV();
-
-                            //if a scrollbar is not visible then load the next page
-                            if (!scrollbarVisible) loadNextPage();
-                        }
-                    } else {
-                        //if a scrollbar is not visible then load the next page
-                        if (element.get(0).clientHeight !== 0 && element.get(0).scrollHeight <= element.get(0).clientHeight) loadNextPage();
-                    }
-                }, 100, 0, false);
-            }
-
-            function scrollToBottom() {
-                if (jScrollPane) element.data('jsp').scrollToPercentY(100, false);
-                else element.scrollTop(element[0].scrollHeight);
+                return !controller.containerId ? element : angular.element(element.find('[infinite-scroll-container="' + controller.containerId + '"]').get(0));
             }
         }
     };


### PR DESCRIPTION
Reworked the infinite scroll directive. Rather than manually create all the elements, I have now changed it to use ng-repeat for the list of items and ng-if for showing/hiding items. This allows us to easily update data by letting angular handle all the diffing - and this also reduced the amount of code required significantly.

Added two new broadcast events. One allows the user to reload all currently loaded pages - essentially if there are 5 pages loaded this will call the paging function for pages 1-5 and update the data when it is returned. I also added a reloadPage event that can be passed a specific page number - this will only request the data for that page and update that page only.

Also split out scrollbar handling. We supported scrolling on an element, on a scroll pane and on the window and this previously involved lots of duplicated checks to see which scrollbar was being used. Now extracted these into separate classes with the same surface API. Now we do a check at the start to determine which type of scrollbar is being used and then use the appropriate class which will handle all future scroll events, interactions and cleanup