### PR TITLE
EL-2941 (Timeline - Angular Migration)

### DIFF
--- a/docs/app/pages/components/components-sections/timeline/timeline/snippets/app.html
+++ b/docs/app/pages/components/components-sections/timeline/timeline/snippets/app.html
@@ -2,21 +2,23 @@
     <div class="col-md-10">
         <button class="btn button-primary" (click)="addEvent()">Add New Event</button>
         <ux-timeline>
-            <ux-timeline-event *ngFor="let event of events" [badgeColor]="event.color"
-                [badgeTitle]="event.date | date:'EEE LLL d'">
+            <li *ngFor="let event of events">
+                <ux-timeline-event [badgeColor]="event.color"
+                    [badgeTitle]="event.date | date:'EEE LLL d'">
 
-                <div class="m-b-sm">
-                    <span>
-                        <i class="hpe-icon hpe-document-time"></i>
-                        <span>{{event.date | date:'EEEE, MMMM d, y, h:mm:ss a'}}</span>        
-                    </span>
-                </div>
-                <p class="m-b-nil">Ticket
-                    <a [href]="event.url">{{event.id}}</a>
-                    was {{event.action}} by {{event.assignee}}.
-                </p>
+                    <div class="m-b-sm">
+                        <span>
+                            <i class="hpe-icon hpe-document-time"></i>
+                            <span>{{event.date | date:'EEEE, MMMM d, y, h:mm:ss a'}}</span>        
+                        </span>
+                    </div>
+                    <p class="m-b-nil">Ticket
+                        <a [href]="event.url">{{event.id}}</a>
+                        was {{event.action}} by {{event.assignee}}.
+                    </p>
 
-            </ux-timeline-event>
+                </ux-timeline-event>
+            </li>
         </ux-timeline>
     </div>
 </div>

