### PR TITLE
EL-2961 - Fixing wrapper issues

### DIFF
--- a/src/hybrid/components/marquee-wizard/marquee-wizard.component.ts
+++ b/src/hybrid/components/marquee-wizard/marquee-wizard.component.ts
@@ -19,7 +19,7 @@ export class MarqueeWizardComponent extends UpgradeComponent {
     @Output() wizardStepsChange: EventEmitter<MarqueeWizardStep[]> = new EventEmitter<MarqueeWizardStep[]>();
 
     constructor(elementRef: ElementRef, injector: Injector) {
-        super('marquee-wizard', elementRef, injector);
+        super('marqueeWizard', elementRef, injector);
     }
 }
 

--- a/src/ng1/directives/selectTable/selectTable.controller.js
+++ b/src/ng1/directives/selectTable/selectTable.controller.js
@@ -150,8 +150,6 @@ export default function selectTableCtrl($timeout, $scope, $filter) {
                 vm.selected.push(value);
             }
         }
-
-        $scope.$digest();
     };
 
     vm.keydown = function(e) {


### PR DESCRIPTION
Marquee wizard selector used hyphen instead of camel case.

The select table component was trying to fire a scope.digest whenever the select function is called. This function is only ever called by ng-click, which already does a digest so we were getting errors in the console about multiple digest cycles - this wasn't related to any changes to the wrappers but just discovered while testing them.