### PR TITLE
Marquee wizard fixes

### DIFF
--- a/docs/app/pages/components/components-sections/wizard/marquee-wizard/marquee-wizard.component.html
+++ b/docs/app/pages/components/components-sections/wizard/marquee-wizard/marquee-wizard.component.html
@@ -265,7 +265,7 @@
     </tr>
     <tr uxd-api-property name="completed" type="boolean">
         Defines whether or not this step has previously been completed. A completed step can be clicked on and jumped to at any time.
-        By default, steps will become 'completed' when the user navigates to a to the next step.
+        By default, steps will become 'completed' when the user navigates to the next step.
     </tr>
 </uxd-api-properties>
 

--- a/src/components/marquee-wizard/marquee-wizard.component.ts
+++ b/src/components/marquee-wizard/marquee-wizard.component.ts
@@ -45,16 +45,6 @@ export class MarqueeWizardComponent extends WizardComponent {
     }
 
     /**
-     * Only go to the previous step if
-     * the current step is valid
-     */
-    previous(): void {
-        if (this.getCurrentStep().valid) {
-            super.previous();
-        }
-    }
-
-    /**
      * Emit the onFinishing event and if valid the onFinish event.
      * Also mark the final step as completed if it is valid
      */


### PR DESCRIPTION
Related PR: https://github.houston.softwaregrp.net/caf/ux-aspects-micro-focus/pull/135

- Fixing typo
- Removing restriction where you can't go to the previous step if there is an error on the current step - this now matches the functionality of the standard wizard