--- a/docs/app/pages/components/components-sections/timeline/timeline/snippets/app.ts
+++ b/docs/app/pages/components/components-sections/timeline/timeline/snippets/app.ts
@@ -7,42 +7,48 @@ import 'chance';
 })
 export class AppComponent {
 
+    private _now = Date.now();
+    private _dayInMilliSeconds = 24 * 60 * 60 * 1000;
+    private _daysAfterFirstEvent = 3;
+    
     events: TimelineEvent[] = [{
-        color: 'alternate3',
-        date: new Date(2018, 0, 29, 11, 10),
+        color: 'accent',
+        date: new Date(this._now + (this._dayInMilliSeconds * 3)),
         url: '#',
-        id: '1234',
+        id: chance.integer({min: 1000, max: 9999}),
         action: 'tested',
         assignee: chance.name()
     }, {
         color: 'alternate2',
-        date: new Date(2018, 0, 26, 14, 0),
+        date: new Date(this._now + (this._dayInMilliSeconds * 2)),
         url: '#',
-        id: '1234',
+        id: chance.integer({min: 1000, max: 9999}),
         action: 'reviewed',
         assignee: chance.name()
     }, {
-        color: 'alternate1',
-        date: new Date(2018, 0, 24, 9, 20),
+        color: 'grey4',
+        date: new Date(this._now + (this._dayInMilliSeconds * 1)),
         url: '#',
-        id: '1234',
+        id: chance.integer({min: 1000, max: 9999}),
         action: 'developed',
         assignee: chance.name()
     }, {
         color: 'primary',
-        date: new Date(2018, 0, 22, 13, 45),
+        date: new Date(this._now),
         url: '#',
-        id: '1234',
+        id: chance.integer({min: 1000, max: 9999}),
         action: 'recorded',
         assignee: chance.name()
     }];
-    
+
     addEvent(): void {
+        this._daysAfterFirstEvent++;
         this.events.unshift({
-            color: 'alternate1',
-            date: new Date(),
+            color: 'grey4',
+            date: new Date(this._now +
+                (this._dayInMilliSeconds * this._daysAfterFirstEvent)),
             url: '#',
-            id: '1234',
+            id: chance.integer({min: 1000, max: 9999}),
             action: 'updated',
             assignee: chance.name()
         });
@@ -53,7 +59,7 @@ interface TimelineEvent {
     color: string;
     date: Date;
     url: string;
-    id: string;
+    id: number;
     action: 'recorded' | 'developed' | 'updated' | 'reviewed' | 'tested' | 'closed';
     assignee: string;
 }

--- a/docs/app/pages/components/components-sections/timeline/timeline/timeline.component.html
+++ b/docs/app/pages/components/components-sections/timeline/timeline/timeline.component.html
@@ -2,20 +2,22 @@
     <div class="col-md-10">
         <button class="btn button-primary" (click)="addEvent()">Add New Event</button>
         <ux-timeline>
-            <ux-timeline-event *ngFor="let event of events" [badgeColor]="event.color" [badgeTitle]="event.date | date:'EEE LLL d'">
+            <li *ngFor="let event of events">
+                <ux-timeline-event [badgeColor]="event.color" [badgeTitle]="event.date | date:'EEE LLL d'">
 
-                <div class="m-b-sm">
-                    <span>
-                        <i class="hpe-icon hpe-document-time"></i>
-                        <span>{{event.date | date:'EEEE, MMMM d, y, h:mm:ss a'}}</span>        
-                    </span>
-                </div>
-                <p class="m-b-nil">Ticket
-                    <a [href]="event.url">{{event.id}}</a>
-                    was {{event.action}} by {{event.assignee}}.
-                </p>
+                    <div class="m-b-sm">
+                        <span>
+                            <i class="hpe-icon hpe-document-time"></i>
+                            <span>{{event.date | date:'EEEE, MMMM d, y, h:mm:ss a'}}</span>        
+                        </span>
+                    </div>
+                    <p class="m-b-nil">Ticket
+                        <a [href]="event.url">{{event.id}}</a>
+                        was {{event.action}} by {{event.assignee}}.
+                    </p>
 
-            </ux-timeline-event>
+                </ux-timeline-event>
+            </li>
         </ux-timeline>
     </div>
 </div>

--- a/docs/app/pages/components/components-sections/timeline/timeline/timeline.component.ts
+++ b/docs/app/pages/components/components-sections/timeline/timeline/timeline.component.ts
@@ -12,32 +12,36 @@ import 'chance';
 @DocumentationSectionComponent('ComponentsTimelineComponent')
 export class ComponentsTimelineComponent extends BaseDocumentationSection implements IPlunkProvider {
 
+    private _now = Date.now();
+    private _dayInMilliSeconds = 24 * 60 * 60 * 1000;
+    private _daysAfterFirstEvent = 3;
+    
     events: TimelineEvent[] = [{
-        color: 'alternate3',
-        date: new Date(2018, 0, 29, 11, 10),
+        color: 'accent',
+        date: new Date(this._now + (this._dayInMilliSeconds * 3)),
         url: '#',
-        id: '1234',
+        id: chance.integer({min: 1000, max: 9999}),
         action: 'tested',
         assignee: chance.name()
     }, {
         color: 'alternate2',
-        date: new Date(2018, 0, 26, 14, 0),
+        date: new Date(this._now + (this._dayInMilliSeconds * 2)),
         url: '#',
-        id: '1234',
+        id: chance.integer({min: 1000, max: 9999}),
         action: 'reviewed',
         assignee: chance.name()
     }, {
-        color: 'alternate1',
-        date: new Date(2018, 0, 24, 9, 20),
+        color: 'grey4',
+        date: new Date(this._now + (this._dayInMilliSeconds * 1)),
         url: '#',
-        id: '1234',
+        id: chance.integer({min: 1000, max: 9999}),
         action: 'developed',
         assignee: chance.name()
     }, {
         color: 'primary',
-        date: new Date(2018, 0, 22, 13, 45),
+        date: new Date(this._now),
         url: '#',
-        id: '1234',
+        id: chance.integer({min: 1000, max: 9999}),
         action: 'recorded',
         assignee: chance.name()
     }];
@@ -58,11 +62,12 @@ export class ComponentsTimelineComponent extends BaseDocumentationSection implem
     }
 
     addEvent(): void {
+        this._daysAfterFirstEvent++;
         this.events.unshift({
-            color: 'alternate1',
-            date: new Date(),
+            color: 'grey4',
+            date: new Date(this._now + (this._dayInMilliSeconds * this._daysAfterFirstEvent)),
             url: '#',
-            id: '1234',
+            id: chance.integer({min: 1000, max: 9999}),
             action: 'updated',
             assignee: chance.name()
         });
@@ -73,7 +78,7 @@ interface TimelineEvent {
     color: string;
     date: Date;
     url: string;
-    id: string;
+    id: number;
     action: 'recorded' | 'developed' | 'updated' | 'reviewed' | 'tested' | 'closed';
     assignee: string;
 }

--- a/e2e/pages/app/timeline/timeline.testpage.component.html
+++ b/e2e/pages/app/timeline/timeline.testpage.component.html
@@ -2,20 +2,22 @@
     <div class="col-md-10">
         <button id="button" class="btn button-primary" (click)="addEvent()">Add New Event</button>
         <ux-timeline id="timeline">
-            <ux-timeline-event *ngFor="let event of events" [badgeColor]="event.color" [badgeTitle]="event.date | date:'EEE LLL d'">
+            <li *ngFor="let event of events">
+                <ux-timeline-event [badgeColor]="event.color" [badgeTitle]="event.date | date:'EEE LLL d'">
 
-                <div class="m-b-sm">
-                    <span>
-                        <i class="hpe-icon hpe-document-time"></i>
-                        <span>{{event.date | date:'EEEE, MMMM d, y, h:mm:ss a'}}</span>        
-                    </span>
-                </div>
-                <p class="m-b-nil">Ticket
-                    <a [href]="event.url">{{event.id}}</a>
-                    was {{event.action}} by {{event.assignee}}.
-                </p>
+                    <div class="m-b-sm">
+                        <span>
+                            <i class="hpe-icon hpe-document-time"></i>
+                            <span>{{event.date | date:'EEEE, MMMM d, y, h:mm:ss a'}}</span>        
+                        </span>
+                    </div>
+                    <p class="m-b-nil">Ticket
+                        <a [href]="event.url">{{event.id}}</a>
+                        was {{event.action}} by {{event.assignee}}.
+                    </p>
 
-            </ux-timeline-event>
+                </ux-timeline-event>
+            </li>
         </ux-timeline>
     </div>
 </div>

--- a/e2e/pages/app/timeline/timeline.testpage.component.ts
+++ b/e2e/pages/app/timeline/timeline.testpage.component.ts
@@ -7,42 +7,47 @@ import 'chance';
 })
 export class TimelineTestPageComponent {
 
+    private _now = Date.now();
+    private _dayInMilliSeconds = 24 * 60 * 60 * 1000;
+    private _daysAfterFirstEvent = 3;
+    
     events: TimelineEvent[] = [{
-        color: 'alternate3',
-        date: new Date(2018, 0, 29, 11, 10),
+        color: 'accent',
+        date: new Date(this._now + (this._dayInMilliSeconds * 3)),
         url: '#',
-        id: '1234',
+        id: chance.integer({min: 1000, max: 9999}),
         action: 'tested',
         assignee: chance.name()
     }, {
         color: 'alternate2',
-        date: new Date(2018, 0, 26, 14, 0),
+        date: new Date(this._now + (this._dayInMilliSeconds * 2)),
         url: '#',
-        id: '1234',
+        id: chance.integer({min: 1000, max: 9999}),
         action: 'reviewed',
         assignee: chance.name()
     }, {
-        color: 'alternate1',
-        date: new Date(2018, 0, 24, 9, 20),
+        color: 'grey4',
+        date: new Date(this._now + this._dayInMilliSeconds),
         url: '#',
-        id: '1234',
+        id: chance.integer({min: 1000, max: 9999}),
         action: 'developed',
         assignee: chance.name()
     }, {
         color: 'primary',
-        date: new Date(2018, 0, 22, 13, 45),
+        date: new Date(this._now),
         url: '#',
-        id: '1234',
+        id: chance.integer({min: 1000, max: 9999}),
         action: 'recorded',
         assignee: chance.name()
     }];
 
     addEvent(): void {
+        this._daysAfterFirstEvent++;
         this.events.unshift({
-            color: 'alternate1',
-            date: new Date(),
+            color: 'grey4',
+            date: new Date(this._now + (this._dayInMilliSeconds * this._daysAfterFirstEvent)),
             url: '#',
-            id: '1234',
+            id: chance.integer({min: 1000, max: 9999}),
             action: 'updated',
             assignee: chance.name()
         });
@@ -53,7 +58,7 @@ interface TimelineEvent {
     color: string;
     date: Date;
     url: string;
-    id: string;
+    id: number;
     action: 'recorded' | 'developed' | 'updated' | 'reviewed' | 'tested' | 'closed';
     assignee: string;
 }

--- a/e2e/tests/components/common/common.spec.ts
+++ b/e2e/tests/components/common/common.spec.ts
@@ -29,7 +29,7 @@ export class Constants {
     DISABLED_BORDER_COLOR = '';
     DISABLED_COLOR = '#a8a8a8';
 
-    ALTERNATE1_BACKGROUND_COLOR = '#3baa43';
+    GREY4_BACKGROUND_COLOR = '#999999';
 }
 
 export class Functions {

--- a/e2e/tests/components/timeline/timeline.e2e-spec.ts
+++ b/e2e/tests/components/timeline/timeline.e2e-spec.ts
@@ -39,38 +39,42 @@ describe('TimelinePage Tests', () => {
     
   });
 
-  it('should display the correct information for events', () => {
-    
+  it('should display the correct information for events', () => {    
+
     // Check elements of various events.
-    expect<any>(page.getEventBadgeTitle(1)).toEqual('Fri Jan 26');
+
+    const now = Date.now();
+
+    const weekdays: string[] = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+    const months: string[] = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+    const dayInMilliSeconds = 24 * 60 * 60 * 1000;
+    
+    // Third event.
+    let thirdEvent = new Date(now + (dayInMilliSeconds * 2));
+    let dayOfWeek = weekdays[thirdEvent.getDay()];
+    let month = months[thirdEvent.getMonth()];
+    let day = thirdEvent.getDate();
+    let badgeTitle = dayOfWeek + ' ' + month + ' ' + day;
+    expect<any>(page.getEventBadgeTitle(1)).toEqual(badgeTitle);
+
     expect<any>(page.getEventBadge(1).getAttribute('class')).toContain('alternate2');
 
-    expect<any>(page.getEventTimestamp(2)).toEqual('Wednesday, January 24, 2018, 9:20:00 AM');
-    
-    expect<any>(functions.getElementColourHex(page.getEventBadge(3), 'background-color')).toBe(constants.PRIMARY_BACKGROUND_COLOR);
-    expect<any>(functions.getElementColourHex(page.getEventBadge(3), 'color')).toBe(constants.WHITE);
+    // First event.
+    expect<any>(page.getEventBadge(3).getAttribute('class')).toContain('primary');
 
     expect<any>(page.getEventPanelText(3)).toContain('was recorded by');
 
-    // Add another event and check it.
+    // Add a fifth event and check it.
     page.addEvent.click();
 
-    const now = new Date();
-    
-    const weekdays: string[] = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
-    const dayOfWeek = weekdays[now.getDay()];
-    
-    const months: string[] = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
-    const month = months[now.getMonth()];
-
-    const day = now.getDate();
-    const badgeTitle = dayOfWeek + ' ' + month + ' ' + day;
-    
+    let newEvent = new Date(now + (dayInMilliSeconds * 4));    
+    dayOfWeek = weekdays[newEvent.getDay()];
+    month = months[newEvent.getMonth()];
+    day = newEvent.getDate();
+    badgeTitle = dayOfWeek + ' ' + month + ' ' + day;
     expect<any>(page.getEventBadgeTitle(0)).toEqual(badgeTitle);
-    expect<any>(page.getEventBadge(0).getAttribute('class')).toContain('alternate1');
 
-    expect<any>(functions.getElementColourHex(page.getEventBadge(0), 'background-color')).toBe(constants.ALTERNATE1_BACKGROUND_COLOR);
-    expect<any>(functions.getElementColourHex(page.getEventBadge(0), 'color')).toBe(constants.WHITE);
+    expect<any>(page.getEventBadge(0).getAttribute('class')).toContain('grey4');
 
     expect<any>(page.getEventPanelText(0)).toContain('was updated by');
   });

--- a/e2e/tests/components/timeline/timeline.po.spec.ts
+++ b/e2e/tests/components/timeline/timeline.po.spec.ts
@@ -10,27 +10,23 @@ export class TimelinePage {
     timeline = element(by.id('timeline'));
     
     getNumberOfEvents() {
-        return this.timeline.$('ul.timeline').$$('ux-timeline-event').count();
+        return this.timeline.$('ul.timeline').$$('li').count();
     }
     
     getEvent(index: number) {
-        return this.timeline.$('ul.timeline').$$('ux-timeline-event').get(index);
+        return this.timeline.$('ul.timeline').$$('li').get(index).$('ux-timeline-event');
     }    
 
     getEventBadge(index: number) {
-        return this.getEvent(index).$('li').$('.timeline-badge');
+        return this.getEvent(index).$('.timeline-badge');
     }
 
     getEventPanel(index: number) {
-        return this.getEvent(index).$('li').$('.timeline-panel');
+        return this.getEvent(index).$('.timeline-panel');
     }
 
     getEventBadgeTitle(index: number) {
         return this.getEventBadge(index).getText();
-    }
-
-    getEventTimestamp(index: number) {
-        return this.getEventPanel(index).$('div').$('span > span').getText();
     }
 
     getEventPanelText(index: number) {

--- a/src/components/timeline/timeline-event/timeline-event.component.html
+++ b/src/components/timeline/timeline-event/timeline-event.component.html
@@ -1,8 +1,6 @@
-<li class="timeline-inverted">
-    <div class="timeline-badge" [ngClass]="badgeColor">
-        <span>{{badgeTitle}}</span>
-    </div>
-    <div class="timeline-panel">
-        <ng-content></ng-content>
-    </div>
-</li>
+<div class="timeline-badge" [ngClass]="badgeColor">
+    <span>{{badgeTitle}}</span>
+</div>
+<div class="timeline-panel">
+    <ng-content></ng-content>
+</div>

--- a/src/components/timeline/timeline.component.less
+++ b/src/components/timeline/timeline.component.less
@@ -25,7 +25,7 @@ ux-timeline {
             transform: translateX(-0.5px);
         }
 
-        li {
+        ux-timeline-event {
             margin-bottom: 20px;
             position: relative;
 
@@ -169,14 +169,12 @@ ux-timeline {
     }
 
     ux-timeline-event {
-        li {
-            .timeline-badge {
-                span {
-                    text-overflow: ellipsis;
-                    white-space: nowrap;
-                    display: block;
-                    overflow: hidden;
-                }
+        .timeline-badge {
+            span {
+                text-overflow: ellipsis;
+                white-space: nowrap;
+                display: block;
+                overflow: hidden;
             }
         }
     }
@@ -188,32 +186,30 @@ ux-timeline {
             }
 
             ux-timeline-event {
-                li {
-                    .timeline-badge {
-                        left: 15px;
-                        margin-left: 0;
-                        top: 36px;
+                .timeline-badge {
+                    left: 15px;
+                    margin-left: 0;
+                    top: 30px;
+                }
+
+                > .timeline-panel {
+                    width: ~'calc(100% - 135px)';
+                    float: right;
+
+                    &:before {
+                        border-left-width: 0;
+                        border-right-width: 8px;
+                        left: -8px;
+                        right: auto;
+                        top: 34px;
                     }
 
-                    > .timeline-panel {
-                        width: ~'calc(100% - 135px)';
-                        float: right;
-
-                        &:before {
-                            border-left-width: 0;
-                            border-right-width: 8px;
-                            left: -8px;
-                            right: auto;
-                            top: 40px;
-                        }
-
-                        &:after {
-                            border-left-width: 0;
-                            border-right-width: 8px;
-                            right: auto;
-                            left: -7px;
-                            top: 41px;
-                        }
+                    &:after {
+                        border-left-width: 0;
+                        border-right-width: 8px;
+                        right: auto;
+                        left: -7px;
+                        top: 35px;
                     }
                 }
             }
@@ -226,11 +222,11 @@ ux-timeline {
                 left: 64px;
             }
 
-            li {
+            ux-timeline-event {
                 > .timeline-badge {
                     left: 15px;
                     margin-left: 0;
-                    top: 36px;
+                    top: 30px;
                 }
 
                 > .timeline-panel {
@@ -241,7 +237,7 @@ ux-timeline {
                         border-right-width: 8px;
                         left: -8px;
                         right: auto;
-                        top: 40px;
+                        top: 34px;
                     }
 
                     &:after {
@@ -249,7 +245,7 @@ ux-timeline {
                         border-right-width: 8px;
                         right: auto;
                         left: -7px;
-                        top: 41px;
+                        top: 35px;
                     }
                 }
             }


### PR DESCRIPTION
Inserted 'li' element between 'ul' element and 'ux-timeline-event' elements.
Removed unused 'li.timeline-inverted' element which originated in the ng1 example.
Now generating a new date and a unique ticker number for each event.
Changed badge colours.
Vertically centered the panel arrow.
Updated the Protractor tests.

https://jira.autonomy.com/browse/EL-2941