### PR TITLE
Fixing issues with color service

### DIFF
--- a/src/data/micro-focus-colors.json
+++ b/src/data/micro-focus-colors.json
@@ -66,7 +66,7 @@
         "chart6": "#ba47e2",
         "ok": "#1aac60",
         "warning": "#f48b34",
-        "critical": "e5004c",
+        "critical": "#e5004c",
         "partition1": "#7425ad",
         "partition9": "#5216ac",
         "partition10": "#5bba36",

--- a/src/ng1/services/colorService/colorService.service.js
+++ b/src/ng1/services/colorService/colorService.service.js
@@ -64,7 +64,9 @@ export default function $colorService() {
   }
 
   $colorService.getColor = function(color) {
-    return colors[color.toLowerCase()];
+    const themeColor = colors[color.toLowerCase()];
+
+    return new ThemeColor(themeColor.getRed(), themeColor.getGreen(), themeColor.getBlue(), themeColor.getAlpha());
   };
 
   $colorService.setColorSet = function(customColorSet) {

--- a/src/services/color/color.service.ts
+++ b/src/services/color/color.service.ts
@@ -16,15 +16,15 @@ export class ColorService {
 
     constructor( @Inject(DOCUMENT) document: any) {
         if (this._colorSet.colorClassSet) {
-            this._setColors();
+            this.setColors();
         } else {
             for (let key in this._colorSet.colorValueSet) {
-                this._colors[key] = this._getColorValueByHex(this._colorSet.colorValueSet[key]);
+                this._colors[key] = this.getColorValueByHex(this._colorSet.colorValueSet[key]);
             }
         }
     }
 
-    private _setColors() {
+    private setColors() {
 
         this._html = '';
 
@@ -47,7 +47,7 @@ export class ColorService {
         this._element.parentNode.removeChild(this._element);
     }
 
-    private _getColorValueByHex(color: string): ThemeColor {
+    private getColorValueByHex(color: string): ThemeColor {
         let hex = color.replace('#', '');
 
         let r = parseInt(hex.substring(0, 2), 16).toString();
@@ -73,7 +73,8 @@ export class ColorService {
     }
 
     getColor(color: ColorIdentifier): ThemeColor {
-        return this._colors[color.toLowerCase()];
+        const themeColor = this._colors[color.toLowerCase()];
+        return new ThemeColor(themeColor.getRed(), themeColor.getGreen(), themeColor.getBlue(), themeColor.getAlpha());
     }
 
     getColorSet() {
@@ -85,10 +86,10 @@ export class ColorService {
         this._colors = {};
 
         if (this._colorSet.colorClassSet) {
-            this._setColors();
+            this.setColors();
         } else {
             for (let key in this._colorSet.colorValueSet) {
-                this._colors[key] = this._getColorValueByHex(this._colorSet.colorValueSet[key]);
+                this._colors[key] = this.getColorValueByHex(this._colorSet.colorValueSet[key]);
             }
         }
     }


### PR DESCRIPTION
- Adding missing hash from color map
- Renaming functions to follow naming conventions
- The getColor function now returns a new instance of a ThemeColor rather than the same instance each time. This previously caused issues if I was to use the setAlpha method, which meant any time that color was used in future had the alpha applied to it.