### PR TITLE
EL-2922 - Adding support for setting family colors in page header

### DIFF
--- a/src/components/page-header/page-header.component.html
+++ b/src/components/page-header/page-header.component.html
@@ -31,7 +31,7 @@
 
             <ux-breadcrumbs [crumbs]="crumbs"></ux-breadcrumbs>
 
-            <h1 class="page-header-title">{{ header }}</h1>
+            <h1 class="page-header-title" [style.backgroundColor]="familyBackground" [style.color]="familyForeground">{{ header }}</h1>
         </div>
 
     </div>

--- a/src/components/page-header/page-header.component.ts
+++ b/src/components/page-header/page-header.component.ts
@@ -2,6 +2,7 @@ import { Component, EventEmitter, Input, Output, ContentChildren, QueryList, Tem
 import { Breadcrumb } from '../breadcrumbs/index';
 import { PageHeaderNavigationItem } from './navigation/navigation.component';
 import { PageHeaderCustomMenuDirective } from './custom-menu/custom-menu.directive';
+import { ColorService } from '../../services/color/index';
 
 @Component({
     selector: 'ux-page-header',
@@ -21,10 +22,33 @@ export class PageHeaderComponent {
     @Input() condensed: boolean = false;
     @Input() iconMenus: PageHeaderIconMenu[];
     @Input() backVisible: boolean = true;
+
+    @Input()
+    set familyBackground(color: string) {
+        this._familyBackground = this._colorService.resolve(color);
+    }
+
+    get familyBackground(): string {
+        return this._familyBackground;
+    }
+
+    @Input()
+    set familyForeground(color: string) {
+        this._familyForeground = this._colorService.resolve(color);
+    }
+
+    get familyForeground(): string {
+        return this._familyForeground;
+    }
     
     @Output() backClick = new EventEmitter();
 
     @ContentChildren(PageHeaderCustomMenuDirective, { read: TemplateRef }) customMenus: QueryList<TemplateRef<any>>;
+
+    private _familyBackground: string;
+    private _familyForeground: string;
+
+    constructor(private _colorService: ColorService) {}
 
     goBack() {
         this.backClick.emit();

--- a/src/components/page-header/page-header.module.ts
+++ b/src/components/page-header/page-header.module.ts
@@ -10,11 +10,13 @@ import { PageHeaderNavigationItemComponent } from './navigation/navigation-item/
 import { PageHeaderNavigationDropdownItemComponent } from './navigation/navigation-dropdown-item/navigation-dropdown-item.component';
 import { PageHeaderCustomMenuDirective } from './custom-menu/custom-menu.directive';
 import { ResizeModule } from '../../directives/resize/index';
+import { ColorServiceModule } from '../../services/color/index';
 
 @NgModule({
     imports: [
         CommonModule,
         BreadcrumbsModule,
+        ColorServiceModule,
         ResizeModule,
         BsDropdownModule.forRoot()
     ],

--- a/src/services/color/color.service.ts
+++ b/src/services/color/color.service.ts
@@ -1,11 +1,6 @@
+import { Injectable, Inject } from '@angular/core';
+import { DOCUMENT } from '@angular/platform-browser';
 import { ColorValueSet, ColorClassSet } from './color.service';
-import {
-    DOCUMENT
-} from '@angular/platform-browser';
-import {
-    Injectable,
-    Inject
-} from '@angular/core';
 
 export class ColorService {
 
@@ -14,7 +9,7 @@ export class ColorService {
     private _colors: ThemeColors;
     private _colorSet: any = colorSets.keppel;
 
-    constructor( @Inject(DOCUMENT) document: any) {
+    constructor(@Inject(DOCUMENT) document: Document) {
         if (this._colorSet.colorClassSet) {
             this.setColors();
         } else {
@@ -48,26 +43,26 @@ export class ColorService {
     }
 
     private getColorValueByHex(color: string): ThemeColor {
-        let hex = color.replace('#', '');
+        const hex = color.replace('#', '');
 
-        let r = parseInt(hex.substring(0, 2), 16).toString();
-        let g = parseInt(hex.substring(2, 4), 16).toString();
-        let b = parseInt(hex.substring(4, 6), 16).toString();
+        const r = parseInt(hex.substring(0, 2), 16).toString();
+        const g = parseInt(hex.substring(2, 4), 16).toString();
+        const b = parseInt(hex.substring(4, 6), 16).toString();
 
         return new ThemeColor(r, g, b, '1');
     }
 
     private getColorValue(color: ColorIdentifier): ThemeColor {
 
-        let target = this._element.querySelector('.' + this._colorSet.colorClassSet[color] + '-color');
+        const target = this._element.querySelector('.' + this._colorSet.colorClassSet[color] + '-color');
 
         if (!target) {
             throw new Error('Invalid color');
         }
 
-        let colorValue = window.getComputedStyle(target).backgroundColor;
+        const colorValue = window.getComputedStyle(target).backgroundColor;
 
-        let rgba = colorValue.match(/^rgba?\((\d+),\s*(\d+),\s*(\d+)(?:,\s*(\d+(?:\.\d+)?))?\)$/);
+        const rgba = colorValue.match(/^rgba?\((\d+),\s*(\d+),\s*(\d+)(?:,\s*(\d+(?:\.\d+)?))?\)$/);
 
         return new ThemeColor(rgba[1], rgba[2], rgba[3], rgba[4]);
     }
@@ -99,7 +94,7 @@ export class ColorService {
             return;
         }
         
-        const colorName = value.replace(/\s+/g, '-').toLowerCase();
+        const colorName = this.resolveColorName(value);
         
         for (let color in this._colors) {
             if (colorName === color.toLowerCase()) {
@@ -132,13 +127,13 @@ export class ThemeColor {
     static parse(value: string): ThemeColor {
         let r, g, b, a = '1';
 
-        var rgbaPattern = /^rgba?\((\d+),\s*(\d+),\s*(\d+)(?:,\s*(\d+(?:\.\d+)?))?\)$/;
-        var shortHexPattern = /^#?([a-f\d])([a-f\d])([a-f\d])$/i;
-        var longHexPattern = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/;
+        const rgbaPattern = /^rgba?\((\d+),\s*(\d+),\s*(\d+)(?:,\s*(\d+(?:\.\d+)?))?\)$/;
+        const shortHexPattern = /^#?([a-f\d])([a-f\d])([a-f\d])$/i;
+        const longHexPattern = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/;
 
-        let rgbaMatch = value.match(rgbaPattern);
-        let shortHexMatch = value.match(shortHexPattern);
-        let longHexMatch = value.match(longHexPattern);
+        const rgbaMatch = value.match(rgbaPattern);
+        const shortHexMatch = value.match(shortHexPattern);
+        const longHexMatch = value.match(longHexPattern);
 
         if (rgbaMatch) {
             r = rgbaMatch[1];
@@ -160,9 +155,9 @@ export class ThemeColor {
     }
 
     toHex() {
-        var red = parseInt(this._r).toString(16);
-        var green = parseInt(this._g).toString(16);
-        var blue = parseInt(this._b).toString(16);
+        let red = parseInt(this._r).toString(16);
+        let green = parseInt(this._g).toString(16);
+        let blue = parseInt(this._b).toString(16);
 
         if (red.length < 2) {
             red = '0' + red;


### PR DESCRIPTION
JIRA: https://jira.autonomy.com/browse/EL-2922

Related: https://github.houston.softwaregrp.net/caf/ux-aspects-micro-focus/pull/128

Adding option to set the family background and foreground colors via attributes on the element. They can either be names from the color palette or css color values.

No documentation required as this is only suitable for MF docs