### PR TITLE
EL-3029 - Removing dark styling

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -21,7 +21,7 @@ module.exports = function (grunt) {
     
     // Register Tasks
     grunt.registerTask('cleanup', ['clean:library', 'clean:documentation', 'clean:ng1', 'clean:styles', 'clean:fonts', 'clean:images', 'clean:less', 'clean:licenses']);
-    grunt.registerTask('lint', ['tslint:library', 'tslint:documentation', 'jshint:ng1', 'stylelint:components']);
+    grunt.registerTask('lint', ['tslint:library', 'tslint:documentation', 'jshint:ng1', 'stylelint']);
     grunt.registerTask('library', ['clean:library', 'run:build_library', 'webpack:ng1']);
     grunt.registerTask('styles', ['clean:styles', 'execute:less']);
     grunt.registerTask('scripts', ['execute:iconset']);

--- a/docs/app/pages/components/components-sections/draggable-panels/draggable-panels-views-ng1/draggable-panels-views-ng1.component.less
+++ b/docs/app/pages/components/components-sections/draggable-panels/draggable-panels-views-ng1/draggable-panels-views-ng1.component.less
@@ -1,24 +1,16 @@
 .draggable-panel-list-demo {
-	background-color: #f7f7f7;
-	height: 400px;
-}
-
-.body-dark .draggable-panel-list-demo {
-	background-color: #404040;
-}
-
-.body-dark .draggable-panel-list-demo div {
-	background-color: #444444;
+    background-color: #f7f7f7;
+    height: 400px;
 }
 
 .draggable-panel-list-demo div {
-	background-color: #ffffff;
+    background-color: #fff;
 }
 
 .list-item-large-demo {
-	height: 130px;
+    height: 130px;
 }
 
 .list-item-small-demo {
-	height: 50px;
+    height: 50px;
 }

--- a/docs/app/pages/components/components-sections/draggable-panels/draggable-panels-views-ng1/snippets/draggable-panels-views.css
+++ b/docs/app/pages/components/components-sections/draggable-panels/draggable-panels-views-ng1/snippets/draggable-panels-views.css
@@ -1,24 +1,16 @@
 .draggable-panel-list-demo {
-	background-color: #f7f7f7;
-	height: 400px;
-}
-
-.body-dark .draggable-panel-list-demo {
-	background-color: #404040;
-}
-
-.body-dark .draggable-panel-list-demo div {
-	background-color: #444444;
+    background-color: #f7f7f7;
+    height: 400px;
 }
 
 .draggable-panel-list-demo div {
-	background-color: #ffffff;
+    background-color: #fff;
 }
 
 .list-item-large-demo {
-	height: 130px;
+    height: 130px;
 }
 
 .list-item-small-demo {
-	height: 50px;
+    height: 50px;
 }

--- a/docs/app/pages/components/components-sections/scrollbar/infinite-scroll-load-more-ng1/infinite-scroll-load-more-ng1.component.less
+++ b/docs/app/pages/components/components-sections/scrollbar/infinite-scroll-load-more-ng1/infinite-scroll-load-more-ng1.component.less
@@ -1,29 +1,17 @@
 .employee-list-container {
-  border: 1px solid #ddd;
-  padding: 5px;
-  padding-left: 0;  
+    border: 1px solid #ddd;
+    padding: 5px;
+    padding-left: 0;
 }
 
 .employee-list {
-  width: 100%;
-  height: 250px;
+    width: 100%;
+    height: 250px;
 }
 
 .employee-item {
-  width: 100%;
-  height: 65px;
-  padding: 10px 20px;
-  border-bottom: 1px solid #eee;
-}
-
-.body-dark .employee-list {
-  border: 1px solid #666666;
-}
-
-.body-dark .employee-item {
-  border-bottom: 1px solid #666666;
-}
-
-.body-dark .employee-item .text-black {
-  color: #fff !important;
+    width: 100%;
+    height: 65px;
+    padding: 10px 20px;
+    border-bottom: 1px solid #eee;
 }

--- a/docs/app/pages/components/components-sections/scrollbar/infinite-scroll-load-more-ng1/snippets/styles.css
+++ b/docs/app/pages/components/components-sections/scrollbar/infinite-scroll-load-more-ng1/snippets/styles.css
@@ -1,29 +1,17 @@
 .employee-list-container {
-  border: 1px solid #ddd;
-  padding: 5px;
-  padding-left: 0;  
+    border: 1px solid #ddd;
+    padding: 5px;
+    padding-left: 0;
 }
 
 .employee-list {
-  width: 100%;
-  height: 250px;
+    width: 100%;
+    height: 250px;
 }
 
 .employee-item {
-  width: 100%;
-  height: 65px;
-  padding: 10px 20px;
-  border-bottom: 1px solid #eee;
-}
-
-.body-dark .employee-list {
-  border: 1px solid #666666;
-}
-
-.body-dark .employee-item {
-  border-bottom: 1px solid #666666;
-}
-
-.body-dark .employee-item .text-black {
-  color: #fff !important;
+    width: 100%;
+    height: 65px;
+    padding: 10px 20px;
+    border-bottom: 1px solid #eee;
 }

--- a/docs/app/pages/components/components-sections/scrollbar/infinite-scroll-ng1/infinite-scroll-ng1.component.less
+++ b/docs/app/pages/components/components-sections/scrollbar/infinite-scroll-ng1/infinite-scroll-ng1.component.less
@@ -1,29 +1,17 @@
 .employee-list-container {
-  border: 1px solid #ddd;
-  padding: 5px;
-  padding-left: 0;  
+    border: 1px solid #ddd;
+    padding: 5px;
+    padding-left: 0;
 }
 
 .employee-list {
-  width: 100%;
-  height: 250px;
+    width: 100%;
+    height: 250px;
 }
 
 .employee-item {
-  width: 100%;
-  height: 65px;
-  padding: 10px 20px;
-  border-bottom: 1px solid #eee;
-}
-
-.body-dark .employee-list {
-  border: 1px solid #666666;
-}
-
-.body-dark .employee-item {
-  border-bottom: 1px solid #666666;
-}
-
-.body-dark .employee-item .text-black {
-  color: #fff !important;
+    width: 100%;
+    height: 65px;
+    padding: 10px 20px;
+    border-bottom: 1px solid #eee;
 }

--- a/docs/app/pages/components/components-sections/scrollbar/infinite-scroll-ng1/snippets/styles.css
+++ b/docs/app/pages/components/components-sections/scrollbar/infinite-scroll-ng1/snippets/styles.css
@@ -1,29 +1,17 @@
 .employee-list-container {
-  border: 1px solid #ddd;
-  padding: 5px;
-  padding-left: 0;  
+    border: 1px solid #ddd;
+    padding: 5px;
+    padding-left: 0;
 }
 
 .employee-list {
-  width: 100%;
-  height: 250px;
+    width: 100%;
+    height: 250px;
 }
 
 .employee-item {
-  width: 100%;
-  height: 65px;
-  padding: 10px 20px;
-  border-bottom: 1px solid #eee;
-}
-
-.body-dark .employee-list {
-  border: 1px solid #666666;
-}
-
-.body-dark .employee-item {
-  border-bottom: 1px solid #666666;
-}
-
-.body-dark .employee-item .text-black {
-  color: #fff !important;
+    width: 100%;
+    height: 65px;
+    padding: 10px 20px;
+    border-bottom: 1px solid #eee;
 }

--- a/docs/app/pages/components/components-sections/search/search-builder-ng1/search-builder-ng1.component.less
+++ b/docs/app/pages/components/components-sections/search/search-builder-ng1/search-builder-ng1.component.less
@@ -1,95 +1,92 @@
 .search-icon {
-	width: 30px;
-	height: 30px;
-	background-image: url('../../../../../assets/img/IconSearchColorized.png');
-	background-size: 100% 100%;
-	margin-top: 8px;
-	margin-right: 15px;
-	min-width: 30px;
+    width: 30px;
+    height: 30px;
+    background-image: url('../../../../../assets/img/IconSearchColorized.png');
+    background-size: 100% 100%;
+    margin-top: 8px;
+    margin-right: 15px;
+    min-width: 30px;
 }
 
 .search-builder-header-inline {
-	display: flex;
+    display: flex;
 }
 
 .search-builder-spark-padding {
-	padding-top: 6px;
-	min-width: 210px;
+    padding-top: 6px;
+    min-width: 210px;
 }
 
 @media (max-width: 440px) {
-	.search-builder-spark-padding {
-		display: none;
-	}
+    .search-builder-spark-padding {
+        display: none;
+    }
 }
 
 .search-builder-title-icon {
-  font-size: 33px;
-  margin-right: 15px;
+    font-size: 33px;
+    margin-right: 15px;
 }
 
 .add-field-list {
-  list-style-type: none;
-  padding: 0;
-  margin: 8px 5px;
+    list-style-type: none;
+    padding: 0;
+    margin: 8px 5px;
 }
 
 .add-field-list .field-name {
-  font-size: 17px;
-  padding: 3px 10px;
-  cursor: pointer;
+    font-size: 17px;
+    padding: 3px 10px;
+    cursor: pointer;
 }
 
 .add-field-list .field-name:hover {
-  background-color: #f2f2f2;
-}
-
-.body-dark .add-field-list .field-name:hover {
-  background-color: #262626;
+    background-color: #f2f2f2;
 }
 
 .add-field-list .field-name .repository-check {
-  margin-right: 10px;
-  transition: opacity 0.2s linear;
+    margin-right: 10px;
+    transition: opacity 0.2s linear;
 }
 
 .add-field-list .field-name.option-deselected .option-check {
-  opacity: 0;
+    opacity: 0;
 }
 
 .add-field-list .field-name.option-deselected:hover .option-check {
-  opacity: 0.5;
+    opacity: 0.5;
 }
 
 .add-field-list .field-name.option-selected .option-check {
-  opacity: 1;
+    opacity: 1;
 }
 
 .show-panel-btn {
-  cursor: pointer;
+    cursor: pointer;
 }
 
 /* Code Modal */
+
 .code-modal-body {
-  height: 520px;
-  overflow-y: hidden;
+    height: 520px;
+    overflow-y: hidden;
 }
 
 .code-modal-list {
-  list-style-type: none;
-  width: 100%;
-  padding: 0;
+    list-style-type: none;
+    width: 100%;
+    padding: 0;
 }
 
 .code-modal-list .code-section {
-  font-size: 18px;
-  padding: 10px 20px;
-  color: #fff;
-  transition: background-color 0.3s linear;
-  cursor: pointer;
+    font-size: 18px;
+    padding: 10px 20px;
+    color: #fff;
+    transition: background-color 0.3s linear;
+    cursor: pointer;
 }
 
 .code-modal-list .code-section:hover,
 .code-modal-list .code-section.active {
-  background-color: rgba(0, 0, 0, 0.2);
+    background-color: rgba(0, 0, 0, 0.2);
 }

--- a/docs/app/pages/components/components-sections/search/search-builder-ng1/snippets/styles.css
+++ b/docs/app/pages/components/components-sections/search/search-builder-ng1/snippets/styles.css
@@ -1,45 +1,41 @@
 .search-builder-title-icon {
-  font-size: 33px;
-  margin-right: 15px;
+    font-size: 33px;
+    margin-right: 15px;
 }
 
 .add-field-list {
-  list-style-type: none;
-  padding: 0;
-  margin: 8px 5px;
+    list-style-type: none;
+    padding: 0;
+    margin: 8px 5px;
 }
 
 .add-field-list .field-name {
-  font-size: 17px;
-  padding: 3px 10px;
-  cursor: pointer;
+    font-size: 17px;
+    padding: 3px 10px;
+    cursor: pointer;
 }
 
 .add-field-list .field-name:hover {
-  background-color: #f2f2f2;
-}
-
-.body-dark .add-field-list .field-name:hover {
-  background-color: #262626;
+    background-color: #f2f2f2;
 }
 
 .add-field-list .field-name .repository-check {
-  margin-right: 10px;
-  transition: opacity 0.2s linear;
+    margin-right: 10px;
+    transition: opacity 0.2s linear;
 }
 
 .add-field-list .field-name.option-deselected .option-check {
-  opacity: 0;
+    opacity: 0;
 }
 
 .add-field-list .field-name.option-deselected:hover .option-check {
-  opacity: 0.5;
+    opacity: 0.5;
 }
 
 .add-field-list .field-name.option-selected .option-check {
-  opacity: 1;
+    opacity: 1;
 }
 
 .show-panel-btn {
-  cursor: pointer;
+    cursor: pointer;
 }

--- a/docs/app/pages/css/css-sections/structure/html-body/html-body.component.html
+++ b/docs/app/pages/css/css-sections/structure/html-body/html-body.component.html
@@ -4,7 +4,7 @@
   <p><strong>Note</strong>: All <code>script</code> tags are loaded at the end.</p>
 </blockquote>
 
-<p>By default, <code>body</code> will have full width. Dark background theme is invoked by adding the <code>.body-dark</code> class to the <code>body</code> tag.</p>
+<p>By default, <code>body</code> will have full width.</p>
 
 <p>The following classes can be used with the wrapper class to format the <code>body</code> similar to the default style:</p>
 

--- a/grunt/stylelint.js
+++ b/grunt/stylelint.js
@@ -3,5 +3,11 @@ const path = require('path');
 module.exports = {
     components: {
         src: path.join(process.cwd(), 'src', 'components', '**', '*.less')
+    },
+    stylesheets: {
+        src: [
+            path.join(process.cwd(), 'src', 'styles', '**', '*.less'),
+            '!' + path.join(process.cwd(), 'src', 'styles', 'hpe-icons.less'),
+        ]
     }
 };

--- a/src/styles/buttons.less
+++ b/src/styles/buttons.less
@@ -294,7 +294,7 @@
 
 .button-primary,
 .btn-primary {
-    &.disabled {
+    &.disabled, &[disabled] {
         .button-primary-disabled;
 
         &:hover,
@@ -306,16 +306,6 @@
     }
 
     &.active[disabled] {
-        .button-primary-disabled;
-    }
-}
-
-.button-primary[disabled], .btn-primary[disabled] {
-    .button-primary-disabled;
-
-    &:hover,
-    &:focus,
-    &:active {
         .button-primary-disabled;
     }
 }

--- a/src/styles/buttons.less
+++ b/src/styles/buttons.less
@@ -1,401 +1,454 @@
 // Primary mixins
 .button-primary-active() {
-  background-color: @btn-primary-bg;
-  color: @btn-primary-active-color;
-  border-color: @btn-primary-bg;
-  box-shadow: @btn-active-shadow;
+    background-color: @btn-primary-bg;
+    color: @btn-primary-active-color;
+    border-color: @btn-primary-bg;
+    box-shadow: @btn-active-shadow;
 }
 
 .button-primary-hover() {
-  .btn-hover-active-color(light, @btn-primary-bg, 5%);
-  color: @btn-primary-hover-color;
-  box-shadow: @btn-shadow;
+    .btn-hover-active-color(light, @btn-primary-bg, 5%);
+
+    color: @btn-primary-hover-color;
+    box-shadow: @btn-shadow;
 }
 
 .button-primary-disabled() {
-  background-color: @btn-primary-disabled-bg;
-  color: @btn-primary-disabled-color;
-  border-color: @btn-primary-disabled-border;
-  box-shadow: @btn-disabled-shadow;
+    background-color: @btn-primary-disabled-bg;
+    color: @btn-primary-disabled-color;
+    border-color: @btn-primary-disabled-border;
+    box-shadow: @btn-disabled-shadow;
 }
 
 // Secondary mixins
 .button-secondary-active() {
-  background-color: @btn-secondary-active-bg;
-  color: @btn-secondary-active-color;
-  border-color: @btn-secondary-active-border;
-  box-shadow: @btn-active-shadow;
+    background-color: @btn-secondary-active-bg;
+    color: @btn-secondary-active-color;
+    border-color: @btn-secondary-active-border;
+    box-shadow: @btn-active-shadow;
 }
 
 .button-secondary-hover() {
-  background-color: @btn-secondary-hover-bg;
-  border: 1px solid @btn-secondary-border;
-  color: @btn-secondary-hover-color;
-  box-shadow: @btn-shadow;
+    background-color: @btn-secondary-hover-bg;
+    border: 1px solid @btn-secondary-border;
+    color: @btn-secondary-hover-color;
+    box-shadow: @btn-shadow;
 }
 
 .button-secondary-disabled() {
-  background-color: @btn-secondary-disabled-bg;
-  color: @btn-secondary-disabled-color;
-  border-color: @btn-secondary-disabled-border;
-  box-shadow: @btn-disabled-shadow;
+    background-color: @btn-secondary-disabled-bg;
+    color: @btn-secondary-disabled-color;
+    border-color: @btn-secondary-disabled-border;
+    box-shadow: @btn-disabled-shadow;
 }
 
 // Accent mixins
 .button-accent-active() {
-  background-color: @btn-accent-bg;
-  color: @btn-accent-active-color;
-  border-color: @btn-accent-bg;
-  box-shadow: @btn-active-shadow;
+    background-color: @btn-accent-bg;
+    color: @btn-accent-active-color;
+    border-color: @btn-accent-bg;
+    box-shadow: @btn-active-shadow;
 }
 
 .button-accent-hover() {
-  .btn-hover-active-color(light, @btn-accent-bg, 5%);
-  color: @btn-accent-hover-color;
-  box-shadow: @btn-shadow;
+    .btn-hover-active-color(light, @btn-accent-bg, 5%);
+
+    color: @btn-accent-hover-color;
+    box-shadow: @btn-shadow;
 }
 
 .button-accent-disabled() {
-  background-color: @btn-accent-disabled-bg;
-  color: @btn-accent-disabled-color;
-  border-color: @btn-accent-disabled-border;
-  box-shadow: @btn-disabled-shadow;
+    background-color: @btn-accent-disabled-bg;
+    color: @btn-accent-disabled-color;
+    border-color: @btn-accent-disabled-border;
+    box-shadow: @btn-disabled-shadow;
 }
 
 .btn {
-  border-radius: @btn-border-radius;
-  font-size: @btn-font-size;
-  font-family: @btn-font-family;
-  text-transform: @btn-text-transform;
-  padding: 4px 15px;
-  box-shadow: @btn-shadow;
-  .hpe-icon {
-    line-height: inherit;
-  }
-  &:active,
-  &.active {
-    box-shadow: @btn-active-shadow;
+    border-radius: @btn-border-radius;
+    font-size: @btn-font-size;
+    font-family: @btn-font-family;
+    text-transform: @btn-text-transform;
+    padding: 4px 15px;
+    box-shadow: @btn-shadow;
+
+    .hpe-icon {
+        line-height: inherit;
+    }
+
+    &:active,
+    &.active {
+        box-shadow: @btn-active-shadow;
+
+        &:focus,
+        &.focus {
+            .aspects-outline;
+        }
+    }
+
     &:focus,
     &.focus {
-      .aspects-outline;
+        .aspects-outline;
     }
-  }
-  &:focus,
-  &.focus {
-    .aspects-outline;
-  }
-  &:hover {
-    box-shadow: @btn-hover-shadow;
-  }
-  &.btn-lg {
-    font-size: @btn-large-font-size;
-    padding: 6px 20px;
-  }
-  &.btn-sm,
-  &.btn-xs {
-    font-size: @btn-small-font-size;
-    padding: 0 10px;
-  }
-  &.btn-link {
-    border: @link-btn-border;
-    box-shadow: @link-btn-shadow;
+
     &:hover {
-      text-decoration: @link-btn-hover-text-decoration;
-      box-shadow: @link-btn-hover-shadow;
+        box-shadow: @btn-hover-shadow;
     }
-    &:focus {
-      text-decoration: @link-btn-focus-text-decoration;
-      box-shadow: @link-btn-focus-shadow;
+
+    &.btn-lg {
+        font-size: @btn-large-font-size;
+        padding: 6px 20px;
     }
-  }
-  .hpe-icon {
-    line-height: inherit;
-  }
+
+    &.btn-sm,
+    &.btn-xs {
+        font-size: @btn-small-font-size;
+        padding: 0 10px;
+    }
+
+    &.btn-link {
+        border: @link-btn-border;
+        box-shadow: @link-btn-shadow;
+
+        &:hover {
+            text-decoration: @link-btn-hover-text-decoration;
+            box-shadow: @link-btn-hover-shadow;
+        }
+
+        &:focus {
+            text-decoration: @link-btn-focus-text-decoration;
+            box-shadow: @link-btn-focus-shadow;
+        }
+    }
+
+    .hpe-icon {
+        line-height: inherit;
+    }
 }
 
 .float-btn-margins {
-  .btn {
-    margin-bottom: 5px;
-  }
+    .btn {
+        margin-bottom: 5px;
+    }
 }
 
 .btn-container {
-  display: flex;
-  align-items: flex-start;
+    display: flex;
+    align-items: flex-start;
 
-  > .btn + .btn,
-  > .btn + .btn-group,
-  > .btn-group + .btn,
-  > .btn-group + .btn-group {
-    margin-left: 8px;
-    &.btn-link {
-        margin-left: 0;
+    > .btn + .btn,
+    > .btn + .btn-group,
+    > .btn-group + .btn,
+    > .btn-group + .btn-group {
+        margin-left: 8px;
+
+        &.btn-link {
+            margin-left: 0;
+        }
     }
-  }
 }
 
 .btn-primary {
-  .button-primary;
+    .button-primary;
 }
 
 //New primary style
 .button-primary,
 .btn-primary {
-  background-color: @btn-primary-bg;
-  border-color: @btn-primary-border;
-  color: @btn-primary-color;
-  &:hover {
-    .button-primary-hover;
-  }
-  &:focus,
-  &.focus {
-    .btn-hover-active-color(light, @btn-primary-bg, 5%);
-    color: @btn-primary-focus-color;
-  }
-  .open {
-    .dropdown-toggle {
-      &.button-primary {
-        background-color: @btn-primary-bg;
-        color: @btn-primary-color;
-      }
-    }
-  }
-  &:active,
-  &.active {
-    .button-primary-active;
-  }
-  .button-primary,
-  .btn-toggle {
-    &.active {
-      .button-primary-active;
-    }
-  }
-  &.btn-link {
-    color: @btn-primary-bg;
-    background-color: transparent;
+    background-color: @btn-primary-bg;
+    border-color: @btn-primary-border;
+    color: @btn-primary-color;
+
     &:hover {
-      background-color: @link-btn-hover;
+        .button-primary-hover;
     }
-    &:focus {
-      background-color: transparent;
+
+    &:focus,
+    &.focus {
+        .btn-hover-active-color(light, @btn-primary-bg, 5%);
+
+        color: @btn-primary-focus-color;
     }
-    &:active {
-      color: @btn-primary-bg;
-      background-color: @link-btn-active;
+
+    .open {
+        .dropdown-toggle {
+            &.button-primary {
+                background-color: @btn-primary-bg;
+                color: @btn-primary-color;
+            }
+        }
     }
-  }
+
+    &:active,
+    &.active {
+        .button-primary-active;
+    }
+
+    .button-primary,
+    .btn-toggle {
+        &.active {
+            .button-primary-active;
+        }
+    }
+
+    &.btn-link {
+        color: @btn-primary-bg;
+        background-color: transparent;
+
+        &:hover {
+            background-color: @link-btn-hover;
+        }
+
+        &:focus {
+            background-color: transparent;
+        }
+
+        &:active {
+            color: @btn-primary-bg;
+            background-color: @link-btn-active;
+        }
+    }
 }
 
 .button-toggle-primary {
-  .button-secondary;
-  &:active,
-  &.active {
-    .button-primary-active;
-    &:hover {
-      .button-primary-hover;
+    .button-secondary;
+
+    &:active,
+    &.active {
+        .button-primary-active;
+
+        &:hover {
+            .button-primary-hover;
+        }
     }
-  }
 }
 
 .button-toggle-accent {
-  .button-secondary;
-  &:active,
-  &.active {
-    .button-accent-active;
-    &:hover {
-      .button-accent-hover;
+    .button-secondary;
+
+    &:active,
+    &.active {
+        .button-accent-active;
+
+        &:hover {
+            .button-accent-hover;
+        }
     }
-  }
 }
 
 .floating-action-button {
-  .child-btn-set {
-    opacity: 0;
-    overflow: hidden;
-    max-height: 0;
-  }
-  .child-btn-set-visible {
-    opacity: 1;
-    transition: opacity 0.3s linear;
-    overflow: visible;
-  }
-  .child-btn-set-top {
-    opacity: 0;
-    max-height: 0;
-    overflow: hidden;
-  }
-  .child-btn-set-top-visible {
-    opacity: 1;
-    transition: opacity 0.3s linear;
-    position: relative;
-    bottom: 150px;
-    overflow: visible;
-  }
-  .child-btn-set-horizontal {
-    visibility: hidden;
-    opacity: 0;
-    &.right {
-      position: absolute;
+    .child-btn-set {
+        opacity: 0;
+        overflow: hidden;
+        max-height: 0;
     }
-    &.left {
-      position: relative;
-      left: -180px;
+
+    .child-btn-set-visible {
+        opacity: 1;
+        transition: opacity 0.3s linear;
+        overflow: visible;
     }
-  }
-  .child-btn-set-visible-horizontal {
-    visibility: visible;
-    opacity: 1;
-    transition: opacity 0.5s, visibility 0.5s;
-  }
-  .btn-circular.button-secondary {
-    box-shadow: @floating-action-child-btn-shadow;
-    &:hover {
-      box-shadow: @floating-action-child-btn-hover-shadow;
+
+    .child-btn-set-top {
+        opacity: 0;
+        max-height: 0;
+        overflow: hidden;
     }
-  }
+
+    .child-btn-set-top-visible {
+        opacity: 1;
+        transition: opacity 0.3s linear;
+        position: relative;
+        bottom: 150px;
+        overflow: visible;
+    }
+
+    .child-btn-set-horizontal {
+        visibility: hidden;
+        opacity: 0;
+
+        &.right {
+            position: absolute;
+        }
+
+        &.left {
+            position: relative;
+            left: -180px;
+        }
+    }
+
+    .child-btn-set-visible-horizontal {
+        visibility: visible;
+        opacity: 1;
+        transition: opacity 0.5s, visibility 0.5s;
+    }
+
+    .btn-circular.button-secondary {
+        box-shadow: @floating-action-child-btn-shadow;
+
+        &:hover {
+            box-shadow: @floating-action-child-btn-hover-shadow;
+        }
+    }
 }
 
 .button-primary,
 .btn-primary {
-  &.disabled {
-    .button-primary-disabled;
-    &:hover,
-    &:focus,
-    &:active,
-    &.active {
-      .button-primary-disabled;
+    &.disabled {
+        .button-primary-disabled;
+
+        &:hover,
+        &:focus,
+        &:active,
+        &.active {
+            .button-primary-disabled;
+        }
     }
-  }
-  &.active[disabled] {
-    .button-primary-disabled;
-  }
+
+    &.active[disabled] {
+        .button-primary-disabled;
+    }
 }
 
-.button-primary[disabled],
-.btn-primary[disabled] {
-  .button-primary-disabled;
-  &:hover,
-  &:focus,
-  &:active {
+.button-primary[disabled], .btn-primary[disabled] {
     .button-primary-disabled;
-  }
+
+    &:hover,
+    &:focus,
+    &:active {
+        .button-primary-disabled;
+    }
 }
 
 fieldset[disabled] {
-  background-color: @btn-primary-disabled-bg;
-  color: @btn-primary-disabled-color;
-  border-color: @btn-primary-disabled-border;
-  .button-primary,
-  .btn-primary {
     background-color: @btn-primary-disabled-bg;
     color: @btn-primary-disabled-color;
     border-color: @btn-primary-disabled-border;
-    &:hover,
-    &:focus,
-    &:active,
-    &.active {
-      background-color: @btn-primary-disabled-bg;
-      color: @btn-primary-disabled-color;
-      border-color: @btn-primary-disabled-border;
+
+    .button-primary,
+    .btn-primary {
+        background-color: @btn-primary-disabled-bg;
+        color: @btn-primary-disabled-color;
+        border-color: @btn-primary-disabled-border;
+
+        &:hover,
+        &:focus,
+        &:active,
+        &.active {
+            background-color: @btn-primary-disabled-bg;
+            color: @btn-primary-disabled-color;
+            border-color: @btn-primary-disabled-border;
+        }
     }
-  }
-  .btn-toggle {
-    &.active {
-      background-color: @btn-primary-disabled-bg;
-      color: @btn-primary-disabled-color;
-      border-color: @btn-primary-disabled-border;
+
+    .btn-toggle {
+        &.active {
+            background-color: @btn-primary-disabled-bg;
+            color: @btn-primary-disabled-color;
+            border-color: @btn-primary-disabled-border;
+        }
     }
-  }
 }
 
 .affix-toolbar {
-  &.multiple-select-mode {
-    .btn[disabled] {
-      opacity: 0.9 !important;
+    &.multiple-select-mode {
+        .btn[disabled] {
+            opacity: 0.9 !important;
+        }
     }
-  }
 }
 
 //Secondary
 .btn-white {
-  .button-secondary;
+    .button-secondary;
 }
 
 //Secondary new style
 .button-secondary,
 .btn-white {
-  color: @btn-secondary-color;
-  background: @btn-secondary-bg;
-  border: 1px solid @btn-secondary-border;
-  box-shadow: @btn-secondary-shadow;
-  &:active,
-  &.active {
-    .button-secondary-active;
-  }
-  &:focus,
-  &.focus {
-    background-color: @btn-secondary-focus-bg;
-    border-color: @btn-secondary-focus-border;
-    color: @btn-secondary-focus-color;
-  }
-  &:hover {
-    .button-secondary-hover;
-  }
-  &.btn-link {
     color: @btn-secondary-color;
-    background-color: transparent;
-    border: none;
+    background: @btn-secondary-bg;
+    border: 1px solid @btn-secondary-border;
+    box-shadow: @btn-secondary-shadow;
+
+    &:active,
+    &.active {
+        .button-secondary-active;
+    }
+
+    &:focus,
+    &.focus {
+        background-color: @btn-secondary-focus-bg;
+        border-color: @btn-secondary-focus-border;
+        color: @btn-secondary-focus-color;
+    }
+
     &:hover {
-      background-color: @link-btn-hover;
+        .button-secondary-hover;
     }
-    &:focus {
-      background-color: transparent;
+
+    &.btn-link {
+        color: @btn-secondary-color;
+        background-color: transparent;
+        border: none;
+
+        &:hover {
+            background-color: @link-btn-hover;
+        }
+
+        &:focus {
+            background-color: transparent;
+        }
+
+        &:active {
+            color: @btn-secondary-color;
+            background-color: @link-btn-active;
+        }
     }
-    &:active {
-      color: @btn-secondary-color;
-      background-color: @link-btn-active;
-    }
-  }
 }
 
 .button-secondary,
 .btn-secondary {
-  &.btn-grouped {
-    &.active {
-      .button-primary-active;
-      border-radius: @btn-border-radius;
+    &.btn-grouped {
+        &.active {
+            .button-primary-active;
+
+            border-radius: @btn-border-radius;
+        }
     }
-  }
 }
 
 .open {
-  .dropdown-toggle {
-    &.button-secondary {
-      background-color: @btn-secondary-hover-bg;
-      color: @btn-secondary-color;
+    .dropdown-toggle {
+        &.button-secondary {
+            background-color: @btn-secondary-hover-bg;
+            color: @btn-secondary-color;
+        }
     }
-  }
 }
 
 .btn-group {
-  &.toggle-buttons {
-    .button-toggle-accent {
-      border-color: @btn-secondary-active-border;
-      &.active {
-        &:hover {
-          .button-accent-hover;
+    &.toggle-buttons {
+        .button-toggle-accent {
+            border-color: @btn-secondary-active-border;
+
+            &.active {
+                &:hover {
+                    .button-accent-hover;
+                }
+            }
         }
-      }
-    }
-    .button-toggle-primary {
-      border-color: @btn-secondary-active-border;
-      &.active {
-        &:hover {
-          .button-primary-hover;
+
+        .button-toggle-primary {
+            border-color: @btn-secondary-active-border;
+
+            &.active {
+                &:hover {
+                    .button-primary-hover;
+                }
+            }
         }
-      }
     }
-  }
 }
 
 .button-secondary.disabled,
@@ -428,53 +481,62 @@ fieldset[disabled] .btn-white:hover,
 fieldset[disabled] .btn-white:focus,
 fieldset[disabled] .btn-white:active,
 fieldset[disabled] .btn-white.active {
-  .button-secondary-disabled;
+    .button-secondary-disabled;
 }
 
 //Accent
 .btn-secondary {
-  .button-accent;
+    .button-accent;
 }
 
 //Accent new stryle
 .button-accent,
 .btn-secondary {
-  background-color: @btn-accent-bg;
-  border-color: @btn-accent-border;
-  color: @btn-accent-color;
-  &:hover {
-    .button-accent-hover;
-  }
-  &:focus,
-  &.focus {
-    .btn-hover-active-color(light, @btn-accent-bg, 5%);
-    color: @btn-accent-focus-color;
-  }
-  &:active,
-  &.active {
-    .button-accent-active;
-  }
-  .open {
-    .dropdown-toggle {
-      &.button-accent {
-        .button-accent-active;
-      }
-    }
-  }
-  &.btn-link {
-    color: @accent;
-    background-color: transparent;
+    background-color: @btn-accent-bg;
+    border-color: @btn-accent-border;
+    color: @btn-accent-color;
+
     &:hover {
-      background-color: @link-btn-hover;
+        .button-accent-hover;
     }
-    &:focus {
-      background-color: transparent;
+
+    &:focus,
+    &.focus {
+        .btn-hover-active-color(light, @btn-accent-bg, 5%);
+
+        color: @btn-accent-focus-color;
     }
-    &:active {
-      color: @btn-accent-active-color;
-      background-color: @link-btn-active;
+
+    &:active,
+    &.active {
+        .button-accent-active;
     }
-  }
+
+    .open {
+        .dropdown-toggle {
+            &.button-accent {
+                .button-accent-active;
+            }
+        }
+    }
+
+    &.btn-link {
+        color: @accent;
+        background-color: transparent;
+
+        &:hover {
+            background-color: @link-btn-hover;
+        }
+
+        &:focus {
+            background-color: transparent;
+        }
+
+        &:active {
+            color: @btn-accent-active-color;
+            background-color: @link-btn-active;
+        }
+    }
 }
 
 .button-accent.disabled,
@@ -507,94 +569,104 @@ fieldset[disabled] .btn-secondary:hover,
 fieldset[disabled] .btn-secondary:focus,
 fieldset[disabled] .btn-secondary:active,
 fieldset[disabled] .btn-secondary.active {
-  .button-accent-disabled;
+    .button-accent-disabled;
 }
 
 // Alert
 .btn-alert {
-  &.btn-grouped {
-    &.active {
-      background-color: @btn-warning-bg;
-      color: @btn-warning-color;
-      border-radius: @btn-border-radius;
+    &.btn-grouped {
+        &.active {
+            background-color: @btn-warning-bg;
+            color: @btn-warning-color;
+            border-radius: @btn-border-radius;
+        }
     }
-  }
 }
 
 .btn-alert {
-  .button-warning;
+    .button-warning;
 }
 
 //Warning new style
 .button-warning {
-  &.btn-grouped {
-    &.active {
-      background-color: @btn-warning-bg;
-      color: @btn-warning-color;
-      border-radius: @btn-border-radius;
+    &.btn-grouped {
+        &.active {
+            background-color: @btn-warning-bg;
+            color: @btn-warning-color;
+            border-radius: @btn-border-radius;
+        }
     }
-  }
 }
 
 .button-warning,
 .btn-alert {
-  background-color: @btn-warning-bg;
-  color: @btn-warning-color;
-  &:hover {
-    background-color: @btn-warning-hover-bg;
-    border-color: @btn-warning-hover-border;
-    color: @btn-warning-hover-color;
-  }
-  &:focus,
-  &.focus {
-    background-color: @btn-warning-focus-bg;
-    border-color: @btn-warning-focus-border;
-    color: @btn-warning-focus-color;
-  }
-  &:active,
-  &.active {
-    background-color: @btn-warning-active-bg;
-    border-color: @btn-warning-active-border;
-    color: @btn-warning-active-color;
-  }
-  .button-warning {
-    &:active,
-    &.active {
-      background-color: @btn-warning-focus-bg;
-      border-color: @btn-warning-focus-color;
-      color: @btn-warning-focus-color;
+    background-color: @btn-warning-bg;
+    color: @btn-warning-color;
+
+    &:hover {
+        background-color: @btn-warning-hover-bg;
+        border-color: @btn-warning-hover-border;
+        color: @btn-warning-hover-color;
     }
-  }
-  .open {
-    .dropdown-toggle {
-      &.button-warning {
+
+    &:focus,
+    &.focus {
         background-color: @btn-warning-focus-bg;
         border-color: @btn-warning-focus-border;
         color: @btn-warning-focus-color;
-      }
     }
-  }
-  .btn-toggle {
+
+    &:active,
     &.active {
-      background-color: @btn-warning-focus-bg;
-      border-color: @btn-warning-focus-border;
-      color: @btn-warning-focus-color;
+        background-color: @btn-warning-active-bg;
+        border-color: @btn-warning-active-border;
+        color: @btn-warning-active-color;
     }
-  }
-  &.btn-link {
-    color: @btn-warning-bg;
-    background-color: transparent;
-    &:hover {
-      background-color: @link-btn-hover;
+
+    .button-warning {
+        &:active,
+        &.active {
+            background-color: @btn-warning-focus-bg;
+            border-color: @btn-warning-focus-color;
+            color: @btn-warning-focus-color;
+        }
     }
-    &:focus {
-      background-color: transparent;
+
+    .open {
+        .dropdown-toggle {
+            &.button-warning {
+                background-color: @btn-warning-focus-bg;
+                border-color: @btn-warning-focus-border;
+                color: @btn-warning-focus-color;
+            }
+        }
     }
-    &:active {
-      color: @btn-warning-bg;
-      background-color: @link-btn-active;
+
+    .btn-toggle {
+        &.active {
+            background-color: @btn-warning-focus-bg;
+            border-color: @btn-warning-focus-border;
+            color: @btn-warning-focus-color;
+        }
     }
-  }
+
+    &.btn-link {
+        color: @btn-warning-bg;
+        background-color: transparent;
+
+        &:hover {
+            background-color: @link-btn-hover;
+        }
+
+        &:focus {
+            background-color: transparent;
+        }
+
+        &:active {
+            color: @btn-warning-bg;
+            background-color: @link-btn-active;
+        }
+    }
 }
 
 .button-warning.disabled,
@@ -629,203 +701,205 @@ fieldset[disabled] .btn-alert:focus,
 fieldset[disabled] .btn-alert:active,
 fieldset[disabled] .btn-alert.active,
 fieldset[disabled] .btn-toggle.active {
-  background-color: @btn-warning-disabled-bg;
-  color: @btn-warning-disabled-color;
-  border-color: @btn-warning-disabled-border;
+    background-color: @btn-warning-disabled-bg;
+    color: @btn-warning-disabled-color;
+    border-color: @btn-warning-disabled-border;
 }
 
 //link disabled style
 .btn-link[disabled] {
-  border: none;
-  background-color: transparent;
-  color: @btn-primary-disabled-color;
+    border: none;
+    background-color: transparent;
+    color: @btn-primary-disabled-color;
 }
 
 button {
-  &.dim {
-    &:before {
-      font-size: 3.125rem;
-      line-height: 1em;
-      font-weight: normal;
-      color: @white;
-      display: block;
-      padding-top: 10px;
+    &.dim {
+        &:before {
+            font-size: 3.125rem;
+            line-height: 1em;
+            font-weight: normal;
+            color: @white;
+            display: block;
+            padding-top: 10px;
+        }
+
+        &:active {
+            &:before {
+                top: 7px;
+                font-size: 3.125rem;
+            }
+        }
     }
-    &:active {
-      &:before {
-        top: 7px;
-        font-size: 3.125rem;
-      }
-    }
-  }
 }
 
 .btn-group {
-  .btn-grouped {
-    &.button-secondary {
-      &:hover {
-        .button-secondary-hover;
-        &:active,
-        &.active {
-          .button-primary-hover;
+    .btn-grouped {
+        &.button-secondary {
+            &:hover {
+                .button-secondary-hover;
+
+                &:active,
+                &.active {
+                    .button-primary-hover;
+                }
+            }
         }
-      }
     }
-  }
 }
 
 .btn-darker-border {
-  border-color: darken(@btn-primary-border, 12%);
-  &:hover,
-  &:focus {
     border-color: darken(@btn-primary-border, 12%);
-  }
+
+    &:hover,
+    &:focus {
+        border-color: darken(@btn-primary-border, 12%);
+    }
 }
 
 //Back
 .btn-back {
-  &:before {
-    position: relative;
-    top: 4px;
-  }
+    &:before {
+        position: relative;
+        top: 4px;
+    }
 }
 
 .btn-back {
-  &:focus {
-    .aspects-outline;
-  }
+    &:focus {
+        .aspects-outline;
+    }
 }
 
 //Back for Header
 .btn-back-header {
-  display: none;
+    display: none;
 }
 
 .back-button {
-  .btn-back-header {
-    display: block;
-    float: left;
-    height: 28px;
-    width: 28px;
-    margin-top: 24px;
-    margin-right: 2px;
-    cursor: pointer;
-    span {
-      width: 100%;
-      height: 100%;
-      padding: 5.5px 1px 0px 5px;
-      svg {
-        g {
-          path {
-            stroke: @btn-primary-border;
-          }
+    .btn-back-header {
+        display: block;
+        float: left;
+        height: 28px;
+        width: 28px;
+        margin-top: 24px;
+        margin-right: 2px;
+        cursor: pointer;
+
+        span {
+            width: 100%;
+            height: 100%;
+            padding: 5.5px 1px 0 5px;
+
+            svg {
+                g {
+                    path {
+                        stroke: @btn-primary-border;
+                    }
+                }
+            }
         }
-      }
     }
-  }
 }
 
 .page-content-navbar-top-light {
-  .back-button {
-    .btn-back-header {
-      &:hover {
-        background-color: darken(@white, 3%);
-      }
+    .back-button {
+        .btn-back-header {
+            &:hover {
+                background-color: darken(@white, 3%);
+            }
+        }
     }
-  }
 }
 
 .page-content-navbar-top-dark {
-  .back-button {
-    .btn-back-header {
-      &:hover {
-        background-color: @navbar-back-button-hover;
-      }
+    .back-button {
+        .btn-back-header {
+            &:hover {
+                background-color: @navbar-back-button-hover;
+            }
+        }
     }
-  }
 }
 
 .affix {
-  .btn-back-header {
-    display: none;
-  }
+    .btn-back-header {
+        display: none;
+    }
 }
 
 .btn-pair {
-  white-space: nowrap;
-  margin-right: 16px;
+    white-space: nowrap;
+    margin-right: 16px;
 }
 
 .btn-pair button {
-  width: 110px;
+    width: 110px;
 }
 
 .btn-pair {
-  button {
-    &:first-child {
-      i {
-        font-size: @font-size-sm;
-        margin-left: -3px;
-        margin-right: 5px;
-      }
+    button {
+        &:first-child {
+            i {
+                font-size: @font-size-sm;
+                margin-left: -3px;
+                margin-right: 5px;
+            }
+        }
+
+        &:last-child {
+            margin-left: 4px;
+
+            i {
+                font-size: @font-size-sm;
+                margin-left: 5px;
+                margin-right: -3px;
+            }
+        }
     }
-    &:last-child {
-      margin-left: 4px;
-      i {
-        font-size: @font-size-sm;
-        margin-left: 5px;
-        margin-right: -3px;
-      }
-    }
-  }
 }
 
 .btn-group {
-  :not(.dropdown-toggle:first-child) {
-    &.btn {
-      margin-bottom: 5px;
-      padding: 6px 12px;
+    :not(.dropdown-toggle:first-child) {
+        &.btn {
+            margin-bottom: 5px;
+            padding: 6px 12px;
+        }
     }
-  }
-  button {
-    &.btn-nav {
-      min-width: 45px;
-    }
-  }
-  .dropdown-toggle {
-    &:focus {
-      .aspects-outline;
 
-      z-index: @button-group-front-z-index;
+    button {
+        &.btn-nav {
+            min-width: 45px;
+        }
     }
-  }
+
+    .dropdown-toggle {
+        &:focus {
+            .aspects-outline;
+
+            z-index: @button-group-front-z-index;
+        }
+    }
 }
 
 .dropdown-menu {
-  margin-top: 5px;
+    margin-top: 5px;
 }
 
 .dropdown-icon-inline {
-  padding-left: 12px;
+    padding-left: 12px;
 }
 
 .dropdown-toggle {
-  .hp-icon,
-  .hpe-icon {
-    margin-left: 3px;
-    line-height: 1;
-    &:first-child {
-      margin-left: 0px;
-    }
-  }
-}
+    .hp-icon,
+    .hpe-icon {
+        margin-left: 3px;
+        line-height: 1;
 
-.body-dark {
-  .dropdown-menu {
-    .divider {
-      background-color: @dropdown-divider-bg-dark;
+        &:first-child {
+            margin-left: 0;
+        }
     }
-  }
 }
 
 .btn-link.disabled,
@@ -844,352 +918,395 @@ fieldset[disabled] .btn-link:focus,
 fieldset[disabled] .btn-link:active,
 fieldset[disabled] .btn-link.active,
 fieldset[disabled] .btn-toggle.active {
-  color: @link-btn-disabled-color;
+    color: @link-btn-disabled-color;
 }
 
 .btn-login {
-  width: 100%;
-  height: 48px;
+    width: 100%;
+    height: 48px;
 }
 
 //addon size
 .input-group-btn {
-  .btn {
-    padding: 6px 15px;
-  }
-  .btn-sm {
-    padding: 5px 10px;
-    height: 30px !important;
-  }
-  .btn-lg {
-    padding: 10px 20px;
-  }
-  >.btn {
-    z-index: @button-group-middle-z-index;
-    &:hover {
-      z-index: @button-group-middle-z-index;
+    .btn {
+        padding: 6px 15px;
     }
-    &:active,
-    &:focus {
-      z-index: @button-group-front-z-index;
-      box-shadow: 0px 0px 1px 1px @accent;
+
+    .btn-sm {
+        padding: 5px 10px;
+        height: 30px !important;
     }
-  }
-  .dropdown-toggle {
-    &:focus {
-      outline: 0;
-      box-shadow: 0px 0px 1px 1px @accent;
-      z-index: @button-group-front-z-index;
+
+    .btn-lg {
+        padding: 10px 20px;
     }
-  }
+
+    > .btn {
+        z-index: @button-group-middle-z-index;
+
+        &:hover {
+            z-index: @button-group-middle-z-index;
+        }
+
+        &:active,
+        &:focus {
+            z-index: @button-group-front-z-index;
+            box-shadow: 0 0 1px 1px @accent;
+        }
+    }
+
+    .dropdown-toggle {
+        &:focus {
+            outline: 0;
+            box-shadow: 0 0 1px 1px @accent;
+            z-index: @button-group-front-z-index;
+        }
+    }
 }
 
 .input-group-sm {
-  .input-group-btn {
-    .btn {
-      height: 34px;
+    .input-group-btn {
+        .btn {
+            height: 34px;
+        }
     }
-  }
 }
 
 .btn-icon {
-  &.btn {
-    padding: 4px 7px;
-    width: 30px;
-  }
-  &.btn-lg {
-    padding: 6px 10px;
-    width: 40px;
-  }
-  &.btn-sm {
-    padding: 0px;
-    width: 20px;
-  }
-  &.btn-circular {
-    border-radius: @btn-circular-border-radius;
-  }
+    &.btn {
+        padding: 4px 7px;
+        width: 30px;
+    }
+
+    &.btn-lg {
+        padding: 6px 10px;
+        width: 40px;
+    }
+
+    &.btn-sm {
+        padding: 0;
+        width: 20px;
+    }
+
+    &.btn-circular {
+        border-radius: @btn-circular-border-radius;
+    }
 }
 
 //Hyperlink styles
 .hyperlink {
-  font-family: @font-family;
-  &:link {
-    color: @hyperlink-color;
-    border-bottom: 2px dotted @primary;
-  }
-  &:hover,
-  &:focus {
-    color: @grey2;
-    border-bottom: 2px solid @primary;
-    outline-color: @accent;
-  }
-  &:active {
-    color: @grey2;
-    border-bottom: 2px solid @grey2;
-  }
-  &:visited {
-    color: @hyperlink-color;
-    border-bottom: 2px solid @hyperlink-color;
-  }
+    font-family: @font-family;
+
+    &:link {
+        color: @hyperlink-color;
+        border-bottom: 2px dotted @primary;
+    }
+
+    &:hover,
+    &:focus {
+        color: @grey2;
+        border-bottom: 2px solid @primary;
+        outline-color: @accent;
+    }
+
+    &:active {
+        color: @grey2;
+        border-bottom: 2px solid @grey2;
+    }
+
+    &:visited {
+        color: @hyperlink-color;
+        border-bottom: 2px solid @hyperlink-color;
+    }
 }
 
 .hyperlink-toggle {
-  .hyperlink();
-
-  &:focus {
-    border-bottom: 2px dotted @grey2;
-
-    &:hover {
-      border-bottom: 2px solid @primary;
-    }
-  }
-
-  &:visited {
-    color: @hyperlink-color;
-    border-bottom: 2px solid @primary;
+    .hyperlink();
 
     &:focus {
-      border-bottom: 2px dotted @grey2;
+        border-bottom: 2px dotted @grey2;
 
-      &:hover {
-        border-bottom: 2px solid @primary;
-      }
+        &:hover {
+            border-bottom: 2px solid @primary;
+        }
     }
-  }
+
+    &:visited {
+        color: @hyperlink-color;
+        border-bottom: 2px solid @primary;
+
+        &:focus {
+            border-bottom: 2px dotted @grey2;
+
+            &:hover {
+                border-bottom: 2px solid @primary;
+            }
+        }
+    }
 }
 
 .hyperlink.text-primary {
-  &:link {
-    color: @primary;
-  }
-  &:hover,
-  &:focus {
-    color: @primary;
-    border-bottom-color: @primary;
-  }
-  &:active {
-    color: @primary;
-    border-bottom-color: @primary;
-  }
-  &:visited {
-    color: @primary;
-    border-bottom-color: @primary;
-  }
+    &:link {
+        color: @primary;
+    }
+
+    &:hover,
+    &:focus {
+        color: @primary;
+        border-bottom-color: @primary;
+    }
+
+    &:active {
+        color: @primary;
+        border-bottom-color: @primary;
+    }
+
+    &:visited {
+        color: @primary;
+        border-bottom-color: @primary;
+    }
 }
 
 .hyperlink-hover {
-  font-family: @font-family;
-  border-bottom: 2px dotted transparent;
-  &:link {
-    color: @hyperlink-color;
-  }
-  &:hover,
-  &:focus {
-    color: @hyperlink-hover-color;
-    border-bottom: 2px dotted @primary;
-    outline-color: @accent;
-  }
-  &:visited {
-    color: @hyperlink-color;
+    font-family: @font-family;
+    border-bottom: 2px dotted transparent;
+
+    &:link {
+        color: @hyperlink-color;
+    }
+
     &:hover,
     &:focus {
-      color: @hyperlink-hover-color;
-      border-bottom: 2px dotted @primary;
+        color: @hyperlink-hover-color;
+        border-bottom: 2px dotted @primary;
+        outline-color: @accent;
     }
-  }
+
+    &:visited {
+        color: @hyperlink-color;
+
+        &:hover,
+        &:focus {
+            color: @hyperlink-hover-color;
+            border-bottom: 2px dotted @primary;
+        }
+    }
 }
 
 //inline dropdown styles
 .inline-dropdown-text {
-  font-size: @font-size-md+0.0625rem;
-  vertical-align: 0;
+    font-size: @font-size-md+0.0625rem;
+    vertical-align: 0;
 }
 
 .btn.inline-dropdown {
-  &.dropdown-toggle {
-    background: transparent;
-    padding-left: 5px;
-    padding-top: 2px;
-    padding-right: 5px;
-    box-shadow: none;
-    outline: none;
-    vertical-align: middle;
-    &>span {
-      border-bottom: 2px dotted @primary;
-      text-transform: none;
-      font-size: @font-size-md+0.0625rem;
-      color: @text-color;
-      &.caret {
-        border-bottom: none;
-      }
-      &.hpe-down {
-        font-size: 0.625rem;
-        border-bottom: none;
-      }
+    &.dropdown-toggle {
+        background: transparent;
+        padding-left: 5px;
+        padding-top: 2px;
+        padding-right: 5px;
+        box-shadow: none;
+        outline: none;
+        vertical-align: middle;
+
+        & > span {
+            border-bottom: 2px dotted @primary;
+            text-transform: none;
+            font-size: @font-size-md+0.0625rem;
+            color: @text-color;
+
+            &.caret {
+                border-bottom: none;
+            }
+
+            &.hpe-down {
+                font-size: 0.625rem;
+                border-bottom: none;
+            }
+        }
+
+        &:hover {
+            background-color: @link-btn-hover !important;
+        }
+
+        &:focus {
+            border: solid 1px @text-color;
+        }
+
+        &.no-line {
+            & > span {
+                border: none;
+            }
+        }
     }
-    &:hover {
-      background-color: @link-btn-hover !important;
-    }
-    &:focus {
-      border: solid 1px @text-color;
-    }
-    &.no-line {
-      &>span {
-        border: none;
-      }
-    }
-  }
 }
 
 .side-inset-toggle,
 .side-inset-splitter-toggle {
-  cursor: pointer;
-  >a {
-    color: white;
-    margin-top: 7px;
-  }
+    cursor: pointer;
 
-  width: 45px;
-  height: 30px;
-  background-color: @primary;
-  &.left {
-    border-radius: 0px 20px 20px 0px;
-    >a {
-      margin-left: 22px;
+    > a {
+        color: white;
+        margin-top: 7px;
     }
-  }
-  &.right {
-    border-radius: 20px 0px 0px 20px;
-    >a {
-      margin-left: 7px;
+
+    width: 45px;
+    height: 30px;
+    background-color: @primary;
+
+    &.left {
+        border-radius: 0 20px 20px 0;
+
+        > a {
+            margin-left: 22px;
+        }
     }
-  }
+
+    &.right {
+        border-radius: 20px 0 0 20px;
+
+        > a {
+            margin-left: 7px;
+        }
+    }
 }
 
 .side-inset-splitter-toggle-container {
-  width: 0;
-  height: 0;
-  position: relative;
-  z-index: @splitter-toggle-z-index;
-  .side-inset-splitter-toggle {
-    width: 32px;
-    height: 30px;
+    width: 0;
+    height: 0;
     position: relative;
-  }
-  &.disabled {
+    z-index: @splitter-toggle-z-index;
+
     .side-inset-splitter-toggle {
-      background-color: @btn-primary-disabled-bg;
-      cursor: not-allowed;
-      > a {
-        color: @btn-primary-disabled-color;
-        cursor: inherit;
-      }
+        width: 32px;
+        height: 30px;
+        position: relative;
     }
-  }
-  &.top {
-    left: ~'calc(100% - 30px)';
-    .side-inset-splitter-toggle {
-      border-radius: 0px 0px 20px 20px;
-      width: 30px;
-      height: 32px;
-      >a {
-        margin-left: 8px;
-        margin-top: 12px;
-      }
+
+    &.disabled {
+        .side-inset-splitter-toggle {
+            background-color: @btn-primary-disabled-bg;
+            cursor: not-allowed;
+
+            > a {
+                color: @btn-primary-disabled-color;
+                cursor: inherit;
+            }
+        }
     }
-  }
-  &.bottom {
-    top: -32px;
-    left: ~'calc(100% - 30px)';
-    .side-inset-splitter-toggle {
-      border-radius: 20px 20px 0px 0px;
-      width: 30px;
-      height: 32px;
-      >a {
-        margin-left: 8px;
-        margin-bottom: 12px;
-      }
+
+    &.top {
+        left: ~'calc(100% - 30px)';
+
+        .side-inset-splitter-toggle {
+            border-radius: 0 0 20px 20px;
+            width: 30px;
+            height: 32px;
+
+            > a {
+                margin-left: 8px;
+                margin-top: 12px;
+            }
+        }
     }
-  }
-  &.left {
-    .side-inset-splitter-toggle {
-      border-radius: 0px 20px 20px 0px;
-      >a {
-        margin-left: 12px;
-      }
+
+    &.bottom {
+        top: -32px;
+        left: ~'calc(100% - 30px)';
+
+        .side-inset-splitter-toggle {
+            border-radius: 20px 20px 0 0;
+            width: 30px;
+            height: 32px;
+
+            > a {
+                margin-left: 8px;
+                margin-bottom: 12px;
+            }
+        }
     }
-  }
-  &.right {
-    left: -32px;
-    .side-inset-splitter-toggle {
-      border-radius: 20px 0px 0px 20px;
-      >a {
-        margin-left: 7px;
-      }
+
+    &.left {
+        .side-inset-splitter-toggle {
+            border-radius: 0 20px 20px 0;
+
+            > a {
+                margin-left: 12px;
+            }
+        }
     }
-  }
+
+    &.right {
+        left: -32px;
+
+        .side-inset-splitter-toggle {
+            border-radius: 20px 0 0 20px;
+
+            > a {
+                margin-left: 7px;
+            }
+        }
+    }
 }
 
 .hidden-drag-handle {
-  cursor: default;
-  display: none;
+    cursor: default;
+    display: none;
 }
 
 //required to prevent IEs disappearing scrollbar
 @-ms-viewport {
-  width: auto !important;
+    width: auto !important;
 }
 
 .scroll-top {
-  position: fixed;
-  width: 45px;
-  height: 30px;
-  background-color: @primary;
-  z-index: @scroll-top-z-index;
-  right: -45px;
-  bottom: 75px;
-  border-radius: 20px 0px 0px 20px;
-  padding: 5px 17px;
-  cursor: pointer;
-  -webkit-transition-property: right;
-  -moz-transition-property: right;
-  -ms-transition-property: right;
-  transition-property: right;
-  -moz-transition-duration: .4s;
-  -ms-transition-duration: .4s;
-  transition-duration: .4s;
+    position: fixed;
+    width: 45px;
+    height: 30px;
+    background-color: @primary;
+    z-index: @scroll-top-z-index;
+    right: -45px;
+    bottom: 75px;
+    border-radius: 20px 0 0 20px;
+    padding: 5px 17px;
+    cursor: pointer;
+    transition-property: right;
+    transition-duration: 0.4s;
 }
 
-/* 
+/*
   Thumbnail
 */
 
 .thumbnail-button-container {
-  .thumbnail-container {
-    width: 100%;
-    border: 2px solid @thumbnail-border;
-    background-size: cover;
-    background-position: top center;
-    border-bottom: 0px;
-  }
-  .thumbnail-button {
-    width: 100%;
-    border: 2px solid @thumbnail-border;
-  }
-  .no-thumbnail {
-    width: 100%;
-    border: 2px solid @thumbnail-border;
-    border-bottom: 0px;
-    position: relative;
-    background-color: @thumbnail-bg;
-    .hpe-document {
-      position: absolute;
-      top: 50%;
-      left: 50%;
-      transform: translate(-50%, -50%);
-      text-align: center;
-      width: 100%;
-      color: @thumbnail-icon-color;
+    .thumbnail-container {
+        width: 100%;
+        border: 2px solid @thumbnail-border;
+        background-size: cover;
+        background-position: top center;
+        border-bottom: 0;
     }
-  }
+
+    .thumbnail-button {
+        width: 100%;
+        border: 2px solid @thumbnail-border;
+    }
+
+    .no-thumbnail {
+        width: 100%;
+        border: 2px solid @thumbnail-border;
+        border-bottom: 0;
+        position: relative;
+        background-color: @thumbnail-bg;
+
+        .hpe-document {
+            position: absolute;
+            top: 50%;
+            left: 50%;
+            transform: translate(-50%, -50%);
+            text-align: center;
+            width: 100%;
+            color: @thumbnail-icon-color;
+        }
+    }
 }

--- a/src/styles/cards.less
+++ b/src/styles/cards.less
@@ -1,1164 +1,987 @@
 .card-view {
-  padding-left: 0;
-  margin: 0 auto;
+    padding-left: 0;
+    margin: 0 auto;
 
-  @media (max-width: 555px) {
+    @media (max-width: 555px) {
+        .card {
+            width: 95%;
+        }
+    }
+
+    @media (min-width: 555px) {
+        .card {
+            width: 46%;
+        }
+    }
+
+    @media (min-width: 800px) {
+        .card {
+            width: 30%;
+        }
+    }
+
+    @media (min-width: 1024px) {
+        .card {
+            width: 46%;
+        }
+    }
+
+    @media (min-width: 1305px) {
+        .card {
+            width: 30%;
+        }
+    }
+
+    @media (min-width: 1640px) {
+        .card {
+            width: 23%;
+        }
+    }
+
+    @media (min-width: 1973px) {
+        .card {
+            width: 18%;
+        }
+    }
+
+    @media (min-width: 2307px) {
+        .card {
+            width: 15%;
+        }
+    }
+
+    @media (min-width: 2639px) {
+        .card {
+            width: 255px;
+        }
+    }
+
     .card {
-      width: 95%;
-    }
-  }
+        position: relative;
+        display: inline-block;
+        padding: 20px;
+        margin: 7px 10px;
+        background-color: @card-bg;
+        border: 1px solid @card-border;
 
-  @media (min-width: 555px) {
-    .card {
-      width: 46%;
-    }
-  }
-
-  @media (min-width: 800px) {
-    .card {
-      width: 30%;
-    }
-  }
-
-  @media (min-width: 1024px) {
-    .card {
-      width: 46%;
-    }
-  }
-
-  @media (min-width: 1305px) {
-    .card {
-      width: 30%;
-    }
-  }
-
-  @media (min-width: 1640px) {
-    .card {
-      width: 23%;
-    }
-  }
-
-  @media (min-width: 1973px) {
-    .card {
-      width: 18%;
-    }
-  }
-
-  @media (min-width: 2307px) {
-    .card {
-      width: 15%;
-    }
-  }
-
-  @media (min-width: 2639px) {
-    .card {
-      width: 255px;
-    }
-  }
-
-  .card {
-    position: relative;
-    display: inline-block;
-    padding: 20px 20px;
-    margin: 7px 10px;
-
-    background-color: @card-bg;
-    border: 1px solid @card-border;
-
-    &.outline {
-      border: 1px solid @card-selected-border;
-    }
-
-    &.callout {
-
-      &.preview-pane-selected-item {
-        border: 1px solid @card-selected-border;
-      }
-
-      &:after, &:before {
-      	border: solid transparent;
-      	content: " ";
-      	height: 0;
-      	width: 0;
-      	position: absolute;
-      	pointer-events: none;
-      }
-
-      &:after {
-      	border-color: rgba(136, 183, 213, 0);
-      	border-width: 14px;
-      }
-      &:before {
-      	border-color: rgba(194, 225, 245, 0);
-      	border-width: 15px;
-      }
-
-      &.top {
-        &:after, &:before {
-          bottom: 100%;
-        	left: 50%;
+        &.outline {
+            border: 1px solid @card-selected-border;
         }
-
-        &:after {
-          border-bottom-color: @card-bg;
-          margin-left: -15px;
-        }
-        &:before {
-          border-bottom-color: @card-border;
-          margin-left: -16px;
-        }
-        &.outline, &.preview-pane-selected-item {
-          &:before {
-            border-bottom-color: @card-selected-border;
-          }
-        }
-      }
-
-      &.right {
-        &:after, &:before {
-          left: 100%;
-        	top: 50%;
-        }
-
-        &:after {
-          border-left-color: @card-bg;
-          margin-top: -15px;
-        }
-        &:before {
-          border-left-color: @card-border;
-          margin-top: -16px;
-        }
-        &.outline, &.preview-pane-selected-item {
-          &:before {
-            border-left-color: @card-selected-border;
-          }
-        }
-      }
-
-      &.bottom {
-        &:after, &:before {
-          top: 100%;
-        	left: 50%;
-        }
-
-        &:after {
-          border-top-color: @card-bg;
-          margin-left: -15px;
-        }
-        &:before {
-          border-top-color: @card-border;
-          margin-left: -16px;
-        }
-        &.outline, &.preview-pane-selected-item {
-          &:before {
-            border-top-color: @card-selected-border;
-          }
-        }
-      }
-
-      &.left {
-        &:after, &:before {
-          right: 100%;
-        	top: 50%;
-        }
-
-        &:after {
-          border-right-color: @card-bg;
-          margin-top: -15px;
-        }
-        &:before {
-          border-right-color: @card-border;
-          margin-top: -16px;
-        }
-        &.outline, &.preview-pane-selected-item {
-          &:before {
-            border-right-color: @card-selected-border;
-          }
-        }
-      }
-    }
-
-    .card-icon {
-      background: url('../img/page.png') no-repeat;
-      width: 24px;
-      height: 28px;
-      background-size: contain;
-    }
-
-    .card-detail {
-      min-height: 44px;
-    }
-
-    .card-label {
-      position: absolute;
-      top: 0;
-      right: 15px;
-    }
-
-    .card-text-emphasis {
-      font-family: @font-family;
-      color: @card-title-color;
-    }
-
-    .card-text-subtle {
-      color: @card-subtitle-color;
-    }
-
-    .overflow-ellipse {
-      white-space: nowrap;
-      overflow:hidden !important;
-      text-overflow: ellipsis;
-    }
-
-    &.clickable {
-      outline: none;
-    }
-
-    &.active {
-      background-color: @card-active-bg;
-      border-color: @border-color;
-      color: inherit;
-      z-index: @stacking-context-z-index;
-      -webkit-transition: none;
-      -moz-transition: none;
-      -o-transition: none;
-      transition: none;
-    }
-
-    &.multiple-select-item--selecting {
-      transition: padding 100ms linear;
-      padding-left: 40px;
-
-      &:before {
-        position: absolute;
-        background: url("../img/blue_checkboxes.png") no-repeat;
-        background-position: -120px 0;
-        height: 22px;
-        width: 22px;
-        left: 8px;
-        top: ~'calc(50% - 11px)';
-        display: block;
-        content: "";
-      }
-
-      &.multiple-select-item--selected {
-
-        &:before {
-          background-position: -168px 0;
-        }
-      }
-    }
-  }
-
-  &.list-stack {
-    .card {
-      .card-label {
-        top: 15px;
-        right: 25px;
-      }
-      .content {
-        .card-text-emphasis {
-          font-size: 1.25rem;
-        }
-      }
-    }
-  }
-
-  &.card-hover {
-    .card {
-      &:hover, &:focus, &.preview-pane-selected-item {
-        background-color: @card-hover-bg;
 
         &.callout {
-          border: 1px solid @card-hover-border;
+            &.preview-pane-selected-item {
+                border: 1px solid @card-selected-border;
+            }
 
-          &.top {
+            &:after, &:before {
+                border: solid transparent;
+                content: " ";
+                height: 0;
+                width: 0;
+                position: absolute;
+                pointer-events: none;
+            }
+
             &:after {
-              border-bottom-color: @card-hover-bg;
+                border-color: rgba(136, 183, 213, 0);
+                border-width: 14px;
             }
+
             &:before {
-              border-bottom-color: @card-hover-border;
+                border-color: rgba(194, 225, 245, 0);
+                border-width: 15px;
             }
-          }
-          &.right {
-            &:after {
-              border-left-color: @card-hover-bg;
+
+            &.top {
+                &:after, &:before {
+                    bottom: 100%;
+                    left: 50%;
+                }
+
+                &:after {
+                    border-bottom-color: @card-bg;
+                    margin-left: -15px;
+                }
+
+                &:before {
+                    border-bottom-color: @card-border;
+                    margin-left: -16px;
+                }
+
+                &.outline, &.preview-pane-selected-item {
+                    &:before {
+                        border-bottom-color: @card-selected-border;
+                    }
+                }
             }
-            &:before {
-              border-left-color: @card-hover-border;
+
+            &.right {
+                &:after, &:before {
+                    left: 100%;
+                    top: 50%;
+                }
+
+                &:after {
+                    border-left-color: @card-bg;
+                    margin-top: -15px;
+                }
+
+                &:before {
+                    border-left-color: @card-border;
+                    margin-top: -16px;
+                }
+
+                &.outline, &.preview-pane-selected-item {
+                    &:before {
+                        border-left-color: @card-selected-border;
+                    }
+                }
             }
-          }
-          &.bottom {
-            &:after {
-              border-top-color: @card-hover-bg;
+
+            &.bottom {
+                &:after, &:before {
+                    top: 100%;
+                    left: 50%;
+                }
+
+                &:after {
+                    border-top-color: @card-bg;
+                    margin-left: -15px;
+                }
+
+                &:before {
+                    border-top-color: @card-border;
+                    margin-left: -16px;
+                }
+
+                &.outline, &.preview-pane-selected-item {
+                    &:before {
+                        border-top-color: @card-selected-border;
+                    }
+                }
             }
-            &:before {
-              border-top-color: @card-hover-border;
+
+            &.left {
+                &:after, &:before {
+                    right: 100%;
+                    top: 50%;
+                }
+
+                &:after {
+                    border-right-color: @card-bg;
+                    margin-top: -15px;
+                }
+
+                &:before {
+                    border-right-color: @card-border;
+                    margin-top: -16px;
+                }
+
+                &.outline, &.preview-pane-selected-item {
+                    &:before {
+                        border-right-color: @card-selected-border;
+                    }
+                }
             }
-          }
-          &.left {
-            &:after {
-              border-right-color: @card-hover-bg;
-            }
-            &:before {
-              border-right-color: @card-hover-border;
-            }
-          }
+        }
+
+        .card-icon {
+            background: url('../img/page.png') no-repeat;
+            width: 24px;
+            height: 28px;
+            background-size: contain;
+        }
+
+        .card-detail {
+            min-height: 44px;
+        }
+
+        .card-label {
+            position: absolute;
+            top: 0;
+            right: 15px;
+        }
+
+        .card-text-emphasis {
+            font-family: @font-family;
+            color: @card-title-color;
+        }
+
+        .card-text-subtle {
+            color: @card-subtitle-color;
+        }
+
+        .overflow-ellipse {
+            white-space: nowrap;
+            overflow: hidden !important;
+            text-overflow: ellipsis;
+        }
+
+        &.clickable {
+            outline: none;
         }
 
         &.active {
-          border-color: @card-border;
+            background-color: @card-active-bg;
+            border-color: @border-color;
+            color: inherit;
+            z-index: @stacking-context-z-index;
+            transition: none;
         }
-      }
+
+        &.multiple-select-item--selecting {
+            transition: padding 100ms linear;
+            padding-left: 40px;
+
+            &:before {
+                position: absolute;
+                background: url("../img/blue_checkboxes.png") no-repeat;
+                background-position: -120px 0;
+                height: 22px;
+                width: 22px;
+                left: 8px;
+                top: ~'calc(50% - 11px)';
+                display: block;
+                content: "";
+            }
+
+            &.multiple-select-item--selected {
+                &:before {
+                    background-position: -168px 0;
+                }
+            }
+        }
     }
-  }
-}
 
-// Deprecated
-
-.body-dark {
-  .card-view {
-    .card {
-      border: 1px solid @card-border-dark;
-
-      &.outline {
-        border-color: @primary;
-      }
-
-      &.callout {
-
-        &.top {
-          &:after {
-            border-bottom-color: @card-callout-border-dark;
-          }
-        }
-        &.bottom {
-          &:after {
-            border-top-color: @card-callout-border-dark;
-          }
-        }
-        &.left {
-          &:after {
-            border-right-color: @card-callout-border-dark;
-          }
-        }
-        &.right {
-          &:after {
-            border-left-color: @card-callout-border-dark;
-          }
-        }
-
-        &:hover {
-          &.top {
-            &:after {
-              border-bottom-color: @card-callout-hover-border-dark;
+    &.list-stack {
+        .card {
+            .card-label {
+                top: 15px;
+                right: 25px;
             }
-          }
-          &.bottom {
-            &:after {
-              border-top-color: @card-callout-hover-border-dark;
+
+            .content {
+                .card-text-emphasis {
+                    font-size: 1.25rem;
+                }
             }
-          }
-          &.left {
-            &:after {
-              border-right-color: @card-callout-hover-border-dark;
-            }
-          }
-          &.right {
-            &:after {
-              border-left-color: @card-callout-hover-border-dark;
-            }
-          }
         }
-      }
     }
-	.card.multiple-select-item--selecting:before {
-		background-position: -528px 0;
-	}
-	.card.multiple-select-item--selecting.multiple-select-item--selected:before {
-		background-position: -576px 0;
-	}
-  }
+
+    &.card-hover {
+        .card {
+            &:hover, &:focus, &.preview-pane-selected-item {
+                background-color: @card-hover-bg;
+
+                &.callout {
+                    border: 1px solid @card-hover-border;
+
+                    &.top {
+                        &:after {
+                            border-bottom-color: @card-hover-bg;
+                        }
+
+                        &:before {
+                            border-bottom-color: @card-hover-border;
+                        }
+                    }
+
+                    &.right {
+                        &:after {
+                            border-left-color: @card-hover-bg;
+                        }
+
+                        &:before {
+                            border-left-color: @card-hover-border;
+                        }
+                    }
+
+                    &.bottom {
+                        &:after {
+                            border-top-color: @card-hover-bg;
+                        }
+
+                        &:before {
+                            border-top-color: @card-hover-border;
+                        }
+                    }
+
+                    &.left {
+                        &:after {
+                            border-right-color: @card-hover-bg;
+                        }
+
+                        &:before {
+                            border-right-color: @card-hover-border;
+                        }
+                    }
+                }
+
+                &.active {
+                    border-color: @card-border;
+                }
+            }
+        }
+    }
 }
 
 //Allow cards to be stacked vertically
 &.stacked {
-  .card {
-    display: block;
-    margin-top: 0;
-    margin-left: 0;
-    margin-bottom: -1px;
-    width: 100%;
-    padding: 20px 10px;
+    .card {
+        display: block;
+        margin-top: 0;
+        margin-left: 0;
+        margin-bottom: -1px;
+        width: 100%;
+        padding: 20px 10px;
 
-    .icon {
-      display: inline-block;
-      vertical-align: top;
-      margin: 5px 10px;
-    }
+        .icon {
+            display: inline-block;
+            vertical-align: top;
+            margin: 5px 10px;
+        }
 
-    .content {
-      display: inline-block;
-      width: ~'calc(100% - 50px)';
-    }
+        .content {
+            display: inline-block;
+            width: ~'calc(100% - 50px)';
+        }
 
-    &:last-child {
-      margin-bottom: 0;
+        &:last-child {
+            margin-bottom: 0;
+        }
     }
-  }
 }
 
 @media (max-width: 1500px) {
-  .preview-pane-listview {
-    .card-view {
-      &.list-stack {
-        .card {
-          .card-label {
-            display: none !important;
-          }
+    .preview-pane-listview {
+        .card-view {
+            &.list-stack {
+                .card {
+                    .card-label {
+                        display: none !important;
+                    }
+                }
+            }
         }
-      }
     }
-  }
 }
 
 @media (max-width: 500px) {
-  .preview-pane-listview {
-    .card-view {
-      &.stacked {
-        .card {
-          .icon {
-            display: none !important;
-          }
-          .card-label {
-            display: none !important;
-          }
-          .content {
-            width: 100% !important;
-          }
+    .preview-pane-listview {
+        .card-view {
+            &.stacked {
+                .card {
+                    .icon {
+                        display: none !important;
+                    }
+
+                    .card-label {
+                        display: none !important;
+                    }
+
+                    .content {
+                        width: 100% !important;
+                    }
+                }
+            }
         }
-      }
     }
-  }
 }
 
 @media (max-width: 400px) {
-  .card-view {
-    &.list-stack {
-      .card {
-        .card-label {
-          display: none !important;
+    .card-view {
+        &.list-stack {
+            .card {
+                .card-label {
+                    display: none !important;
+                }
+            }
         }
-      }
     }
-  }
 }
 
 @media (max-width: 278px) {
-  .preview-pane-listview {
-    .card-view {
-       &.stacked {
-        .card {
-          .content {
-            .pull-right {
-              display: none;
+    .preview-pane-listview {
+        .card-view {
+            &.stacked {
+                .card {
+                    .content {
+                        .pull-right {
+                            display: none;
+                        }
+                    }
+                }
             }
-          }
         }
-      }
     }
-  }
 }
-
 
 // When preview panel is open - switch to stacked
 .preview-pane-listview {
-  .stacked();
+    .stacked();
 
-  .card-view {
-    overflow-x: hidden;
+    .card-view {
+        overflow-x: hidden;
 
-    .card {
-      padding-top: 15px;
-    }
-
-    .preview-pane-selected-item {
-      background-color: @card-hover-bg;
-      &.multiple-select-item--selecting {
-        background-color: @card-bg;
-        &:hover {
-          background-color: @card-hover-bg;
+        .card {
+            padding-top: 15px;
         }
-      }
+
+        .preview-pane-selected-item {
+            background-color: @card-hover-bg;
+
+            &.multiple-select-item--selecting {
+                background-color: @card-bg;
+
+                &:hover {
+                    background-color: @card-hover-bg;
+                }
+            }
+        }
     }
-  }
 }
 
 .card-tab-container {
-
-  position: relative;
-  overflow: hidden;
-
-  .page-btn {
-    position: absolute;
-    width: 30px;
-    height: 30px;
-    border-radius: 50%;
-    top: ~"calc(50% - 15px)";
-    color: @card-tab-pagination-color;
-    cursor: pointer;
-    -webkit-transition : background-color 500ms linear;
-    -moz-transition : background-color 500ms linear;
-    -o-transition : background-color 500ms linear;
-    transition: background-color 500ms linear;
-    background-color: @card-tab-pagination-bg;
-    text-align: center;
-
-    &:hover {
-      background-color: rgba(51, 51, 51, 0.8);
-      color: @card-tab-pagination-hover-color;
-    }
-
-    &.previous {
-      left: 10px;
-
-      i {
-        position: relative;
-        top: 50%;
-        transform: translateX(-10%) translateY(-60%)
-      }
-    }
-
-    &.next {
-      right: 10px;
-
-      i {
-        position: relative;
-        top: 50%;
-        transform: translateX(10%) translateY(-60%)
-      }
-    }
-  }
-
-  .card-tabs {
     position: relative;
-    padding: 5px 0;
-    margin: 0 auto;
-    height: 190px;
-    left: 0;
-    width: 200px;
-    -webkit-transition : left 500ms ease-in-out;
-    -moz-transition : left 500ms ease-in-out;
-    -o-transition : left 500ms ease-in-out;
-    transition: left 500ms ease-in-out;
-    white-space: nowrap;
-    margin-bottom: 8px;
+    overflow: hidden;
 
-    .card-tab {
-      position: relative;
-      display: inline-block;
-      width: 190px;
-      height: 170px;
-      margin: 5px;
-      background-color: @card-tab-bg;
-      border: 1px solid @card-tab-border;
-      -webkit-transition : border 500ms linear;
-      -moz-transition : border 500ms linear;
-      -o-transition : border 500ms linear;
-      transition: border 500ms linear;
-      box-shadow: 0 1px 8px @card-tab-border;
-      cursor: pointer;
-      -webkit-transition : opacity 500ms linear;
-      -moz-transition : opacity 500ms linear;
-      -o-transition : opacity 500ms linear;
-      transition: opacity 500ms linear;
+    .page-btn {
+        position: absolute;
+        width: 30px;
+        height: 30px;
+        border-radius: 50%;
+        top: ~"calc(50% - 15px)";
+        color: @card-tab-pagination-color;
+        cursor: pointer;
+        transition: background-color 500ms linear;
+        background-color: @card-tab-pagination-bg;
+        text-align: center;
 
-      &.active {
-
-        border: 1px solid @card-tab-active-border;
-
-        &:after,
-        &:before {
-          border: solid transparent;
-          content: " ";
-          height: 0;
-          width: 0;
-          position: absolute;
-          pointer-events: none;
+        &:hover {
+            background-color: rgba(51, 51, 51, 0.8);
+            color: @card-tab-pagination-hover-color;
         }
 
-        &.top {
-          &:after,
-          &:before {
-            bottom: 100%;
-            left: 50%;
-          }
+        &.previous {
+            left: 10px;
 
-          &:after {
-            border-bottom-color: @card-tab-bg;
-            margin-left: -9px;
-            border-width: 9px;
-          }
-
-          &:before {
-            border-bottom-color: @card-tab-active-border;
-            margin-left: -10px;
-            border-width: 10px;
-          }
+            i {
+                position: relative;
+                top: 50%;
+                transform: translateX(-10%) translateY(-60%);
+            }
         }
 
-        &.bottom {
+        &.next {
+            right: 10px;
 
-          &:after,
-          &:before {
-            top: 100%;
-            left: 50%;
-          }
-
-          &:after {
-            border-top-color: @card-tab-bg;
-            margin-left: -9px;
-            border-width: 9px;
-          }
-
-          &:before {
-            border-top-color: @card-tab-active-border;
-            margin-left: -10px;
-            border-width: 10px;
-          }
+            i {
+                position: relative;
+                top: 50%;
+                transform: translateX(10%) translateY(-60%);
+            }
         }
-      }
-
-      &:hover {
-        border: 1px solid @card-tab-hover-border;
-      }
     }
-  }
-}
 
-//Deprecated
-.body-dark {
-  .card-view {
-    .card {
-      .card-text-emphasis {
-        color: white;
-      }
-    }
-    &.list-stack {
-      .card {
-        .content {
-          .card-text-emphasis {
-            color: white;
-          }
+    .card-tabs {
+        position: relative;
+        padding: 5px 0;
+        margin: 0 auto;
+        height: 190px;
+        left: 0;
+        width: 200px;
+        transition: left 500ms ease-in-out;
+        white-space: nowrap;
+        margin-bottom: 8px;
+
+        .card-tab {
+            position: relative;
+            display: inline-block;
+            width: 190px;
+            height: 170px;
+            margin: 5px;
+            background-color: @card-tab-bg;
+            border: 1px solid @card-tab-border;
+            box-shadow: 0 1px 8px @card-tab-border;
+            cursor: pointer;
+            transition: border 500ms linear, opacity 500ms linear;
+
+            &.active {
+                border: 1px solid @card-tab-active-border;
+
+                &:after,
+                &:before {
+                    border: solid transparent;
+                    content: " ";
+                    height: 0;
+                    width: 0;
+                    position: absolute;
+                    pointer-events: none;
+                }
+
+                &.top {
+                    &:after,
+                    &:before {
+                        bottom: 100%;
+                        left: 50%;
+                    }
+
+                    &:after {
+                        border-bottom-color: @card-tab-bg;
+                        margin-left: -9px;
+                        border-width: 9px;
+                    }
+
+                    &:before {
+                        border-bottom-color: @card-tab-active-border;
+                        margin-left: -10px;
+                        border-width: 10px;
+                    }
+                }
+
+                &.bottom {
+                    &:after,
+                    &:before {
+                        top: 100%;
+                        left: 50%;
+                    }
+
+                    &:after {
+                        border-top-color: @card-tab-bg;
+                        margin-left: -9px;
+                        border-width: 9px;
+                    }
+
+                    &:before {
+                        border-top-color: @card-tab-active-border;
+                        margin-left: -10px;
+                        border-width: 10px;
+                    }
+                }
+            }
+
+            &:hover {
+                border: 1px solid @card-tab-hover-border;
+            }
         }
-      }
     }
-    &.card-hover {
-      .card {
-        background-color: @card-bg-dark;
-        &:hover, &:focus, &.preview-pane-selected-item {
-          background-color: @card-hover-bg-dark;
-        }
-      }
-    }
-  }
 }
 
 /*
   Draggable Card Control
 */
 
-/*
-  Dark Theme
-*/
-
-// Deprecated
-.body-dark {
-  .draggable-card-container {
-    background-color: @draggable-card-bg-dark;
-    border: 1px solid @draggable-card-border-dark;
-
-    .card-container {
-      .card {
-        background-color: @draggable-card-child-bg-dark;
-        margin: 0;
-        border: 1px solid @draggable-card-child-border-dark;
-        box-shadow: 1px 1px 3px @draggable-card-child-shadow-dark;
-
-        &.active {
-          box-shadow: 1px 1px 3px @draggable-card-child-shadow-dark;
-
-          .callout {
-            background-color: @draggable-card-child-bg-dark;
-          }
-
-          &.right {
-            .callout {
-              box-shadow: 2px -1.5px 1px rgba(26, 26, 26, 0.3);
-            }
-          }
-
-          &.left {
-            .callout {
-              box-shadow: 1.5px -1px 1px rgba(26, 26, 26, 0.3);
-            }
-          }
-        }
-
-        .close-btn {
-          &:before, &:after {
-            background: @grey8 !important;
-          }
-        }
-
-        .arrow-up {
-          background-image: url('../img/uparrow.png') !important;
-        }
-
-        .arrow-down {
-          background-image: url('../img/downarrow.png') !important;
-        }
-
-        .drag-handle {
-          background-image: url('../img/draghandle.png') !important;
-        }
-
-        &.draggable {
-          &.dragging {
-            z-index: 2;
-            box-shadow: 0px 3px 15px @draggable-card-child-shadow-dark;
-
-            &.active {
-              &.right {
-                .callout {
-                  box-shadow: 2.5px -2px 2px rgba(26, 26, 26, 0.3);
-                }
-              }
-
-              &.left {
-                .callout {
-                  box-shadow: 1.5px -2px 2px rgba(26, 26, 26, 0.3);
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-
-  }
-}
-
-/*
-  Light Theme (default)
-*/
-
 .draggable-card-outer-container {
-  height: 100%;
-  padding: 5px;
-  padding-left: 0;
-  background-color: @draggable-card-container-bg;
-  border: 1px solid @draggable-card-container-border;
+    height: 100%;
+    padding: 5px;
+    padding-left: 0;
+    background-color: @draggable-card-container-bg;
+    border: 1px solid @draggable-card-container-border;
 }
 
 .draggable-card-scroller {
-  height: 100%;
-  min-width: 215px;
+    height: 100%;
+    min-width: 215px;
 }
 
 .draggable-card-container {
-  position: relative;
-  width: 100%;
-  height: 100%;
-  background-color: @draggable-card-container-bg;
-  overflow-y: visible;
-  overflow-x: hidden;
-
-  &:active, &:focus {
-    outline: none;
-  }
-
-  &.disable-editing {
-    .card {
-      &.draggable {
-        .title-container {
-          .hp-edit {
-            display: none;
-          }
-        }
-      }
-    }
-  }
-
-  &.disable-removing {
-    .card {
-      &.draggable {
-        .title-container {
-          .close-btn  {
-            display: none;
-          }
-        }
-      }
-    }
-  }
-
-  .card-container {
     position: relative;
     width: 100%;
-    padding: 5px 20px;
+    height: 100%;
+    background-color: @draggable-card-container-bg;
+    overflow-y: visible;
+    overflow-x: hidden;
 
-    &.tabbed {
-      .card {
-        border: 1px solid @primary;
-      }
+    &:active, &:focus {
+        outline: none;
     }
 
-    .card {
-      position: relative;
-      width: 100%;
-      min-height: 30px;
-      background-color: @draggable-card-bg;
-      margin: 0;
-      border: 1px solid @draggable-card-border;
-      box-shadow: 1px 1px 3px @draggable-card-border;
-      padding: 5px 10px;
-      cursor: pointer;
-      -webkit-transition: border-color 0.5s;
-      transition: border-color 0.5s;
-      -moz-user-select: none;
-      -webkit-user-select: none;
-      -ms-user-select: none;
-      user-select: none;
-
-      .show-on-hover {
-        -webkit-transition: opacity 0.3s;
-        transition: opacity 0.3s;
-        opacity: 0;
-      }
-
-      &:hover {
-        .show-on-hover {
-          opacity: 0.8;
-
-          &:hover {
-            opacity: 1;
-          }
-
-          &.disabled {
-            opacity: 0.2;
-            cursor: default;
-            &:hover {
-              opacity: 0.2;
+    &.disable-editing {
+        .card {
+            &.draggable {
+                .title-container {
+                    .hp-edit {
+                        display: none;
+                    }
+                }
             }
-          }
         }
-      }
+    }
 
-      &.fixed {
-        .title {
-          font-size: 1.125rem;
-          width: 100%;
-          height: 25px;
-          white-space: nowrap;
-          overflow: hidden;
-          text-overflow: ellipsis;
+    &.disable-removing {
+        .card {
+            &.draggable {
+                .title-container {
+                    .close-btn {
+                        display: none;
+                    }
+                }
+            }
         }
-      }
+    }
 
-      &.draggable {
+    .card-container {
+        position: relative;
+        width: 100%;
+        padding: 5px 20px;
 
-        &.dragging {
-          z-index: 2;
-          box-shadow: 0px 3px 15px @draggable-card-shadow;
-
-          &.active {
-            &.right {
-              .callout {
-                box-shadow: 2.5px -2px 2px rgba(102, 102, 102, 0.15);
-              }
+        &.tabbed {
+            .card {
+                border: 1px solid @primary;
             }
-
-            &.left {
-              .callout {
-                box-shadow: 1.5px -2px 2px rgba(102, 102, 102, 0.15);
-              }
-            }
-          }
         }
 
-        &.disable-editing {
-          .title-container {
-            .hp-edit {
-              display: none;
-            }
-          }
-        }
-
-        &.disable-removing {
-          .title-container {
-            .close-btn {
-              display: none;
-            }
-          }
-        }
-
-        .title-container {
-          display: flex;
-          justify-content: space-between;
-          width: 100%;
-          height: 25px;
-
-          .title {
-            flex: 1 0 auto;
-            display: inline-flex;
-            align-items: baseline;
-            font-size: 1.125rem;
-            padding-right: 8px;
-            max-width: ~'calc(100% - 50px)';
-            height: 25px;
-            .title-text {
-              padding-right: 3px;
-              overflow: hidden;
-              text-overflow: ellipsis;
-              white-space: nowrap;
-              height: 25px;
-            }
-            .title-subtext {
-              padding-right: 4px;
-            }
-          }
-
-          .draggable-icon {
-            padding-left: 5px;
-            padding-right: 5px;
-          }
-
-          .hp-edit {
-            vertical-align: super;
-          }
-
-          .close-btn {
-          	display: inline-block;
+        .card {
             position: relative;
-          	overflow: hidden;
-          	width: 17px;
-            height: 17px;
-            top: 4px;
-
-          	&::before {
-          		-moz-transform: rotate(45deg);
-          		-ms-transform: rotate(45deg);
-          		-o-transform: rotate(45deg);
-          		-webkit-transform: rotate(45deg);
-          		background: @draggable-card-close-btn-color;
-          		content: '';
-          		height: 1px;
-          		left: 0;
-          		margin-top: -1px;
-          		position: absolute;
-          		top: 50%;
-          		transform: rotate(45deg);
-          		width: 100%;
-          	}
-          	&::after {
-          		-moz-transform: rotate(-45deg);
-          		-ms-transform: rotate(-45deg);
-          		-o-transform: rotate(-45deg);
-          		-webkit-transform: rotate(-45deg);
-          		background: @draggable-card-close-btn-color;
-          		content: '';
-          		height: 1px;
-          		left: 0;
-          		margin-top: -1px;
-          		position: absolute;
-          		top: 50%;
-          		transform: rotate(-45deg);
-          		width: 100%;
-          	}
-          }
-        }
-
-        .content-area {
-          position: relative;
-
-          .drag-container {
-            position: absolute;
-            top: 0;
-            left: 0;
-            display: inline-block;
-            width: 20px;
-            min-height: 60px;
-            height: 100%;
-
-            .center-controls {
-
-              position: relative;
-              top: 50%;
-              transform: translateY(-50%);
-
-              .arrow-up {
-                background-image: url('../img/uparrow-dark.png');
-                width: 14px;
-                height: 13px;
-                background-repeat: no-repeat;
-                background-size: 13px;
-                padding-left: 0px;
-                margin: 4px 3px;
-              }
-
-              .drag-handle {
-                background-image: url('../img/draghandle-dark.png');
-                width: 14px;
-                height: 24px;
-                background-repeat: no-repeat;
-                background-size: 13px;
-                padding-left: 0px;
-                margin: 4px 3px;
-                cursor: ns-resize;
-              }
-
-              .arrow-down {
-                background-image: url('../img/downarrow-dark.png');
-                width: 14px;
-                height: 13px;
-                background-repeat: no-repeat;
-                background-size: 13px;
-                padding-left: 0px;
-                margin: 4px 3px;
-              }
-            }
-          }
-
-          .card-template {
-            display: inline-block;
-            padding: 5px 0px;
             width: 100%;
-            padding-left: 25px;
-            overflow: hidden;
-          }
-        }
-      }
-
-      &:hover {
-        border-color: @draggable-card-hover-border;
-      }
-
-      .callout {
-        display: none;
-      }
-
-      &.active {
-          border-color: @draggable-card-active-border;
-          box-shadow: 1px 1px 3px @draggable-card-active-shadow;
-
-          .callout {
-            position: absolute;
-            display: block;
-            width: 9px;
-            height: 9px;
+            min-height: 30px;
             background-color: @draggable-card-bg;
-            border-top: 1px solid @draggable-card-active-border;
-            border-right: 1px solid @draggable-card-active-border;
-          }
+            margin: 0;
+            border: 1px solid @draggable-card-border;
+            box-shadow: 1px 1px 3px @draggable-card-border;
+            padding: 5px 10px;
+            cursor: pointer;
+            transition: border-color 0.5s;
+            -moz-user-select: none;
+            -webkit-user-select: none;
+            -ms-user-select: none;
+            user-select: none;
 
-          &.right {
-            .callout {
-              top: ~'calc(50% - 2px)';
-              right: -2px;
-              box-shadow: 1.5px -1px 1px rgba(102, 102, 102, 0.2);
-              transform: rotateZ(45deg) translateY(-50%);
+            .show-on-hover {
+                transition: opacity 0.3s;
+                opacity: 0;
             }
-          }
 
-          &.left {
-            .callout {
-              top: ~'calc(50% - 8px)';
-              left: -2px;
-              box-shadow: 1px -1.5px 1px rgba(102, 102, 102, 0.2);
-              transform: rotateZ(-135deg) translateY(-50%);
+            &:hover {
+                .show-on-hover {
+                    opacity: 0.8;
+
+                    &:hover {
+                        opacity: 1;
+                    }
+
+                    &.disabled {
+                        opacity: 0.2;
+                        cursor: default;
+
+                        &:hover {
+                            opacity: 0.2;
+                        }
+                    }
+                }
             }
-          }
-      }
+
+            &.fixed {
+                .title {
+                    font-size: 1.125rem;
+                    width: 100%;
+                    height: 25px;
+                    white-space: nowrap;
+                    overflow: hidden;
+                    text-overflow: ellipsis;
+                }
+            }
+
+            &.draggable {
+                &.dragging {
+                    z-index: 2;
+                    box-shadow: 0 3px 15px @draggable-card-shadow;
+
+                    &.active {
+                        &.right {
+                            .callout {
+                                box-shadow: 2.5px -2px 2px rgba(102, 102, 102, 0.15);
+                            }
+                        }
+
+                        &.left {
+                            .callout {
+                                box-shadow: 1.5px -2px 2px rgba(102, 102, 102, 0.15);
+                            }
+                        }
+                    }
+                }
+
+                &.disable-editing {
+                    .title-container {
+                        .hp-edit {
+                            display: none;
+                        }
+                    }
+                }
+
+                &.disable-removing {
+                    .title-container {
+                        .close-btn {
+                            display: none;
+                        }
+                    }
+                }
+
+                .title-container {
+                    display: flex;
+                    justify-content: space-between;
+                    width: 100%;
+                    height: 25px;
+
+                    .title {
+                        flex: 1 0 auto;
+                        display: inline-flex;
+                        align-items: baseline;
+                        font-size: 1.125rem;
+                        padding-right: 8px;
+                        max-width: ~'calc(100% - 50px)';
+                        height: 25px;
+
+                        .title-text {
+                            padding-right: 3px;
+                            overflow: hidden;
+                            text-overflow: ellipsis;
+                            white-space: nowrap;
+                            height: 25px;
+                        }
+
+                        .title-subtext {
+                            padding-right: 4px;
+                        }
+                    }
+
+                    .draggable-icon {
+                        padding-left: 5px;
+                        padding-right: 5px;
+                    }
+
+                    .hp-edit {
+                        vertical-align: super;
+                    }
+
+                    .close-btn {
+                        display: inline-block;
+                        position: relative;
+                        overflow: hidden;
+                        width: 17px;
+                        height: 17px;
+                        top: 4px;
+
+                        &:before {
+                            -moz-transform: rotate(45deg);
+                            -ms-transform: rotate(45deg);
+                            -o-transform: rotate(45deg);
+                            -webkit-transform: rotate(45deg);
+                            background: @draggable-card-close-btn-color;
+                            content: '';
+                            height: 1px;
+                            left: 0;
+                            margin-top: -1px;
+                            position: absolute;
+                            top: 50%;
+                            transform: rotate(45deg);
+                            width: 100%;
+                        }
+
+                        &:after {
+                            -moz-transform: rotate(-45deg);
+                            -ms-transform: rotate(-45deg);
+                            -o-transform: rotate(-45deg);
+                            -webkit-transform: rotate(-45deg);
+                            background: @draggable-card-close-btn-color;
+                            content: '';
+                            height: 1px;
+                            left: 0;
+                            margin-top: -1px;
+                            position: absolute;
+                            top: 50%;
+                            transform: rotate(-45deg);
+                            width: 100%;
+                        }
+                    }
+                }
+
+                .content-area {
+                    position: relative;
+
+                    .drag-container {
+                        position: absolute;
+                        top: 0;
+                        left: 0;
+                        display: inline-block;
+                        width: 20px;
+                        min-height: 60px;
+                        height: 100%;
+
+                        .center-controls {
+                            position: relative;
+                            top: 50%;
+                            transform: translateY(-50%);
+
+                            .arrow-up {
+                                background-image: url('../img/uparrow-dark.png');
+                                width: 14px;
+                                height: 13px;
+                                background-repeat: no-repeat;
+                                background-size: 13px;
+                                padding-left: 0;
+                                margin: 4px 3px;
+                            }
+
+                            .drag-handle {
+                                background-image: url('../img/draghandle-dark.png');
+                                width: 14px;
+                                height: 24px;
+                                background-repeat: no-repeat;
+                                background-size: 13px;
+                                padding-left: 0;
+                                margin: 4px 3px;
+                                cursor: ns-resize;
+                            }
+
+                            .arrow-down {
+                                background-image: url('../img/downarrow-dark.png');
+                                width: 14px;
+                                height: 13px;
+                                background-repeat: no-repeat;
+                                background-size: 13px;
+                                padding-left: 0;
+                                margin: 4px 3px;
+                            }
+                        }
+                    }
+
+                    .card-template {
+                        display: inline-block;
+                        padding: 5px 0;
+                        width: 100%;
+                        padding-left: 25px;
+                        overflow: hidden;
+                    }
+                }
+            }
+
+            &:hover {
+                border-color: @draggable-card-hover-border;
+            }
+
+            .callout {
+                display: none;
+            }
+
+            &.active {
+                border-color: @draggable-card-active-border;
+                box-shadow: 1px 1px 3px @draggable-card-active-shadow;
+
+                .callout {
+                    position: absolute;
+                    display: block;
+                    width: 9px;
+                    height: 9px;
+                    background-color: @draggable-card-bg;
+                    border-top: 1px solid @draggable-card-active-border;
+                    border-right: 1px solid @draggable-card-active-border;
+                }
+
+                &.right {
+                    .callout {
+                        top: ~'calc(50% - 2px)';
+                        right: -2px;
+                        box-shadow: 1.5px -1px 1px rgba(102, 102, 102, 0.2);
+                        transform: rotateZ(45deg) translateY(-50%);
+                    }
+                }
+
+                &.left {
+                    .callout {
+                        top: ~'calc(50% - 8px)';
+                        left: -2px;
+                        box-shadow: 1px -1.5px 1px rgba(102, 102, 102, 0.2);
+                        transform: rotateZ(-135deg) translateY(-50%);
+                    }
+                }
+            }
+        }
     }
-  }
 }
 
 /*
   Flippable Cards
 */
 .flip-container {
-  perspective: 1000px;
-  transform-style: preserve-3d;
-  display: inline-block;
-  /*  UPDATED! flip the pane when hovered */
-  .flipper {
-    &.flip-card {
-      transform: none;
-      .back {
-        transform: rotateY(0deg);
-      }
-      .front {
-        transform: rotateY(180deg);
-      }
-    }
-  }
+    perspective: 1000px;
+    transform-style: preserve-3d;
+    display: inline-block;
 
-  &.vertical {
-    position: relative;
-    .back {
-      transform: rotateX(180deg);
-    }
+    /*  UPDATED! flip the pane when hovered */
     .flipper {
-      &.flip-card {
-        transform: none;
-        .back {
-          transform: rotateX(0deg);
+        &.flip-card {
+            transform: none;
+
+            .back {
+                transform: rotateY(0deg);
+            }
+
+            .front {
+                transform: rotateY(180deg);
+            }
         }
-        .front {
-          transform: rotateX(-180deg);
+    }
+
+    &.vertical {
+        position: relative;
+
+        .back {
+            transform: rotateX(180deg);
         }
 
-      }
+        .flipper {
+            &.flip-card {
+                transform: none;
+
+                .back {
+                    transform: rotateX(0deg);
+                }
+
+                .front {
+                    transform: rotateX(-180deg);
+                }
+            }
+        }
     }
-  }
 }
 
 .flip-container, .front, .back {
-  width: 280px;
-  height: 200px;
+    width: 280px;
+    height: 200px;
 }
 
 /* flip speed */
 .flipper {
-  transition: 0.6s;
-  transform-style: preserve-3d;
-
-  position: relative;
+    transition: 0.6s;
+    transform-style: preserve-3d;
+    position: relative;
 }
 
 .hover-flipper .front,
 .hover-flipper .back {
-  transition-delay: 0.3s;
+    transition-delay: 0.3s;
 }
 
 /* hide back of pane during swap */
 .front, .back {
-  backface-visibility: hidden;
-  transition: 0.6s;
-  transform-style: flat;
-  position: absolute;
-  top: 0;
-  left: 0;
-  box-shadow: 0px 2px 10px #999;
+    backface-visibility: hidden;
+    transition: 0.6s;
+    transform-style: flat;
+    position: absolute;
+    top: 0;
+    left: 0;
+    box-shadow: 0 2px 10px #999;
 }
 
 /* front pane, placed above back */
 .front {
-  z-index: 2;
-  transform: rotateY(0deg);
+    z-index: 2;
+    transform: rotateY(0deg);
 }
 
 /* back, initially hidden pane */
 .back {
-  transform: rotateY(-180deg);
+    transform: rotateY(-180deg);
 }

--- a/src/styles/charts.less
+++ b/src/styles/charts.less
@@ -1,505 +1,432 @@
 .flot-chart {
-  display: block;
-  height: 200px;
+    display: block;
+    height: 200px;
 }
- 
+
 .flot-chart-timeline {
-  display: block;
-  height: 80px;
+    display: block;
+    height: 80px;
 }
 
 .flot-chart-stack {
-  display: block;
-  height: 400px;
+    display: block;
+    height: 400px;
 }
+
 .flot-chart-content {
-  width: 100%;
-  height: 100%;
+    width: 100%;
+    height: 100%;
 }
 
 .flot-chart-scroll {
-  position: relative;
-  width: 25px;
-  height: 25px;
-  background-color: @flot-scroll-button-bg;
-  border-radius: 50%;
-  text-align: center;
-  opacity: 0.7;
-  cursor: pointer;
+    position: relative;
+    width: 25px;
+    height: 25px;
+    background-color: @flot-scroll-button-bg;
+    border-radius: 50%;
+    text-align: center;
+    opacity: 0.7;
+    cursor: pointer;
 
-  &:hover {
-    opacity: 0.9;
-  }
+    &:hover {
+        opacity: 0.9;
+    }
 
-  .left {
-    border:       solid @flot-scroll-button-color;
-    border-width: 0 3px 3px 0;
-    display:      inline-block;
-    padding:      3px;
-    transform: rotate(135deg) translateX(0px) translateY(-1px);
-  }
+    .left {
+        border: solid @flot-scroll-button-color;
+        border-width: 0 3px 3px 0;
+        display: inline-block;
+        padding: 3px;
+        transform: rotate(135deg) translateX(0) translateY(-1px);
+    }
 
-  .right {
-    border:       solid @flot-scroll-button-color;
-    border-width: 0 3px 3px 0;
-    display:      inline-block;
-    padding:      3px;
-    transform: rotate(-45deg) translateX(-1px) translateY(0px);
-  }
+    .right {
+        border: solid @flot-scroll-button-color;
+        border-width: 0 3px 3px 0;
+        display: inline-block;
+        padding: 3px;
+        transform: rotate(-45deg) translateX(-1px) translateY(0);
+    }
 }
 
 .chartcolors {
-  img {
-   height: 300px;
-  }
-  .colorname {
-    opacity: 0.6;
-    font-size: 0.875rem;
-    margin-bottom: 10px;
-  }
-  p {
-   margin-bottom: 0;
-  }
+    img {
+        height: 300px;
+    }
+
+    .colorname {
+        opacity: 0.6;
+        font-size: 0.875rem;
+        margin-bottom: 10px;
+    }
+
+    p {
+        margin-bottom: 0;
+    }
 }
 
-.chart-alternate1{
-  color:@alternate1;
+.chart-alternate1 {
+    color: @alternate1;
 }
 
 .spark-label-left {
-   display: inline-block;
-   width:15%;
-   vertical-align: top;
+    display: inline-block;
+    width: 15%;
+    vertical-align: top;
 
-   div {
-     float: right;
-   }
+    div {
+        float: right;
+    }
 }
 
 .spark-line {
-  width: 75%;
+    width: 75%;
 }
 
 .spark {
-  overflow: hidden;
-  background-color: @spark-chart1-track;
+    overflow: hidden;
+    background-color: @spark-chart1-track;
 
-  &.inline {
-   margin-bottom: 0;
-   display:inline-block;
-   width:100%;
-   float: left;
-  }
-  .fill {
-   transition: none;
-   background-color: @spark-chart1-fill;
-  }
+    &.inline {
+        margin-bottom: 0;
+        display: inline-block;
+        width: 100%;
+        float: left;
+    }
+
+    .fill {
+        transition: none;
+        background-color: @spark-chart1-fill;
+    }
 }
 
 .spark-label .x-large {
-  font-size: 24px; 
-  max-height: 24px;
-  display: inline-block;
+    font-size: 24px;
+    max-height: 24px;
+    display: inline-block;
 }
 
 .spark-label .large {
-  font-size: 16px;
+    font-size: 16px;
 }
 
 .spark-label .medium {
-  font-size: 14px; 
+    font-size: 14px;
 }
 
 .spark-label .small {
-  font-size: 11px; 
+    font-size: 11px;
 }
 
 .spark-label .light {
-  opacity: 0.6; 
+    opacity: 0.6;
 }
 
 .spark-chart1 {
-  background-color: @spark-chart1-track;
-  .fill {
-      background-color: @spark-chart1-fill;
-  }
+    background-color: @spark-chart1-track;
+
+    .fill {
+        background-color: @spark-chart1-fill;
+    }
 }
 
 .spark-chart2 {
-  background-color: @spark-chart2-track;
-  .fill {
-      background-color: @spark-chart2-fill;
-  }
+    background-color: @spark-chart2-track;
+
+    .fill {
+        background-color: @spark-chart2-fill;
+    }
 }
 
 .spark-chart3 {
-  background-color: @spark-chart3-track;
-  .fill {
-      background-color: @spark-chart3-fill;
-  }
+    background-color: @spark-chart3-track;
+
+    .fill {
+        background-color: @spark-chart3-fill;
+    }
 }
 
 .spark-chart4 {
-  background-color: @spark-chart4-track;
-  .fill {
-      background-color: @spark-chart4-fill;
-  }
+    background-color: @spark-chart4-track;
+
+    .fill {
+        background-color: @spark-chart4-fill;
+    }
 }
 
 .spark-chart5 {
-  background-color: @spark-chart5-track;
-  .fill {
-    background-color: @spark-chart5-fill;
-  }
+    background-color: @spark-chart5-track;
+
+    .fill {
+        background-color: @spark-chart5-fill;
+    }
 }
 
 .spark-chart6 {
-  background-color: @spark-chart6-track;
-  .fill {
-    background-color: @spark-chart6-fill;
-  }
+    background-color: @spark-chart6-track;
+
+    .fill {
+        background-color: @spark-chart6-fill;
+    }
 }
 
-.spark-ok{
-  background-color: @spark-ok-track;
-  .fill {
-      background-color: @spark-ok-fill;
-  }
+.spark-ok {
+    background-color: @spark-ok-track;
+
+    .fill {
+        background-color: @spark-ok-fill;
+    }
 }
 
 .spark-warning {
-  background-color: @spark-warning-track;
-  .fill {
-      background-color: @spark-warning-fill;
-  }
+    background-color: @spark-warning-track;
+
+    .fill {
+        background-color: @spark-warning-fill;
+    }
 }
 
 .spark-critical {
-  background-color: @spark-critical-track;
-  .fill {
-      background-color: @spark-critical-fill;
-  }
+    background-color: @spark-critical-track;
+
+    .fill {
+        background-color: @spark-critical-fill;
+    }
 }
 
 .spark-vibrant1 {
-  background-color: @spark-vibrant1-track;
-  .fill {
-      background-color: @spark-vibrant1-fill;
-  }
+    background-color: @spark-vibrant1-track;
+
+    .fill {
+        background-color: @spark-vibrant1-fill;
+    }
 }
 
 .spark-vibrant2 {
-  background-color: @spark-vibrant2-track;
-  .fill {
-      background-color: @spark-vibrant2-fill;
-  }
+    background-color: @spark-vibrant2-track;
+
+    .fill {
+        background-color: @spark-vibrant2-fill;
+    }
 }
 
 .spark-primary {
-  background-color: @spark-primary-track;
-  .fill {
-      background-color: @spark-primary-fill;
-  }
+    background-color: @spark-primary-track;
+
+    .fill {
+        background-color: @spark-primary-fill;
+    }
 }
 
 .spark-accent {
-  background-color: @spark-accent-track;
-  .fill {
-      background-color: @spark-accent-fill;
-  }
+    background-color: @spark-accent-track;
+
+    .fill {
+        background-color: @spark-accent-fill;
+    }
 }
 
 //Sankey
-
 .fill_style(@fill_color: #ffffff, @fill_opacity: 1, @stroke_color: #ccc, @stroke_opacity: 1, @stroke_width: 1) {
-  stroke-width: @stroke_width;
-  fill: @fill_color;
-  fill-opacity: @fill_opacity;
-  stroke: @stroke_color;
-  stroke-opacity: @stroke_opacity;
+    stroke-width: @stroke_width;
+    fill: @fill_color;
+    fill-opacity: @fill_opacity;
+    stroke: @stroke_color;
+    stroke-opacity: @stroke_opacity;
 }
 
 .font_style(@font_weight: @font-weight-regular, @font_size: @font-size, @fill_color: #ffffff) {
-  font-weight: @font_weight;
-  font-size: @font_size;
-  fill: @fill_color;
+    font-weight: @font_weight;
+    font-size: @font_size;
+    fill: @fill_color;
 }
 
 .gradient-stop(@stop_color, @stop_opacity) {
-  stop-color: @stop_color;
-  stop-opacity: @stop_opacity;
-
+    stop-color: @stop_color;
+    stop-opacity: @stop_opacity;
 }
 
 .sankey {
-  font-size: @font-size;
+    font-size: @font-size;
 
-  path.link {
-    pointer-events: fill;
-  }
-
-  .node {
-    .callout {
-      .font-light;
-      fill: @sankey-node-callout-fill;
+    path.link {
+        pointer-events: fill;
     }
 
-    .node-label, .callout {
-      &.default-hide {
-        fill: none;
-      }
+    .node {
+        .callout {
+            .font-light;
+
+            fill: @sankey-node-callout-fill;
+        }
+
+        .node-label,
+        .callout {
+            &.default-hide {
+                fill: none;
+            }
+        }
+
+        .callout-value {
+            font-size: @font-size-xl;
+        }
+
+        .callout-label {
+            font-size: @font-size-md;
+        }
+
+        .text {
+            pointer-events: none;
+
+            &.tspan {
+                pointer-events: none;
+            }
+        }
+
+        .callout-right,
+        .node-label-right {
+            text-anchor: end;
+        }
+
+        &.hover {
+            .node-label,
+            .callout-left,
+            .callout-right {
+                fill: @sankey-label-hover-color;
+            }
+        }
     }
-
-    .callout-value {
-      font-size: @font-size-xl;
-    }
-
-    .callout-label {
-      font-size: @font-size-md;
-    }
-
-    .text {
-      pointer-events: none;
-
-      &.tspan {
-        pointer-events: none;
-      }
-    }
-
-    .callout-right,
-    .node-label-right {
-      text-anchor: end;
-    }
-
-    &.hover {
-      .node-label,
-      .callout-left,
-      .callout-right {
-        fill: @sankey-label-hover-color;
-      }
-
-    }
-
-  }
 }
-
-
 
 .aspects-sankey-light {
-  .node {
-    font-size: @font-size;
-    .node-body {
-      .fill_style;
-      cursor: default;
-      shape-rendering: crispEdges;
-    }
+    .node {
+        font-size: @font-size;
 
-    .node-label {
-      .font_style(@font-weight-light, @font-size-lg, @sankey-label-color);
-    }
-
-    &.target-node, &.link-node {
-      &.hover {
         .node-body {
-          fill: @sankey-node-hover-bg;
-          stroke:none;
+            .fill_style;
+
+            cursor: default;
+            shape-rendering: crispEdges;
         }
-      }
-    }
 
-    &.target-node{
-      .callout-value, .callout-unit, .node-label {
-          fill: @sankey-target-node-color;
-        }
-        .callout-label{
-          fill: @sankey-target-node-callout-color;
-        }
-    }
-    &.link-node{
-      .callout-left {
-        .callout-unit {
-          fill: @sankey-link-node-unit-color;
-        }
-      }
-      .node-label {
-        fill: @sankey-link-node-unit-color;
-      }
-      .callout-left{
-        display: none;
-      }
-      .callout-right{
-        fill: @sankey-link-node-color;
-      }
-    }
-  }
-
-  .link {
-    .fill_style(@sankey-link-bg, 0.07, @sankey-link-bg, 0);
-    &.hover {
-      .fill_style(@sankey-link-hover-bg, 0.5, @sankey-link-hover-bg, 0);
-    }
-  }
-
-  .column{
-    &.hover, &:hover{
-      fill: @sankey-column-hover-bg;
-      .col-header {
-        fill: @sankey-column-hover-bg;
-      }
-      .col-body{
-        fill: @sankey-column-hover-bg;
-      }
-    }
-  }
-
-  .col-body {
-    fill: @sankey-column-bg;
-  }
-
-  .col-header {
-    fill: @sankey-column-bg;
-
-    .header-text {
-      .font-light;
-      font-size: @font-size;
-      .col-num {
-        .font-regular;
-        font-size: @sankey-number-font-size;
-        fill: @sankey-header-color;
-      }
-      .col-title {
-        .font-light;
-        font-size: @font-size-xl;
-        fill: @sankey-header-color;
-      }
-    }
-  }
-
-  .header-seperator {
-    stroke-dasharray: 4,2;
-    stroke: @sankey-divider;
-    stroke-width: 1px;
-  }
-
-  #overflowGradient {
-    .stop1 {
-      .gradient-stop(@sankey-overflow-bg, 0.75);
-    }
-    .stop2 {
-      .gradient-stop(@sankey-overflow-bg, 0);
-    }
-  }
-  svg {
-		display: block;
-	}
-
-}
-
-//Dark Backgroud Sankey chart
-
-.body-dark {
-
-  .fill_style(@dark-fill_color: #262626, @dark-fill_opacity: 1, @dark-stroke_color: #444444, @dark-stroke_opacity: 1, @dark-stroke_width: 1) {
-    stroke-width: @dark-stroke_width;
-    fill: @dark-fill_color;
-    fill-opacity: @dark-fill_opacity;
-    stroke: @dark-stroke_color;
-    stroke-opacity: @dark-stroke_opacity;
-  }
-
-  .font_style(@dark-font_weight: @dark-font_weight_normal, @dark-font_size: @font-size, @dark-fill_color: #262626) {
-    font-weight: @dark-font_weight;
-    font-size: @dark-font_size;
-    fill: @dark-fill_color;
-  }
-
-  .sankey {
-
-    .node {
-      &.hover {
-        .node-label,
-        .callout-left,
-        .callout-right {
-          fill: @sankey-node-hover-fill-dark;
-        }
-      }
-    }
-  }
-
-
-
-  .aspects-sankey-light {
-    .node {
-      .node-body {
-        .fill_style;
-        cursor: default;
-        shape-rendering: crispEdges;
-      }
-      &.target-node{
-        .callout-value, .callout-unit, .node-label {
-            fill:@sankey-target-node-fill;
-          }
-          .callout-label{
-            fill:@sankey-node-hover-fill-dark;
-          }
-      }
-      &.link-node{
-        .callout-left {
-          .callout-unit {
-            fill:@sankey-link-node-hover-fill-dark;
-          }
-        }
         .node-label {
-            fill:@sankey-link-node-hover-fill-dark;
+            .font_style(@font-weight-light, @font-size-lg, @sankey-label-color);
         }
-        .callout-right{
-          fill:@sankey-node-hover-fill-dark;
+
+        &.target-node,
+        &.link-node {
+            &.hover {
+                .node-body {
+                    fill: @sankey-node-hover-bg;
+                    stroke: none;
+                }
+            }
         }
-      }
+
+        &.target-node {
+            .callout-value,
+            .callout-unit,
+            .node-label {
+                fill: @sankey-target-node-color;
+            }
+
+            .callout-label {
+                fill: @sankey-target-node-callout-color;
+            }
+        }
+
+        &.link-node {
+            .callout-left {
+                .callout-unit {
+                    fill: @sankey-link-node-unit-color;
+                }
+            }
+
+            .node-label {
+                fill: @sankey-link-node-unit-color;
+            }
+
+            .callout-left {
+                display: none;
+            }
+
+            .callout-right {
+                fill: @sankey-link-node-color;
+            }
+        }
     }
 
     .link {
-      .fill_style(#cccccc, 0.07, #cccccc, 0);
-      &.hover {
-        .fill_style(@accent, 0.5, @accent, 0);
-      }
+        .fill_style(@sankey-link-bg, 0.07, @sankey-link-bg, 0);
+
+        &.hover {
+            .fill_style(@sankey-link-hover-bg, 0.5, @sankey-link-hover-bg, 0);
+        }
     }
 
-    .column{
-      &.hover, &:hover{
-        fill: @sankey-column-hover-fill;
-        .col-header {
-          fill: @sankey-column-hover-fill;
+    .column {
+        &.hover,
+        &:hover {
+            fill: @sankey-column-hover-bg;
+
+            .col-header {
+                fill: @sankey-column-hover-bg;
+            }
+
+            .col-body {
+                fill: @sankey-column-hover-bg;
+            }
         }
-        .col-body{
-          fill: @sankey-column-hover-fill;
-        }
-      }
     }
 
     .col-body {
-      fill: @sankey-column-fill-dark;
+        fill: @sankey-column-bg;
     }
 
     .col-header {
-      fill: @sankey-column-fill-dark;
+        fill: @sankey-column-bg;
 
-      .header-text {
-        .font-light;
-        .col-num {
-          .font-regular;
-          fill: @sankey-column-header-fill-dark;
+        .header-text {
+            .font-light;
+
+            font-size: @font-size;
+
+            .col-num {
+                .font-regular;
+
+                font-size: @sankey-number-font-size;
+                fill: @sankey-header-color;
+            }
+
+            .col-title {
+                .font-light;
+
+                font-size: @font-size-xl;
+                fill: @sankey-header-color;
+            }
         }
-        .col-title {
-          .font-light;
-          fill: @sankey-column-header-fill-dark;
-        }
-      }
     }
 
-  }
-}
+    .header-seperator {
+        stroke-dasharray: 4, 2;
+        stroke: @sankey-divider;
+        stroke-width: 1px;
+    }
 
+    #overflowGradient {
+        .stop1 {
+            .gradient-stop(@sankey-overflow-bg, 0.75);
+        }
+
+        .stop2 {
+            .gradient-stop(@sankey-overflow-bg, 0);
+        }
+    }
+
+    svg {
+        display: block;
+    }
+}
 
 //maximise button
 .partition-expand {
@@ -514,901 +441,945 @@
     background-color: @partition-map-maximize-btn-bg;
 
     &:focus {
-      &:hover {
+        &:hover {
+            background-color: @partition-map-maximize-btn-hover-bg;
+            border-color: @partition-map-maximize-btn-hover-border;
+            outline: none;
+            box-shadow: @partition-map-maximize-btn-shadow 1px 3px 8px;
+        }
+    }
+
+    &:active,
+    &:hover,
+    &:focus {
         background-color: @partition-map-maximize-btn-hover-bg;
         border-color: @partition-map-maximize-btn-hover-border;
         outline: none;
         box-shadow: @partition-map-maximize-btn-shadow 1px 3px 8px;
-      }
     }
 
-  &:active, &:hover, &:focus {
-    background-color: @partition-map-maximize-btn-hover-bg;
-    border-color: @partition-map-maximize-btn-hover-border;
-    outline: none;
-    box-shadow: @partition-map-maximize-btn-shadow 1px 3px 8px;
-  }
+    &:active,
+    &:focus {
+        border: @partition-map-maximize-btn-active-border solid 1px;
+    }
 
-  &:active, &:focus {
-    border: @partition-map-maximize-btn-active-border solid 1px;
-  }
-
-  &.maximized {
-    right: 25px;
-  }
+    &.maximized {
+        right: 25px;
+    }
 }
 
 .partition-map-box {
-	width: 100%;
-	height: 600px;
+    width: 100%;
+    height: 600px;
 }
 
 @media screen and (max-width: 650px) {
-  .partition-map-container {
-    .edit-container {
-      .segment-list {
-        .segment {
-          .drag-box,
-          .close-box {
-            width: 40px;
-          }
-          .group-label {
-            margin-left: 40px;
-            margin-right: 40px;
-          }
+    .partition-map-container {
+        .edit-container {
+            .segment-list {
+                .segment {
+                    .drag-box,
+                    .close-box {
+                        width: 40px;
+                    }
+
+                    .group-label {
+                        margin-left: 40px;
+                        margin-right: 40px;
+                    }
+                }
+
+                .selection-segment {
+                    border-left-width: 40px;
+                    border-right-width: 40px;
+                }
+            }
         }
-        .selection-segment {
-          border-left-width: 40px;
-          border-right-width: 40px;
-        }
-      }
     }
-  }
 }
 
 .partition-map-container {
-  position: relative;
-  width: 100%;
-  height: 100%;
-  background-color: @partition-map-bg;
-
-  .edit-container {
-    position: absolute;
-    width: 100%;
-    height: 100%;
-    background-color: @partition-map-edit-bg;
-    z-index: 10;
-
-    &.fade-in {
-      opacity:0;
-      -webkit-animation:fadeIn ease-in 1;
-      -moz-animation:fadeIn ease-in 1;
-      animation:fadeIn ease-in 1;
-
-      -webkit-animation-fill-mode:forwards;
-      -moz-animation-fill-mode:forwards;
-      animation-fill-mode:forwards;
-
-      -webkit-animation-duration:0.3s;
-      -moz-animation-duration:0.3s;
-      animation-duration:0.3s;
-    }
-
-    .root-segment {
-      position: relative;
-      width: 100%;
-      height: 150px;
-      padding: 47px 0;
-
-      .done-btn {
-        width: 40px;
-        height: 40px;
-        background-color: @partition-map-edit-done-btn-bg;
-        border-radius: 50%;
-        margin: 0 auto;
-        padding: 15px 0;
-        cursor: pointer;
-
-        &:hover {
-          background-color: @partition-map-edit-done-btn-hover-bg;
-        }
-
-        .icon {
-          background-image: url('../img/check.png');
-          background-repeat: no-repeat;
-          background-size: contain;
-          width: 16px;
-          height: 16px;
-          margin: 0 auto;
-        }
-      }
-
-      .done-text {
-        text-align: center;
-        color: @partition-map-edit-done-btn-color;
-      }
-    }
-
-    .segment-list {
-      position: relative;
-      padding-left: 0;
-      list-style-type: none;
-      margin: 0;
-      height: ~'calc(100% - 150px)';
-
-      .segment {
-        position: absolute;
-        width: 100%;
-        height: 150px;
-
-        -webkit-transition: box-shadow 0.1s ease-in-out, background-color 0.3s linear;
-        -moz-transition: box-shadow 0.1s ease-in-out, background-color 0.3s linear;
-        -o-transition: box-shadow 0.1s ease-in-out, background-color 0.3s linear;
-         transition: box-shadow 0.1s ease-in-out, background-color 0.3s linear;
-        box-shadow: 0 0 0 @partition-map-edit-segment-shadow;
-
-        .dropdown-menu {
-          -webkit-transition: opacity 0.1s ease-in-out;
-          -moz-transition: opacity 0.1s ease-in-out;
-          -o-transition: opacity 0.1s ease-in-out;
-           transition: opacity 0.1s ease-in-out;
-          opacity: 0;
-
-          &.show-groups {
-            opacity: 1;
-          }
-        }
-
-        .group-label {
-          position: relative;
-          color: @partition-map-edit-color;
-          text-align: center;
-          top: 50%;
-          transform: translateY(-50%);
-          margin: 0 100px;
-          font-size: 1.25rem;
-
-          .icon {
-            font-size: 0.9375rem;
-            margin-left: 5px;
-            cursor: pointer;
-            opacity: 0.8;
-
-            &:hover {
-              opacity: 1;
-            }
-          }
-        }
-
-        &.dragging {
-          box-shadow: 0 1px 25px @partition-map-dragging-shadow;
-          z-index: 1;
-
-          .drag-box {
-            cursor: ns-resize;
-            .up-icon, .down-icon {
-              cursor: ns-resize;
-            }
-          }
-        }
-
-        .drag-box {
-          position: relative;
-          float: left;
-          height: 100%;
-          width: 100px;
-          background-color: rgba(0, 0, 0, 0.2);
-          overflow: hidden;
-
-          .up-icon {
-            position: absolute;
-            cursor: pointer;
-            background-image: url('../img/uparrow.png');
-            left: ~'calc(50% - 6px)';
-            top: ~'calc(50% - 26px)';
-            width: 10px;
-            height: 8px;
-            background-repeat: no-repeat;
-            background-size: contain;
-            margin: 0 auto;
-            opacity: 0.8;
-
-            &:hover {
-              opacity: 1;
-            }
-          }
-
-          .down-icon {
-            position: absolute;
-            cursor: pointer;
-            background-image: url('../img/downarrow.png');
-            left: ~'calc(50% - 6px)';
-            bottom: ~'calc(50% - 28px)';;
-            width: 10px;
-            height: 8px;
-            background-repeat: no-repeat;
-            background-size: contain;
-            margin: 0 auto;
-            opacity: 0.8;
-
-            &:hover {
-              opacity: 1;
-            }
-          }
-
-          .icon {
-            position: relative;
-            background-image: url('../img/draghandle.png');
-            width: 14px;
-            height: 18px;
-            background-repeat: no-repeat;
-            background-size: contain;
-            margin: 0 auto;
-            top: 50%;
-            transform: translateY(-50%);
-            cursor: ns-resize;
-            opacity: 0.8;
-
-            &:hover {
-              opacity: 1;
-            }
-          }
-        }
-
-        .close-box {
-          float: right;
-          height: 100%;
-          width: 100px;
-          background-color: rgba(0, 0, 0, 0.2);
-
-          .icon {
-            position: relative;
-            background-image: url('../img/close-white.png');
-            width: 14px;
-            height: 14px;
-            background-repeat: no-repeat;
-            background-size: contain;
-            margin: 0 auto;
-            top: 50%;
-            transform: translateY(-50%);
-            cursor: pointer;
-          }
-        }
-      }
-
-      .selection-segment {
-        position: absolute;
-        width: 100%;
-        height: 150px;
-        background-color: @partition-map-selection-segment-bg;
-        border-left: 100px solid rgba(0, 0, 0, 0.1);
-        border-right: 100px solid rgba(0, 0, 0, 0.1);
-
-        .selection-label {
-          position: relative;
-          color: @grey2;
-          text-align: center;
-          top: 50%;
-          transform: translateY(-50%);
-          margin: 0;
-          font-size: 1.25rem;
-
-          .icon {
-            font-size: 0.9375rem;
-            margin-left: 5px;
-            cursor: pointer;
-            opacity: 0.8;
-
-            &:hover {
-              opacity: 1;
-            }
-          }
-        }
-      }
-
-    }
-  }
-
-
-  .partition-map {
     position: relative;
     width: 100%;
     height: 100%;
+    background-color: @partition-map-bg;
 
-    @-webkit-keyframes fadeIn { from { opacity:0; } to { opacity:1; } }
-    @-moz-keyframes fadeIn { from { opacity:0; } to { opacity:1; } }
-    @keyframes fadeIn { from { opacity:0; } to { opacity:1; } }
+    .edit-container {
+        position: absolute;
+        width: 100%;
+        height: 100%;
+        background-color: @partition-map-edit-bg;
+        z-index: 10;
 
-    &.maximized {
-      overflow: hidden;
-      width: ~'calc(100% - 235px)';
-      display: inline-block;
-      float: left;
+        &.fade-in {
+            opacity: 0;
+            -webkit-animation: fadeIn ease-in 1;
+            -moz-animation: fadeIn ease-in 1;
+            animation: fadeIn ease-in 1;
+            -webkit-animation-fill-mode: forwards;
+            -moz-animation-fill-mode: forwards;
+            animation-fill-mode: forwards;
+            -webkit-animation-duration: 0.3s;
+            -moz-animation-duration: 0.3s;
+            animation-duration: 0.3s;
+        }
+
+        .root-segment {
+            position: relative;
+            width: 100%;
+            height: 150px;
+            padding: 47px 0;
+
+            .done-btn {
+                width: 40px;
+                height: 40px;
+                background-color: @partition-map-edit-done-btn-bg;
+                border-radius: 50%;
+                margin: 0 auto;
+                padding: 15px 0;
+                cursor: pointer;
+
+                &:hover {
+                    background-color: @partition-map-edit-done-btn-hover-bg;
+                }
+
+                .icon {
+                    background-image: url('../img/check.png');
+                    background-repeat: no-repeat;
+                    background-size: contain;
+                    width: 16px;
+                    height: 16px;
+                    margin: 0 auto;
+                }
+            }
+
+            .done-text {
+                text-align: center;
+                color: @partition-map-edit-done-btn-color;
+            }
+        }
+
+        .segment-list {
+            position: relative;
+            padding-left: 0;
+            list-style-type: none;
+            margin: 0;
+            height: ~'calc(100% - 150px)';
+
+            .segment {
+                position: absolute;
+                width: 100%;
+                height: 150px;
+                transition: box-shadow 0.1s ease-in-out, background-color 0.3s linear;
+                box-shadow: 0 0 0 @partition-map-edit-segment-shadow;
+
+                .dropdown-menu {
+                    transition: opacity 0.1s ease-in-out;
+                    opacity: 0;
+
+                    &.show-groups {
+                        opacity: 1;
+                    }
+                }
+
+                .group-label {
+                    position: relative;
+                    color: @partition-map-edit-color;
+                    text-align: center;
+                    top: 50%;
+                    transform: translateY(-50%);
+                    margin: 0 100px;
+                    font-size: 1.25rem;
+
+                    .icon {
+                        font-size: 0.9375rem;
+                        margin-left: 5px;
+                        cursor: pointer;
+                        opacity: 0.8;
+
+                        &:hover {
+                            opacity: 1;
+                        }
+                    }
+                }
+
+                &.dragging {
+                    box-shadow: 0 1px 25px @partition-map-dragging-shadow;
+                    z-index: 1;
+
+                    .drag-box {
+                        cursor: ns-resize;
+
+                        .up-icon,
+                        .down-icon {
+                            cursor: ns-resize;
+                        }
+                    }
+                }
+
+                .drag-box {
+                    position: relative;
+                    float: left;
+                    height: 100%;
+                    width: 100px;
+                    background-color: rgba(0, 0, 0, 0.2);
+                    overflow: hidden;
+
+                    .up-icon {
+                        position: absolute;
+                        cursor: pointer;
+                        background-image: url('../img/uparrow.png');
+                        left: ~'calc(50% - 6px)';
+                        top: ~'calc(50% - 26px)';
+                        width: 10px;
+                        height: 8px;
+                        background-repeat: no-repeat;
+                        background-size: contain;
+                        margin: 0 auto;
+                        opacity: 0.8;
+
+                        &:hover {
+                            opacity: 1;
+                        }
+                    }
+
+                    .down-icon {
+                        position: absolute;
+                        cursor: pointer;
+                        background-image: url('../img/downarrow.png');
+                        left: ~'calc(50% - 6px)';
+                        bottom: ~'calc(50% - 28px)';
+                        width: 10px;
+                        height: 8px;
+                        background-repeat: no-repeat;
+                        background-size: contain;
+                        margin: 0 auto;
+                        opacity: 0.8;
+
+                        &:hover {
+                            opacity: 1;
+                        }
+                    }
+
+                    .icon {
+                        position: relative;
+                        background-image: url('../img/draghandle.png');
+                        width: 14px;
+                        height: 18px;
+                        background-repeat: no-repeat;
+                        background-size: contain;
+                        margin: 0 auto;
+                        top: 50%;
+                        transform: translateY(-50%);
+                        cursor: ns-resize;
+                        opacity: 0.8;
+
+                        &:hover {
+                            opacity: 1;
+                        }
+                    }
+                }
+
+                .close-box {
+                    float: right;
+                    height: 100%;
+                    width: 100px;
+                    background-color: rgba(0, 0, 0, 0.2);
+
+                    .icon {
+                        position: relative;
+                        background-image: url('../img/close-white.png');
+                        width: 14px;
+                        height: 14px;
+                        background-repeat: no-repeat;
+                        background-size: contain;
+                        margin: 0 auto;
+                        top: 50%;
+                        transform: translateY(-50%);
+                        cursor: pointer;
+                    }
+                }
+            }
+
+            .selection-segment {
+                position: absolute;
+                width: 100%;
+                height: 150px;
+                background-color: @partition-map-selection-segment-bg;
+                border-left: 100px solid rgba(0, 0, 0, 0.1);
+                border-right: 100px solid rgba(0, 0, 0, 0.1);
+
+                .selection-label {
+                    position: relative;
+                    color: @grey2;
+                    text-align: center;
+                    top: 50%;
+                    transform: translateY(-50%);
+                    margin: 0;
+                    font-size: 1.25rem;
+
+                    .icon {
+                        font-size: 0.9375rem;
+                        margin-left: 5px;
+                        cursor: pointer;
+                        opacity: 0.8;
+
+                        &:hover {
+                            opacity: 1;
+                        }
+                    }
+                }
+            }
+        }
     }
 
-    .no-data {
-      position: relative;
-      top: 50%;
-      transform: translateY(-50%);
-      font-weight: bold;
-      text-align: center;
-    }
-
-    .loading {
-      position: absolute;
-      top: 0;
-      left: 0;
-      right: 0;
-      bottom: 0;
-      background: @partition-map-loading-bg;
-
-
-      &.fade-in {
-      	opacity:0;
-      	-webkit-animation:fadeIn ease-in 1;
-      	-moz-animation:fadeIn ease-in 1;
-      	animation:fadeIn ease-in 1;
-
-      	-webkit-animation-fill-mode:forwards;
-      	-moz-animation-fill-mode:forwards;
-      	animation-fill-mode:forwards;
-
-      	-webkit-animation-duration:0.3s;
-      	-moz-animation-duration:0.3s;
-      	animation-duration:0.3s;
-      }
-
-      .contents {
+    .partition-map {
         position: relative;
         width: 100%;
         height: 100%;
-        text-align: center;
 
-        .vertically-centered {
-          position: relative;
-          top: 50%;
-          transform: translateY(-50%);
+        @-webkit-keyframes fadeIn {
+            from {
+                opacity: 0;
+            }
 
-          .loading-text {
-            font-weight: bold;
-          }
+            to {
+                opacity: 1;
+            }
         }
-      }
+
+        @-moz-keyframes fadeIn {
+            from {
+                opacity: 0;
+            }
+
+            to {
+                opacity: 1;
+            }
+        }
+
+        @keyframes fadeIn {
+            from {
+                opacity: 0;
+            }
+
+            to {
+                opacity: 1;
+            }
+        }
+
+        &.maximized {
+            overflow: hidden;
+            width: ~'calc(100% - 235px)';
+            display: inline-block;
+            float: left;
+        }
+
+        .no-data {
+            position: relative;
+            top: 50%;
+            transform: translateY(-50%);
+            font-weight: bold;
+            text-align: center;
+        }
+
+        .loading {
+            position: absolute;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            background: @partition-map-loading-bg;
+
+            &.fade-in {
+                opacity: 0;
+                -webkit-animation: fadeIn ease-in 1;
+                -moz-animation: fadeIn ease-in 1;
+                animation: fadeIn ease-in 1;
+                -webkit-animation-fill-mode: forwards;
+                -moz-animation-fill-mode: forwards;
+                animation-fill-mode: forwards;
+                -webkit-animation-duration: 0.3s;
+                -moz-animation-duration: 0.3s;
+                animation-duration: 0.3s;
+            }
+
+            .contents {
+                position: relative;
+                width: 100%;
+                height: 100%;
+                text-align: center;
+
+                .vertically-centered {
+                    position: relative;
+                    top: 50%;
+                    transform: translateY(-50%);
+
+                    .loading-text {
+                        font-weight: bold;
+                    }
+                }
+            }
+        }
+
+        .close-option {
+            position: absolute;
+            right: 0;
+            margin: 15px 22px;
+            cursor: pointer;
+
+            .text {
+                font-family: @font-family;
+                font-weight: @font-weight-light;
+                color: @white;
+                text-transform: uppercase;
+                padding-right: 8px;
+                opacity: 0.7;
+                font-size: 0.875rem;
+                vertical-align: top;
+                -webkit-user-select: none;
+                -moz-user-select: none;
+                -ms-user-select: none;
+                user-select: none;
+            }
+
+            .icon {
+                background-image: url("../img/close-white.png");
+                width: 12px;
+                height: 12px;
+                display: inline-block;
+                background-size: contain;
+                background-repeat: no-repeat;
+            }
+        }
+
+        text {
+            pointer-events: none;
+            -webkit-user-select: none;
+            -moz-user-select: none;
+            -ms-user-select: none;
+            user-select: none;
+        }
+
+        image {
+            pointer-events: none;
+        }
     }
-
-    .close-option {
-      position: absolute;
-      right: 0;
-      margin: 15px 22px;
-      cursor: pointer;
-
-      .text {
-        font-family: @font-family;
-        font-weight: @font-weight-light;
-        color: @white;
-        text-transform: uppercase;
-        padding-right: 8px;
-        opacity: 0.7;
-        font-size: 0.875rem;
-        vertical-align: top;
-        -webkit-user-select: none;
-        -moz-user-select: none;
-        -ms-user-select: none;
-        user-select: none;
-      }
-
-      .icon {
-        background-image: url("../img/close-white.png");
-        width: 12px;
-        height: 12px;
-        display: inline-block;
-        background-size: contain;
-        background-repeat: no-repeat;
-      }
-    }
-
-    text {
-      pointer-events: none;
-      -webkit-user-select: none;
-      -moz-user-select: none;
-      -ms-user-select: none;
-      user-select: none;
-    }
-
-    image {
-      pointer-events: none;
-    }
-
-  }
 }
 
 .partition-popover {
-  font-family: @font-family;
-  max-width: none;
-  border: 1px solid @partition-map-popover-border;
-  background-color: @partition-map-popover-bg;
-  border-radius: 0;
-  box-shadow: -3px 4px 14px @partition-map-popover-shadow;
-  z-index: @popover-z-index;
+    font-family: @font-family;
+    max-width: none;
+    border: 1px solid @partition-map-popover-border;
+    background-color: @partition-map-popover-bg;
+    border-radius: 0;
+    box-shadow: -3px 4px 14px @partition-map-popover-shadow;
+    z-index: @popover-z-index;
 
     &.bottom {
-      .arrow {
-        &:after {
-          border-bottom-color: @partition-map-popover-bg !important;
+        .arrow {
+            &:after {
+                border-bottom-color: @partition-map-popover-bg !important;
+            }
         }
-      }
     }
 
     &.top {
-      .arrow {
-        &:after {
-          border-top-color: @partition-map-popover-bg !important;
+        .arrow {
+            &:after {
+                border-top-color: @partition-map-popover-bg !important;
+            }
         }
-      }
     }
 
-  .popover-content {
-    padding: 0;
-  }
-
-  .popover-container {
-    width: 520px;
-    height: 240px;
-    max-width: 520px;
-    max-height: 240px;
-    overflow: hidden;
-
-    .user-content {
-      position: relative;
-      display: inline-block;
-      float: left;
-      width: 285px;
-      height: 240px;
-      border-right: 1px solid @partition-map-popover-border;
-      padding-top: 9px;
-      padding-bottom: 9px;
-      padding-left: 14px;
-
-      &.full-width {
-        width: 100%;
-        border-right: none;
-      }
+    .popover-content {
+        padding: 0;
     }
 
-    .data-content {
-      display: inline-block;
-      float: left;
-      width: 234px;
-      height: 240px;
-      padding-top: 3px;
-      padding-bottom: 3px;
+    .popover-container {
+        width: 520px;
+        height: 240px;
+        max-width: 520px;
+        max-height: 240px;
+        overflow: hidden;
 
-      .scroll-pane {
-        height: 100%;
-        margin-right: 1px;
+        .user-content {
+            position: relative;
+            display: inline-block;
+            float: left;
+            width: 285px;
+            height: 240px;
+            border-right: 1px solid @partition-map-popover-border;
+            padding-top: 9px;
+            padding-bottom: 9px;
+            padding-left: 14px;
 
-        .jspDrag {
-          background: #989898;
+            &.full-width {
+                width: 100%;
+                border-right: none;
+            }
         }
 
-      }
-
-      .child-list {
-        padding-left: 10px;
-        list-style: none;
-
-        .child-item {
-          cursor: pointer;
-          font-size: 1rem;
-          color: @white;
-          padding: 2px 10px;
-          border-bottom: 1px solid @partition-map-popover-border;
-
-          &:hover {
-            background-color: @partition-map-popover-hover-bg;
-          }
-
-          .color-block {
+        .data-content {
             display: inline-block;
-            width: 26px;
-            height: 12px;
-            margin-right: 8px;
-          }
+            float: left;
+            width: 234px;
+            height: 240px;
+            padding-top: 3px;
+            padding-bottom: 3px;
 
-          .item-key {
-            width: 102px;
-            display: inline-block;
-            white-space: nowrap;
-            overflow: hidden;
-            text-overflow: ellipsis;
-            margin-bottom: 0;
-            vertical-align: bottom;
-          }
+            .scroll-pane {
+                height: 100%;
+                margin-right: 1px;
 
-          .item-value {
-            width: 45px;
-            display: inline-block;
-            white-space: nowrap;
-            overflow: hidden;
-            text-overflow: ellipsis;
-            margin-bottom: 0;
-            text-align: right;
-          }
+                .jspDrag {
+                    background: #989898;
+                }
+            }
+
+            .child-list {
+                padding-left: 10px;
+                list-style: none;
+
+                .child-item {
+                    cursor: pointer;
+                    font-size: 1rem;
+                    color: @white;
+                    padding: 2px 10px;
+                    border-bottom: 1px solid @partition-map-popover-border;
+
+                    &:hover {
+                        background-color: @partition-map-popover-hover-bg;
+                    }
+
+                    .color-block {
+                        display: inline-block;
+                        width: 26px;
+                        height: 12px;
+                        margin-right: 8px;
+                    }
+
+                    .item-key {
+                        width: 102px;
+                        display: inline-block;
+                        white-space: nowrap;
+                        overflow: hidden;
+                        text-overflow: ellipsis;
+                        margin-bottom: 0;
+                        vertical-align: bottom;
+                    }
+
+                    .item-value {
+                        width: 45px;
+                        display: inline-block;
+                        white-space: nowrap;
+                        overflow: hidden;
+                        text-overflow: ellipsis;
+                        margin-bottom: 0;
+                        text-align: right;
+                    }
+                }
+            }
         }
-      }
     }
-  }
 }
 
 .partition-docked-popover {
-
-  display: inline-block;
-  width: 235px;
-  height: 100%;
-  background-color: @partition-map-docked-popover-bg;
-
-  -webkit-box-shadow: inset -12px 15px 30px -5px @partition-map-docked-popover-shadow;
-  -moz-box-shadow: inset -12px 15px 30px -5px @partition-map-docked-popover-shadow;
-  box-shadow: inset -12px 15px 30px -5px @partition-map-docked-popover-shadow;
-
-  .callout {
-    position: absolute;
-    top: 115px;
-    width: 0;
-    height: 0;
-    border-style: solid;
-    border-width: 10px 0 10px 12px;
-    z-index: @chart-callout-z-index;
-    border-color: transparent transparent transparent transparent;
-    margin-left: -1px;
-  }
-
-  .user-content {
-    max-height: 250px;
-    overflow: hidden;
-  }
-
-  .data-content {
     display: inline-block;
-    float: left;
-    width: 100%;
-    height: 240px;
-    padding-top: 15px;
-    padding-bottom: 9px;
-    padding-right: 10px;
+    width: 235px;
+    height: 100%;
+    background-color: @partition-map-docked-popover-bg;
+    -webkit-box-shadow: inset -12px 15px 30px -5px @partition-map-docked-popover-shadow;
+    -moz-box-shadow: inset -12px 15px 30px -5px @partition-map-docked-popover-shadow;
+    box-shadow: inset -12px 15px 30px -5px @partition-map-docked-popover-shadow;
 
-    .scroll-pane {
-      height: 100%;
+    .callout {
+        position: absolute;
+        top: 115px;
+        width: 0;
+        height: 0;
+        border-style: solid;
+        border-width: 10px 0 10px 12px;
+        z-index: @chart-callout-z-index;
+        border-color: transparent;
+        margin-left: -1px;
     }
 
-    .child-list {
-      padding-left: 10px;
-      list-style: none;
-
-      .child-item {
-        cursor: pointer;
-        font-size: 1rem;
-        color: @white;
-        padding: 2px 10px;
-        border-bottom: 1px solid @partition-map-docked-popover-border;
-
-        &:hover {
-          background-color: @partition-map-docked-popover-hover-bg;
-        }
-
-        .color-block {
-          display: inline-block;
-          width: 26px;
-          height: 12px;
-          margin-right: 8px;
-        }
-
-        .item-key {
-          width: ~'calc(100% - 85px)';
-          display: inline-block;
-          white-space: nowrap;
-          overflow: hidden;
-          text-overflow: ellipsis;
-          margin-bottom: 0;
-          vertical-align: bottom;
-        }
-
-        .item-value {
-          width: 45px;
-          display: inline-block;
-          white-space: nowrap;
-          overflow: hidden;
-          text-overflow: ellipsis;
-          margin-bottom: 0;
-          text-align: right;
-        }
-      }
+    .user-content {
+        max-height: 250px;
+        overflow: hidden;
     }
-  }
 
+    .data-content {
+        display: inline-block;
+        float: left;
+        width: 100%;
+        height: 240px;
+        padding-top: 15px;
+        padding-bottom: 9px;
+        padding-right: 10px;
+
+        .scroll-pane {
+            height: 100%;
+        }
+
+        .child-list {
+            padding-left: 10px;
+            list-style: none;
+
+            .child-item {
+                cursor: pointer;
+                font-size: 1rem;
+                color: @white;
+                padding: 2px 10px;
+                border-bottom: 1px solid @partition-map-docked-popover-border;
+
+                &:hover {
+                    background-color: @partition-map-docked-popover-hover-bg;
+                }
+
+                .color-block {
+                    display: inline-block;
+                    width: 26px;
+                    height: 12px;
+                    margin-right: 8px;
+                }
+
+                .item-key {
+                    width: ~'calc(100% - 85px)';
+                    display: inline-block;
+                    white-space: nowrap;
+                    overflow: hidden;
+                    text-overflow: ellipsis;
+                    margin-bottom: 0;
+                    vertical-align: bottom;
+                }
+
+                .item-value {
+                    width: 45px;
+                    display: inline-block;
+                    white-space: nowrap;
+                    overflow: hidden;
+                    text-overflow: ellipsis;
+                    margin-bottom: 0;
+                    text-align: right;
+                }
+            }
+        }
+    }
 }
 
 .partition-fullscreen-icon {
-  background-image: url("../img/fullscreen.png");
-  width: 18px;
-  height: 18px;
-  display: inline-block;
-  background-size: contain;
-  background-repeat: no-repeat;
-  vertical-align: sub;
+    background-image: url("../img/fullscreen.png");
+    width: 18px;
+    height: 18px;
+    display: inline-block;
+    background-size: contain;
+    background-repeat: no-repeat;
+    vertical-align: sub;
 }
 
 .partition-close-icon {
-  background-image: url("../img/fullscreen-exit.png");
-  width: 18px;
-  height: 18px;
-  display: inline-block;
-  background-size: contain;
-  background-repeat: no-repeat;
-  vertical-align: sub;
+    background-image: url("../img/fullscreen-exit.png");
+    width: 18px;
+    height: 18px;
+    display: inline-block;
+    background-size: contain;
+    background-repeat: no-repeat;
+    vertical-align: sub;
 }
 
 /* Social Chart */
-.sigma-wrapper{
-  position: relative;
-}
-.sigma-chart-detail{
-  position: absolute;
-  top:0;
-  right: 0;
-  height: 100%;
-  transition: linear right 60ms;
-  &.node{
-    width: 250px;
-    height: 100%;
-    .panel{
-      box-shadow: -10px 0 20px -5px @social-chart-shadow;
-    }
-  }
-  &.edge{
-    width: 500px;
-    height: 25%;
-    .panel{
-      box-shadow: -10px 10px 10px -5px @social-chart-shadow;
-    }
-  }
-  .panel{
-    position: absolute;
-    width: 100%;
-    height: 100%;
-    .node-detail-container {
-      height: 100%;
-    }
-  }
 
-  .fullscreen-shadow{
-    box-shadow:inset -12px 15px 30px -5px @social-chart-shadow; 
-  }
+.sigma-wrapper {
+    position: relative;
 }
-@media (max-width: 600px) {
-  .sigma-chart-detail {
+
+.sigma-chart-detail {
+    position: absolute;
+    top: 0;
+    right: 0;
+    height: 100%;
+    transition: linear right 60ms;
+
+    &.node {
+        width: 250px;
+        height: 100%;
+
+        .panel {
+            box-shadow: -10px 0 20px -5px @social-chart-shadow;
+        }
+    }
+
     &.edge {
-      width: 100% !important;
-      min-width: 100% !important;
-      left: 0;
-      .panel {
-        box-shadow: 0 10px 10px -5px @social-chart-shadow;
-        .edge-detail {
-          width: 524px;
+        width: 500px;
+        height: 25%;
+
+        .panel {
+            box-shadow: -10px 10px 10px -5px @social-chart-shadow;
         }
-      }
     }
-    .jspCorner {
-      background: transparent;
+
+    .panel {
+        position: absolute;
+        width: 100%;
+        height: 100%;
+
+        .node-detail-container {
+            height: 100%;
+        }
     }
-  }
+
+    .fullscreen-shadow {
+        box-shadow: inset -12px 15px 30px -5px @social-chart-shadow;
+    }
 }
+
+@media (max-width: 600px) {
+    .sigma-chart-detail {
+        &.edge {
+            width: 100% !important;
+            min-width: 100% !important;
+            left: 0;
+
+            .panel {
+                box-shadow: 0 10px 10px -5px @social-chart-shadow;
+
+                .edge-detail {
+                    width: 524px;
+                }
+            }
+        }
+
+        .jspCorner {
+            background: transparent;
+        }
+    }
+}
+
 .sigma-chart-title {
-  position:absolute;
-  top: 15px;
-  left: 100px;
-  font-size: 1.5rem;
-  color: @social-chart-title-color;
-  text-shadow: 0px 0px 10px @social-chart-sigma-title-shadow;
-  font-family: @font-family;
-  font-weight: @font-weight-light;
-  opacity: 0;
-  transition: opacity 0.5s linear; 
-}
-.sigma-chart-title-visible {
-  opacity: 1;
-}
-
-.sigma-chart-actions{
-  position: absolute;
-  top:0;
-  left:0;
-  height: 100px;
-  ul{
-    list-style: none;
-    padding-top: 10px;
-    li{
-      .hide-select;
-      i{
-        .hide-select;
-        padding: 15px;
-        color: @white;
-        cursor: pointer;
-        text-shadow:0px 0px 10px @social-chart-sigma-title-shadow;
-        &:hover{
-          background-color: rgba(255, 255, 255, 0.1)
-        }
-      }
-    }
-  }
-}
-
-.hide-select{
-  &::selection {
-    background: transparent;
-  }
-  &::-moz-selection {
-    background: transparent;
-  }
-}
-
-.sigma-chart-popover{
-  position: absolute;
-  top:0;
-  left: 0;
-  background-color: @social-chart-popover-bg;
-  box-shadow: -10px 10px 10px -5px @social-chart-shadow;
-  height: 22%;
-  width: 390px;
-  z-index: @popover-z-index;
-
-  .callout{
     position: absolute;
-    width: 0px;
-    height: 0px;
-    content: "";
-    border:0.8em solid transparent;
-  }
+    top: 15px;
+    left: 100px;
+    font-size: 1.5rem;
+    color: @social-chart-title-color;
+    text-shadow: 0 0 10px @social-chart-sigma-title-shadow;
+    font-family: @font-family;
+    font-weight: @font-weight-light;
+    opacity: 0;
+    transition: opacity 0.5s linear;
+}
 
-  &.bottom {
-    .arrow {
-      &::before{
-        .callout;
-        left:45%;
-        top: -17%;
-        border-bottom: 20px solid @social-chart-popover-border;
-      }
-    }
-  }
-  &.top {
-    .arrow {
-      &::before{
-        .callout;
-        left:45%;
-        top: 100%;
-        border-top: 20px solid @social-chart-popover-border;
-      }
-    }
-  }
-  &.left {
-    .arrow {
-      &::before{
-        .callout;
-        left:100%;
-        top: 45%;
-        border-left: 20px solid @social-chart-popover-border;
-      }
-    }
-  }
-  &.right {
-    .arrow {
-      &::before{
-        .callout;
-        left:-32px;
-        top: 45%;
-        border-right: 20px solid @social-chart-popover-border;
-      }
-    }
-  }
+.sigma-chart-title-visible {
+    opacity: 1;
+}
 
+.sigma-chart-actions {
+    position: absolute;
+    top: 0;
+    left: 0;
+    height: 100px;
+
+    ul {
+        list-style: none;
+        padding-top: 10px;
+
+        li {
+            .hide-select;
+
+            i {
+                .hide-select;
+
+                padding: 15px;
+                color: @white;
+                cursor: pointer;
+                text-shadow: 0 0 10px @social-chart-sigma-title-shadow;
+
+                &:hover {
+                    background-color: rgba(255, 255, 255, 0.1);
+                }
+            }
+        }
+    }
+}
+
+.hide-select {
+    &::selection {
+        background: transparent;
+    }
+
+    &::-moz-selection {
+        background: transparent;
+    }
+}
+
+.sigma-chart-popover {
+    position: absolute;
+    top: 0;
+    left: 0;
+    background-color: @social-chart-popover-bg;
+    box-shadow: -10px 10px 10px -5px @social-chart-shadow;
+    height: 22%;
+    width: 390px;
+    z-index: @popover-z-index;
+
+    .callout {
+        position: absolute;
+        width: 0;
+        height: 0;
+        content: "";
+        border: 0.8em solid transparent;
+    }
+
+    &.bottom {
+        .arrow {
+            &:before {
+                .callout;
+
+                left: 45%;
+                top: -17%;
+                border-bottom: 20px solid @social-chart-popover-border;
+            }
+        }
+    }
+
+    &.top {
+        .arrow {
+            &:before {
+                .callout;
+
+                left: 45%;
+                top: 100%;
+                border-top: 20px solid @social-chart-popover-border;
+            }
+        }
+    }
+
+    &.left {
+        .arrow {
+            &:before {
+                .callout;
+
+                left: 100%;
+                top: 45%;
+                border-left: 20px solid @social-chart-popover-border;
+            }
+        }
+    }
+
+    &.right {
+        .arrow {
+            &:before {
+                .callout;
+
+                left: -32px;
+                top: 45%;
+                border-right: 20px solid @social-chart-popover-border;
+            }
+        }
+    }
 }
 
 /*Social Chart maximise button*/
+
 .sigma-chart-maximise-control {
+    position: absolute;
+    top: 0;
+    right: 0;
+    z-index: 1004;
 
-  position: absolute;
-  top: 0;
-  right: 0;
-  z-index: 1004;
+    .social-expand {
+        z-index: @chart-maximise-button-z-index;
+        background-color: @social-chart-maximize-btn-bg;
+        border: @social-chart-maximize-btn-border solid 1px;
+        box-shadow: social-chart-maximize-btn-shadow 1px 3px 8px;
+        outline: none;
+        border-radius: 100%;
 
-  .social-expand {
-    z-index: @chart-maximise-button-z-index;
-    background-color: @social-chart-maximize-btn-bg;
-    border: @social-chart-maximize-btn-border solid 1px;
-    box-shadow: social-chart-maximize-btn-shadow 1px 3px 8px;
-    outline: none;
-    border-radius: 100%;
+        &:active,
+        &:hover,
+        &:focus {
+            background-color: @social-chart-maximize-btn-hover-bg;
+            border-color: @social-chart-maximize-btn-hover-border;
+            outline: none;
+        }
 
-    &:active, &:hover, &:focus {
-      background-color: @social-chart-maximize-btn-hover-bg;
-      border-color: @social-chart-maximize-btn-hover-border;
-      outline: none;
+        &:active,
+        &:focus {
+            border: @social-chart-maximize-btn-active-border solid 1px;
+        }
+
+        &.fullscreen {
+            right: 25px;
+        }
     }
-
-    &:active, &:focus {
-      border: @social-chart-maximize-btn-active-border solid 1px;
-    }
-
-    &.fullscreen {
-      right: 25px;
-    }
-  }
 }
 
 .sigma-panel-close-icon {
-  z-index: 1;
-  background-image: url("../img/close-white.png");
-  width: 12px;
-  height: 12px;
-  display: inline-block;
-  background-size: contain;
-  background-repeat: no-repeat;
-  .opacity(0.5);
-  position: absolute;
-  top: 22px;
-  right:30px;
-  &:hover{
-    cursor: pointer;
-    .opacity(1);
-  }
+    z-index: 1;
+    background-image: url("../img/close-white.png");
+    width: 12px;
+    height: 12px;
+    display: inline-block;
+    background-size: contain;
+    background-repeat: no-repeat;
+    .opacity(0.5);
+
+    position: absolute;
+    top: 22px;
+    right: 30px;
+
+    &:hover {
+        cursor: pointer;
+        .opacity(1);
+    }
 }
 
 //custom tooltip
 .customTooltip {
-  line-height: 0.875rem;
-  padding-top: 1px;
-  padding-right: 4px;
-  padding-left: 4px;
-  font-size: 0.875rem;
-  text-align: left;
-  color: @flot-tooltip-color;
-  background: @flot-tooltip-bg;
-  border: 4px solid @flot-tooltip-border;
-  border-radius: 0px;
-  padding-bottom: 0;
-  border-bottom: 0;
-  box-shadow: 1px 1px 2px @flot-tooltip-shadow;
-  pointer-events: none;
-  &:after {
-    content: "";
-    position: relative;
-    display: block;
-    width: 0;
-    height: 0;
-    border-width: 6px;
-    border-style: solid;
-    border-color: @flot-tooltip-border transparent transparent transparent;
-    left: 5px;
-    bottom: -5px;
-    border-bottom-width: 0px;
-  }
-  &.tipRight {
+    line-height: 0.875rem;
+    padding: 1px 4px 0;
+    font-size: 0.875rem;
+    text-align: left;
+    color: @flot-tooltip-color;
+    background: @flot-tooltip-bg;
+    border: 4px solid @flot-tooltip-border;
+    border-radius: 0;
+    border-bottom: 0;
+    box-shadow: 1px 1px 2px @flot-tooltip-shadow;
+    pointer-events: none;
+
     &:after {
-      content: "";
-      position: relative;
-      display: block;
-      width: 0;
-      height: 0;
-      border-width: 6px;
-      border-style: solid;
-      border-color: @flot-tooltip-border transparent transparent transparent;
-      left: calc(100% - 16px);
-      bottom: -5px;
-      border-bottom-width: 0px;
+        content: "";
+        position: relative;
+        display: block;
+        width: 0;
+        height: 0;
+        border-width: 6px;
+        border-style: solid;
+        border-color: @flot-tooltip-border transparent transparent transparent;
+        left: 5px;
+        bottom: -5px;
+        border-bottom-width: 0;
     }
-  }
+
+    &.tipRight {
+        &:after {
+            content: "";
+            position: relative;
+            display: block;
+            width: 0;
+            height: 0;
+            border-width: 6px;
+            border-style: solid;
+            border-color: @flot-tooltip-border transparent transparent transparent;
+            left: calc(100% - 16px);
+            bottom: -5px;
+            border-bottom-width: 0;
+        }
+    }
 }
 
 .nested-donut-container {
-  display: inline-block;
+    display: inline-block;
 }

--- a/src/styles/colors.less
+++ b/src/styles/colors.less
@@ -1,155 +1,157 @@
 .primary-color {
-  background: @primary;
+    background: @primary;
 }
 
 .accent-color {
-  background: @accent;
+    background: @accent;
 }
 
 .secondary-color {
-  background: @secondary;
-  border: 1px solid @grey5;
+    background: @secondary;
+    border: 1px solid @grey5;
 }
 
 .alternate1-color {
-  background: @alternate1;
+    background: @alternate1;
 }
 
 .alternate2-color {
-  background: @alternate2;
+    background: @alternate2;
 }
 
 .alternate3-color {
-  background: @alternate3;
+    background: @alternate3;
 }
 
 .vibrant1-color {
-  background: @vibrant1;
+    background: @vibrant1;
 }
 
 .vibrant2-color {
-  background: @vibrant2;
+    background: @vibrant2;
 }
 
 .grey1-color {
-  background: @grey1;
+    background: @grey1;
 }
 
 .grey2-color {
-  background: @grey2;
+    background: @grey2;
 }
 
 .grey3-color {
-  background: @grey3;
+    background: @grey3;
 }
 
 .grey4-color {
-  background: @grey4;
+    background: @grey4;
 }
 
 .grey5-color {
-  background: @grey5;
+    background: @grey5;
 }
 
 .grey6-color {
-  background: @grey6;
+    background: @grey6;
 }
 
 .grey7-color {
-  background: @grey7;
+    background: @grey7;
 }
 
 .grey8-color {
-  background: @grey8;
+    background: @grey8;
 }
 
 .chart1-color {
-  background: @chart1;
+    background: @chart1;
 }
 
 .chart2-color {
-  background: @chart2;
+    background: @chart2;
 }
 
 .chart3-color {
-  background: @chart3;
+    background: @chart3;
 }
 
 .chart4-color {
-  background: @chart4;
+    background: @chart4;
 }
 
 .chart5-color {
-  background: @chart5;
+    background: @chart5;
 }
 
 .chart6-color {
-  background: @chart6;
+    background: @chart6;
 }
 
 .ok-color {
-  background: @ok;
+    background: @ok;
 }
 
 .warning-color {
-  background: @warning;
+    background: @warning;
 }
 
 .critical-color {
-  background: @critical;
+    background: @critical;
 }
 
 .partition1-color {
-  background: @partition1;
+    background: @partition1;
 }
 
 .partition9-color {
-  background: @partition9;
+    background: @partition9;
 }
 
 .partition10-color {
-  background: @partition10;
+    background: @partition10;
 }
 
 .partition11-color {
-  background: @partition11;
+    background: @partition11;
 }
 
 .partition12-color {
-  background: @partition12;
+    background: @partition12;
 }
 
 .partition13-color {
-  background: @partition13;
+    background: @partition13;
 }
 
 .partition14-color {
-  background: @partition14;
+    background: @partition14;
 }
 
 .social-chart-node-color {
-  background: @social-chart-node-color;
+    background: @social-chart-node-color;
 }
 
 .social-chart-edge-color {
-  background: @social-chart-edge-color;
+    background: @social-chart-edge-color;
 }
 
 .color-chart {
-  position: absolute;
-  visibility: hidden;
+    position: absolute;
+    visibility: hidden;
 }
 
 .color-box-container {
-  width: 150px;
-  display: inline-block;
-  .color-box {
-    height: 120px;
-    width: 120px;
-  }
-  p {
-    width: 120px;
+    width: 150px;
     display: inline-block;
-    margin-bottom: 5px;
-  }
+
+    .color-box {
+        height: 120px;
+        width: 120px;
+    }
+
+    p {
+        width: 120px;
+        display: inline-block;
+        margin-bottom: 5px;
+    }
 }

--- a/src/styles/component-list.less
+++ b/src/styles/component-list.less
@@ -1,105 +1,101 @@
 .component-list {
-	align-items: flex-end;
-	display: flex;
-    
-	.component-stack {
-		flex: 1;
+    align-items: flex-end;
+    display: flex;
 
-		.component-container {
+    .component-stack {
+        flex: 1;
 
-			.component-list-component {
-				display: flex;
-				padding: 5px;
-				transition: background-color 0.3s linear;
+        .component-container {
+            .component-list-component {
+                display: flex;
+                padding: 5px;
+                transition: background-color 0.3s linear;
 
-				&.hoverable:hover {
-					background-color: @component-list-field-hover;
+                &.hoverable:hover {
+                    background-color: @component-list-field-hover;
 
-					.component-remove {
-						opacity: 1;
-					}
+                    .component-remove {
+                        opacity: 1;
+                    }
 
-					.component-remove[disabled] {
-						opacity: 0.5;
-					}
+                    .component-remove[disabled] {
+                        opacity: 0.5;
+                    }
 
-					.component-remove[disabled] .hpe-icon {
-						cursor: default;
-					}
+                    .component-remove[disabled] .hpe-icon {
+                        cursor: default;
+                    }
 
-					.component-remove {
+                    .component-remove {
+                        .hpe-icon {
+                            cursor: pointer;
+                        }
+                    }
+                }
 
-						.hpe-icon {
-							cursor: pointer;
-						}
-					}
-				}
+                .component-content {
+                    flex: 1;
+                }
 
-				.component-content {
-					flex: 1;
-				}
+                .component-remove {
+                    flex: none;
+                    opacity: 0;
+                    transition: opacity 0.3s linear;
+                    width: 32px;
 
-				.component-remove {
-					flex: none;
-					opacity: 0;
-					transition: opacity 0.3s linear;
-					width: 32px;
+                    .hpe-icon {
+                        color: @component-list-remove-color;
+                        margin: 9px;
+                    }
+                }
+            }
+        }
+    }
 
-					.hpe-icon {
-						color: @component-list-remove-color;
-						margin: 9px;
-					}
-				}
-			}
-		}
-	}
+    .component-options {
+        align-items: center;
+        cursor: pointer;
+        display: flex;
+        flex: none;
+        margin-bottom: 7px;
+        margin-left: 48px;
 
-	.component-options {
+        .component-add-btn {
+            align-items: center;
+            background-color: @component-list-add-bg;
+            opacity: @component-list-add-bg-opacity;
+            border-radius: 50%;
+            color: @component-list-add-icon-color;
+            display: inline-flex;
+            height: 30px;
+            justify-content: center;
+            transition: background-color 0.3s linear;
+            width: 30px;
+        }
 
-		align-items: center;
-		cursor: pointer;
-		display: flex;
-		flex: none;
-		margin-bottom: 7px;
-		margin-left: 48px;
+        &:hover {
+            .component-add-btn {
+                background-color: @component-list-add-hover-bg;
+                opacity: @component-list-add-hover-bg-opacity;
+            }
+        }
 
-		.component-add-btn {
-			align-items: center;
-			background-color: @component-list-add-bg;
-			opacity: @component-list-add-bg-opacity;
-			border-radius: 50%;
-			color: @component-list-add-icon-color;
-			display: inline-flex;
-			height: 30px;
-			justify-content: center;
-			transition: background-color 0.3s linear;
-			width: 30px;
-		}
+        .component-add-text {
+            color: @component-list-add-color;
+            margin-bottom: 0;
+            padding-left: 8px;
+        }
+    }
 
-		&:hover {
-			.component-add-btn {
-				background-color: @component-list-add-hover-bg;
-				opacity: @component-list-add-hover-bg-opacity;
-			}
-		}
+    .component-options[disabled] {
+        cursor: default;
+        opacity: 0.5;
+        outline: none;
 
-		.component-add-text {
-			color: @component-list-add-color;
-			margin-bottom: 0;
-			padding-left: 8px;
-		}
-	}
-
-	.component-options[disabled] {
-		cursor: default;
-		opacity: 0.5;
-		outline: none;
-
-		&:hover {
-
-			.component-add-btn {
-				background-color: @component-list-add-bg;
-			}
-		}
-	}
+        &:hover {
+            .component-add-btn {
+                background-color: @component-list-add-bg;
+            }
+        }
+    }
 }

--- a/src/styles/contacts.less
+++ b/src/styles/contacts.less
@@ -1,125 +1,139 @@
-.contacts-list-container{
-  display: inline-flex;
-  .contacts-list {
-    list-style: none;
-    display: inherit;
-    margin: 0;
-    padding: 0;
+.contacts-list-container {
+    display: inline-flex;
 
-    * > .status {
-      height: 4px;
-      margin-bottom: 1px;
-    }
-  }
-  * > .contact , .contact-overflow, .organization {
-    .contact-item;
-    &.medium{
-      .medium-contact-item;
-    }
-    &.small{
-      .small-contact-item;
-    }
-  }
-  .contact-overflow-container {
-    margin-left: 1px;
-  }
-  .contact-overflow-clickable {
-    cursor: pointer;
-  }
-  .contact-overflow {
-    margin-top: 5px;
-  }
-  .contact-overflow-label {
-    height: 14px;
-    font-size: 0.625rem;
-    color: @contacts-overflow-color;
-    background-color: @contacts-overflow-bg;
-    border-radius: 7px;
-    padding: 0px 5px;
-    margin: 0 5px;
-    position: relative;
-    &.medium {
-      top: -35px;
-    }
-    &.small {
-      top: -27px;
-    }
-  }
-  .organization {
-    margin-top: 5px;
-    border-radius: 0px 3px 3px 0px;
-    border: 1px solid;
-    border-left: 0;
-  }
+    .contacts-list {
+        list-style: none;
+        display: inherit;
+        margin: 0;
+        padding: 0;
 
-  .organization-label {
-    height: 14px;
-    font-size: 0.625rem;
-    color: @contacts-label-color;
-    position: relative;
-    left: -7px;
-    &.risk{
-      width: 14px;
-      background-color: @contacts-risk-color;
-      border-radius: 100%;
+        * > .status {
+            height: 4px;
+            margin-bottom: 1px;
+        }
     }
-    &.external{
-      background-color: @contacts-external-color;
-      border-radius: 7px;
-      padding: 0px 5px;
-      &::before{
-        content:"EXT";
-      }
+
+    * > .contact,
+    .contact-overflow,
+    .organization {
+        .contact-item;
+
+        &.medium {
+            .medium-contact-item;
+        }
+
+        &.small {
+            .small-contact-item;
+        }
     }
-  }
 
-  .contact-item{
-    text-align: center;
-    white-space: nowrap;
-  }
+    .contact-overflow-container {
+        margin-left: 1px;
+    }
 
-  .medium-contact-item {
-    min-height: 30px;
-    height: 30px;
-    min-width: 30px;
-    font-size: 1.125rem;
-    padding: 2px 5px;
-  }
+    .contact-overflow-clickable {
+        cursor: pointer;
+    }
 
-  .small-contact-item{
-    min-height: 22px;
-    height: 22px;
-    min-width: 22px;
-    font-size: 0.875rem;
-    padding: 0px 5px;
-  }
+    .contact-overflow {
+        margin-top: 5px;
+    }
+
+    .contact-overflow-label {
+        height: 14px;
+        font-size: 0.625rem;
+        color: @contacts-overflow-color;
+        background-color: @contacts-overflow-bg;
+        border-radius: 7px;
+        padding: 0 5px;
+        margin: 0 5px;
+        position: relative;
+
+        &.medium {
+            top: -35px;
+        }
+
+        &.small {
+            top: -27px;
+        }
+    }
+
+    .organization {
+        margin-top: 5px;
+        border-radius: 0 3px 3px 0;
+        border: 1px solid;
+        border-left: 0;
+    }
+
+    .organization-label {
+        height: 14px;
+        font-size: 0.625rem;
+        color: @contacts-label-color;
+        position: relative;
+        left: -7px;
+
+        &.risk {
+            width: 14px;
+            background-color: @contacts-risk-color;
+            border-radius: 100%;
+        }
+
+        &.external {
+            background-color: @contacts-external-color;
+            border-radius: 7px;
+            padding: 0 5px;
+
+            &:before {
+                content: "EXT";
+            }
+        }
+    }
+
+    .contact-item {
+        text-align: center;
+        white-space: nowrap;
+    }
+
+    .medium-contact-item {
+        min-height: 30px;
+        height: 30px;
+        min-width: 30px;
+        font-size: 1.125rem;
+        padding: 2px 5px;
+    }
+
+    .small-contact-item {
+        min-height: 22px;
+        height: 22px;
+        min-width: 22px;
+        font-size: 0.875rem;
+        padding: 0 5px;
+    }
 }
 
 .contacts-arrow {
-  vertical-align: bottom;
-  padding-bottom: 7px;
+    vertical-align: bottom;
+    padding-bottom: 7px;
 }
+
 .contacts-popover {
-  font-family: @font-family;
-  max-width: none;
-  border-radius: 0;
-  border: 1px solid @contacts-popover-border;
-  background-color: @contacts-popover-bg;
-  color: @contacts-popover-color;
-  z-index: 10019;
-  .contacts-popover-arrow
-  {
-  	&:after {
-  		border-top-color: @contacts-popover-bg !important;
-  		border-bottom-color: @contacts-popover-bg !important;
-  	}
-  }
-  .contact-link:hover {
-	background: rgba(255, 255, 255, 0.1);
-	cursor: pointer;
-	}
-}
-.body-dark .contacts-popover {
-  border: 1px solid @contacts-popover-border;
-  background-color: @contacts-popover-bg;
+    font-family: @font-family;
+    max-width: none;
+    border-radius: 0;
+    border: 1px solid @contacts-popover-border;
+    background-color: @contacts-popover-bg;
+    color: @contacts-popover-color;
+    z-index: 10019;
+
+    .contacts-popover-arrow {
+        &:after {
+            border-top-color: @contacts-popover-bg !important;
+            border-bottom-color: @contacts-popover-bg !important;
+        }
+    }
+
+    .contact-link:hover {
+        background: rgba(255, 255, 255, 0.1);
+        cursor: pointer;
+    }
 }

--- a/src/styles/controls.less
+++ b/src/styles/controls.less
@@ -1,310 +1,343 @@
 .form-control {
-  background-color: @form-control-bg;
-  background-image: none;
-  border: 1px solid @form-control-border;
-  border-radius: @form-control-border-radius;
-  display: block;
-  font-size: @font-size-lg;
-  padding: 4px 12px;
-  transition: border-color 0.15s ease-in-out 0s, box-shadow 0.15s ease-in-out 0s;
-  width: 100%;
-  color: @form-control-color;
-  box-shadow: none;
+    background-color: @form-control-bg;
+    background-image: none;
+    border: 1px solid @form-control-border;
+    border-radius: @form-control-border-radius;
+    display: block;
+    font-size: @font-size-lg;
+    padding: 4px 12px;
+    transition: border-color 0.15s ease-in-out 0s, box-shadow 0.15s ease-in-out 0s;
+    width: 100%;
+    color: @form-control-color;
+    box-shadow: none;
 }
 
-.form-control[disabled], .form-control[readonly], fieldset[disabled] .form-control{
-  cursor:default;
-  color: @form-control-disabled-color;
+.form-control[disabled], .form-control[readonly], fieldset[disabled] .form-control {
+    cursor: default;
+    color: @form-control-disabled-color;
 }
 
 .form-control::-moz-placeholder {
-  color: @form-control-placeholder-color;
+    color: @form-control-placeholder-color;
 }
 
 .form-control::-webkit-input-placeholder {
-  color: @form-control-placeholder-color;
+    color: @form-control-placeholder-color;
 }
 
-:-ms-input-placeholder.form-control
-{
-  color: @form-control-placeholder-color;
+:-ms-input-placeholder.form-control {
+    color: @form-control-placeholder-color;
 }
-input::-ms-clear, input::-ms-reveal {
-	display: none;
+
+input::-ms-clear,
+input::-ms-reveal {
+    display: none;
 }
 
 .input-lg {
- font-size: @font-size-lg;
+    font-size: @font-size-lg;
 }
 
 .input-sm {
-  font-size: @font-size-sm;
+    font-size: @font-size-sm;
 }
 
-textarea{
-  resize:none;
+textarea {
+    resize: none;
 }
-label{
-  font-weight:normal;
+
+label {
+    font-weight: normal;
 }
 
 .form-label {
-  .opacity(0.7);
+    .opacity(0.7);
 }
-.form-information{
-  .opacity(0.7);
-  float:right;
+
+.form-information {
+    .opacity(0.7);
+
+    float: right;
 }
+
 .form-control {
-  &:focus {
-    border-color: @form-control-focus-border;
-    outline: 0;
-    box-shadow:none;
-  }
-}
-.form-control-feedback {
-  display:none;
-  &.hp-icon, &.hpe-icon{
-    line-height: 34px;
-  }
-}
-.form-control-validation{
-  color: @form-control-validation;
-}
-
-.has-error {
-  .form-control-validation{
-    color: @form-control-invalid-color;
-  }
-}
-.has-error ~ .form-group-validation {
-  .form-control-validation{
-    color: @form-control-invalid-color;
-  }
-}
-.has-feedback{
-  position:relative;
-  .form-control-feedback{
-    display:block;
-  }
-}
-.has-success,.has-secondary,.has-error{
-  .form-control:focus{
-    box-shadow: none;
-  }
-}
-.has-success {
-  .form-control {
-    border-color: @form-control-success-color;
-  }
-}
-
-.has-secondary {
-  .form-control {
-    border-color: @form-control-focus-border; // not documented / supported
-  }
-}
-
-.has-error {
-  .form-control {
-    border-color: @form-control-invalid-border;
-
     &:focus {
-      border-color: @form-control-invalid-border;
+        border-color: @form-control-focus-border;
+        outline: 0;
+        box-shadow: none;
     }
-  }
+}
 
-  .input-group-addon {
-    background-color: @form-control-bg;
-    border-color: @form-control-border;
-    color: @text-color;
-  }
+.form-control-feedback {
+    display: none;
+
+    &.hp-icon,
+    &.hpe-icon {
+        line-height: 34px;
+    }
+}
+
+.form-control-validation {
+    color: @form-control-validation;
+}
+
+.has-error {
+    .form-control-validation {
+        color: @form-control-invalid-color;
+    }
+}
+
+.has-error ~ .form-group-validation {
+    .form-control-validation {
+        color: @form-control-invalid-color;
+    }
+}
+
+.has-feedback {
+    position: relative;
+
+    .form-control-feedback {
+        display: block;
+    }
+}
+
+.has-success,
+.has-secondary,
+.has-error {
+    .form-control:focus {
+        box-shadow: none;
+    }
 }
 
 .has-success {
-  .control-label {
-    color: @form-control-success-color;
-  }
+    .form-control {
+        border-color: @form-control-success-color;
+    }
 }
 
 .has-secondary {
-  .control-label {
-    color: @accent; // not documented / supported
-  }
+    .form-control {
+        border-color: @form-control-focus-border; // not documented / supported
+    }
 }
 
-.has-error{
-  .control-label, .help-block,.error-text,.form-control-feedback {
-    color: @form-control-invalid-color;
-  }
+.has-error {
+    .form-control {
+        border-color: @form-control-invalid-border;
+
+        &:focus {
+            border-color: @form-control-invalid-border;
+        }
+    }
+
+    .input-group-addon {
+        background-color: @form-control-bg;
+        border-color: @form-control-border;
+        color: @text-color;
+    }
+}
+
+.has-success {
+    .control-label {
+        color: @form-control-success-color;
+    }
+}
+
+.has-secondary {
+    .control-label {
+        color: @accent; // not documented / supported
+    }
+}
+
+.has-error {
+    .control-label,
+    .help-block,
+    .error-text,
+    .form-control-feedback {
+        color: @form-control-invalid-color;
+    }
 }
 
 .help-block {
-  color: #737373;
+    color: #737373;
 }
 
 .input-group-addon {
-  background-color: @form-control-bg;
-  border: 1px solid @form-control-border;
-  border-radius: 1px;
-  color: inherit;
-  font-size: @font-size;
-  font-weight: 400;
-  line-height: 1;
-  padding: 5px 12px;
-  text-align: center;
+    background-color: @form-control-bg;
+    border: 1px solid @form-control-border;
+    border-radius: 1px;
+    color: inherit;
+    font-size: @font-size;
+    font-weight: 400;
+    line-height: 1;
+    padding: 5px 12px;
+    text-align: center;
 }
 
 .inner-addon {
-	position: relative;
+    position: relative;
 }
 
 /* style icon */
+
 .inner-addon .hpe-icon {
-	position: absolute;
-	padding: 10px;
-	pointer-events: none;
+    position: absolute;
+    padding: 10px;
+    pointer-events: none;
 }
 
 .inner-addon-button {
-  position: relative;
-  .hpe-icon {
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    height: 16px;
-    margin: auto 10px;
-    cursor: pointer;
-    z-index: @inner-addon-button-z-index;
-  }
+    position: relative;
+
+    .hpe-icon {
+        position: absolute;
+        top: 0;
+        bottom: 0;
+        height: 16px;
+        margin: auto 10px;
+        cursor: pointer;
+        z-index: @inner-addon-button-z-index;
+    }
 }
 
 /* align icon */
-.left-addon .hpe-icon  {
-	left:  0px;
+
+.left-addon .hpe-icon {
+    left: 0;
 }
+
 .right-addon .hpe-icon {
-	right: 0px;
+    right: 0;
 }
 
 /* add padding  */
-.left-addon input  {
-	padding-left:  30px;
+
+.left-addon input {
+    padding-left: 30px;
 }
+
 .right-addon input {
-	padding-right: 30px;
+    padding-right: 30px;
 }
 
 //removing the curve from addons
-.input-group .form-control:last-child, .input-group-addon:last-child, .input-group-btn:last-child>.btn, .input-group-btn:last-child>.btn-group>.btn, .input-group-btn:last-child>.dropdown-toggle, .input-group-btn:first-child>.btn:not(:first-child), .input-group-btn:first-child>.btn-group:not(:first-child)>.btn{
-  border-top-right-radius: @form-control-border-radius;
-  border-bottom-right-radius: @form-control-border-radius;
+.input-group .form-control:last-child, .input-group-addon:last-child, .input-group-btn:last-child > .btn, .input-group-btn:last-child > .btn-group > .btn, .input-group-btn:last-child > .dropdown-toggle, .input-group-btn:first-child > .btn:not(:first-child),.input-group-btn:first-child > .btn-group:not(:first-child) > .btn {
+    border-top-right-radius: @form-control-border-radius;
+    border-bottom-right-radius: @form-control-border-radius;
 }
-.input-group .form-control:first-child, .input-group-addon:first-child, .input-group-btn:first-child>.btn, .input-group-btn:first-child>.btn-group>.btn, .input-group-btn:first-child>.dropdown-toggle, .input-group-btn:last-child>.btn:not(:last-child):not(.dropdown-toggle), .input-group-btn:last-child>.btn-group:not(:last-child)>.btn {
-  border-top-left-radius: @form-control-border-radius;
-  border-bottom-left-radius: @form-control-border-radius;
+
+.input-group .form-control:first-child, .input-group-addon:first-child, .input-group-btn:first-child > .btn, .input-group-btn:first-child > .btn-group > .btn, .input-group-btn:first-child > .dropdown-toggle, .input-group-btn:last-child > .btn:not(:last-child):not(.dropdown-toggle), .input-group-btn:last-child > .btn-group:not(:last-child) > .btn {
+    border-top-left-radius: @form-control-border-radius;
+    border-bottom-left-radius: @form-control-border-radius;
 }
 
 .input-group {
-  .form-control {
-	  height: 34px;
-	}
-  .input-group-btn {
-    button {
-      height: 34px;
+    .form-control {
+        height: 34px;
     }
-  }
+
+    .input-group-btn {
+        button {
+            height: 34px;
+        }
+    }
 }
 
 // Need to remove these light and dark styles
-
 //login page form control
 .login-form-control {
-  background-color: @login-form-bg;
-  background-image: none;
-  border: none;
-  border-bottom: 1px solid @login-form-border;
-  border-radius: 1px;
-  display: block;
-  font-size: 1.125rem;
-  padding: 4px 12px;
-  transition: border-color 0.15s ease-in-out 0s, box-shadow 0.15s ease-in-out 0s;
-  width: 100%;
-  height: 45px;
-  box-shadow: none;
-}
-
-.login-form-control-dark{
-  color: @login-form-dark-color;
-  .login-form-control;
-}
-
-.login-form-control-light{
-  color: @login-form-light-color;
-  .login-form-control;
-}
-.login-form-control {
-  &:focus {
+    background-color: @login-form-bg;
+    background-image: none;
     border: none;
-    border-bottom:  1px solid @login-form-border;
-    outline: 0;
+    border-bottom: 1px solid @login-form-border;
+    border-radius: 1px;
+    display: block;
+    font-size: 1.125rem;
+    padding: 4px 12px;
+    transition: border-color 0.15s ease-in-out 0s, box-shadow 0.15s ease-in-out 0s;
+    width: 100%;
+    height: 45px;
     box-shadow: none;
-  }
 }
+
+.login-form-control-dark {
+    color: @login-form-dark-color;
+    .login-form-control;
+}
+
+.login-form-control-light {
+    color: @login-form-light-color;
+    .login-form-control;
+}
+
+.login-form-control {
+    &:focus {
+        border: none;
+        border-bottom: 1px solid @login-form-border;
+        outline: 0;
+        box-shadow: none;
+    }
+}
+
 .login-form-control:-ms-input-placeholder {
-  color: @login-form-color;
+    color: @login-form-color;
 }
+
 .login-form-control::-webkit-input-placeholder {
-   color: @login-form-color;
+    color: @login-form-color;
 }
+
 select {
-  &.form-control {
-    font-size:@font-size-lg;
-  }
+    &.form-control {
+        font-size: @font-size-lg;
+    }
 }
 
 //===============================
 // multi-select-checkbox styling
 //===============================
-
-.multi-select-checkbox{
-  display: inline-block;
-  *display: inline;
-  vertical-align: middle;
-  margin: 0;
-  padding: 0;
-  width: 22px;
-  height: 22px;
-  background: url(../img/blue_checkboxes.png) no-repeat;
-  border: none;
-  cursor: pointer;
-  margin-right: 1px;
+.multi-select-checkbox {
+    display: inline-block;
+    *display: inline;
+    vertical-align: middle;
+    margin: 0;
+    padding: 0;
+    width: 22px;
+    height: 22px;
+    background: url(../img/blue_checkboxes.png) no-repeat;
+    border: none;
+    cursor: pointer;
+    margin-right: 1px;
 }
 
 .donot-disp {
-  display: none;
-}
-.multi-select-checkbox {
-  background-position: 0 0;
-}
-.multi-select-checkbox {
-  &:hover, &:focus {
-    .aspects-outline;
-  }
-}
-.multi-select-checkbox {
-  &.multi-select-checkbox-checked {
-    background-position: -48px 0;
-  }
+    display: none;
 }
 
-.single-select-selected-bg
-{
-  background-color: @single-select-selected-bg;
+.multi-select-checkbox {
+    background-position: 0 0;
+}
+
+.multi-select-checkbox {
+    &:hover,
+    &:focus {
+        .aspects-outline;
+    }
+}
+
+.multi-select-checkbox {
+    &.multi-select-checkbox-checked {
+        background-position: -48px 0;
+    }
+}
+
+.single-select-selected-bg {
+    background-color: @single-select-selected-bg;
 }
 
 //Date picker
 //====================
+
 /*!
 * Datepicker for Bootstrap
 *
@@ -314,191 +347,217 @@ select {
 * http://www.apache.org/licenses/LICENSE-2.0
 *
 */
+
 .datepicker {
-  padding: 4px;
-  border-radius: 4px;
-  direction: ltr;
-  /*.dow {
+    padding: 4px;
+    border-radius: 4px;
+    direction: ltr;
+
+    /*.dow {
   border-top: 1px solid #ddd !important;
 }*/
 }
+
 .datepicker-inline {
-  width: 220px;
+    width: 220px;
 }
-.datepicker {
-  &.datepicker-rtl {
-    direction: rtl;
 
-    table {
-      tr {
-        td {
-          span {
-            float: right;
-          }
+.datepicker {
+    &.datepicker-rtl {
+        direction: rtl;
+
+        table {
+            tr {
+                td {
+                    span {
+                        float: right;
+                    }
+                }
+            }
         }
-      }
     }
-  }
-}
-.datepicker-dropdown {
-  top: 0;
-  left: 0;
-}
-.datepicker-dropdown {
-  &:before {
-    content: '';
-    display: inline-block;
-    border-left: 7px solid transparent;
-    border-right: 7px solid transparent;
-    border-bottom: 7px solid @grey5;
-    border-top: 0;
-    border-bottom-color: rgba(0, 0, 0, 0.2);
-    position: absolute;
-  }
-  &:after {
-    content: '';
-    display: inline-block;
-    border-left: 6px solid transparent;
-    border-right: 6px solid transparent;
-    border-bottom: 6px solid @white;
-    border-top: 0;
-    position: absolute;
-  }
 }
 
 .datepicker-dropdown {
-  &.datepicker-orient-left{
+    top: 0;
+    left: 0;
+}
+
+.datepicker-dropdown {
     &:before {
-      left: 6px;
+        content: '';
+        display: inline-block;
+        border-left: 7px solid transparent;
+        border-right: 7px solid transparent;
+        border-bottom: 7px solid @grey5;
+        border-top: 0;
+        border-bottom-color: rgba(0, 0, 0, 0.2);
+        position: absolute;
     }
-  }
-}
-.datepicker-dropdown {
-  &.datepicker-orient-left:after {
-    left: 7px;
-  }
-}
-.datepicker-dropdown {
-  &.datepicker-orient-right:before {
-    right: 6px;
-  }
-}
-.datepicker-dropdown {
-  &.datepicker-orient-right:after {
-    right: 7px;
-  }
-}
-.datepicker-dropdown {
-  &.datepicker-orient-top:before {
-    top: -7px;
-  }
-}
-.datepicker-dropdown {
-  &.datepicker-orient-top:after {
-    top: -6px;
-  }
-}
-.datepicker-dropdown {
-  &.datepicker-orient-bottom {
-    &:before {
-      bottom: -7px;
-      border-bottom: 0;
-      border-top: 7px solid @date-picker-color-dark;
-    }
-  }
-}
-.datepicker-dropdown {
-  &.datepicker-orient-bottom {
+
     &:after {
-      bottom: -6px;
-      border-bottom: 0;
-      border-top: 6px solid @white;
+        content: '';
+        display: inline-block;
+        border-left: 6px solid transparent;
+        border-right: 6px solid transparent;
+        border-bottom: 6px solid @white;
+        border-top: 0;
+        position: absolute;
     }
-  }
 }
+
+.datepicker-dropdown {
+    &.datepicker-orient-left {
+        &:before {
+            left: 6px;
+        }
+    }
+}
+
+.datepicker-dropdown {
+    &.datepicker-orient-left:after {
+        left: 7px;
+    }
+}
+
+.datepicker-dropdown {
+    &.datepicker-orient-right:before {
+        right: 6px;
+    }
+}
+
+.datepicker-dropdown {
+    &.datepicker-orient-right:after {
+        right: 7px;
+    }
+}
+
+.datepicker-dropdown {
+    &.datepicker-orient-top:before {
+        top: -7px;
+    }
+}
+
+.datepicker-dropdown {
+    &.datepicker-orient-top:after {
+        top: -6px;
+    }
+}
+
+.datepicker-dropdown {
+    &.datepicker-orient-bottom {
+        &:before {
+            bottom: -7px;
+            border-bottom: 0;
+            border-top: 7px solid @date-picker-color-dark;
+        }
+    }
+}
+
+.datepicker-dropdown {
+    &.datepicker-orient-bottom {
+        &:after {
+            bottom: -6px;
+            border-bottom: 0;
+            border-top: 6px solid @white;
+        }
+    }
+}
+
 .datepicker > div {
-  display: none;
+    display: none;
 }
+
 .datepicker {
-  &.days {
-    div {
-      &.datepicker-days {
-        display: block;
-      }
+    &.days {
+        div {
+            &.datepicker-days {
+                display: block;
+            }
+        }
     }
-  }
 }
+
 .datepicker {
-  &.months {
-    div {
-      &.datepicker-months {
-        display: block;
-      }
+    &.months {
+        div {
+            &.datepicker-months {
+                display: block;
+            }
+        }
     }
-  }
 }
+
 .datepicker {
-  &.years {
-    div {
-      &.datepicker-years {
-        display: block;
-      }
+    &.years {
+        div {
+            &.datepicker-years {
+                display: block;
+            }
+        }
     }
-  }
 }
+
 .datepicker {
-  table {
-    margin: 0;
-    -webkit-touch-callout: none;
-    -webkit-user-select: none;
-    -khtml-user-select: none;
-    -moz-user-select: none;
-    -ms-user-select: none;
-    user-select: none;
-    font-size: 0.875rem;
-  }
-}
-.datepicker {
-  table {
-    tr {
-      th, td {
-        text-align: center;
-        width: 30px;
-        height: 30px;
-        border-radius: 4px;
-        border: none;
-      }
+    table {
+        margin: 0;
+        -webkit-touch-callout: none;
+        -webkit-user-select: none;
+        -khtml-user-select: none;
+        -moz-user-select: none;
+        -ms-user-select: none;
+        user-select: none;
+        font-size: 0.875rem;
     }
-  }
 }
+
+.datepicker {
+    table {
+        tr {
+            th,
+            td {
+                text-align: center;
+                width: 30px;
+                height: 30px;
+                border-radius: 4px;
+                border: none;
+            }
+        }
+    }
+}
+
 .table-striped .datepicker table tr td,
 .table-striped .datepicker table tr th {
-  background-color: transparent;
+    background-color: transparent;
 }
+
 .datepicker table tr td.day:hover,
 .datepicker table tr td.day.focused {
-  background: @date-picker-hover-bg;
-  cursor: pointer;
+    background: @date-picker-hover-bg;
+    cursor: pointer;
 }
 
 .datepicker table tr td.old,
 .datepicker table tr td.new {
-  color: @date-picker-disabled-hover-bg;
+    color: @date-picker-disabled-hover-bg;
 }
+
 .datepicker table tr td.disabled,
 .datepicker table tr td.disabled:hover {
-  background: none;
-  color: @date-picker-disabled-hover-bg;
-  cursor: default;
+    background: none;
+    color: @date-picker-disabled-hover-bg;
+    cursor: default;
 }
+
 .datepicker table tr td.today,
 .datepicker table tr td.today:hover,
 .datepicker table tr td.today.disabled,
 .datepicker table tr td.today.disabled:hover {
-  color: @date-picker-today-color;
-  background-color: @date-picker-today-bg;
-  border-color: @date-picker-today-border;
+    color: @date-picker-today-color;
+    background-color: @date-picker-today-bg;
+    border-color: @date-picker-today-border;
 }
+
 .datepicker table tr td.today:hover,
 .datepicker table tr td.today:hover:hover,
 .datepicker table tr td.today.disabled:hover,
@@ -519,10 +578,11 @@ select {
 .open .dropdown-toggle.datepicker table tr td.today:hover,
 .open .dropdown-toggle.datepicker table tr td.today.disabled,
 .open .dropdown-toggle.datepicker table tr td.today.disabled:hover {
-  color: @date-picker-today-color;
-  background-color: @date-picker-today-disabled-bg;
-  border-color: @date-picker-today-disabled-border;
+    color: @date-picker-today-color;
+    background-color: @date-picker-today-disabled-bg;
+    border-color: @date-picker-today-disabled-border;
 }
+
 .datepicker table tr td.today:active,
 .datepicker table tr td.today:hover:active,
 .datepicker table tr td.today.disabled:active,
@@ -535,8 +595,9 @@ select {
 .open .dropdown-toggle.datepicker table tr td.today:hover,
 .open .dropdown-toggle.datepicker table tr td.today.disabled,
 .open .dropdown-toggle.datepicker table tr td.today.disabled:hover {
-  background-image: none;
+    background-image: none;
 }
+
 .datepicker table tr td.today.disabled,
 .datepicker table tr td.today:hover.disabled,
 .datepicker table tr td.today.disabled.disabled,
@@ -597,31 +658,36 @@ fieldset[disabled] .datepicker table tr td.today.active,
 fieldset[disabled] .datepicker table tr td.today:hover.active,
 fieldset[disabled] .datepicker table tr td.today.disabled.active,
 fieldset[disabled] .datepicker table tr td.today.disabled:hover.active {
-  background-color: @date-picker-today-bg;
-  border-color: @date-picker-today-border;
+    background-color: @date-picker-today-bg;
+    border-color: @date-picker-today-border;
 }
+
 .datepicker table tr td.today:hover:hover {
-  color: @date-picker-today-color;
+    color: @date-picker-today-color;
 }
+
 .datepicker table tr td.today.active:hover {
-  color: @white;
+    color: @white;
 }
+
 .datepicker table tr td.range,
 .datepicker table tr td.range:hover,
 .datepicker table tr td.range.disabled,
 .datepicker table tr td.range.disabled:hover {
-  background: @date-picker-today-btn-hover-bg;
-  border-radius: 0;
+    background: @date-picker-today-btn-hover-bg;
+    border-radius: 0;
 }
+
 .datepicker table tr td.range.today,
 .datepicker table tr td.range.today:hover,
 .datepicker table tr td.range.today.disabled,
 .datepicker table tr td.range.today.disabled:hover {
-  color: @date-picker-today-color;
-  background-color: @date-picker-range-today-bg;
-  border-color: @date-picker-range-today-border;
-  border-radius: 0;
+    color: @date-picker-today-color;
+    background-color: @date-picker-range-today-bg;
+    border-color: @date-picker-range-today-border;
+    border-radius: 0;
 }
+
 .datepicker table tr td.range.today:hover,
 .datepicker table tr td.range.today:hover:hover,
 .datepicker table tr td.range.today.disabled:hover,
@@ -642,10 +708,11 @@ fieldset[disabled] .datepicker table tr td.today.disabled:hover.active {
 .open .dropdown-toggle.datepicker table tr td.range.today:hover,
 .open .dropdown-toggle.datepicker table tr td.range.today.disabled,
 .open .dropdown-toggle.datepicker table tr td.range.today.disabled:hover {
-  color: @date-picker-today-color;
-  background-color: @date-picker-range-today-hover-bg;
-  border-color: @date-picker-range-today-hover-border;
+    color: @date-picker-today-color;
+    background-color: @date-picker-range-today-hover-bg;
+    border-color: @date-picker-range-today-hover-border;
 }
+
 .datepicker table tr td.range.today:active,
 .datepicker table tr td.range.today:hover:active,
 .datepicker table tr td.range.today.disabled:active,
@@ -658,8 +725,9 @@ fieldset[disabled] .datepicker table tr td.today.disabled:hover.active {
 .open .dropdown-toggle.datepicker table tr td.range.today:hover,
 .open .dropdown-toggle.datepicker table tr td.range.today.disabled,
 .open .dropdown-toggle.datepicker table tr td.range.today.disabled:hover {
-  background-image: none;
+    background-image: none;
 }
+
 .datepicker table tr td.range.today.disabled,
 .datepicker table tr td.range.today:hover.disabled,
 .datepicker table tr td.range.today.disabled.disabled,
@@ -720,18 +788,20 @@ fieldset[disabled] .datepicker table tr td.range.today.active,
 fieldset[disabled] .datepicker table tr td.range.today:hover.active,
 fieldset[disabled] .datepicker table tr td.range.today.disabled.active,
 fieldset[disabled] .datepicker table tr td.range.today.disabled:hover.active {
-  background-color: @date-picker-range-today-bg;
-  border-color: @date-picker-range-today-border;
+    background-color: @date-picker-range-today-bg;
+    border-color: @date-picker-range-today-border;
 }
+
 .datepicker table tr td.selected,
 .datepicker table tr td.selected:hover,
 .datepicker table tr td.selected.disabled,
 .datepicker table tr td.selected.disabled:hover {
-  color: @white;
-  background-color: @date-picker-selected-bg;
-  border-color: @date-picker-selected-border;
-  text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.25);
+    color: @white;
+    background-color: @date-picker-selected-bg;
+    border-color: @date-picker-selected-border;
+    text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.25);
 }
+
 .datepicker table tr td.selected:hover,
 .datepicker table tr td.selected:hover:hover,
 .datepicker table tr td.selected.disabled:hover,
@@ -752,10 +822,11 @@ fieldset[disabled] .datepicker table tr td.range.today.disabled:hover.active {
 .open .dropdown-toggle.datepicker table tr td.selected:hover,
 .open .dropdown-toggle.datepicker table tr td.selected.disabled,
 .open .dropdown-toggle.datepicker table tr td.selected.disabled:hover {
-  color: @white;
-  background-color: @date-picker-selected-hover-bg;
-  border-color: @date-picker-selected-hover-border;
+    color: @white;
+    background-color: @date-picker-selected-hover-bg;
+    border-color: @date-picker-selected-hover-border;
 }
+
 .datepicker table tr td.selected:active,
 .datepicker table tr td.selected:hover:active,
 .datepicker table tr td.selected.disabled:active,
@@ -768,8 +839,9 @@ fieldset[disabled] .datepicker table tr td.range.today.disabled:hover.active {
 .open .dropdown-toggle.datepicker table tr td.selected:hover,
 .open .dropdown-toggle.datepicker table tr td.selected.disabled,
 .open .dropdown-toggle.datepicker table tr td.selected.disabled:hover {
-  background-image: none;
+    background-image: none;
 }
+
 .datepicker table tr td.selected.disabled,
 .datepicker table tr td.selected:hover.disabled,
 .datepicker table tr td.selected.disabled.disabled,
@@ -830,18 +902,20 @@ fieldset[disabled] .datepicker table tr td.selected.active,
 fieldset[disabled] .datepicker table tr td.selected:hover.active,
 fieldset[disabled] .datepicker table tr td.selected.disabled.active,
 fieldset[disabled] .datepicker table tr td.selected.disabled:hover.active {
-  background-color: @date-picker-selected-bg;
-  border-color: @date-picker-selected-border;
+    background-color: @date-picker-selected-bg;
+    border-color: @date-picker-selected-border;
 }
+
 .datepicker table tr td.active,
 .datepicker table tr td.active:hover,
 .datepicker table tr td.active.disabled,
 .datepicker table tr td.active.disabled:hover {
-  color: @white;
-  background-color: @date-picker-active-disabled-bg;
-  border-color: @date-picker-active-disabled-border;
-  text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.25);
+    color: @white;
+    background-color: @date-picker-active-disabled-bg;
+    border-color: @date-picker-active-disabled-border;
+    text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.25);
 }
+
 .datepicker table tr td.active:hover,
 .datepicker table tr td.active:hover:hover,
 .datepicker table tr td.active.disabled:hover,
@@ -862,10 +936,11 @@ fieldset[disabled] .datepicker table tr td.selected.disabled:hover.active {
 .open .dropdown-toggle.datepicker table tr td.active:hover,
 .open .dropdown-toggle.datepicker table tr td.active.disabled,
 .open .dropdown-toggle.datepicker table tr td.active.disabled:hover {
-  color: @white;
-  background-color: @accent;
-  border-color: @date-picker-active-disabled-hover-border;
+    color: @white;
+    background-color: @accent;
+    border-color: @date-picker-active-disabled-hover-border;
 }
+
 .datepicker table tr td.active:active,
 .datepicker table tr td.active:hover:active,
 .datepicker table tr td.active.disabled:active,
@@ -878,8 +953,9 @@ fieldset[disabled] .datepicker table tr td.selected.disabled:hover.active {
 .open .dropdown-toggle.datepicker table tr td.active:hover,
 .open .dropdown-toggle.datepicker table tr td.active.disabled,
 .open .dropdown-toggle.datepicker table tr td.active.disabled:hover {
-  background-image: none;
+    background-image: none;
 }
+
 .datepicker table tr td.active.disabled,
 .datepicker table tr td.active:hover.disabled,
 .datepicker table tr td.active.disabled.disabled,
@@ -940,37 +1016,42 @@ fieldset[disabled] .datepicker table tr td.active.active,
 fieldset[disabled] .datepicker table tr td.active:hover.active,
 fieldset[disabled] .datepicker table tr td.active.disabled.active,
 fieldset[disabled] .datepicker table tr td.active.disabled:hover.active {
-  background-color: @date-picker-active-disabled-bg;
-  border-color: @date-picker-active-disabled-border;
+    background-color: @date-picker-active-disabled-bg;
+    border-color: @date-picker-active-disabled-border;
 }
+
 .datepicker table tr td span {
-  display: block;
-  width: 23%;
-  height: 54px;
-  line-height: 54px;
-  float: left;
-  margin: 1%;
-  cursor: pointer;
-  border-radius: 4px;
+    display: block;
+    width: 23%;
+    height: 54px;
+    line-height: 54px;
+    float: left;
+    margin: 1%;
+    cursor: pointer;
+    border-radius: 4px;
 }
+
 .datepicker table tr td span:hover {
-  background: @date-picker-today-btn-hover-bg;
+    background: @date-picker-today-btn-hover-bg;
 }
+
 .datepicker table tr td span.disabled,
 .datepicker table tr td span.disabled:hover {
-  background: none;
-  color: @date-picker-disabled-hover-bg;
-  cursor: default;
+    background: none;
+    color: @date-picker-disabled-hover-bg;
+    cursor: default;
 }
+
 .datepicker table tr td span.active,
 .datepicker table tr td span.active:hover,
 .datepicker table tr td span.active.disabled,
 .datepicker table tr td span.active.disabled:hover {
-  color: @white;
-  background-color: @date-picker-active-disabled-bg;
-  border-color: @date-picker-active-disabled-border;
-  text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.25);
+    color: @white;
+    background-color: @date-picker-active-disabled-bg;
+    border-color: @date-picker-active-disabled-border;
+    text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.25);
 }
+
 .datepicker table tr td span.active:hover,
 .datepicker table tr td span.active:hover:hover,
 .datepicker table tr td span.active.disabled:hover,
@@ -991,10 +1072,11 @@ fieldset[disabled] .datepicker table tr td.active.disabled:hover.active {
 .open .dropdown-toggle.datepicker table tr td span.active:hover,
 .open .dropdown-toggle.datepicker table tr td span.active.disabled,
 .open .dropdown-toggle.datepicker table tr td span.active.disabled:hover {
-  color: @date-picker-active-color;
-  background-color: @date-picker-active-bg;
-  border-color: @date-picker-active-disabled-hover-border;
+    color: @date-picker-active-color;
+    background-color: @date-picker-active-bg;
+    border-color: @date-picker-active-disabled-hover-border;
 }
+
 .datepicker table tr td span.active:active,
 .datepicker table tr td span.active:hover:active,
 .datepicker table tr td span.active.disabled:active,
@@ -1007,8 +1089,9 @@ fieldset[disabled] .datepicker table tr td.active.disabled:hover.active {
 .open .dropdown-toggle.datepicker table tr td span.active:hover,
 .open .dropdown-toggle.datepicker table tr td span.active.disabled,
 .open .dropdown-toggle.datepicker table tr td span.active.disabled:hover {
-  background-image: none;
+    background-image: none;
 }
+
 .datepicker table tr td span.active.disabled,
 .datepicker table tr td span.active:hover.disabled,
 .datepicker table tr td span.active.disabled.disabled,
@@ -1069,572 +1152,612 @@ fieldset[disabled] .datepicker table tr td span.active.active,
 fieldset[disabled] .datepicker table tr td span.active:hover.active,
 fieldset[disabled] .datepicker table tr td span.active.disabled.active,
 fieldset[disabled] .datepicker table tr td span.active.disabled:hover.active {
-  background-color: @date-picker-active-disabled-bg;
-  border-color: @date-picker-active-disabled-border;
+    background-color: @date-picker-active-disabled-bg;
+    border-color: @date-picker-active-disabled-border;
 }
+
 .datepicker {
-  table {
-    tr {
-      td {
-        span {
-          &.old, &.new {
-            color: @date-picker-disabled-hover-bg;
-          }
+    table {
+        tr {
+            td {
+                span {
+                    &.old,
+                    &.new {
+                        color: @date-picker-disabled-hover-bg;
+                    }
+                }
+            }
         }
-      }
     }
-  }
 }
+
 .datepicker {
-  th {
-    &.datepicker-switch {
-      width: 145px;
+    th {
+        &.datepicker-switch {
+            width: 145px;
+        }
     }
-  }
 }
+
 .datepicker thead tr:first-child th,
 .datepicker tfoot tr th {
-  cursor: pointer;
+    cursor: pointer;
 }
+
 .datepicker thead tr:first-child th:hover,
 .datepicker tfoot tr th:hover {
-  background: @date-picker-today-btn-hover-bg;
+    background: @date-picker-today-btn-hover-bg;
 }
+
 .datepicker {
-  .cw {
-    font-size: 0.625rem;
-    width: 12px;
-    padding: 0 2px 0 5px;
-    vertical-align: middle;
-  }
+    .cw {
+        font-size: 0.625rem;
+        width: 12px;
+        padding: 0 2px 0 5px;
+        vertical-align: middle;
+    }
 }
+
 .datepicker {
-  thead {
-    tr {
-      &:first-child {
-        th {
-          &.cw {
-            cursor: default;
-            background-color: transparent;
-          }
+    thead {
+        tr {
+            &:first-child {
+                th {
+                    &.cw {
+                        cursor: default;
+                        background-color: transparent;
+                    }
+                }
+            }
         }
-      }
     }
-  }
 }
 
 .date {
-  .input-group-addon{
-    line-height: 1.428571429;
-    text-align: center;
-    vertical-align: middle;
-  }
+    .input-group-addon {
+        line-height: 1.428571429;
+        text-align: center;
+        vertical-align: middle;
+    }
 }
+
 .date {
-  .input-group-addon {
-    i {
-      cursor: pointer;
-      width: 16px;
-      height: 16px;
+    .input-group-addon {
+        i {
+            cursor: pointer;
+            width: 16px;
+            height: 16px;
+        }
     }
-  }
 }
+
 .input-daterange {
-  &.input-group{
-    display:block;
-    .clearfix();
-  }
+    &.input-group {
+        display: block;
+        .clearfix();
+    }
 }
+
 .input-daterange {
-  input {
-    text-align: center;
-  }
+    input {
+        text-align: center;
+    }
 }
+
 .input-daterange {
-  .date {
-    display:table;
-    float: left;
-    width: 50%;
-    padding-left:15px;
-    &:first-child{
-      padding-right:15px;
-      padding-left:0;
+    .date {
+        display: table;
+        float: left;
+        width: 50%;
+        padding-left: 15px;
+
+        &:first-child {
+            padding-right: 15px;
+            padding-left: 0;
+        }
     }
-  }
 }
+
 .input-daterange {
-  input {
-    &:first-child {
-      border-radius: 3px 0 0 3px;
+    input {
+        &:first-child {
+            border-radius: 3px 0 0 3px;
+        }
+
+        &:last-child {
+            border-radius: 0 3px 3px 0;
+        }
     }
-    &:last-child {
-      border-radius: 0 3px 3px 0;
-    }
-  }
 }
+
 .input-daterange {
-  .input-group-addon {
-    min-width: 16px;
-    font-weight: normal;
-    line-height: 1.428571429;
-    text-align: center;
-    vertical-align: middle;
-    border-right-width:0;
-    &.input-group-join{
-      padding: 4px 5px;
-      width:30px;
-      height:34px;
-      background-color: @date-picker-today-btn-hover-bg;
-      float:left;
-      line-height: 1.5em;
-      margin-left:-15px;
-      margin-right:-15px;
+    .input-group-addon {
+        min-width: 16px;
+        font-weight: normal;
+        line-height: 1.428571429;
+        text-align: center;
+        vertical-align: middle;
+        border-right-width: 0;
+
+        &.input-group-join {
+            padding: 4px 5px;
+            width: 30px;
+            height: 34px;
+            background-color: @date-picker-today-btn-hover-bg;
+            float: left;
+            line-height: 1.5em;
+            margin-left: -15px;
+            margin-right: -15px;
+        }
     }
-  }
-}
-.datepicker {
-  &.dropdown-menu {
-    position: absolute;
-    top: 100%;
-    left: 0;
-    float: left;
-    display: none;
-    min-width: 160px;
-    list-style: none;
-    background-color: @date-picker-dropdown-bg;
-    border: 1px solid @date-picker-dropdown-border;
-    border-radius: 5px;
-    -webkit-box-shadow: 0 5px 10px @date-picker-dropdown-shadow;
-    -moz-box-shadow: 0 5px 10px @date-picker-dropdown-shadow;
-    box-shadow: 0 5px 10px @date-picker-dropdown-shadow;
-    -webkit-background-clip: padding-box;
-    -moz-background-clip: padding;
-    background-clip: padding-box;
-    *border-right-width: 2px;
-    *border-bottom-width: 2px;
-    color: @grey2;
-    font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
-    font-size: 0.8125rem;
-    line-height: 1.428571429;
-  }
-}
-.datepicker {
-  &.dropdown-menu {
-    th, td {
-      padding: 4px 5px;
-    }
-  }
 }
 
 .datepicker {
-  table {
-    outline: none;
-  }
+    &.dropdown-menu {
+        position: absolute;
+        top: 100%;
+        left: 0;
+        float: left;
+        display: none;
+        min-width: 160px;
+        list-style: none;
+        background-color: @date-picker-dropdown-bg;
+        border: 1px solid @date-picker-dropdown-border;
+        border-radius: 5px;
+        -webkit-box-shadow: 0 5px 10px @date-picker-dropdown-shadow;
+        -moz-box-shadow: 0 5px 10px @date-picker-dropdown-shadow;
+        box-shadow: 0 5px 10px @date-picker-dropdown-shadow;
+        -webkit-background-clip: padding-box;
+        -moz-background-clip: padding;
+        background-clip: padding-box;
+        *border-right-width: 2px;
+        *border-bottom-width: 2px;
+        color: @grey2;
+        font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+        font-size: 0.8125rem;
+        line-height: 1.428571429;
+    }
+}
 
-  th, td, span {
-    outline-color: @date-picker-dropdown-outline;
-  }
+.datepicker {
+    &.dropdown-menu {
+        th,
+        td {
+            padding: 4px 5px;
+        }
+    }
+}
+
+.datepicker {
+    table {
+        outline: none;
+    }
+
+    th,
+    td,
+    span {
+        outline-color: @date-picker-dropdown-outline;
+    }
 }
 
 //Bootstrap timepicker styling
-
 .timepicker-arrow {
-  color: @timepicker-arrow-color;
+    color: @timepicker-arrow-color;
 }
+
 .timepicker-arrow:hover,
 .timepicker-arrow:focus {
-   color: @timepicker-arrow-hover-color;
+    color: @timepicker-arrow-hover-color;
 }
 
- //Integrated date-time picker styling
+//Integrated date-time picker styling
 .timezone-dropdown {
-  padding: 4px 5px 4px 5px !important;
+    padding: 4px 5px !important;
 }
+
 .timezone-dropdown > span {
-  border: none !important;
+    border: none !important;
 }
 
 .date-picker {
-	border-radius: 0px;
+    border-radius: 0;
 
-	.today-btn {
-    border: none !important;
-    box-shadow: none !important;
-    width: 100% !important;
-    font-size: 1rem;
-    color: @date-picker-today-btn-color;
-    background-color: @date-picker-today-btn-bg !important;
-    text-transform: none;
+    .today-btn {
+        border: none !important;
+        box-shadow: none !important;
+        width: 100% !important;
+        font-size: 1rem;
+        color: @date-picker-today-btn-color;
+        background-color: @date-picker-today-btn-bg !important;
+        text-transform: none;
 
-    &:hover {
-      border: none !important;
-      box-shadow: none !important;
-      background-color: @date-picker-today-btn-hover-bg !important;
+        &:hover {
+            border: none !important;
+            box-shadow: none !important;
+            background-color: @date-picker-today-btn-hover-bg !important;
+        }
     }
-  }
-  table {
-	  thead {
-		 color: @date-picker-dropdown-color;
-		 font-family: @font-family;
-     font-weight: @font-weight-semibold;
-	   }
-	   tr th, tr td, tr td span {
-		border-radius: 0px;
-	   }
- }
+
+    table {
+        thead {
+            color: @date-picker-dropdown-color;
+            font-family: @font-family;
+            font-weight: @font-weight-semibold;
+        }
+
+        tr th,
+        tr td,
+        tr td span {
+            border-radius: 0;
+        }
+    }
 }
 
 .timepicker-light {
- 	padding: 12px;
+    padding: 12px;
 }
 
 .popover {
-  &.date-picker-popover {
-
-    .popover-content {
-      padding: 0;
-    }
-
-    .date-picker-popover-arrow {
-      border-width: 8px;
-
-      &:after {
-        border-width: 7px;
-      }
-    }
-
-    &.bottom {
-      left: 40px;
-      margin-top: 7px;
-
-      .date-picker-popover-arrow {
-        left: 7% !important; // required to override inline style added by bootstrap.js
-        top: -16px;
-        margin-left: -8px;
-
-        &:after {
-          left: 10%;
-          margin-left: -7px;
-          top: -6px;
+    &.date-picker-popover {
+        .popover-content {
+            padding: 0;
         }
-      }
-    }
 
-    &.top {
-      left: 40px;
+        .date-picker-popover-arrow {
+            border-width: 8px;
 
-      .date-picker-popover-arrow {
-        left: 7% !important; // required to override inline style added by bootstrap.js
-        bottom: -16px;
-        margin-left: -8px;
-
-        &:after {
-          left: 10%;
-          margin-left: -7px;
-          bottom: -6px;
+            &:after {
+                border-width: 7px;
+            }
         }
-      }
+
+        &.bottom {
+            left: 40px;
+            margin-top: 7px;
+
+            .date-picker-popover-arrow {
+                left: 7% !important; // required to override inline style added by bootstrap.js
+                top: -16px;
+                margin-left: -8px;
+
+                &:after {
+                    left: 10%;
+                    margin-left: -7px;
+                    top: -6px;
+                }
+            }
+        }
+
+        &.top {
+            left: 40px;
+
+            .date-picker-popover-arrow {
+                left: 7% !important; // required to override inline style added by bootstrap.js
+                bottom: -16px;
+                margin-left: -8px;
+
+                &:after {
+                    left: 10%;
+                    margin-left: -7px;
+                    bottom: -6px;
+                }
+            }
+        }
     }
-  }
 }
-
 
 .date-picker {
-  font-family: @font-family !important;
-  .datepicker table {
-	width: 100%;
-  }
-}
-.timepicker {
-  width: 100%;
-  table-layout: fixed;
+    font-family: @font-family !important;
 
-  button.meridian-btn {
-	  padding: 4px 11px !important;
-	}
-	input {
-    font-size: 0.875rem;
-	}
+    .datepicker table {
+        width: 100%;
+    }
+}
+
+.timepicker {
+    width: 100%;
+    table-layout: fixed;
+
+    button.meridian-btn {
+        padding: 4px 11px !important;
+    }
+
+    input {
+        font-size: 0.875rem;
+    }
 }
 
 .timepicker-dark {
-  background-color: @grey8;
-  padding: 12px;
-  margin-top: 6px;
-  border-top: 1px solid @grey5;
+    background-color: @grey8;
+    padding: 12px;
+    margin-top: 6px;
+    border-top: 1px solid @grey5;
 }
 
 /* Modal */
+
 .modal {
-  z-index: @modal-z-index !important;
+    z-index: @modal-z-index !important;
 }
 
 .modal-open {
-  .datepicker {
-    &.dropdown-menu {
-      z-index: @modal-z-index + 1 !important;
+    .datepicker {
+        &.dropdown-menu {
+            z-index: @modal-z-index + 1 !important;
+        }
     }
-  }
 }
 
 .modal-open {
-  .affix-container {
-    .affix {
-      z-index: @modal-open-z-index;
+    .affix-container {
+        .affix {
+            z-index: @modal-open-z-index;
+        }
     }
-  }
 }
+
 .modal-open {
-  .navbar-static-side-container {
-    z-index: @modal-open-z-index;
-  }
+    .navbar-static-side-container {
+        z-index: @modal-open-z-index;
+    }
 }
+
 /* Modal End */
 
 /* TOOLTIPS */
 
 .tooltip {
-  word-wrap: break-word;
-  font-size: 0.875rem;
-  font-family: @font-family;
-  z-index: @tooltip-z-index;
+    word-wrap: break-word;
+    font-size: 0.875rem;
+    font-family: @font-family;
+    z-index: @tooltip-z-index;
 }
+
 .tooltip {
-  &.in {
-    .opacity(100);
-  }
+    &.in {
+        .opacity(100);
+    }
 }
 
 .tooltip-inner {
-  background-color: @tooltip-bg;
-  box-shadow: 1px 1px 2px @tooltip-shadow;
-  border-radius: 0;
-  text-align: left;
-  max-width: 400px;
+    background-color: @tooltip-bg;
+    box-shadow: 1px 1px 2px @tooltip-shadow;
+    border-radius: 0;
+    text-align: left;
+    max-width: 400px;
 }
 
 .tooltip {
-  &.top {
-    .tooltip-arrow {
-      border-top-color: @tooltip-bg;
+    &.top {
+        .tooltip-arrow {
+            border-top-color: @tooltip-bg;
+        }
     }
-  }
 }
 
 .tooltip {
-  &.right {
-    .tooltip-arrow {
-      border-right-color: @tooltip-bg;
+    &.right {
+        .tooltip-arrow {
+            border-right-color: @tooltip-bg;
+        }
     }
-  }
 }
 
 .tooltip {
-  &.bottom {
-    .tooltip-arrow {
-      border-bottom-color: @tooltip-bg;
+    &.bottom {
+        .tooltip-arrow {
+            border-bottom-color: @tooltip-bg;
+        }
     }
-  }
 }
 
 .tooltip {
-  &.left {
-    .tooltip-arrow {
-      border-left-color: @tooltip-bg;
+    &.left {
+        .tooltip-arrow {
+            border-left-color: @tooltip-bg;
+        }
     }
-  }
 }
 
 // Should probably be removed?
-.black-tooltip{
-  &+.tooltip{
+.black-tooltip {
+    & + .tooltip {
+        width: 350px;
 
-    width:350px;
+        > .tooltip-inner {
+            background-color: @tooltip-black-bg-border;
+            font-family: @font-family;
+            font-size: 0.875rem;
+            display: inline-block;
+        }
 
-    >.tooltip-inner{
-      background-color: @tooltip-black-bg-border;
-      font-family: @font-family;
-      font-size: 0.875rem;
-      display:inline-block;
+        &.right {
+            > .tooltip-arrow {
+                border-right-color: @tooltip-black-bg-border;
+            }
+        }
+
+        &.left {
+            > .tooltip-arrow {
+                border-left-color: @tooltip-black-bg-border;
+            }
+        }
+
+        &.top {
+            > .tooltip-arrow {
+                border-top-color: @tooltip-black-bg-border;
+            }
+        }
+
+        &.bottom {
+            > .tooltip-arrow {
+                border-bottom-color: @tooltip-black-bg-border;
+            }
+        }
     }
-    &.right{
-      >.tooltip-arrow{
-      border-right-color: @tooltip-black-bg-border;
-      }
-    }
-    &.left{
-      >.tooltip-arrow{
-      border-left-color: @tooltip-black-bg-border;
-      }
-    }
-    &.top{
-      >.tooltip-arrow{
-      border-top-color: @tooltip-black-bg-border;
-      }
-    }
-    &.bottom{
-      >.tooltip-arrow{
-      border-bottom-color: @tooltip-black-bg-border;
-      }
-    }
-  }
 }
+
 .linkTooltip {
-  pointer-events: none;
-}
-//JQuery knob input
-.dial{
-  &:focus{
-  .aspects-outline;
-  }
+    pointer-events: none;
 }
 
+//JQuery knob input
+.dial {
+    &:focus {
+        .aspects-outline;
+    }
+}
 
 //Float label
-
-.float-label{
-  position: relative;
-  input{
+.float-label {
     position: relative;
-    height: 45px;
-  	padding-top: 16px;
-  	border: none;
-    border-bottom: 1px solid @float-label-border;
 
-    // Needs checked - are login class names changing?
-    &.login-form-control-light{
-      border-bottom: 1px solid @float-label-border;
-      &:focus {
-        border-bottom: 1px solid @login-form-border;
-      }
+    input {
+        position: relative;
+        height: 45px;
+        padding-top: 16px;
+        border: none;
+        border-bottom: 1px solid @float-label-border; // Needs checked - are login class names changing?
+        &.login-form-control-light {
+            border-bottom: 1px solid @float-label-border;
+
+            &:focus {
+                border-bottom: 1px solid @login-form-border;
+            }
+        }
+
+        &.login-form-control-dark {
+            border-bottom: 1px solid @login-form-border;
+
+            &:focus {
+                border-bottom: 1px solid @float-label-border;
+            }
+        }
+
+        &.input-lg {
+            height: 50px;
+        }
+    } //IE10+ browsers
+
+    @media all and (-ms-high-contrast: none),
+        (-ms-high-contrast: active) {
+        input:focus + label {
+            font-size: @font-size-sm;
+            .opacity(1);
+
+            z-index: @float-label-z-index;
+            top: -1px;
+            color: @accent;
+            transition: 0.4s;
+        }
     }
 
-    &.login-form-control-dark {
-      border-bottom: 1px solid @login-form-border;
-      &:focus {
-        border-bottom: 1px solid @float-label-border;
-      }
+    label,
+    input [data-toggle="floatLabel"][data-value=""] + label {
+        position: absolute;
+        top: 15px;
+        .opacity(0);
+
+        width: 100%;
+        text-indent: 1.1em;
+        font-size: @font-size-sm;
+        color: lighten(@grey2, 60%);
+        pointer-events: none;
+        text-transform: capitalize;
     }
 
+    input[data-toggle="floatLabel"]:not([data-value=""]) + label {
+        font-size: @font-size-sm;
+        .opacity(1);
 
-    &.input-sm{
+        z-index: @float-label-z-index;
+        top: -1px;
+        color: lighten(@text-color, 30%);
+        transition: all 0.5s ease-in-out;
+    }
 
+    input.input-lg:focus + label,
+    input.input-lg:valid + label {
+        font-size: @font-size-md;
+        z-index: @float-label-z-index;
+        .opacity(1);
+
+        top: 0%;
+        color: @accent;
+        text-indent: 1em;
+        transition: 0.2s top linear;
     }
-    &.input-lg{
-      height: 50px;
+
+    .input-group-addon ~ label,
+    &.input-group label,
+    .input-group label {
+        display: none;
     }
-  }
-//IE10+ browsers
-@media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
- input:focus + label {
-    font-size: @font-size-sm;
-    .opacity(1);
-    z-index: @float-label-z-index;
-    top:-1px;
-    color: @accent;
-    transition: 0.4s;
-  }
 }
-
-  label, input [data-toggle="floatLabel"][data-value=""] + label {
-    position: absolute;
-    top: 15px;
-    .opacity(0);
-    width: 100%;
-    text-indent: 1.1em;
-    font-size: @font-size-sm;
-    color: lighten(@grey2, 60%);
-    pointer-events: none;
-    text-transform: capitalize;
-  }
-
-  input[data-toggle="floatLabel"]:not([data-value=""]) + label{
-    font-size: @font-size-sm;
-    .opacity(1);
-    z-index: @float-label-z-index;
-    top:-1px;
-    color: lighten(@text-color, 30%);
-    transition: all 0.5s ease-in-out;
-  }
-
-  input.input-lg:focus + label, input.input-lg:valid+label{
-    font-size: @font-size-md;
-    z-index: @float-label-z-index;
-    .opacity(1);
-    top:0%;
-    color: @accent;
-    text-indent: 1em;
-    transition: 0.2s top linear;
-  }
-  .input-group-addon ~ label, &.input-group label, .input-group label{
-    display: none;
-  }
-}
-//IE 9
-:root .float-label input:focus + label {
-    font-size: @font-size-sm e(" \0/IE9");
-    opacity: 1 e(" \0/IE9");
-    -ms-filter: ~"progid:DXImageTransform.Microsoft.Alpha(opacity=(100))" e(" \0/IE9");
-    z-index:  @float-label-z-index e("\0/IE9");
-    top:-1px e("\0/IE9");
-    color: @accent e("\0/IE9");
-    transition: 0.4s e("\0/IE9");
-  }
 
 //ui-tree
-.angular-ui-tree{
-  > ol {
-    padding-left: 10px;
-  }
-  ol{
-    list-style: none;
-    position: relative;
-    padding-left: 18px;
-  }
-  &.showTreeOutline, &.show-tree-outline {
-      li {
-      position: relative;
-      &::before, &::after{
-        content: "";
-        position: absolute;
-        left: -12px;
-      }
-      &::before{
-        border-top: 1px dashed @treeview-outline;
-        top: 12px;
-        width: 10px;
-        height: 0;
-      }
-      &::after{
-        border-left: 1px dashed @treeview-outline;
-        height: 100%;
-        width: 0px;
-        top: 2px;
-      }
+.angular-ui-tree {
+    > ol {
+        padding-left: 10px;
     }
-    ol > li {
-      &:last-child::after{
-        height: 10px;
-      }
-    }
-  }
 
-  .ng-hide-add,
-  .ng-hide-remove {
-  .opacity(0);
-  }
+    ol {
+        list-style: none;
+        position: relative;
+        padding-left: 18px;
+    }
+
+    &.showTreeOutline,
+    &.show-tree-outline {
+        li {
+            position: relative;
+
+            &:before,
+            &:after {
+                content: "";
+                position: absolute;
+                left: -12px;
+            }
+
+            &:before {
+                border-top: 1px dashed @treeview-outline;
+                top: 12px;
+                width: 10px;
+                height: 0;
+            }
+
+            &:after {
+                border-left: 1px dashed @treeview-outline;
+                height: 100%;
+                width: 0;
+                top: 2px;
+            }
+        }
+
+        ol > li {
+            &:last-child:after {
+                height: 10px;
+            }
+        }
+    }
+
+    .ng-hide-add,
+    .ng-hide-remove {
+        .opacity(0);
+    }
 }
 
-tree-view > div:first-child > ol:nth-of-type(1){
-    border:none;
-    > li::before, > li::after{
-      border:none !important;
+tree-view > div:first-child > ol:nth-of-type(1) {
+    border: none;
+
+    > li:before,
+    > li:after {
+        border: none !important;
     }
 }
 
 .angular-ui-tree-handle {
     color: @text-color;
-
 }
 
 .angular-ui-tree-placeholder {
@@ -1650,66 +1773,86 @@ tree-view > div:first-child > ol:nth-of-type(1){
     color: @white !important;
 }
 
-
 /* --- Tree --- */
+
 .tree-node {
     color: @treeview-color;
-    padding: 1px 1px;
-    &.highlight{
-      background-color: @shift-select-selected-light;
-      .title-readonly{
-        cursor: text;
-      }
-      > input{ 
-        line-height: 1em !important;
-        border:none !important;
-        margin-left: -5px;
-        .aspects-outline;
-        padding-left: 5px;
-      }
-      .title-readonly:focus{
-        background-color: transparent!important;
-      }
+    padding: 1px;
+
+    &.highlight {
+        background-color: @shift-select-selected-light;
+
+        .title-readonly {
+            cursor: text;
+        }
+
+        > input {
+            line-height: 1em !important;
+            border: none !important;
+            margin-left: -5px;
+            .aspects-outline;
+
+            padding-left: 5px;
+        }
+
+        .title-readonly:focus {
+            background-color: transparent !important;
+        }
     }
+
     &:hover {
-      background-color: @treeview-hover-bg;
+        background-color: @treeview-hover-bg;
     }
-    &:active, &:active:focus, &:focus{
-      outline: 0;
+
+    &:active,
+    &:active:focus,
+    &:focus {
+        outline: 0;
     }
-    a.btn{
-      vertical-align: text-top;
-      padding-bottom: 0px;
+
+    a.btn {
+        vertical-align: text-top;
+        padding-bottom: 0;
     }
-    .chevron{
-      width: 13px !important;
-      span {
-        color: @text-color;
-        opacity: 0.5;
-        &:hover {
-          opacity: 1;
+
+    .chevron {
+        width: 13px !important;
+
+        span {
+            color: @text-color;
+            opacity: 0.5;
+
+            &:hover {
+                opacity: 1;
+            }
         }
-      }
     }
-    .tree-action-button{
-      font-size: 0.625rem !important;
-      padding: 4px !important;
+
+    .tree-action-button {
+        font-size: 0.625rem !important;
+        padding: 4px !important;
     }
-    .icon{
-      margin-right: 3px;
+
+    .icon {
+        margin-right: 3px;
     }
-    a:focus, span:focus{
-      .aspects-outline;
+
+    a:focus,
+    span:focus {
+        .aspects-outline;
     }
-    a:active, a:active:focus{
-      .aspects-outline;
+
+    a:active,
+    a:active:focus {
+        .aspects-outline;
     }
-    .toggle{
-      &.empty{
-        > span {
-          color: lighten(@text-color, 50%);
+
+    .toggle {
+        &.empty {
+            > span {
+                color: lighten(@text-color, 50%);
+            }
         }
-      }
     }
 }
 
@@ -1725,6 +1868,7 @@ tree-view > div:first-child > ol:nth-of-type(1){
     user-select: none;
     cursor: pointer;
 }
+
 .tree-handle {
     padding: 2px;
 }
@@ -1734,485 +1878,502 @@ tree-view > div:first-child > ol:nth-of-type(1){
 */
 
 .static-tooltip {
-  position: fixed;
-  width: 250px;
-  background-color: @static-tooltip-bg;
-  border: 1px solid @static-tooltip-border;
-  box-shadow: 2px 2px 2px @static-tooltip-shadow;
-  z-index: @static-tooltip-z-index;
-  padding: 5px 10px;
-  transition: border-color 0.3s linear;
-
-  .callout {
-    position: absolute;
-    display: inline-block;
-    width: 9px;
-    height: 9px;
+    position: fixed;
+    width: 250px;
     background-color: @static-tooltip-bg;
+    border: 1px solid @static-tooltip-border;
+    box-shadow: 2px 2px 2px @static-tooltip-shadow;
+    z-index: @static-tooltip-z-index;
+    padding: 5px 10px;
     transition: border-color 0.3s linear;
-  }
-
-  &.right {
-    .callout {
-      right: -5px;
-      transform: translateY(-50%) rotate(45deg);
-      border-right: 1px solid @static-tooltip-border;
-      border-top: 1px solid @static-tooltip-border;
-    }
-  }
-
-  &.left {
-    .callout {
-      left: -5px;
-      transform: translateY(-50%) rotate(45deg);
-      border-left: 1px solid @static-tooltip-border;
-      border-bottom: 1px solid @static-tooltip-border;
-    }
-  }
-
-  &.up {
-    .callout {
-      transform: translateX(-50%) rotate(45deg);
-      top: -5px;
-      border-left: 1px solid @static-tooltip-border;
-      border-top: 1px solid @static-tooltip-border;
-    }
-  }
-
-  &.down {
-    .callout {
-      transform: translateX(-50%) rotate(45deg);
-      bottom: -5px;
-      border-right: 1px solid @static-tooltip-border;
-      border-bottom: 1px solid @static-tooltip-border;
-    }
-  }
-
-  &.up, &.down {
-    &.start {
-      .callout {
-        left: 19px;
-      }
-    }
-    &.middle {
-      .callout {
-        left: 50%;
-      }
-    }
-    &.end {
-      .callout {
-        right: 9px;
-      }
-    }
-  }
-
-  &.left, &.right {
-    &.start {
-      .callout {
-        top: 19px;
-      }
-    }
-    &.middle {
-      .callout {
-        top: 50%;
-      }
-    }
-    &.end {
-      .callout {
-        bottom: 9px;
-      }
-    }
-  }
-
-  .content {
-    color: @static-tooltip-color;
-    font-family: @font-family;
-    font-weight: @font-weight-semibold;
-    text-rendering: optimizeLegibility;
-    margin: 0;
-  }
-
-  .footer {
-    display: block;
-    text-align: right;
-    opacity: 0;
-    transition: opacity 0.3s linear;
-
-    .hide-tips {
-      color: @static-tooltip-hide-tips;
-      font-size: 0.875rem;
-    }
-  }
-
-  &:hover {
-    border-color: @static-tooltip-hover-border;
 
     .callout {
-      border-color: @static-tooltip-hover-border;
+        position: absolute;
+        display: inline-block;
+        width: 9px;
+        height: 9px;
+        background-color: @static-tooltip-bg;
+        transition: border-color 0.3s linear;
+    }
+
+    &.right {
+        .callout {
+            right: -5px;
+            transform: translateY(-50%) rotate(45deg);
+            border-right: 1px solid @static-tooltip-border;
+            border-top: 1px solid @static-tooltip-border;
+        }
+    }
+
+    &.left {
+        .callout {
+            left: -5px;
+            transform: translateY(-50%) rotate(45deg);
+            border-left: 1px solid @static-tooltip-border;
+            border-bottom: 1px solid @static-tooltip-border;
+        }
+    }
+
+    &.up {
+        .callout {
+            transform: translateX(-50%) rotate(45deg);
+            top: -5px;
+            border-left: 1px solid @static-tooltip-border;
+            border-top: 1px solid @static-tooltip-border;
+        }
+    }
+
+    &.down {
+        .callout {
+            transform: translateX(-50%) rotate(45deg);
+            bottom: -5px;
+            border-right: 1px solid @static-tooltip-border;
+            border-bottom: 1px solid @static-tooltip-border;
+        }
+    }
+
+    &.up,
+    &.down {
+        &.start {
+            .callout {
+                left: 19px;
+            }
+        }
+
+        &.middle {
+            .callout {
+                left: 50%;
+            }
+        }
+
+        &.end {
+            .callout {
+                right: 9px;
+            }
+        }
+    }
+
+    &.left,
+    &.right {
+        &.start {
+            .callout {
+                top: 19px;
+            }
+        }
+
+        &.middle {
+            .callout {
+                top: 50%;
+            }
+        }
+
+        &.end {
+            .callout {
+                bottom: 9px;
+            }
+        }
+    }
+
+    .content {
+        color: @static-tooltip-color;
+        font-family: @font-family;
+        font-weight: @font-weight-semibold;
+        text-rendering: optimizeLegibility;
+        margin: 0;
     }
 
     .footer {
-      opacity: 1;
+        display: block;
+        text-align: right;
+        opacity: 0;
+        transition: opacity 0.3s linear;
+
+        .hide-tips {
+            color: @static-tooltip-hide-tips;
+            font-size: 0.875rem;
+        }
     }
-  }
+
+    &:hover {
+        border-color: @static-tooltip-hover-border;
+
+        .callout {
+            border-color: @static-tooltip-hover-border;
+        }
+
+        .footer {
+            opacity: 1;
+        }
+    }
 }
 
 /*
   Search Builder Control
 */
+
 search-builder {
-  width: 100%;
-  height: 100%;
-
-  .search-group {
     width: 100%;
+    height: 100%;
 
-    .search-group-title {
-      color: @search-builder-group-title-color;
-      font-size: 1.188rem;
-    }
+    .search-group {
+        width: 100%;
 
-    .search-group-content {
-      display: table;
-      width: 100%;
-      min-height: 44px;
-      padding-left: 20px;
+        .search-group-title {
+            color: @search-builder-group-title-color;
+            font-size: 1.188rem;
+        }
 
-      .operator-label {
-          display: table-cell;
-          width: 100px;
-          border-left: 0 solid @search-builder-operator-border;
-          padding-left: 5px;
-          vertical-align: middle;
-          text-transform: uppercase;
-          color: @search-builder-operator-border;
-          opacity: 0;
-          transition: opacity 0.3s linear;
+        .search-group-content {
+            display: table;
+            width: 100%;
+            min-height: 44px;
+            padding-left: 20px;
 
-          &.search-builder-show {
-            opacity: 1;
-            border-left-width: 4px;
-          }
-
-          &.or {
-            border-left-color: @search-builder-operator-or-border;
-          }
-
-          &.and {
-            border-left-color: @search-builder-operator-and-border;
-          }
-
-          &.not {
-            border-left-color: @search-builder-operator-not-border;
-          }
-      }
-
-      .field-list {
-        display: table-cell;
-
-        .field-collection {
-          list-style-type: none;
-          padding-left: 0;
-          margin: 0;
-          opacity: 0;
-          transition: opacity 0.3s linear;
-
-          &.search-builder-show {
-            opacity: 1;
-          }
-
-          .field {
-            margin-right: 10px;
-            transition: background-color 0.3s linear;
-
-            &:hover {
-              background-color: @search-builder-field-hover;
-
-              .search-component {
-                .component-remove {
-                  opacity: 1;
-                }
-              }
-            }
-
-            .placeholder-field {
-              .form-control();
-              height: 34px;
-              border: 1px dashed @search-builder-placeholder-border;
-            }
-
-            .search-component {
-              display: table;
-              width: 100%;
-              padding: 5px;
-
-              .component-container {
+            .operator-label {
                 display: table-cell;
-                width: ~'calc(100% - 35px)';
-
-                .input-group {
-                  line-height: 0;
-                }
-              }
-
-              .component-remove {
-                display: table-cell;
-                text-align: center;
-                width: 30px;
-                height: 100%;
+                width: 100px;
+                border-left: 0 solid @search-builder-operator-border;
+                padding-left: 5px;
                 vertical-align: middle;
+                text-transform: uppercase;
+                color: @search-builder-operator-border;
                 opacity: 0;
                 transition: opacity 0.3s linear;
 
-                .hpe-close {
-                  color: @search-builder-remove-color;
-                  cursor: pointer;
-                  margin: 9px;
+                &.search-builder-show {
+                    opacity: 1;
+                    border-left-width: 4px;
                 }
-              }
+
+                &.or {
+                    border-left-color: @search-builder-operator-or-border;
+                }
+
+                &.and {
+                    border-left-color: @search-builder-operator-and-border;
+                }
+
+                &.not {
+                    border-left-color: @search-builder-operator-not-border;
+                }
             }
-          }
+
+            .field-list {
+                display: table-cell;
+
+                .field-collection {
+                    list-style-type: none;
+                    padding-left: 0;
+                    margin: 0;
+                    opacity: 0;
+                    transition: opacity 0.3s linear;
+
+                    &.search-builder-show {
+                        opacity: 1;
+                    }
+
+                    .field {
+                        margin-right: 10px;
+                        transition: background-color 0.3s linear;
+
+                        &:hover {
+                            background-color: @search-builder-field-hover;
+
+                            .search-component {
+                                .component-remove {
+                                    opacity: 1;
+                                }
+                            }
+                        }
+
+                        .placeholder-field {
+                            .form-control();
+
+                            height: 34px;
+                            border: 1px dashed @search-builder-placeholder-border;
+                        }
+
+                        .search-component {
+                            display: table;
+                            width: 100%;
+                            padding: 5px;
+
+                            .component-container {
+                                display: table-cell;
+                                width: ~'calc(100% - 35px)';
+
+                                .input-group {
+                                    line-height: 0;
+                                }
+                            }
+
+                            .component-remove {
+                                display: table-cell;
+                                text-align: center;
+                                width: 30px;
+                                height: 100%;
+                                vertical-align: middle;
+                                opacity: 0;
+                                transition: opacity 0.3s linear;
+
+                                .hpe-close {
+                                    color: @search-builder-remove-color;
+                                    cursor: pointer;
+                                    margin: 9px;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            .placeholder-field {
+                padding: 5px 40px 5px 5px;
+
+                .form-control {
+                    height: 34px;
+                    border: 1px dashed @search-builder-placeholder-border;
+                }
+            }
+
+            .add-field {
+                display: table-cell;
+                width: 160px;
+                vertical-align: bottom;
+                padding-bottom: 5px;
+
+                &.limit-reached {
+                    .button-container {
+                        cursor: default;
+
+                        .add-button {
+                            background-color: @search-builder-add-disabled-bg;
+                            cursor: default;
+
+                            .hpe-icon.hpe-add {
+                                cursor: default;
+                            }
+                        }
+
+                        &:hover {
+                            .add-button {
+                                cursor: default;
+                                background-color: @search-builder-add-disabled-bg;
+                            }
+                        }
+                    }
+                }
+
+                .button-container {
+                    cursor: pointer;
+                    -webkit-user-select: none;
+                    -moz-user-select: none;
+                    -ms-user-select: none;
+                    user-select: none;
+
+                    &:hover {
+                        .add-button {
+                            background-color: @search-builder-add-hover-bg;
+                        }
+                    }
+
+                    .add-button {
+                        display: inline-block;
+                        width: 30px;
+                        height: 30px;
+                        border-radius: 50%;
+                        background-color: @search-builder-add-bg;
+                        transition: background-color 0.3s linear;
+
+                        .hpe-icon.hpe-add {
+                            display: block;
+                            color: @search-builder-add-icon-color;
+                            font-weight: 700;
+                            text-align: center;
+                            height: 30px;
+                            line-height: 30px;
+                            cursor: pointer;
+                        }
+                    }
+
+                    .add-text {
+                        display: inline-block;
+                        color: @search-builder-add-color;
+                        font-size: 0.9375rem;
+                        padding-left: 8px;
+                        max-width: 120px;
+                        vertical-align: sub;
+                        overflow: hidden;
+                        text-overflow: ellipsis;
+                        white-space: nowrap;
+                    }
+                }
+            }
         }
-      }
 
-      .placeholder-field {
-        padding: 5px 40px 5px 5px;
-
-        .form-control {
-          height: 34px;
-          border: 1px dashed @search-builder-placeholder-border;
-        }
-      }
-
-      .add-field {
-        display: table-cell;
-        width: 160px;
-        vertical-align: bottom;
-        padding-bottom: 5px;
-
-        &.limit-reached {
-          .button-container {
-            cursor: default;
-
-            .add-button {
-              background-color: @search-builder-add-disabled-bg;
-              cursor: default;
-
-              .hpe-icon.hpe-add {
-                cursor: default;
-              }
-            }
-
-            &:hover {
-              .add-button {
-                cursor: default;
-                background-color: @search-builder-add-disabled-bg;
-              }
-            }
-          }
-        }
-
-        .button-container {
-          cursor: pointer;
-          -webkit-user-select: none;
-          -moz-user-select: none;
-          -ms-user-select: none;
-          user-select: none;
-
-          &:hover {
-            .add-button {
-              background-color: @search-builder-add-hover-bg;
-            }
-          }
-
-          .add-button {
-              display: inline-block;
-              width: 30px;
-              height: 30px;
-              border-radius: 50%;
-              background-color: @search-builder-add-bg;
-              transition: background-color 0.3s linear;
-
-              .hpe-icon.hpe-add {
-                display: block;
-                color: @search-builder-add-icon-color;
-                font-weight: 700;
-                text-align: center;
-                height: 30px;
-                line-height: 30px;
-                cursor: pointer;
-              }
-            }
-
-            .add-text {
-              display: inline-block;
-              color: @search-builder-add-color;
-              font-size: 0.9375rem;
-              padding-left: 8px;
-              max-width: 120px;
-              vertical-align: sub;
-              overflow: hidden;
-              text-overflow: ellipsis;
-              white-space: nowrap;
-            }
-          }
+        .group-divider {
+            border-top-color: @search-builder-divider;
+            margin-top: 29px;
+            margin-bottom: 19px;
         }
     }
-
-    .group-divider {
-      border-top-color: @search-builder-divider;
-      margin-top: 29px;
-      margin-bottom: 19px;
-    }
-  }
 }
 
 /*
   Hover Actions
 */
+
 .hover-actions {
-
-  .hover-action {
-    display: inline-block;
-    padding: 6px;
-    color: @text-color;
-    opacity: 0;
-    transition: opacity 0.15s linear;
-  }
-
-  &.hovered, &.focused, &.action-hovered {
     .hover-action {
-      opacity: 0.5;
-
-      &:hover, &:focus {
-        opacity: 1;
-      }
+        display: inline-block;
+        padding: 6px;
+        color: @text-color;
+        opacity: 0;
+        transition: opacity 0.15s linear;
     }
-  }
-}
-//select-table styling
 
+    &.hovered,
+    &.focused,
+    &.action-hovered {
+        .hover-action {
+            opacity: 0.5;
+
+            &:hover,
+            &:focus {
+                opacity: 1;
+            }
+        }
+    }
+}
+
+//select-table styling
 .select-table-container {
-  border: 2px solid @table-hover-bg;
-  padding-top: 5px;
-  .scroll-pane {
-    margin-right: 5px;
-  }
+    border: 2px solid @table-hover-bg;
+    padding-top: 5px;
+
+    .scroll-pane {
+        margin-right: 5px;
+    }
 }
 
 table.select-table {
-  margin-bottom: 1px;
-  
-  tr:focus{
-    background-color: @table-hover-bg;
-  }
-  td.highlight{
-    background-color: @table-hover-bg;
-    font-family: @font-family;
-    font-weight: @font-weight-semibold;
-  }
+    margin-bottom: 1px;
+
+    tr:focus {
+        background-color: @table-hover-bg;
+    }
+
+    td.highlight {
+        background-color: @table-hover-bg;
+        font-family: @font-family;
+        font-weight: @font-weight-semibold;
+    }
 }
+
 table.select-table tr {
-	cursor: pointer;
+    cursor: pointer;
 }
-table.select-table tr > td{
- padding: 3px 10px;
- line-height: 25px;
+
+table.select-table tr > td {
+    padding: 3px 10px;
+    line-height: 25px;
 }
 
 table.select-table tr:focus {
-	outline: none;
+    outline: none;
 }
 
 table.select-table > tbody > tr.highlight {
-  td {
-    background-color: @select-table-highlight-bg;
-    font-family: @font-family;
-    font-weight: @font-weight-semibold;
-  }
+    td {
+        background-color: @select-table-highlight-bg;
+        font-family: @font-family;
+        font-weight: @font-weight-semibold;
+    }
 }
 
-table.select-table tr > td{
-  border: none;
+table.select-table tr > td {
+    border: none;
 }
 
 .popover {
-  z-index: @popover-z-index;
-  font-family: @font-family;
+    z-index: @popover-z-index;
+    font-family: @font-family;
 }
 
-/* 
+/*
   Number Picker
 */
+
 .number-picker {
-  display: inline-flex;
-  input {
-    &.form-control {
-      -webkit-appearance: none;
-      text-align: right;
-      border-right-width: 0;
-      padding-left: 10px;
-      padding-right: 10px;
-      width: ~"calc(100% - 27px)";
-      &:focus {
-        border-right-width: 1px;
-      }
-    }
-  }
-  &.invalid-entry {
+    display: inline-flex;
+
     input {
-      border: 1px solid @number-picker-invalid-entry-border;
+        &.form-control {
+            -webkit-appearance: none;
+            text-align: right;
+            border-right-width: 0;
+            padding-left: 10px;
+            padding-right: 10px;
+            width: ~"calc(100% - 27px)";
+
+            &:focus {
+                border-right-width: 1px;
+            }
+        }
     }
-    i {
-      border-left-width: 0;
-    }
-  }
 
-  .number-picker-icons {
-    display: flex;
-    flex-direction: column;
-    height: 34px;
-    text-align: center;
-
-    i {
-      cursor: pointer;
-      font-size: 0.875rem;
-      color: @number-picker-icon-color;
-      padding: 1px 5px 1px 5px;
-      border: 1px solid @number-picker-icon-border;
-      border-bottom-width: 0;
-      width: 27px;
-
-      &:last-child {
-        border-bottom-width: 1px;
-        padding-top: 0;
-      }
-
-      &:hover {
-        color: darken(@number-picker-icon-color, 40%);
-        background-color: lighten(@number-picker-icon-color, 15%);
-      }
-
-      &:active {
-        border: 1px solid darken(@number-picker-icon-color, 30%);
-
-        + i {
-          border-top-width: 0;
+    &.invalid-entry {
+        input {
+            border: 1px solid @number-picker-invalid-entry-border;
         }
 
-        &.disabled {
-          border: 1px solid @number-picker-icon-border;
+        i {
+            border-left-width: 0;
         }
-      }
-      
-      &.disabled {
-        background-color: lighten(@number-picker-icon-color, 15%);
-        cursor: default;
-        color: @number-picker-icon-color;
-      }
-
-
     }
-  }
 
+    .number-picker-icons {
+        display: flex;
+        flex-direction: column;
+        height: 34px;
+        text-align: center;
+
+        i {
+            cursor: pointer;
+            font-size: 0.875rem;
+            color: @number-picker-icon-color;
+            padding: 1px 5px;
+            border: 1px solid @number-picker-icon-border;
+            border-bottom-width: 0;
+            width: 27px;
+
+            &:last-child {
+                border-bottom-width: 1px;
+                padding-top: 0;
+            }
+
+            &:hover {
+                color: darken(@number-picker-icon-color, 40%);
+                background-color: lighten(@number-picker-icon-color, 15%);
+            }
+
+            &:active {
+                border: 1px solid darken(@number-picker-icon-color, 30%);
+
+                + i {
+                    border-top-width: 0;
+                }
+
+                &.disabled {
+                    border: 1px solid @number-picker-icon-border;
+                }
+            }
+
+            &.disabled {
+                background-color: lighten(@number-picker-icon-color, 15%);
+                cursor: default;
+                color: @number-picker-icon-color;
+            }
+        }
+    }
 }

--- a/src/styles/documentation.less
+++ b/src/styles/documentation.less
@@ -1,89 +1,89 @@
 // Is this file even used anymore?
 
 .elements-docs-header {
-  background-color: @grey2;
-  color: @white;
+    background-color: @grey2;
+    color: @white;
 
-  img {
-    height: 16px;
-  }
+    img {
+        height: 16px;
+    }
 }
 
 .elements-docs-header {
-  h1, h2 {
-    opacity: 0.8;
-  }
+    h1, h2 {
+        opacity: 0.8;
+    }
 }
 
 .elements-docs-header p {
-  line-height: 0;
-  opacity: 0.5;
-  padding-bottom: 20px;
+    line-height: 0;
+    opacity: 0.5;
+    padding-bottom: 20px;
 }
 
 .element-docs-content {
-  margin-bottom: 50px;
-  .nav-tabs > li.active > a,
-  .nav-tabs > li.active > a:hover,
-  .nav-tabs > li.active > a:focus,
-  .nav-tabs > li > a:hover,
-  .nav-tabs > li > a:focus {
-    background-color: darken(@grey8, 2%);
-    border-color: transparent;
-  }
+    margin-bottom: 50px;
 
-  .minimal-tab > li.active > a,
-  .minimal-tab > li.active > a:hover,
-  .minimal-tab > li.active > a:focus {
-    border-bottom: 3px solid @primary;
-    background-color: transparent;
-  }
+    .nav-tabs > li.active > a,
+    .nav-tabs > li.active > a:hover,
+    .nav-tabs > li.active > a:focus,
+    .nav-tabs > li > a:hover,
+    .nav-tabs > li > a:focus {
+        background-color: darken(@grey8, 2%);
+        border-color: transparent;
+    }
 
-  .wrapper-content {
-    padding-top: 0px;
-    margin-top: -10px;
-  }
+    .minimal-tab > li.active > a,
+    .minimal-tab > li.active > a:hover,
+    .minimal-tab > li.active > a:focus {
+        border-bottom: 3px solid @primary;
+        background-color: transparent;
+    }
 
-  tab-heading span {
-    line-height: 2;
-  }
+    .wrapper-content {
+        padding-top: 0;
+        margin-top: -10px;
+    }
+
+    tab-heading span {
+        line-height: 2;
+    }
 }
 
 .m-l-neg {
-  margin-left: -35px;
+    margin-left: -35px;
 }
 
 .element-docs-content hr {
-  border-top: 1px solid darken(@white,20%);
-  margin-top :0;
+    border-top: 1px solid darken(@white, 20%);
+    margin-top: 0;
 }
 
 .uxd-customize-example {
-  margin-top: 15px;
+    margin-top: 15px;
 
-  .uxd-customize-row {
+    .uxd-customize-row {
+        &:not(:first-child) {
+            margin-top: 15px;
+        }
 
-    &:not(:first-child) {
-      margin-top: 15px;
+        & > div {
+            display: flex;
+            align-items: center;
+            min-height: 36px;
+            margin: 0 -0.5em;
+
+            & > * {
+                padding: 0 0.5em;
+            }
+
+            & > input {
+                min-width: 8rem;
+            }
+
+            & > ux-number-picker-ng1 {
+                width: 100%;
+            }
+        }
     }
-
-    & > div {
-      display: flex;
-      align-items: center;
-      min-height: 36px;
-      margin: 0 -0.5em;
-
-      & > * {
-        padding: 0 0.5em;
-      }
-
-      & > input {
-        min-width: 8rem;
-      }
-
-      & > ux-number-picker-ng1 {
-        width: 100%;
-      }
-    }
-  }
 }

--- a/src/styles/error.less
+++ b/src/styles/error.less
@@ -1,4 +1,4 @@
 .loginerrormsg {
-  margin-top: 5px;
-  color: @white;
+    margin-top: 5px;
+    color: @white;
 }

--- a/src/styles/facets.less
+++ b/src/styles/facets.less
@@ -1,368 +1,308 @@
 .ellipsis {
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  vertical-align: bottom;
-  display: inline-block;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    vertical-align: bottom;
+    display: inline-block;
 }
 
 .facets-container {
-  background-color: @facets-container-bg;
-  padding: 10px;
-}
-.body-dark {
-  .facets-container {
-    background: @facets-container-bg-dark;
-  }
+    background-color: @facets-container-bg;
+    padding: 10px;
 }
 
 .facet-header {
-  display: block;
-  color: inherit;
-  border-bottom: 1px solid @facet-header-border;
-  &:hover, &:focus, &:visited, &:active {
+    display: block;
     color: inherit;
-  }
-  .facet-name {
-    font-family: @font-family;
-    font-weight: @font-weight-semibold;
-    margin-bottom: 10px;
-    margin-top: 10px;
-    margin-left: 10px;
-    color: inherit;
-    max-width: ~"calc(100% - 30px)";
-    .ellipsis;
-  }
-  .hp-icon, .hpe-icon {
-    margin-top: 13px;
-    margin-right: 10px;
-  }
-}
-.body-dark {
-  .facet-header {
-    border-bottom: 1px solid @facet-header-border-dark;
-    & .facet-name {
-      color: @facet-name-color-dark;
+    border-bottom: 1px solid @facet-header-border;
+
+    &:hover,
+    &:focus,
+    &:visited,
+    &:active {
+        color: inherit;
     }
-  }
+
+    .facet-name {
+        font-family: @font-family;
+        font-weight: @font-weight-semibold;
+        margin-bottom: 10px;
+        margin-top: 10px;
+        margin-left: 10px;
+        color: inherit;
+        max-width: ~"calc(100% - 30px)";
+        .ellipsis;
+    }
+
+    .hp-icon,
+    .hpe-icon {
+        margin-top: 13px;
+        margin-right: 10px;
+    }
 }
+
 .facet {
-  margin-bottom: 20px;
-  &:last-child {
-    margin-bottom: 0;
-  }
-  .facet-scroll {
-    overflow: hidden;
-    max-height: 233px;
-    background: @facet-background no-repeat;
-    background-image:
-    -webkit-radial-gradient(50% 0, farthest-side, rgba(0,0,0,0.1), rgba(0,0,0,0)),
-    -webkit-radial-gradient(50% 100%,farthest-side, rgba(0,0,0,0.1), rgba(0,0,0,0));
-    background-image:
-    -moz-radial-gradient(50% 0, farthest-side, rgba(0,0,0,0.1), rgba(0,0,0,0)),
-    -moz-radial-gradient(50% 100%,farthest-side, rgba(0,0,0,0.1), rgba(0,0,0,0));
-    background-image:
-    radial-gradient(farthest-side at 50% 0, rgba(0,0,0,0.1), rgba(0,0,0,0)),
-    radial-gradient(farthest-side at 50% 100%, rgba(0,0,0,0.1), rgba(0,0,0,0));
-    background-position: 0 0, 0 100%;
-    background-size: 100% 14px;
-    ul {
-      margin-bottom:0px;
+    margin-bottom: 20px;
+
+    &:last-child {
+        margin-bottom: 0;
     }
-  }
-  .facet-options {
-    position: relative;
-    z-index: @facet-z-index;
-    padding: 0;
-    list-style: none;
 
-    &:before {
-       content: "";
-       position: relative;
-       z-index: @facet-before-z-index;
-       display: block;
-       height: 25px;
-       margin: 0 0 -25px;
-       background: -webkit-linear-gradient(top,#FFF,#FFF 30%,rgba(249, 249, 249, 0));
-       background: -moz-linear-gradient(top,#FFF,#FFF 30%,rgba(249, 249, 249, 0));
-       background: linear-gradient(to bottom,#FFF,#FFF 30%,rgba(249, 249, 249, 0));
+    .facet-scroll {
+        overflow: hidden;
+        max-height: 233px;
+        background: @facet-background no-repeat;
+        background-image: -webkit-radial-gradient(50% 0, farthest-side, rgba(0, 0, 0, 0.1), rgba(0, 0, 0, 0)), -webkit-radial-gradient(50% 100%, farthest-side, rgba(0, 0, 0, 0.1), rgba(0, 0, 0, 0));
+        background-image: -moz-radial-gradient(50% 0, farthest-side, rgba(0, 0, 0, 0.1), rgba(0, 0, 0, 0)), -moz-radial-gradient(50% 100%, farthest-side, rgba(0, 0, 0, 0.1), rgba(0, 0, 0, 0));
+        background-image: radial-gradient(farthest-side at 50% 0, rgba(0, 0, 0, 0.1), rgba(0, 0, 0, 0)), radial-gradient(farthest-side at 50% 100%, rgba(0, 0, 0, 0.1), rgba(0, 0, 0, 0));
+        background-position: 0 0, 0 100%;
+        background-size: 100% 14px;
+
+        ul {
+            margin-bottom: 0;
+        }
     }
-    &:after {
-       content: "";
-       position: relative;
-       z-index: @facet-before-z-index;
-       display: block;
-       height: 30px;
-       margin: -30px 0 0;
-       background: -webkit-linear-gradient(top,rgba(249, 249, 249, 0),#FFF 70%,#FFF);
-       background:    -moz-linear-gradient(top,rgba(249, 249, 249, 0),#FFF 70%,#FFF);
-       background:   linear-gradient(to bottom,rgba(249, 249, 249, 0),#FFF 70%,#FFF);
-    }
-    .facet-option {
 
-      &.disabled {
-        a {
-          .facet-option-check {
-            opacity: 0.5;
-
-              &.invisible {
-                opacity: 0 !important;
-              }
-          }
-          .facet-option-name {
-            opacity: 0.5;
-          }
-          .facet-option-count {
-            opacity: 0.5;
-          }
-        }
-      }
-
-      a {
-        padding: 5px;
-        display: block;
-        color: @text-color;
-        padding-bottom: 0;
-        label{
-          cursor: pointer;
-        }
-        .facet-option-check {
-          margin-right: 5px;
-          .el-checkbox {
-            width: 14px;
-            height: 14px;
-            font-size: 10px;
-            &.simplified {
-              width: 16px;
-              font-size: 16px;
-            }
-          }
-        }
-        .facet-option-count {
-          color: lighten(@text-color, 20%);
-        }
-        .facet-option-name {
-          max-width: ~"calc(100% - 75px)";
-          .ellipsis;
-          vertical-align: top;
-        }
-        &:hover {
-          background-color: @selected-facet-hover-bg;
-          .el-checkbox, .el-radiobutton {
-              border: 2px solid @accent;
-
-              &.disabled {
-                  border: 1px solid #e4e4e4;
-              }
-
-              &.simplified {
-                  color: #cacaca;
-                  border-color: transparent;
-                  border-width: 1px;
-
-                  &.checked, &.indeterminate {
-                      color: @accent;
-
-                      &.disabled {
-                          color: #cacaca;
-                      }
-                  }
-
-                  &.disabled {
-                      color: transparent;
-                  }
-              }
-          }
-        }
-        &:focus {
-          background-color: @selected-facet-hover-bg;
-        }
-      }
-      &:last-child a {
-      }
-    }
-  }
-  &:last-child {
-    margin-bottom: 0;
-  }
-  a {
-    outline-style: none;
-    &:focus {
-      background-color: @selected-facet-hover-bg;
-    }
-  }
-}
-.body-dark {
-  .facet {
-    a{
-      &:focus {
-        background-color: @facet-focus-bg-dark;
-      }
-    }
     .facet-options {
-      .facet-option {
-        a {
-          color: @facet-option-color-dark;
-          & .facet-option-count {
-            color: @facet-option-count-color-dark;
-          }
-          &:hover, &:focus {
-            background-color: @facet-focus-bg-dark;
-          }
+        position: relative;
+        z-index: @facet-z-index;
+        padding: 0;
+        list-style: none;
+
+        &:before {
+            content: "";
+            position: relative;
+            z-index: @facet-before-z-index;
+            display: block;
+            height: 25px;
+            margin: 0 0 -25px;
+            background: -webkit-linear-gradient(top, #fff, #fff 30%, rgba(249, 249, 249, 0));
+            background: -moz-linear-gradient(top, #fff, #fff 30%, rgba(249, 249, 249, 0));
+            background: linear-gradient(to bottom, #fff, #fff 30%, rgba(249, 249, 249, 0));
         }
-      }
-	  &:before {
 
-		background: -webkit-linear-gradient(top, @facet-before-after-bg-dark, @facet-before-after-bg-dark 70%, @facet-before-after-bg-dark);
-		background: -moz-linear-gradient(top, @facet-before-after-bg-dark, @facet-before-after-bg-dark 70%, @facet-before-after-bg-dark);
-		background: linear-gradient(to bottom, @facet-before-after-bg-dark, @facet-before-after-bg-dark 30%, rgba(249, 249, 249, 0));
+        &:after {
+            content: "";
+            position: relative;
+            z-index: @facet-before-z-index;
+            display: block;
+            height: 30px;
+            margin: -30px 0 0;
+            background: -webkit-linear-gradient(top, rgba(249, 249, 249, 0), #fff 70%, #fff);
+            background: -moz-linear-gradient(top, rgba(249, 249, 249, 0), #fff 70%, #fff);
+            background: linear-gradient(to bottom, rgba(249, 249, 249, 0), #fff 70%, #fff);
+        }
 
-	  }
+        .facet-option {
+            &.disabled {
+                a {
+                    .facet-option-check {
+                        opacity: 0.5;
 
-	  &:after {
+                        &.invisible {
+                            opacity: 0 !important;
+                        }
+                    }
 
-		background: -webkit-linear-gradient(top, @facet-before-after-bg-dark, @facet-before-after-bg-dark 70%, @facet-before-after-bg-dark );
-		background: -moz-linear-gradient(top, @facet-before-after-bg-dark, @facet-before-after-bg-dark 70%, @facet-before-after-bg-dark);
-		background: linear-gradient(to bottom, @facet-before-after-bg-dark, @facet-before-after-bg-dark 70%, @facet-before-after-bg-dark);
-	  }
+                    .facet-option-name {
+                        opacity: 0.5;
+                    }
+
+                    .facet-option-count {
+                        opacity: 0.5;
+                    }
+                }
+            }
+
+            a {
+                padding: 5px;
+                display: block;
+                color: @text-color;
+                padding-bottom: 0;
+
+                label {
+                    cursor: pointer;
+                }
+
+                .facet-option-check {
+                    margin-right: 5px;
+
+                    .el-checkbox {
+                        width: 14px;
+                        height: 14px;
+                        font-size: 10px;
+
+                        &.simplified {
+                            width: 16px;
+                            font-size: 16px;
+                        }
+                    }
+                }
+
+                .facet-option-count {
+                    color: lighten(@text-color, 20%);
+                }
+
+                .facet-option-name {
+                    max-width: ~"calc(100% - 75px)";
+                    vertical-align: top;
+                    .ellipsis();
+                }
+
+                &:hover {
+                    background-color: @selected-facet-hover-bg;
+
+                    .el-checkbox,
+                    .el-radiobutton {
+                        border: 2px solid @accent;
+
+                        &.disabled {
+                            border: 1px solid #e4e4e4;
+                        }
+
+                        &.simplified {
+                            color: #cacaca;
+                            border-color: transparent;
+                            border-width: 1px;
+
+                            &.checked,
+                            &.indeterminate {
+                                color: @accent;
+
+                                &.disabled {
+                                    color: #cacaca;
+                                }
+                            }
+
+                            &.disabled {
+                                color: transparent;
+                            }
+                        }
+                    }
+                }
+
+                &:focus {
+                    background-color: @selected-facet-hover-bg;
+                }
+            }
+        }
     }
-	.facet-scroll {
-		background: @facet-scroll-bg-dark no-repeat;
-		background-image:
-		-webkit-radial-gradient(50% 0, farthest-side, rgb(51,51,51), rgba(0,0,0,0)),
-		-webkit-radial-gradient(50% 100%,farthest-side, rgb(51,51,51), rgba(0,0,0,0));
-		background-image:
-		-moz-radial-gradient(50% 0, farthest-side, rgb(51,51,51), rgba(0,0,0,0)),
-		-moz-radial-gradient(50% 100%,farthest-side, rgb(51,51,51), rgba(0,0,0,0));
-		background-image: radial-gradient(farthest-side at 50% 0, rgb(51, 51, 51), rgba(0, 0, 0, 0)),
-		radial-gradient(farthest-side at 50% 100%, rgb(51, 51, 51), rgba(0, 0, 0, 0));
-		background-position: 0 0, 0 100%;
-		background-size: 100% 14px;
-	}
-  }
+
+    &:last-child {
+        margin-bottom: 0;
+    }
+
+    a {
+        outline-style: none;
+
+        &:focus {
+            background-color: @selected-facet-hover-bg;
+        }
+    }
 }
 
 .facets-selected-clear {
-  display: inline-block;
-  margin-top: 4px;
-  height: 12px;
-  width: 20px;
-  background-image: url(../img/filter_clear_light.png);
-  background-repeat: no-repeat;
-  border:1px solid @facets-clear-border;
-  &:hover, &:focus {
-    border : 1px solid @facets-clear-hover-border;
-    outline-style: none;
-  }
-}
+    display: inline-block;
+    margin-top: 4px;
+    height: 12px;
+    width: 20px;
+    background-image: url(../img/filter_clear_light.png);
+    background-repeat: no-repeat;
+    border: 1px solid @facets-clear-border;
 
-.body-dark {
-  .facets-selected-clear {
-    background-image: url(../img/filter_clear_dark.png);
-  }
+    &:hover,
+    &:focus {
+        border: 1px solid @facets-clear-hover-border;
+        outline-style: none;
+    }
 }
 
 .facets-selected-container {
-  margin-bottom: 20px;
-  .facets-selected-title {
-    font-weight: @font-weight-bold;
-    margin-bottom: 5px;
-  }
-  .facets-none-selected {
-    margin-bottom: 0;
-    .text-muted;
-  }
-  ul {
-    padding-left: 0;
-    list-style: none;
-    margin-bottom: 0;
-    li {
-      display: list-item;
-      max-width: 100%;
-      float: left;
-      a {
-        outline-style: none;
-        word-break: break-word;
-        padding: 5px;
-        display: block;
-        border: 1px solid @selected-facet-border;
-        margin-right: 5px;
+    margin-bottom: 20px;
+
+    .facets-selected-title {
+        font-weight: @font-weight-bold;
         margin-bottom: 5px;
-        background-color: @selected-facet-bg;
-        color: @selected-facet-color;
-        .hp-icon, .hpe-icon {
-          opacity: 0.5;
-        }
-        &:hover, &:focus {
-          background-color: @selected-facet-hover-bg;
-          .hp-icon, .hpe-icon {
-            opacity: 1;
-          }
-        }
-      }
     }
-  }
-}
-.body-dark {
-  .facets-selected-container {
+
+    .facets-none-selected {
+        margin-bottom: 0;
+        .text-muted;
+    }
+
     ul {
-      li {
-        a {
-          border: 1px solid @selected-facet-border-dark;
-          color:@selected-facet-color-dark;
-          &:hover, &:focus {
-            background-color: @selected-facet-hover-focus-bg-dark;
-          }
+        padding-left: 0;
+        list-style: none;
+        margin-bottom: 0;
+
+        li {
+            display: list-item;
+            max-width: 100%;
+            float: left;
+
+            a {
+                outline-style: none;
+                word-break: break-word;
+                padding: 5px;
+                display: block;
+                border: 1px solid @selected-facet-border;
+                margin-right: 5px;
+                margin-bottom: 5px;
+                background-color: @selected-facet-bg;
+                color: @selected-facet-color;
+
+                .hp-icon,
+                .hpe-icon {
+                    opacity: 0.5;
+                }
+
+                &:hover,
+                &:focus {
+                    background-color: @selected-facet-hover-bg;
+
+                    .hp-icon,
+                    .hpe-icon {
+                        opacity: 1;
+                    }
+                }
+            }
         }
-      }
     }
-  }
 }
-.facet-dynamic{
-  .input-container{
-    padding: 10px;
-    border-top: 1px solid @dynamic-facet-divider;
-    textarea + ul{
-      position: static;
-      box-shadow: none;
-      width: 100%;
-      li.active > a{
-        background-color: @dynamic-facet-active-bg;
-        color: @dynamic-facet-active-color;
-      }
-      &.dropdown-menu {
-        min-width: 10px;
-      }
-    }
-    a{
-      padding: 3px;
-      text-transform: uppercase;
-		  white-space: normal;
-    }
-  }
-  .facet-options-dynamic{
-    display: inline-block;
-    width: 100%;
-  }
-}
-.body-dark {
-  .facet-dynamic {
+
+.facet-dynamic {
     .input-container {
-      background: @facets-container-bg-dark;
-      border-top: 1px solid @dynamic-facet-input-border-dark;
+        padding: 10px;
+        border-top: 1px solid @dynamic-facet-divider;
+
+        textarea + ul {
+            position: static;
+            box-shadow: none;
+            width: 100%;
+
+            li.active > a {
+                background-color: @dynamic-facet-active-bg;
+                color: @dynamic-facet-active-color;
+            }
+
+            &.dropdown-menu {
+                min-width: 10px;
+            }
+        }
+
+        a {
+            padding: 3px;
+            text-transform: uppercase;
+            white-space: normal;
+        }
     }
-  }
-}
-.body-dark {
-  .facet-dynamic {
-    .input-container {
-      textarea + ul li.active > a {
-        background: @facets-container-bg-dark;
-      }
+
+    .facet-options-dynamic {
+        display: inline-block;
+        width: 100%;
     }
-  }
 }
 
 .count-font-light {
-  color: @facet-count-color;
+    color: @facet-count-color;
 }

--- a/src/styles/filters.less
+++ b/src/styles/filters.less
@@ -2,241 +2,200 @@
 //Filter Button Styles --- Start
 //============================
 .btn-group {
-  .filter-dropdown {
-    padding: 6px;
-    padding-right: 7px;
-    padding-left: 6px;
-  }
-}
-.btn-group { 
-  .filter-dropdown, .btn-clear {
-    border: 0;
-    background: none;
-    text-transform: none;
-    box-shadow: none;
-    font-size: @font-size;
-  }
+    .filter-dropdown {
+        padding: 6px;
+        padding-right: 7px;
+        padding-left: 6px;
+    }
 }
 
-.body-dark {
-  .btn-group {
-    .filter-dropdown {
-      color: @filter-dropdown-color-dark;
+.btn-group {
+    .filter-dropdown,
+    .btn-clear {
+        border: 0;
+        background: none;
+        text-transform: none;
+        box-shadow: none;
+        font-size: @font-size;
     }
-  }
-  .btn-clear {
-    color: @filter-dropdown-color-dark;
-  }
 }
 
 .filter-dropdown {
-  &:hover {
-    background-color: @filter-dropdown-hover-bg;
-    border-radius: 0px;
-    border-color: @filter-dropdown-hover-border;
-    text-decoration:none;
-  }
-
-  &:focus {
-    background-color: @filter-dropdown-focus-bg;
-    border-radius: 0px;
-    border-color: @filter-dropdown-focus-border;
-    text-decoration:none;
-  }
-}
-
-.body-dark {
-  .filter-dropdown {
-    &:focus, &:hover {
-      background-color: @filter-dropdown-hover-focus-bg-dark;
-    }
-  }
-}
-
-.filter {
-  .dropdown-toggle {
-    .hpe-down {
-      font-size: 0.625rem;
-      margin-left: 3px;
-    }
-  }
-  .dropdown-menu>li {
-    &>a {
-       padding: 6px;
-    span {
-      margin-left: 10px;
-    }
-    &:focus, &:hover {
-      color: inherit; 
-     }
-    }
-  }
-}
-.filter-selected {
-  font-family: @font-family;
-  font-weight: 600;
-}
-
-.filter-selected {
-  text-decoration: none;
-  background-color: @filter-selected-bg;
-}
-
-.filter {
-  .dropdown-menu>li>a {
     &:hover {
-      text-decoration: none;
-      background-color: @filter-option-hover-bg;
+        background-color: @filter-dropdown-hover-bg;
+        border-radius: 0;
+        border-color: @filter-dropdown-hover-border;
+        text-decoration: none;
     }
+
     &:focus {
-      text-decoration: none;
-      background-color: @filter-option-focus-bg;
+        background-color: @filter-dropdown-focus-bg;
+        border-radius: 0;
+        border-color: @filter-dropdown-focus-border;
+        text-decoration: none;
     }
-  }
 }
 
-.body-dark {
-  .filter-selected {
-    background-color: @filter-selected-bg-dark;
-  }
-  .filter {
-    .dropdown-menu > li > a {
-      &:focus, &:hover {
-        background-color: @filter-dropdown-hover-focus-bg-dark;
-      }
+.filter {
+    .dropdown-toggle {
+        .hpe-down {
+            font-size: 0.625rem;
+            margin-left: 3px;
+        }
     }
-  }
+
+    .dropdown-menu > li {
+        & > a {
+            padding: 6px;
+
+            span {
+                margin-left: 10px;
+            }
+
+            &:focus,
+            &:hover {
+                color: inherit;
+            }
+        }
+    }
 }
-.sorter-container{
-  white-space: nowrap;
+
+.filter-selected {
+    font-family: @font-family;
+    font-weight: 600;
 }
+
+.filter-selected {
+    text-decoration: none;
+    background-color: @filter-selected-bg;
+}
+
+.filter {
+    .dropdown-menu > li > a {
+        &:hover {
+            text-decoration: none;
+            background-color: @filter-option-hover-bg;
+        }
+
+        &:focus {
+            text-decoration: none;
+            background-color: @filter-option-focus-bg;
+        }
+    }
+}
+
+.sorter-container {
+    white-space: nowrap;
+}
+
 .sorter-title {
-  vertical-align: middle;
+    vertical-align: middle;
 }
+
 .sorter-icon {
-  display: inline-block;
-  vertical-align: text-bottom;
+    display: inline-block;
+    vertical-align: text-bottom;
 }
+
 .sorter-text {
-  margin: 0;
-  display: inline-block;
-  width: ~'calc(100% - 38px)';
+    margin: 0;
+    display: inline-block;
+    width: ~'calc(100% - 38px)';
 }
+
 .sorter-text > span {
-  margin-right: 10px;
+    margin-right: 10px;
 }
 
 .sorter-option-disabled {
-  opacity: 0.5;
+    opacity: 0.5;
 }
 
-.body-dark {
-  .sorter-title {
-    color: @filter-sorter-title-color-dark;
-  }
-}
 .form-control {
-  &.filter-text {
-    opacity: 0.9;
-    font-size: @font-size-lg;
-    line-height: normal;
-  }
+    &.filter-text {
+        opacity: 0.9;
+        font-size: @font-size-lg;
+        line-height: normal;
+    }
 }
 
-.expand-input-close{
-  color: @text-color;
-  font-family: @font-family;
-  font-weight: @font-weight-light;
-  font-size: @font-size-md;
+.expand-input-close {
+    color: @text-color;
+    font-family: @font-family;
+    font-weight: @font-weight-light;
+    font-size: @font-size-md;
 }
 
 .btn-clear {
-  &:focus {
-    outline: 0;
-  }
-  &:hover {
-    outline: 0;
-    color: @btn-clear-hover-color;
-  }
-}
-.body-dark {
-  .btn {
-    &.listview-clear {
-      background: url(../img/filter_clear_dark.png) no-repeat;
-      &:active {
-        background: url(../img/filter_clear_dark.png) no-repeat;
-      }
+    &:focus {
+        outline: 0;
     }
-  }
+
+    &:hover {
+        outline: 0;
+        color: @btn-clear-hover-color;
+    }
 }
 
 .btn {
-  &.listview-clear {
-    background: url(../img/filter_clear_light.png) no-repeat;
-    width: 22px;
-    height: 12px;
-    margin-left: 3px;
-    margin-right: 10px;
-    margin-bottom: 2px;
-    display: none;
-    padding-right: 9px;
-    box-shadow: none;
-    &:active {
-      background: url(../img/filter_clear_light.png) no-repeat;
+    &.listview-clear {
+        background: url(../img/filter_clear_light.png) no-repeat;
+        width: 22px;
+        height: 12px;
+        margin-left: 3px;
+        margin-right: 10px;
+        margin-bottom: 2px;
+        display: none;
+        padding-right: 9px;
+        box-shadow: none;
+
+        &:active {
+            background: url(../img/filter_clear_light.png) no-repeat;
+        }
+
+        &:focus {
+            .aspects-outline;
+        }
+
+        &.clear-selected {
+            outline: 0;
+            color: @btn-clear-hover-color;
+            font-weight: bold;
+            display: inline-block;
+        }
     }
-    &:hover{
-      
-    }
-    &:focus{
-      .aspects-outline;
-    }
-    &.clear-selected {
-      outline: 0;
-      color: @btn-clear-hover-color;
-      font-weight: bold;
-      display: inline-block;
-    }
-  }
 }
 
-.dynamic-filter{
-  width: 220px;
-  .input-container{
-    padding: 10px;
-    border-top: 1px solid @dynamic-filter-divider;
-  }
-  .default-container{
-    span{
-      margin-left: 10px;
-    }
-  }
-  input + ul{
-    position: static;
-    box-shadow: none;
-    li.active > a{
-      background-color: @dynamic-filter-option-active;
-      color:inherit;
-    }
-  }
-  a{
-      padding: 3px;
-      text-transform: none;
-  }
-}
-.body-dark {
-  .dynamic-filter {
+.dynamic-filter {
+    width: 220px;
+
     .input-container {
-      border-top: 1px solid @dynamic-filter-border-dark;
+        padding: 10px;
+        border-top: 1px solid @dynamic-filter-divider;
     }
-  }
-}
-.body-dark {
-  .dynamic-filter {
-    input + ul li.active > a {
-      background-color: @dynamic-filter-active-bg-dark;
+
+    .default-container {
+        span {
+            margin-left: 10px;
+        }
     }
-  }
+
+    input + ul {
+        position: static;
+        box-shadow: none;
+
+        li.active > a {
+            background-color: @dynamic-filter-option-active;
+            color: inherit;
+        }
+    }
+
+    a {
+        padding: 3px;
+        text-transform: none;
+    }
 }
+
 //============================
 //Filter Button Styles --- End
 //============================

--- a/src/styles/forms.less
+++ b/src/styles/forms.less
@@ -1,38 +1,45 @@
 form {
-	.form-group-validate {
-		margin-bottom: 30px;
-		input {
-			&.ng-invalid {
-				&.ng-dirty, &.ng-touched {
-					border: 1px solid @form-control-invalid-border;
-				}
-			}
-		}
-		.form-control-feedback {
-			color: @form-control-invalid-color;
-		}
-	}
-	.form-group-validate-on-submit {
-		margin-bottom: 30px;
-		input {
-			&.ng-invalid {
-				&.on-submit {
-					border: 1px solid @form-control-invalid-border;
-				}
-			}
-		}
-		.form-control-feedback {
-			color: @form-control-invalid-color;
-		}
-	}
-	.validation-error-text {
-		color: @form-control-invalid-color;
-		float: left;
-		opacity: 0.9;
-	}
-	.button-primary {
-		&.disabled {
-			box-shadow: none;
-		}
-	}
+    .form-group-validate {
+        margin-bottom: 30px;
+
+        input {
+            &.ng-invalid {
+                &.ng-dirty, &.ng-touched {
+                    border: 1px solid @form-control-invalid-border;
+                }
+            }
+        }
+
+        .form-control-feedback {
+            color: @form-control-invalid-color;
+        }
+    }
+
+    .form-group-validate-on-submit {
+        margin-bottom: 30px;
+
+        input {
+            &.ng-invalid {
+                &.on-submit {
+                    border: 1px solid @form-control-invalid-border;
+                }
+            }
+        }
+
+        .form-control-feedback {
+            color: @form-control-invalid-color;
+        }
+    }
+
+    .validation-error-text {
+        color: @form-control-invalid-color;
+        float: left;
+        opacity: 0.9;
+    }
+
+    .button-primary {
+        &.disabled {
+            box-shadow: none;
+        }
+    }
 }

--- a/src/styles/hierarchy-bar.less
+++ b/src/styles/hierarchy-bar.less
@@ -1,125 +1,125 @@
 .hierarchy-bar-container {
-        display: flex;
-        position: relative;
-        width: 100%;
-        height: 50px;
-        border-bottom: 1px solid @organization-chart-hierarchy-bar-border;
-        box-shadow: 0px 0px 5px @organization-chart-hierarchy-bar-border;
-        align-items: center;
-        padding: 0 25px;
-        overflow: hidden;
+    display: flex;
+    position: relative;
+    width: 100%;
+    height: 50px;
+    border-bottom: 1px solid @organization-chart-hierarchy-bar-border;
+    box-shadow: 0 0 5px @organization-chart-hierarchy-bar-border;
+    align-items: center;
+    padding: 0 25px;
+    overflow: hidden;
 
-        &.overflow {       
-            .hierarchy-bar-list {
-                position: absolute;
-                right: 25px;
-                top: 14px;
-            }
-        }
-
-        .overflow-ellipsis {
+    &.overflow {
+        .hierarchy-bar-list {
             position: absolute;
-            top: 0;
-            left: 0;
-            bottom: 0;
-            width: 47px;
-            z-index: 1;
-            padding: 16px 0 16px 16px;
-            text-align: left;
-            background-color: @white;
-            box-shadow: 0px 0 25px 0px @btn-secondary-active-hover-shadow;
+            right: 25px;
+            top: 14px;
+        }
+    }
+
+    .overflow-ellipsis {
+        position: absolute;
+        top: 0;
+        left: 0;
+        bottom: 0;
+        width: 47px;
+        z-index: 1;
+        padding: 16px 0 16px 16px;
+        text-align: left;
+        background-color: @white;
+        box-shadow: 0 0 25px 0 @btn-secondary-active-hover-shadow;
+        cursor: pointer;
+
+        .ellipsis {
+            display: block;
+            line-height: 18px;
+            height: 15px;
+            margin: 0;
+            color: @organization-chart-hierarchy-bar-color;
+        }
+    }
+
+    .hierarchy-bar-action {
+        display: inline-flex;
+        border: 1px solid @organization-chart-hierarchy-bar-border;
+        border-radius: 50%;
+        width: 32px;
+        height: 32px;
+        justify-content: center;
+        align-items: center;
+        color: @accent;
+        font-size: 1.2rem;
+        margin-right: 20px;
+        min-width: 32px;
+    }
+
+    .hierarchy-bar-list {
+        list-style-type: none;
+        margin: 0;
+        padding: 0;
+        white-space: nowrap;
+
+        .hierarchy-bar-list-item {
+            display: inline-block;
+            color: @organization-chart-hierarchy-bar-color;
+            margin-left: 5px;
             cursor: pointer;
 
-            .ellipsis {
-                display: block;
-                line-height: 18px;
-                height: 15px;
-                margin: 0;
-                color: @organization-chart-hierarchy-bar-color;
-            }
-        }
-
-        .hierarchy-bar-action {
-            display: inline-flex;
-            border: 1px solid @organization-chart-hierarchy-bar-border;
-            border-radius: 50%;
-            width: 32px;
-            height: 32px; 
-            justify-content: center;
-            align-items: center; 
-            color: @accent;
-            font-size: 1.2rem; 
-            margin-right: 20px;
-            min-width: 32px;
-        }
-
-        .hierarchy-bar-list {
-            list-style-type: none;
-            margin: 0;
-            padding: 0;
-            white-space: nowrap;
-
-            .hierarchy-bar-list-item {
+            .hierarchy-bar-image {
                 display: inline-block;
-                color: @organization-chart-hierarchy-bar-color;
-                margin-left: 5px;
-                cursor: pointer;
+                max-width: 20px;
+                max-height: 18px;
+                vertical-align: text-top;
+            }
 
-                .hierarchy-bar-image {
-                    display: inline-block;
-                    max-width: 20px;
-                    max-height: 18px;
-                    vertical-align: text-top;
+            .hpe-next {
+                color: @organization-chart-hierarchy-bar-arrow;
+                transform: translateY(1px);
+
+                &.active {
+                    color: @primary;
                 }
 
-                .hpe-next {
-                    color: @organization-chart-hierarchy-bar-arrow;
-                    transform: translateY(1px);
-
-                    &.active {
+                &.visible {
+                    &:hover {
                         color: @primary;
                     }
+                }
+            }
+
+            &:first-of-type {
+                margin-left: 0;
+            }
+
+            &:last-of-type {
+                color: @organization-chart-hierarchy-bar-active-color;
+                font-weight: 600;
+                padding-right: 10px;
+
+                .hpe-next {
+                    display: none;
 
                     &.visible {
-                        &:hover {
-                            color: @primary; 
-                        }
-                    }
-
-                }
-
-                &:first-of-type {
-                    margin-left: 0;
-                }
-
-                &:last-of-type {
-                    color: @organization-chart-hierarchy-bar-active-color;
-                    font-weight: 600;
-                    padding-right: 10px;
-
-                    .hpe-next {
-                        display: none;
-
-                        &.visible {
-                            display: inline-block;
-                        }
-                    
+                        display: inline-block;
                     }
                 }
+            }
 
-                .load-more {
-                    font-family:@font-family;
-                    color: @hyperlink-color;
-                    border-bottom: 2px dotted @primary;
-                    &:hover, &:focus{
-                        color: @grey2;
-                        border-bottom: 2px solid @primary;
-                        outline-color: @accent;
-                    }
+            .load-more {
+                font-family: @font-family;
+                color: @hyperlink-color;
+                border-bottom: 2px dotted @primary;
+
+                &:hover,
+                &:focus {
+                    color: @grey2;
+                    border-bottom: 2px solid @primary;
+                    outline-color: @accent;
                 }
             }
         }
     }
+}
 
 .hierarchy-bar-popover {
     border-radius: 0;
@@ -127,11 +127,11 @@
     .popover-content {
         padding: 0;
 
-        .hierarchy-bar-popover-list { 
+        .hierarchy-bar-popover-list {
             margin: 0;
             padding: 0;
             list-style-type: none;
-            
+
             .hierarchy-bar-popover-list-item {
                 padding: 6px 20px;
                 font-size: 1rem;
@@ -148,7 +148,7 @@
 
                 &:hover {
                     background-color: @organization-chart-hierarchy-bar-popover-hover;
-                } 
+                }
 
                 .hierarchy-bar-popover-list-item-image {
                     display: inline-block;
@@ -160,6 +160,4 @@
             }
         }
     }
-
-
 }

--- a/src/styles/hotkeys.less
+++ b/src/styles/hotkeys.less
@@ -1,15 +1,16 @@
 .hotkey-group-hint {
-  width: auto;
-  min-width: 25px;
-  padding: 0px 2px;
-  height: 25px;
-  color: inherit;
-  border-radius: 2px;
-  border: 2px solid @hotkey-hint-color;
-  text-align: center;
-  text-transform: lowercase;
-  transition: opacity 0.2s;
-  &:hover{
-    .opacity(0.3);
-  }
+    width: auto;
+    min-width: 25px;
+    padding: 0 2px;
+    height: 25px;
+    color: inherit;
+    border-radius: 2px;
+    border: 2px solid @hotkey-hint-color;
+    text-align: center;
+    text-transform: lowercase;
+    transition: opacity 0.2s;
+
+    &:hover {
+        .opacity(0.3);
+    }
 }

--- a/src/styles/icons.less
+++ b/src/styles/icons.less
@@ -1,60 +1,80 @@
-.hp-icon, .hpe-icon {
-  vertical-align: baseline;
+.hp-icon,
+.hpe-icon {
+    vertical-align: baseline;
 }
 
-.hp-rotate-90, .hpe-rotate-90{
-  .rotate(90deg);
-}
-.hp-rotate-180, .hpe-rotate-180{
-  .rotate(180deg);
-}
-.hp-rotate-270, .hpe-rotate-270{
-  .rotate(270deg);
-}
-.hp-flip-vertical, .hpe-flip-vertical{
-  -webkit-transform: scale(1, -1);
-  -ms-transform: scale(1, -1);
-  transform: scale(1, -1);
-}
-.hp-flip-horizontal, .hpe-flip-horizontal{
-  -webkit-transform: scale(-1, 1);
-  -ms-transform: scale(-1, 1);
-  transform: scale(-1, 1);
-}
-.hp-fw, .hpe-fw{
-  width: 1.28571429em;
-  text-align: center;
+.hp-rotate-90,
+.hpe-rotate-90 {
+    .rotate(90deg);
 }
 
-.hp-lg, .hpe-lg{
-  font-size: 1.33333333em;
-  line-height: 0.75em;
-  vertical-align: -15%;
+.hp-rotate-180,
+.hpe-rotate-180 {
+    .rotate(180deg);
 }
-.hp-2x, .hpe-2x{
-  font-size: 2em;
+
+.hp-rotate-270,
+.hpe-rotate-270 {
+    .rotate(270deg);
 }
-.hp-3x, .hpe-3x{
-  font-size: 3em;
+
+.hp-flip-vertical,
+.hpe-flip-vertical {
+    -webkit-transform: scale(1, -1);
+    -ms-transform: scale(1, -1);
+    transform: scale(1, -1);
 }
-.hp-4x, .hpe-4x{
-  font-size: 4em;
+
+.hp-flip-horizontal,
+.hpe-flip-horizontal {
+    -webkit-transform: scale(-1, 1);
+    -ms-transform: scale(-1, 1);
+    transform: scale(-1, 1);
 }
-.hp-5x, .hpe-5x{
-  font-size: 5em;
+
+.hp-fw,
+.hpe-fw {
+    width: 1.28571429em;
+    text-align: center;
+}
+
+.hp-lg,
+.hpe-lg {
+    font-size: 1.33333333em;
+    line-height: 0.75em;
+    vertical-align: -15%;
+}
+
+.hp-2x,
+.hpe-2x {
+    font-size: 2em;
+}
+
+.hp-3x,
+.hpe-3x {
+    font-size: 3em;
+}
+
+.hp-4x,
+.hpe-4x {
+    font-size: 4em;
+}
+
+.hp-5x,
+.hpe-5x {
+    font-size: 5em;
 }
 
 //===================
 // additional icons
 //===================
-
 .hpe-document-placeholder {
-  content: url('../img/hDoc.svg');
-  height: 24px;
-  margin: 10px 0px;
+    content: url('../img/hDoc.svg');
+    height: 24px;
+    margin: 10px 0;
 }
 
 .hpe-detail-view-icon {
-  padding-top: 5px;
-  padding-bottom: 14px;
+    padding-top: 5px;
+    padding-bottom: 14px;
 }

--- a/src/styles/input-controls.less
+++ b/src/styles/input-controls.less
@@ -1,12 +1,14 @@
 //================
 // New Checkboxes
 //================
-
-.el-checkbox-label, .el-radiobutton-label, .el-toggleswitch-label,  {
+.el-checkbox-label,
+.el-radiobutton-label,
+.el-toggleswitch-label {
     margin-bottom: 5px;
     white-space: nowrap;
 
-    .el-checkbox, .el-radiobutton {
+    .el-checkbox,
+    .el-radiobutton {
         font-family: 'hpe-icons';
         width: 22px;
         height: 22px;
@@ -18,14 +20,14 @@
         align-items: center;
         justify-content: center;
         overflow: hidden;
-
         .hpe-icon-checkmark();
 
         &.indeterminate {
             .hpe-icon-subtract();
         }
 
-        &.checked, &.indeterminate {
+        &.checked,
+        &.indeterminate {
             background-color: @accent;
             color: #fff;
             border-color: transparent;
@@ -34,13 +36,16 @@
         &.disabled {
             border-color: @grey6;
 
-            &.checked, &.indeterminate {
+            &.checked,
+            &.indeterminate {
                 background-color: @grey6;
             }
         }
     }
 
-    .el-checkbox, .el-radiobutton, .el-toggleswitch {
+    .el-checkbox,
+    .el-radiobutton,
+    .el-toggleswitch {
         display: inline-flex;
         cursor: pointer;
         color: transparent;
@@ -58,14 +63,16 @@
             border-color: transparent;
             background-color: transparent;
 
-            &.checked, &.indeterminate {
+            &.checked,
+            &.indeterminate {
                 color: @accent;
                 background-color: transparent;
                 border-color: transparent;
             }
 
             &.disabled {
-                &.checked, &.indeterminate {
+                &.checked,
+                &.indeterminate {
                     color: #cacaca;
                 }
             }
@@ -75,13 +82,15 @@
             outline: 1px dotted #000;
         }
 
-        input[type="checkbox"], input[type="radio"] {
+        input[type="checkbox"],
+        input[type="radio"] {
             display: none;
         }
     }
 
     &:hover {
-        .el-checkbox, .el-radiobutton {
+        .el-checkbox,
+        .el-radiobutton {
             border: 2px solid @accent;
 
             &.disabled {
@@ -93,7 +102,8 @@
                 border-color: transparent;
                 border-width: 1px;
 
-                &.checked, &.indeterminate {
+                &.checked,
+                &.indeterminate {
                     color: @accent;
 
                     &.disabled {
@@ -157,7 +167,9 @@
         }
     }
 
-    .el-checkbox-content, .el-radiobutton-content, .el-toggleswitch-content {
+    .el-checkbox-content,
+    .el-radiobutton-content,
+    .el-toggleswitch-content {
         display: inline-block;
         margin-left: 7px;
         margin-top: 1px;
@@ -191,7 +203,8 @@
     }
 }
 
-@media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+@media all and (-ms-high-contrast: none),
+    (-ms-high-contrast: active) {
     /* Internet Explorer workaround for border-radius rendering issue. */
     .el-toggleswitch-nub {
         background-clip: padding-box;
@@ -201,6 +214,7 @@
 /*
     Dynamic Select
 */
+
 .el-dynamicselect {
     display: inline-block;
     position: relative;
@@ -312,18 +326,20 @@ tags-input .tags .input::-webkit-input-placeholder {
     color: @form-control-placeholder-color;
     opacity: 1;
 }
- 
-tags-input .tags .input:-moz-placeholder { /* Firefox 18- */
-    color: @form-control-placeholder-color; 
-    opacity: 1; 
-}
- 
-tags-input .tags .input::-moz-placeholder {  /* Firefox 19+ */
+
+tags-input .tags .input:-moz-placeholder {
+    /* Firefox 18- */
     color: @form-control-placeholder-color;
-    opacity: 1;  
+    opacity: 1;
 }
- 
-tags-input .tags .input:-ms-input-placeholder {  
+
+tags-input .tags .input::-moz-placeholder {
+    /* Firefox 19+ */
     color: @form-control-placeholder-color;
-    opacity: 1;  
+    opacity: 1;
+}
+
+tags-input .tags .input:-ms-input-placeholder {
+    color: @form-control-placeholder-color;
+    opacity: 1;
 }

--- a/src/styles/labels.less
+++ b/src/styles/labels.less
@@ -1,202 +1,200 @@
 .label {
-  background-color: @label-bg;
-  color: @label-color;
-  font-family: @font-family;
-  font-size: @label-size;
-  font-weight: @label-weight;
-  padding: 3px 8px;
-  text-shadow: none;
-  border-radius: 1.25em;
-  text-transform:uppercase;
+    background-color: @label-bg;
+    color: @label-color;
+    font-family: @font-family;
+    font-size: @label-size;
+    font-weight: @label-weight;
+    padding: 3px 8px;
+    text-shadow: none;
+    border-radius: 1.25em;
+    text-transform: uppercase;
 
-  &.flat-edge-right {
-    border-top-right-radius: 0;
-    border-bottom-right-radius: 0;
-    text-transform: none;
-  }
+    &.flat-edge-right {
+        border-top-right-radius: 0;
+        border-bottom-right-radius: 0;
+        text-transform: none;
+    }
 
-  &.flat-edge-left {
-    border-top-left-radius: 0;
-    border-bottom-left-radius: 0;
-    text-transform: none;
-  }
+    &.flat-edge-left {
+        border-top-left-radius: 0;
+        border-bottom-left-radius: 0;
+        text-transform: none;
+    }
 }
 
-.label-primary{
-  background-color: @label-primary;
-  color: @label-color;
+.label-primary {
+    background-color: @label-primary;
+    color: @label-color;
 }
 
 .label-outline-primary {
-  background-color: @label-color;
-  color: @label-primary;
-  border: 1px solid @label-primary;
+    background-color: @label-color;
+    color: @label-primary;
+    border: 1px solid @label-primary;
 }
 
-.label-accent{
-  background-color: @label-accent;
-  color: @label-color;
+.label-accent {
+    background-color: @label-accent;
+    color: @label-color;
 }
 
 .label-outline-accent {
-  background-color: @label-color;
-  color: @label-accent;
-  border: 1px solid @label-accent;
+    background-color: @label-color;
+    color: @label-accent;
+    border: 1px solid @label-accent;
 }
 
-.label-alternate1{
-  background-color: @label-alternate1;
-  color: @label-color;
+.label-alternate1 {
+    background-color: @label-alternate1;
+    color: @label-color;
 }
 
 .label-outline-alternate1 {
-  background-color: @label-color;
-  color: @label-alternate1;
-  border: 1px solid @label-alternate1;
+    background-color: @label-color;
+    color: @label-alternate1;
+    border: 1px solid @label-alternate1;
 }
 
-.label-alternate2{
-  background-color: @label-alternate2;
-  color: @label-color;
+.label-alternate2 {
+    background-color: @label-alternate2;
+    color: @label-color;
 }
 
 .label-outline-alternate2 {
-  background-color: @label-color;
-  color: @label-alternate2;
-  border: 1px solid @label-alternate2;
+    background-color: @label-color;
+    color: @label-alternate2;
+    border: 1px solid @label-alternate2;
 }
 
-.label-alternate3{
-  background-color: @label-alternate3;
-  color: @label-color;
+.label-alternate3 {
+    background-color: @label-alternate3;
+    color: @label-color;
 }
 
 .label-outline-alternate3 {
-  background-color: @label-color;
-  color: @label-alternate3;
-  border: 1px solid @label-alternate3;
+    background-color: @label-color;
+    color: @label-alternate3;
+    border: 1px solid @label-alternate3;
 }
 
 .label-vibrant1 {
-  background-color: @label-vibrant1;
-  color: @label-color;
+    background-color: @label-vibrant1;
+    color: @label-color;
 }
 
 .label-outline-vibrant1 {
-  background-color: @label-color;
-  color: @label-vibrant1;
-  border: 1px solid @label-vibrant1;
+    background-color: @label-color;
+    color: @label-vibrant1;
+    border: 1px solid @label-vibrant1;
 }
 
 .label-vibrant2 {
-  background-color: @label-vibrant2;
-  color: @label-color;
+    background-color: @label-vibrant2;
+    color: @label-color;
 }
 
 .label-outline-vibrant2 {
-  background-color: @label-color;
-  color: @label-vibrant2;
-  border: 1px solid @label-vibrant2;
+    background-color: @label-color;
+    color: @label-vibrant2;
+    border: 1px solid @label-vibrant2;
 }
 
-.label-alert{
-  .label-accent;
+.label-alert {
+    .label-accent;
 }
 
-.label-critical{
-  background-color: @critical;
-  color: @label-color;
+.label-critical {
+    background-color: @critical;
+    color: @label-color;
 }
 
 .label-outline-critical {
-  background-color: @label-color;
-  color: @critical;
-  border: 1px solid @critical;
+    background-color: @label-color;
+    color: @critical;
+    border: 1px solid @critical;
 }
 
-.label-ok{
-  background-color: @ok;
-  color: @label-color;
+.label-ok {
+    background-color: @ok;
+    color: @label-color;
 }
 
 .label-outline-ok {
-  background-color: @label-color;
-  color: @ok;
-  border: 1px solid @ok;
+    background-color: @label-color;
+    color: @ok;
+    border: 1px solid @ok;
 }
 
-.label-warning{
-  background-color: @warning;
-  color: @label-color;
+.label-warning {
+    background-color: @warning;
+    color: @label-color;
 }
 
 .label-outline-warning {
-  background-color: @label-color;
-  color: @warning;
-  border: 1px solid @warning;
+    background-color: @label-color;
+    color: @warning;
+    border: 1px solid @warning;
 }
 
-.label-error{
-  .label-critical;
+.label-error {
+    .label-critical;
 }
 
-.label-default{
-  .label-accent;
+.label-default {
+    .label-accent;
 }
 
 .label-grey1 {
-  background-color: @grey1;
-  color: @label-color;
+    background-color: @grey1;
+    color: @label-color;
 }
 
 .label-outline-grey1 {
-  background-color: @label-color;
-  color: @grey1;
-  border: 1px solid @grey1;
+    background-color: @label-color;
+    color: @grey1;
+    border: 1px solid @grey1;
 }
 
 .label-grey2 {
-  background-color: @grey2;
-  color: @label-color;
+    background-color: @grey2;
+    color: @label-color;
 }
 
 .label-outline-grey2 {
-  background-color: @label-color;
-  color: @grey2;
-  border: 1px solid @grey2;
+    background-color: @label-color;
+    color: @grey2;
+    border: 1px solid @grey2;
 }
 
 .label-grey3 {
-  background-color: @grey3;
-  color: @label-color;
+    background-color: @grey3;
+    color: @label-color;
 }
 
 .label-outline-grey3 {
-  background-color: @label-color;
-  color: @grey3;
-  border: 1px solid @grey3;
+    background-color: @label-color;
+    color: @grey3;
+    border: 1px solid @grey3;
 }
 
 .label-grey4 {
-  background-color: @grey4;
-  color: @label-color;
+    background-color: @grey4;
+    color: @label-color;
 }
 
 .label-outline-grey4 {
-  background-color: @label-color;
-  color: @grey4;
-  border: 1px solid @grey4;
+    background-color: @label-color;
+    color: @grey4;
+    border: 1px solid @grey4;
 }
 
 .label-grey5 {
-  background-color: @grey5;
-  color: @label-color;
+    background-color: @grey5;
+    color: @label-color;
 }
 
 .label-outline-grey5 {
-  background-color: @label-color;
-  color: @grey5;
-  border: 1px solid @grey5;
+    background-color: @label-color;
+    color: @grey5;
+    border: 1px solid @grey5;
 }
-
-

--- a/src/styles/main.less
+++ b/src/styles/main.less
@@ -1,71 +1,61 @@
 html {
-  height: 100%;
-  -ms-overflow-style: scrollbar;
-  font-size: @font-size-base;
+    height: 100%;
+    -ms-overflow-style: scrollbar;
+    font-size: @font-size-base;
 }
 
 body {
-  color: @text-color;
-  font-size: @font-size;
-  font-family: @font-family;
-  position: relative;
-  font-weight: @font-weight;
+    color: @text-color;
+    font-size: @font-size;
+    font-family: @font-family;
+    position: relative;
+    font-weight: @font-weight;
 }
 
 html,
 body,
 .wrapper {
-  min-height: 100%;
+    min-height: 100%;
 }
 
 code {
- font-size: 75%;
+    font-size: 75%;
 }
 
 td > code {
-  word-break: break-word;
-}
-
-.body-dark {
-  code {
-    background: @code-bg-dark;
-  }
+    word-break: break-word;
 }
 
 a {
-  &:hover, &:focus {
-    text-decoration: none;
-    cursor: pointer;
-  }
+    &:hover,
+    &:focus {
+        text-decoration: none;
+        cursor: pointer;
+    }
 }
 
 .page-content {
-  margin-left: @sidebar-width;
-  min-height: 100%;
+    margin-left: @sidebar-width;
+    min-height: 100%;
 }
 
 .container-max {
-  max-width: 1000px;
+    max-width: 1000px;
 }
 
 .container-left {
-  margin-left: 0;
+    margin-left: 0;
 }
 
 .container-right {
-  margin-right: 0;
+    margin-right: 0;
 }
 
 .row-divider {
-  height: 1px;
-  margin: 9px 0px;
-  overflow: hidden;
-  background-color: @border-color;
-}
-.body-dark {
-  .row-divider {
-    background-color: @row-divider-bg-dark;
-  }
+    height: 1px;
+    margin: 9px 0;
+    overflow: hidden;
+    background-color: @border-color;
 }
 
 .form-control,
@@ -82,76 +72,78 @@ a {
 .popover,
 .progress,
 .progress-bar {
-  box-shadow: none;
+    box-shadow: none;
 }
 
 .ui-draggable {
-  .hpebox-title, .ebox-title {
-    cursor: move;
-  }
+    .hpebox-title,
+    .ebox-title {
+        cursor: move;
+    }
 }
 
 .border-bottom {
-  border-bottom: 1px solid @border-color !important;
+    border-bottom: 1px solid @border-color !important;
 }
 
 // HP Content Wrappers
 .wrapper-content {
-  padding: 20px 20px 40px;
+    padding: 20px 20px 40px;
 }
 
 .page-wrapper-cover {
-  margin: 0px !important;
+    margin: 0 !important;
 }
 
 .page-heading {
-  width: 100%;
-  padding: 9px 0px 2px 23px;
-  z-index: @stacking-context-z-index;
+    width: 100%;
+    padding: 9px 0 2px 23px;
+    z-index: @stacking-context-z-index;
 }
 
-ul, ol {
-  &.unstyled {
-    list-style: none outside none;
-    margin-left: 0;
-  }
+ul,
+ol {
+    &.unstyled {
+        list-style: none outside none;
+        margin-left: 0;
+    }
 }
 
-.no-overflow
-{
-  overflow: hidden !important;
+.no-overflow {
+    overflow: hidden !important;
 }
 
-.full-height
-{
-  height: 100%;
+.full-height {
+    height: 100%;
 }
 
-.full-width
-{
-  width: 100%;
+.full-width {
+    width: 100%;
 }
 
 .footer {
-  &.condensed-panel {
-    &.hidden-navbar, &.hide-navbar {
-      .page-heading {
-        margin-top:-8px;
-      }
+    &.condensed-panel {
+        &.hidden-navbar,
+        &.hide-navbar {
+            .page-heading {
+                margin-top: -8px;
+            }
+        }
+
+        .page-heading {
+            margin-top: -8px;
+        }
     }
-    .page-heading {
-      margin-top:-8px;
-    }
-  }
 }
 
 .aspects-focus-outline:focus {
-  .aspects-outline;
+    .aspects-outline;
 }
 
 /* CODEPEN */
+
 body > div#ux-codepen-container {
-  padding: 15px;
-  margin-right: auto;
-  margin-left: auto;
+    padding: 15px;
+    margin-right: auto;
+    margin-left: auto;
 }

--- a/src/styles/mixins.less
+++ b/src/styles/mixins.less
@@ -1,58 +1,61 @@
 // Placeholder text
 .placeholder(@color: @white) {
-  &::-moz-placeholder           { color: @color;   // Firefox
-    opacity: 1; } // See https://github.com/twbs/bootstrap/pull/11526
-  &:-ms-input-placeholder       { color: @color; } // Internet Explorer 10+
-  &::-webkit-input-placeholder  { color: @color; } // Safari and Chrome
+    &::-moz-placeholder {
+        color: @color; // Firefox
+        opacity: 1;
+    } // See https://github.com/twbs/bootstrap/pull/11526
+    &:-ms-input-placeholder {
+        color: @color;
+    } // Internet Explorer 10+
+    &::-webkit-input-placeholder {
+        color: @color;
+    } // Safari and Chrome
 }
 
-.rotate(@deg){
-  -webkit-transform:rotate(@deg);
-  -moz-transform:rotate(@deg);
-  -ms-transform:rotate(@deg);
-  transform:rotate(@deg);
+.rotate(@deg) {
+    transform: rotate(@deg);
 }
 
 .opacity (@opacity) {
-  -webkit-opacity: 	@opacity;
-  -moz-opacity: 		@opacity;
-  opacity: 		@opacity;
-  @opacityPercentage: @opacity * 100;
-  -ms-filter: ~"progid:DXImageTransform.Microsoft.Alpha(opacity=(@{opacityPercentage}))"; 
-  filter: ~"alpha(opacity = (@{opacityPercentage}))";
+    opacity: @opacity;
+    @opacityPercentage: @opacity * 100;
+
+    filter: ~"alpha(opacity = (@{opacityPercentage}))";
 }
 
+.clearfix {
+    zoom: 1;
 
-.clearfix{
-  zoom:1;
-  &:before, &:after{
-    content:""; 
-    display:table;
-  }
-  &:after{ 
-    clear: both;
-  }
+    &:before,
+    &:after {
+        content: "";
+        display: table;
+    }
+
+    &:after {
+        clear: both;
+    }
 }
 
-.aspects-outline{
-  outline: 1px dotted;
-  outline: auto -webkit-focus-ring-color;
-  outline-color: @aspects-outline;
-  outline-offset: 0px;
+.aspects-outline {
+    outline: 1px dotted;
+    outline: auto -webkit-focus-ring-color;
+    outline-color: @aspects-outline;
+    outline-offset: 0;
 }
 
-.elements-force-outline{
-  outline-style: solid;
-  outline-width: 1px;
-  .aspects-outline;
+.elements-force-outline {
+    outline-style: solid;
+    outline-width: 1px;
+    .aspects-outline;
 }
 
 .btn-hover-active-color(light, @color, @percent) {
-  background-color: darken(@color, @percent);
-  border-color: darken(@color, @percent);
+    background-color: darken(@color, @percent);
+    border-color: darken(@color, @percent);
 }
 
 .btn-hover-active-color(dark, @color, @percent) {
-  background-color: lighten(@color, @percent);
-  border-color: lighten(@color, @percent);
+    background-color: lighten(@color, @percent);
+    border-color: lighten(@color, @percent);
 }

--- a/src/styles/modal.less
+++ b/src/styles/modal.less
@@ -1,282 +1,267 @@
 .side-modal {
- position: fixed;
- right:0;
- top: 0;
- bottom: 0;
- z-index: @modal-z-index;
- background: @side-modal-background;
- color: @side-modal-color;
- box-shadow: 1px 0px 20px 0px rgba(51, 51, 51, 1);
- overflow-x: hidden;
- 
- &.side-modal-animated {
-  max-width: 0;
-  transition: max-width 0.4s cubic-bezier(0.4, 0, 0.2, 1);
- }
-
- &.side-modal-animated-open {
-  max-width: 100vw;
- }
-
- .side-modal-content {
-   position: absolute;
-   top: 0;
-   bottom: 60px;
-   overflow-y: auto;
- }
-
- .side-modal-header-affix {
-  .header {
-    position: absolute;
+    position: fixed;
+    right: 0;
     top: 0;
-    width: 100%;
-  }
-  .main {
-    position: absolute;
-    top: 60px;
-    padding-top: 5px;
-    bottom: 60px;
-    overflow-y: auto;
-    width: 100%;
-    padding-right: 4px;
-    padding-bottom: 5px;
+    bottom: 0;
+    z-index: @modal-z-index;
+    background: @side-modal-background;
+    color: @side-modal-color;
+    box-shadow: 1px 0 20px 0 rgba(51, 51, 51, 1);
+    overflow-x: hidden;
 
-    &.footer-hidden {
-      bottom: 0;
+    &.side-modal-animated {
+        max-width: 0;
+        transition: max-width 0.4s cubic-bezier(0.4, 0, 0.2, 1);
     }
-  }
- }
 
- .header {
-   min-height: 60px;
-
-   .modalheader {
-     display: inline-block;
-   }
-
-   .modal-close {
-     position: absolute;
-     right: 0px;
-     padding-top: 20px;
-     padding-right: 10px;
-     color: @side-modal-close-color;
-
-     button {
-       border: 0;
-       box-shadow: none;
-
-       &:hover, &:active, &:focus {
-         border: 0;
-         color: @side-modal-close-hover-color;
-         background:none;
-         outline:0;
-       }
-     }
-   }
- }
-
- .main {
-   padding: 20px;
- }
-
- .footer {
-    position: absolute;;
-    bottom:0 ;
-    width: 100%;
-    border-top: 1px solid @side-modal-footer-border;
-    &>div {
-      text-align: right;
-      padding: 15px;
-      padding-right: 25px;
+    &.side-modal-animated-open {
+        max-width: 100vw;
     }
-    .btn {
-      min-width: 80px;
+
+    .side-modal-content {
+        position: absolute;
+        top: 0;
+        bottom: 60px;
+        overflow-y: auto;
     }
-   }
+
+    .side-modal-header-affix {
+        .header {
+            position: absolute;
+            top: 0;
+            width: 100%;
+        }
+
+        .main {
+            position: absolute;
+            top: 60px;
+            padding-top: 5px;
+            bottom: 60px;
+            overflow-y: auto;
+            width: 100%;
+            padding-right: 4px;
+            padding-bottom: 5px;
+
+            &.footer-hidden {
+                bottom: 0;
+            }
+        }
+    }
+
+    .header {
+        min-height: 60px;
+
+        .modalheader {
+            display: inline-block;
+        }
+
+        .modal-close {
+            position: absolute;
+            right: 0;
+            padding-top: 20px;
+            padding-right: 10px;
+            color: @side-modal-close-color;
+
+            button {
+                border: 0;
+                box-shadow: none;
+
+                &:hover,
+                &:active,
+                &:focus {
+                    border: 0;
+                    color: @side-modal-close-hover-color;
+                    background: none;
+                    outline: 0;
+                }
+            }
+        }
+    }
+
+    .main {
+        padding: 20px;
+    }
+
+    .footer {
+        position: absolute;
+        bottom: 0;
+        width: 100%;
+        border-top: 1px solid @side-modal-footer-border;
+
+        & > div {
+            text-align: right;
+            padding: 15px;
+            padding-right: 25px;
+        }
+
+        .btn {
+            min-width: 80px;
+        }
+    }
 }
 
-.modal-content {  
-  #sigma-container {
-    display: block !important;
-  }
-  .modal-footer {
-    .btn {
-      min-Width: 80px;
+.modal-content {
+    #sigma-container {
+        display: block !important;
     }
-  }
+
+    .modal-footer {
+        .btn {
+            min-width: 80px;
+        }
+    }
 }
 
 .modal-content > #sigma-container {
-  overflow-y: hidden !important;
+    overflow-y: hidden !important;
 }
 
-.modal-backdrop{
-  opacity:0.5;
+.modal-backdrop {
+    opacity: 0.5;
 }
 
 .square-modal-window {
-  .modal-content {
-    border-radius: 0;
+    .modal-content {
+        border-radius: 0;
 
-    .dismiss {
-      position: absolute;
-      right: 0;
-      top: 0px;
+        .dismiss {
+            position: absolute;
+            right: 0;
+            top: 0;
 
-      .btn-close {
-		    position: absolute;
-        width: 40px;
-        height: 40px;
-        box-shadow: none;
-        background-color: @square-modal-close-bg;
-        outline: none;
-        transform: translateX(-50%) translateY(-50%);
-        z-index: @modal-dismiss-z-index;
+            .btn-close {
+                position: absolute;
+                width: 40px;
+                height: 40px;
+                box-shadow: none;
+                background-color: @square-modal-close-bg;
+                outline: none;
+                transform: translateX(-50%) translateY(-50%);
+                z-index: @modal-dismiss-z-index;
 
-        &:hover {
-          background-color: @square-modal-close-hover-bg;
+                &:hover {
+                    background-color: @square-modal-close-hover-bg;
+                }
+
+                .hpe-close {
+                    color: @square-modal-close-color;
+                    font-size: 1.125rem;
+                    padding-top: 2px;
+                }
+            }
         }
-
-        .hpe-close {
-          color: @square-modal-close-color;
-          font-size: 1.125rem;
-          padding-top: 2px;
-        }
-      }
     }
-
-  }
 }
+
 .btn-circular.button-dark {
-  background: @btn-dark;
+    background: @btn-dark;
 }
+
 .display-panel-item-selected {
-  background-color: @display-panel-bg;
-  outline: 0;
-}
-// Deprecated
-.body-dark {
-  .display-panel-item-selected {
-    background-color: @display-panel-item-selected-bg-dark;
+    background-color: @display-panel-bg;
     outline: 0;
-  }
 }
+
 .display-panel {
-  display: flex;
-  flex-direction: column;
-  position: fixed;
-  right:0;
-  top: 0;
-  bottom: 0;
-  z-index: @display-panel-z-index;
-  background: @display-panel-bg;
-  color: @display-panel-color;
-  border-left: 1px solid @display-panel-border;
-  box-shadow: 1px 0px 20px 0px @display-panel-shadow;
-
- .display-panel-content {
-   position: absolute;
-   top: 0;
-   bottom: 0;
-   overflow: hidden;
-   padding-right: 5px;
- }
-
- .display-panel-header-affix {
-   display: flex;
-   flex-direction: column;
-  .header {
+    display: flex;
+    flex-direction: column;
+    position: fixed;
+    right: 0;
     top: 0;
-    margin-bottom: 5px;
-  }
-  .main {
-    flex: 1;
-    padding-top: 10px;
-    width: 100%
-  }
- }
+    bottom: 0;
+    z-index: @display-panel-z-index;
+    background: @display-panel-bg;
+    color: @display-panel-color;
+    border-left: 1px solid @display-panel-border;
+    box-shadow: 1px 0 20px 0 @display-panel-shadow;
 
- .header {
-   min-height: 60px;
-   .modalheader {
-     display: inline-block;
-   }
-   .modal-close {
-     position: absolute;
-     right: 0px;
-     padding-top: 20px;
-     padding-right: 25px;
-     button {
-       border: 0;
-       box-shadow: none;
-       color: @display-panel-close-color;
-
-       &:hover, &:active, &:focus {
-         border: 0;
-         color: @display-panel-close-hover-color;
-         background:none;
-         outline:0;
-       }
-       i {
-         padding-right: 14px;
-       }
-     }
-   }
- }
- .main {
-   padding: 20px;
- }
- .footer {
-    background-color: @display-panel-footer-bg;
-    border-top: 1px solid @display-panel-footer-border;
-    margin-top: 5px;
-    &>div {
-      text-align: right;
-      padding: 15px;
-      padding-right: 25px;
+    .display-panel-content {
+        position: absolute;
+        top: 0;
+        bottom: 0;
+        overflow: hidden;
+        padding-right: 5px;
     }
-   }
-   &.fixed-display-panel {
-      position: fixed !important;
-      bottom:0 ;
-      z-index: @fixed-display-panel-z-index;
-   }
 
-   &.float-display-panel {
-     position: absolute !important;
-   }
+    .display-panel-header-affix {
+        display: flex;
+        flex-direction: column;
+
+        .header {
+            top: 0;
+            margin-bottom: 5px;
+        }
+
+        .main {
+            flex: 1;
+            padding-top: 10px;
+            width: 100%;
+        }
+    }
+
+    .header {
+        min-height: 60px;
+
+        .modalheader {
+            display: inline-block;
+        }
+
+        .modal-close {
+            position: absolute;
+            right: 0;
+            padding-top: 20px;
+            padding-right: 25px;
+
+            button {
+                border: 0;
+                box-shadow: none;
+                color: @display-panel-close-color;
+
+                &:hover,
+                &:active,
+                &:focus {
+                    border: 0;
+                    color: @display-panel-close-hover-color;
+                    background: none;
+                    outline: 0;
+                }
+
+                i {
+                    padding-right: 14px;
+                }
+            }
+        }
+    }
+
+    .main {
+        padding: 20px;
+    }
+
+    .footer {
+        background-color: @display-panel-footer-bg;
+        border-top: 1px solid @display-panel-footer-border;
+        margin-top: 5px;
+
+        & > div {
+            text-align: right;
+            padding: 15px;
+            padding-right: 25px;
+        }
+    }
+
+    &.fixed-display-panel {
+        position: fixed !important;
+        bottom: 0;
+        z-index: @fixed-display-panel-z-index;
+    }
+
+    &.float-display-panel {
+        position: absolute !important;
+    }
 }
 
 .display-panel-animate {
-  transition: transform 0.4s cubic-bezier(0.4, 0, 0.2, 1);
-} 
-
-//dark display panel
-// Deprecated
-.body-dark {
-  .display-panel {
-    background: @display-panel-bg-dark;
-    color: @display-panel-color-dark;
-    .modalheader {
-      color: @display-panel-modal-color-dark;
-    }
-    .footer {
-      background: @display-panel-footer-bg-dark;
-    }
-    .modal-close {
-      opacity: 0.8;
-      &:hover, &:focus {
-        opacity: 1;
-      }
-      button{
-        background: @display-panel-modal-button-bg-dark;
-        color: @display-panel-modal-button-color-dark;
-        &:hover, &:focus{
-          color:@display-panel-modal-button-color-dark;
-        }
-      }
-    }
-  }
+    transition: transform 0.4s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
 /*
@@ -284,686 +269,526 @@
 */
 
 .marquee-modal-window {
+    .modal-dialog {
+        text-rendering: optimizeLegibility;
+        width: 900px;
 
-  .modal-dialog {
-    text-rendering: optimizeLegibility;
-    width: 900px;
-
-    &.modal-sm {
-      width: 600px;
-    }
-
-    &.modal-md {
-      width: 900px;
-    }
-
-    &.modal-lg {
-      width: 1100px;
-    }
-
-    .modal-content {
-      border-radius: 0;
-
-      .dismiss {
-        position: absolute;
-        right: 0;
-
-        .btn-close {
-		      position: absolute;
-          width: 40px;
-          height: 40px;
-          box-shadow: none;
-          background-color: @marquee-modal-close-bg;
-          outline: none;
-          transform: translateX(-50%) translateY(-50%);
-          z-index: @modal-dismiss-z-index;
-
-          &:hover {
-            background-color: @marquee-modal-close-hover-bg;
-          }
-
-          .hpe-close {
-            color: @marquee-modal-close-color;
-            font-size: 1.125rem;
-            padding-top: 2px;
-          }
-        }
-      }
-
-      .side-panel {
-        position: absolute;
-        width: 240px;
-        height: 100%;
-        background-color: @marquee-modal-side-panel-bg;
-
-        .marquee-logo {
-          color: @marquee-modal-side-panel-color;
-          padding: 20px;
-          padding-bottom: 5px;
+        &.modal-sm {
+            width: 600px;
         }
 
-        .marquee-info-panel {
-          font-family: @font-family;
-          font-weight: @font-weight-light;
-          padding: 20px;
-          color: @marquee-modal-side-panel-color;
-
-          .title {
-            margin-top: 0;
-            margin-bottom: 20px;
-          }
-
-          .description {
-            margin: 0;
-          }
+        &.modal-md {
+            width: 900px;
         }
 
-        .marquee-wizard-info-panel {
-          font-family: @font-family;
-          font-weight: @font-weight-light;
-          padding: 20px;
-          color: @marquee-modal-side-panel-color;
-          padding-bottom: 0;
+        &.modal-lg {
+            width: 1100px;
+        }
 
-          .title {
-            margin-top: 0;
-            margin-bottom: 20px;
-            white-space: nowrap;
-          }
+        .modal-content {
+            border-radius: 0;
 
-          .description {
-            max-height: 110px;
-            overflow-y: hidden;
-            p {
-              margin: 0;
-              max-height: 120px;
+            .dismiss {
+                position: absolute;
+                right: 0;
+
+                .btn-close {
+                    position: absolute;
+                    width: 40px;
+                    height: 40px;
+                    box-shadow: none;
+                    background-color: @marquee-modal-close-bg;
+                    outline: none;
+                    transform: translateX(-50%) translateY(-50%);
+                    z-index: @modal-dismiss-z-index;
+
+                    &:hover {
+                        background-color: @marquee-modal-close-hover-bg;
+                    }
+
+                    .hpe-close {
+                        color: @marquee-modal-close-color;
+                        font-size: 1.125rem;
+                        padding-top: 2px;
+                    }
+                }
             }
-          }
-        }
-      }
 
-      .main-panel {
-        display: inline-block;
-        width: ~'calc(100% - 240px)';
-        float: right;
-        background-color: @marquee-modal-bg;
+            .side-panel {
+                position: absolute;
+                width: 240px;
+                height: 100%;
+                background-color: @marquee-modal-side-panel-bg;
 
-        .marquee-header {
-            padding: 35px 35px 0;
+                .marquee-logo {
+                    color: @marquee-modal-side-panel-color;
+                    padding: 20px;
+                    padding-bottom: 5px;
+                }
 
-            .marquee-title {
-              margin: 0;
-              color: @marquee-modal-title-color;
+                .marquee-info-panel {
+                    font-family: @font-family;
+                    font-weight: @font-weight-light;
+                    padding: 20px;
+                    color: @marquee-modal-side-panel-color;
+
+                    .title {
+                        margin-top: 0;
+                        margin-bottom: 20px;
+                    }
+
+                    .description {
+                        margin: 0;
+                    }
+                }
+
+                .marquee-wizard-info-panel {
+                    font-family: @font-family;
+                    font-weight: @font-weight-light;
+                    padding: 20px;
+                    color: @marquee-modal-side-panel-color;
+                    padding-bottom: 0;
+
+                    .title {
+                        margin-top: 0;
+                        margin-bottom: 20px;
+                        white-space: nowrap;
+                    }
+
+                    .description {
+                        max-height: 110px;
+                        overflow-y: hidden;
+
+                        p {
+                            margin: 0;
+                            max-height: 120px;
+                        }
+                    }
+                }
+            }
+
+            .main-panel {
+                display: inline-block;
+                width: ~'calc(100% - 240px)';
+                float: right;
+                background-color: @marquee-modal-bg;
+
+                .marquee-header {
+                    padding: 35px 35px 0;
+
+                    .marquee-title {
+                        margin: 0;
+                        color: @marquee-modal-title-color;
+                    }
+                }
+
+                .marquee-body {
+                    position: relative;
+                    padding: 15px 35px;
+                }
+
+                .marquee-footer {
+                    width: 100%;
+                    height: 60px;
+                    background-color: @marquee-modal-footer-bg;
+                    text-align: right;
+                    padding: 15px;
+                }
             }
         }
+    }
 
-        .marquee-body {
-          position: relative;
-          padding: 15px 35px;
+    .modal-close {
+        position: absolute;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        width: 40px;
+        height: 40px;
+        background-color: #333;
+        border: none;
+        border-radius: 50%;
+        transform: translateX(-50%) translateY(-50%);
+        font-size: 1.125rem;
+        color: #999;
+        outline: none;
+
+        i {
+            position: relative;
         }
 
-        .marquee-footer {
-          width: 100%;
-          height: 60px;
-          background-color: @marquee-modal-footer-bg;
-          text-align: right;
-          padding: 15px;
+        &:hover {
+            background-color: #222;
         }
-      }
     }
-  }
-
-  .modal-close {
-    position: absolute;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    width: 40px;
-    height: 40px;
-    background-color: #333;
-    border: none;
-    border-radius: 50%;
-    transform: translateX(-50%) translateY(-50%);
-    font-size: 1.125rem;
-    color: #999;
-    outline: none;
-
-    i {
-      position: relative;
-    }
-
-    &:hover {
-      background-color: #222;
-    }
-  }
 }
 
 @media (max-width: 1140px) {
-  .marquee-modal-window {
-
-    .modal-dialog {
-
-      &.modal-lg {
-        width: 900px;
-      }
+    .marquee-modal-window {
+        .modal-dialog {
+            &.modal-lg {
+                width: 900px;
+            }
+        }
     }
-  }
 }
 
 @media (max-width: 940px) {
-  .marquee-modal-window {
+    .marquee-modal-window {
+        .modal-dialog {
+            width: 730px;
 
-    .modal-dialog {
-      width: 730px;
-
-      &.modal-lg, &.modal-md {
-        width: 730px;
-      }
+            &.modal-lg,
+            &.modal-md {
+                width: 730px;
+            }
+        }
     }
-  }
 }
 
 @media (max-width: 768px) {
-  .marquee-modal-window {
+    .marquee-modal-window {
+        .modal-dialog {
+            width: ~'calc(100% - 20px)';
 
-    .modal-dialog {
-      width: ~'calc(100% - 20px)';
-
-      &.modal-lg, &.modal-md, &.modal-sm {
-        width: ~'calc(100% - 20px)';
-      }
+            &.modal-lg,
+            &.modal-md,
+            &.modal-sm {
+                width: ~'calc(100% - 20px)';
+            }
+        }
     }
-  }
 }
 
 @media (max-width: 600px) {
-  .marquee-modal-window {
+    .marquee-modal-window {
+        .modal-dialog {
+            &.modal-lg,
+            &.modal-md,
+            &.modal-sm {
+                .side-panel {
+                    width: 170px;
+                }
 
-    .modal-dialog {
+                .main-panel {
+                    width: ~'calc(100% - 170px)';
+                }
+            }
 
-      &.modal-lg, &.modal-md, &.modal-sm {
-        .side-panel {
-          width: 170px;
+            .side-panel {
+                width: 170px;
+            }
+
+            .main-panel {
+                width: ~'calc(100% - 170px)';
+            }
         }
-        .main-panel {
-          width: ~'calc(100% - 170px)';
-        }
-      }
-
-      .side-panel {
-        width: 170px;
-      }
-      .main-panel {
-        width: ~'calc(100% - 170px)';
-      }
     }
-  }
 }
 
 @media (max-width: 470px) {
-  .marquee-modal-window {
+    .marquee-modal-window {
+        .modal-dialog {
+            .side-panel {
+                display: none;
+            }
 
-    .modal-dialog {
-
-      .side-panel {
-        display: none;
-      }
-      .main-panel {
-        width: 100% !important;
-      }
+            .main-panel {
+                width: 100% !important;
+            }
+        }
     }
-  }
 }
-
 
 /*
   Search builder modal
 */
 
-// Deprecated
-.body-dark {
-
-  /*
-    Specific to the modal search builder
-  */
-  .search-builder-modal-window {
-    .modal-dialog .modal-content {
-      background-color: @search-builder-modal-content-bg-dark;
-
-      .search-builder-header {
-        background-color: @search-builder-modal-header-footer-bg-dark;
-
-        .search-builder-title {
-          color: @search-builder-title-color-dark;
-        }
-      }
-
-      .search-builder-footer {
-        background-color: @search-builder-modal-header-footer-bg-dark;
-      }
-    }
-  }
-
-  /*
-    Dark search builder control
-  */
-  .search-builder-body {
-    .search-group {
-      .search-group-title {
-        color: @search-builder-title-color-dark;
-      }
-
-      .group-divider {
-        border-color: @search-builder-divider-dark;
-      }
-
-      .search-group-content {
-        .field-list {
-          .field-collection {
-            .field {
-              &:hover {
-                background-color: @search-builder-field-hover-dark;
-              }
-
-              .search-component {
-                .component-container {
-                  .form-label {
-                    color: @search-builder-component-form-label-dark;
-                  }
-
-                  .hpe-icon {
-                    color: @search-builder-component-icon-dark !important;
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-
-    }
-  }
-}
-
-
 .search-builder-modal-window {
+    .modal-dialog {
+        text-rendering: optimizeLegibility;
+        width: 900px;
 
-  .modal-dialog {
-    text-rendering: optimizeLegibility;
-    width: 900px;
-
-    &.modal-sm {
-      width: 600px;
-    }
-
-    &.modal-md {
-      width: 900px;
-    }
-
-    &.modal-lg {
-      width: 1100px;
-    }
-
-    .search-group:last-of-type {
-      hr {
-        display: none;
-      }
-    }
-
-    .modal-content {
-      border-radius: 0;
-
-      .dismiss {
-        position: absolute;
-        right: 0;
-
-        .btn-close {
-		      position: absolute;
-          width: 40px;
-          height: 40px;
-          box-shadow: none;
-          background-color: @search-builder-modal-close-bg;
-          outline: none;
-          transform: translateX(-50%) translateY(-50%);
-          z-index: @modal-dismiss-z-index;
-
-          &:hover {
-            background-color: @search-builder-modal-close-hover-bg;
-          }
-
-          .hpe-close {
-            color: @search-builder-modal-close-color;
-            font-size: 1.125rem;
-            padding-top: 2px;
-          }
+        &.modal-sm {
+            width: 600px;
         }
-      }
 
-      .search-builder-header {
-          padding: 15px 35px 15px;
-          background-color: @search-builder-modal-header-bg;
-
-          .search-builder-title {
-            margin: 0;
-            color: @search-builder-modal-header-color;
-          }
-      }
-
-      .search-builder-scroll-container {
-        position: relative;
-        height: 600px;
-        margin-right: 5px;
-        overflow-x: hidden;
-        
-        .search-builder-scroller {
-          height: 100%;
-          overflow-y: auto;
-
+        &.modal-md {
+            width: 900px;
         }
-      }
 
-      .search-builder-body {
-        position: relative;
-        padding: 15px 35px;
-      }
+        &.modal-lg {
+            width: 1100px;
+        }
 
-      .search-builder-footer {
-        width: 100%;
-        height: 60px;
-        background-color: @search-builder-modal-footer-bg;
-        text-align: right;
-        padding: 15px;
-      }
+        .search-group:last-of-type {
+            hr {
+                display: none;
+            }
+        }
 
+        .modal-content {
+            border-radius: 0;
+
+            .dismiss {
+                position: absolute;
+                right: 0;
+
+                .btn-close {
+                    position: absolute;
+                    width: 40px;
+                    height: 40px;
+                    box-shadow: none;
+                    background-color: @search-builder-modal-close-bg;
+                    outline: none;
+                    transform: translateX(-50%) translateY(-50%);
+                    z-index: @modal-dismiss-z-index;
+
+                    &:hover {
+                        background-color: @search-builder-modal-close-hover-bg;
+                    }
+
+                    .hpe-close {
+                        color: @search-builder-modal-close-color;
+                        font-size: 1.125rem;
+                        padding-top: 2px;
+                    }
+                }
+            }
+
+            .search-builder-header {
+                padding: 15px 35px;
+                background-color: @search-builder-modal-header-bg;
+
+                .search-builder-title {
+                    margin: 0;
+                    color: @search-builder-modal-header-color;
+                }
+            }
+
+            .search-builder-scroll-container {
+                position: relative;
+                height: 600px;
+                margin-right: 5px;
+                overflow-x: hidden;
+
+                .search-builder-scroller {
+                    height: 100%;
+                    overflow-y: auto;
+                }
+            }
+
+            .search-builder-body {
+                position: relative;
+                padding: 15px 35px;
+            }
+
+            .search-builder-footer {
+                width: 100%;
+                height: 60px;
+                background-color: @search-builder-modal-footer-bg;
+                text-align: right;
+                padding: 15px;
+            }
+        }
     }
-  }
 }
 
 @media (max-width: 1140px) {
-  .search-builder-modal-window {
-    .modal-dialog {
-      &.modal-lg {
-        width: 900px;
-      }
+    .search-builder-modal-window {
+        .modal-dialog {
+            &.modal-lg {
+                width: 900px;
+            }
+        }
     }
-  }
 }
 
 @media (max-width: 940px) {
-  .search-builder-modal-window {
-    .modal-dialog {
-      width: 730px;
+    .search-builder-modal-window {
+        .modal-dialog {
+            width: 730px;
 
-      &.modal-lg, &.modal-md {
-        width: 730px;
-      }
+            &.modal-lg,
+            &.modal-md {
+                width: 730px;
+            }
+        }
     }
-  }
 }
 
 @media (max-width: 768px) {
-  .search-builder-modal-window {
+    .search-builder-modal-window {
+        .modal-dialog {
+            width: ~'calc(100% - 20px)';
 
-    .modal-dialog {
-      width: ~'calc(100% - 20px)';
-
-      &.modal-lg, &.modal-md, &.modal-sm {
-        width: ~'calc(100% - 20px)';
-      }
+            &.modal-lg,
+            &.modal-md,
+            &.modal-sm {
+                width: ~'calc(100% - 20px)';
+            }
+        }
     }
-  }
 }
 
 @media (max-width: 600px) {
-  .search-builder-modal-window {
-    .modal-dialog {
-      &.modal-lg, &.modal-md, &.modal-sm {
-        .side-panel {
-          width: 170px;
+    .search-builder-modal-window {
+        .modal-dialog {
+            &.modal-lg,
+            &.modal-md,
+            &.modal-sm {
+                .side-panel {
+                    width: 170px;
+                }
+            }
         }
-      }
     }
-  }
 }
 
 @media (max-width: 470px) {
-  .marquee-modal-window {
+    .marquee-modal-window {
+        .modal-dialog {
+            .side-panel {
+                display: none;
+            }
 
-    .modal-dialog {
-
-      .side-panel {
-        display: none;
-      }
-      .main-panel {
-        width: 100% !important;
-      }
+            .main-panel {
+                width: 100% !important;
+            }
+        }
     }
-  }
 }
 
 /*
   Modal Inset Panel
 */
 
-// Deprecated
-
-.body-dark {
-  .modal-panel-region {
-    .modal-panel {
-      background-color: @modal-inset-panel-bg-dark;
-
-      &.right {
-        border-left: 1px solid @modal-inset-panel-right-left-border-dark;
-        box-shadow: -3px 0px 15px @modal-inset-panel-right-left-shadow-dark;
-      }
-
-      &.left {
-        border-right: 1px solid @modal-inset-panel-right-left-border-dark;
-        box-shadow: 3px 0px 15px @modal-inset-panel-right-left-shadow-dark;
-      }
-
-      .modal-panel-header {
-        border-bottom: 1px solid @modal-inset-panel-header-border-dark;
-
-        .header-content {
-          color: @white;
-        }
-
-        .close-container{
-          color: @modal-inset-panel-close-color;
-          font-size: 0.875rem;
-          opacity: 0.8;
-          &:hover, &:focus {
-            opacity: 1;
-            color: @modal-inset-panel-close-color;
-          }
-        }
-      }
-      .user-container{
-        border-bottom: 1px solid @modal-inset-panel-user-container-border-dark;
-      }
-    }
-  }
-}
-
 .modal-panel-detail-text {
-  color: @modal-inset-panel-detail-text-color;
+    color: @modal-inset-panel-detail-text-color;
 }
 
 .modal-panel-region {
-  position: absolute;
-  z-index: 100000;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  overflow: hidden;
+    position: absolute;
+    z-index: 100000;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    overflow: hidden;
 
-  .modal-panel {
-    background-color: @modal-inset-panel-bg;
-    height: 100%;
-    display: inline-block;
-
-    &.right {
-      float: right;
-      border-left: 1px solid @modal-inset-panel-border;
-      box-shadow: -3px 0px 15px @modal-inset-panel-shadow;
-    }
-
-    &.left {
-      float: left;
-      border-right: 1px solid @modal-inset-panel-border;
-      box-shadow: 3px 0px 15px @modal-inset-panel-shadow;
-    }
-
-    .modal-panel-header {
-      display: table;
-      width: 100%;
-      height: 50px;
-      max-height: 50px;
-      border-bottom: 1px solid @modal-inset-panel-header-border;
-
-      .header-content {
-        display: table-cell;
+    .modal-panel {
+        background-color: @modal-inset-panel-bg;
         height: 100%;
-        padding: 0px 15px;
-        vertical-align: middle;
-        color: @modal-inset-panel-header-color;
+        display: inline-block;
 
-        h1, h2, h3, h4, h5, h6, p {
-          margin: 0;
+        &.right {
+            float: right;
+            border-left: 1px solid @modal-inset-panel-border;
+            box-shadow: -3px 0 15px @modal-inset-panel-shadow;
         }
-      }
 
-      .close-container {
-        color: @modal-inset-panel-close-color;
-        display: table-cell;
-        width: 50px;
-        height: 100%;
-        vertical-align: middle;
-        text-align: center;
-        cursor: pointer;
-        font-size: 0.875rem;
-        &:hover, &:focus {
-          color: @modal-inset-panel-close-hover-color;
+        &.left {
+            float: left;
+            border-right: 1px solid @modal-inset-panel-border;
+            box-shadow: 3px 0 15px @modal-inset-panel-shadow;
         }
-      }
-    }
 
-    .modal-panel-content {
-      width: 100%;
-      height: 100%;
-    }
+        .modal-panel-header {
+            display: table;
+            width: 100%;
+            height: 50px;
+            max-height: 50px;
+            border-bottom: 1px solid @modal-inset-panel-header-border;
 
-    .modal-panel-header + .modal-panel-content {
-      height: ~'calc(100% - 50px)';
+            .header-content {
+                display: table-cell;
+                height: 100%;
+                padding: 0 15px;
+                vertical-align: middle;
+                color: @modal-inset-panel-header-color;
+
+                h1,
+                h2,
+                h3,
+                h4,
+                h5,
+                h6,
+                p {
+                    margin: 0;
+                }
+            }
+
+            .close-container {
+                color: @modal-inset-panel-close-color;
+                display: table-cell;
+                width: 50px;
+                height: 100%;
+                vertical-align: middle;
+                text-align: center;
+                cursor: pointer;
+                font-size: 0.875rem;
+
+                &:hover,
+                &:focus {
+                    color: @modal-inset-panel-close-hover-color;
+                }
+            }
+        }
+
+        .modal-panel-content {
+            width: 100%;
+            height: 100%;
+        }
+
+        .modal-panel-header + .modal-panel-content {
+            height: ~'calc(100% - 50px)';
+        }
     }
-  }
 }
 
-
 .modal-header-dark {
-  background-color: @grey2;
-  color: @white;
-  border-top-left-radius: 6px;
-  border-top-right-radius: 6px;
+    background-color: @grey2;
+    color: @white;
+    border-top-left-radius: 6px;
+    border-top-right-radius: 6px;
 }
 
 .modal-window-dark-header .modal-content {
-  /* Added this code to remove unwanted background caused by setting modal-header-dark border-radius */
-  /*This can also be done by making content background transparent and then re-setting individual backgrounds. */
-  border-top-left-radius: 8px;
-  border-top-right-radius: 8px;
+    /* Added this code to remove unwanted background caused by setting modal-header-dark border-radius */
+
+    /*This can also be done by making content background transparent and then re-setting individual backgrounds. */
+    border-top-left-radius: 8px;
+    border-top-right-radius: 8px;
 }
 
 /* Modal centering */
+
 .modal {
-  text-align: center;
-  padding: 0!important;
+    text-align: center;
+    padding: 0 !important;
 }
 
 .modal:before {
-  content: '';
-  display: inline-block;
-  height: 100%;
-  vertical-align: middle;
-  margin-right: -4px;
+    content: '';
+    display: inline-block;
+    height: 100%;
+    vertical-align: middle;
+    margin-right: -4px;
 }
 
 .modal-dialog {
-  display: inline-block;
-  text-align: left;
-  vertical-align: middle;
+    display: inline-block;
+    text-align: left;
+    vertical-align: middle;
 }
 
 .side-modal {
-  text-align: left;
-} 
+    text-align: left;
+}
 
 @media (max-width: 300px) {
-  .modal-dialog {
-    width: ~'calc(100% - 20px)';
-    margin: 10px 0;
-  }
-}
-
-//Deprecated
-
-//dark modal view
-.body-dark{
-  .modal-content{
-    background: @modal-content-bg-dark;
-  }
-  .modal-header{
-    color: @modal-header-color-dark; 
-    border-bottom: 1px solid @modal-header-border-dark;
-  }
-  .modal-body{
-    color: @modal-body-color-dark;
-    hr{
-      color: @modal-body-hr-color-border-dark;
-      border-top: 1px solid @modal-body-hr-color-border-dark;
+    .modal-dialog {
+        width: ~'calc(100% - 20px)';
+        margin: 10px 0;
     }
-    .input-group-addon{
-      background: @modal-body-bg-dark;
-    }
-    .form-control{
-      color: @modal-body-form-color-dark;
-      background: @modal-body-bg-dark;
-    }
-  }
-  .modal-footer{
-    border-top: 1px solid @modal-footer-border-dark;
-  }
-}
-
-//Deprecated
-
-//dark side modal
-.body-dark{
-  .side-modal{
-    background: @side-modal-bg-dark;
-    color: @side-modal-color-dark;
-    .header{
-      color: @side-modal-header-color-dark;
-      .modal-close{
-        opacity: 0.8;
-        &:hover, &:focus {
-          opacity: 1;
-        }
-        .btn-white{
-          background: @side-modal-close-btn-bg-dark;
-          color: @side-modal-close-btn-color-dark;
-          &:hover, &:focus{
-            background: @side-modal-close-btn-hover-bg-dark;
-            color: @side-modal-close-btn-hover-color-dark;
-          }
-        }
-      }
-    }
-    .footer{
-      border-top: 1px solid @side-modal-footer-border-dark;
-    }
-  }
-  
 }

--- a/src/styles/navigation.less
+++ b/src/styles/navigation.less
@@ -1,941 +1,936 @@
 .nav > li > a {
-  font-weight: 600;
-  padding: 14px 20px 14px 25px;
-  &:focus {
-    outline: 0;
-  }
+    font-weight: 600;
+    padding: 14px 20px 14px 25px;
+
+    &:focus {
+        outline: 0;
+    }
 }
 
 .nav.navbar-right {
-  margin-right: 0;
-  position: fixed;
-  right: 5px;
+    margin-right: 0;
+    position: fixed;
+    right: 5px;
 }
 
 .navbar-default {
-  .nav > li > a {
-    font-weight:300;
-    font-size: 0.9375rem;
-    span.arrow {
-      font-size: 0.625rem;
-      line-height: inherit;
-      position: relative;
-      top: 4px;
-      right: 3px;
+    .nav > li > a {
+        font-weight: 300;
+        font-size: 0.9375rem;
+
+        span.arrow {
+            font-size: 0.625rem;
+            line-height: inherit;
+            position: relative;
+            top: 4px;
+            right: 3px;
+        }
     }
-  }
-  .nav-fourth-level >li > a {
-      font-size: 0.875rem;
-      line-height: 1.2;
-  }
-  .nav-fifth-level >li > a {
-    font-size: 0.8125rem;
-    line-height: 0.9;
-  }
+
+    .nav-fourth-level > li > a {
+        font-size: 0.875rem;
+        line-height: 1.2;
+    }
+
+    .nav-fifth-level > li > a {
+        font-size: 0.8125rem;
+        line-height: 0.9;
+    }
 }
 
 .navbar-default {
-  .nav ul > li > a {
-    span {
-      &.arrow {
-        font-size: 0.625rem;
-        position: relative;
-        line-height: inherit;
-        right: 10px;
-      }
+    .nav ul > li > a {
+        span {
+            &.arrow {
+                font-size: 0.625rem;
+                position: relative;
+                line-height: inherit;
+                right: 10px;
+            }
+        }
     }
-  }
 }
 
 .nav > li > a {
-  i {
-    margin-right: 6px;
-    font-size: 1rem;
-  }
+    i {
+        margin-right: 6px;
+        font-size: 1rem;
+    }
 }
 
 .heading {
-  font-size: 2.5rem;
-  margin-top: -8px;
-  margin-bottom: 3px;
-  word-wrap: break-word;
+    font-size: 2.5rem;
+    margin-top: -8px;
+    margin-bottom: 3px;
+    word-wrap: break-word;
 }
 
 .dynamic-name-callout {
-  font-size: 1.75rem;
-  opacity: 0.5;
-  margin-left: 2px;
+    font-size: 1.75rem;
+    opacity: 0.5;
+    margin-left: 2px;
 }
 
-
-.back-button{
-  //only indents when text overflows due to positioning
-  //corrects indent in this case
-  .heading{
-    margin-left: 27px;
-  }
+.back-button {
+    //only indents when text overflows due to positioning
+    //corrects indent in this case
+    .heading {
+        margin-left: 27px;
+    }
 }
 
 .navbar {
-  border: 0;
+    border: 0;
 }
+
 .nav-header {
-  height: 85px;
-  padding: 0px 25px 12px 25px;
-  .text-muted {
-    color: @nav-header-text-muted-color;
-  }
-  a {
-    color: @nav-header-color;
-    text-decoration: none;
-  }
+    height: 85px;
+    padding: 0 25px 12px;
+
+    .text-muted {
+        color: @nav-header-text-muted-color;
+    }
+
+    a {
+        color: @nav-header-color;
+        text-decoration: none;
+    }
 }
 
 .nav > li.nav-header {
-  display: flex;
-  align-items: flex-end;
+    display: flex;
+    align-items: flex-end;
 }
 
 .sidebar-nav > li {
-  &.active {
-    border-left: 0;
-  }
+    &.active {
+        border-left: 0;
+    }
 }
 
 .nav.nav-second-level > li {
-  &.active {
-    border: none;
-  }
+    &.active {
+        border: none;
+    }
 }
 
 .nav {
-  &.nav-second-level {
-    &.collapse[style] {
-      height: auto !important;
+    &.nav-second-level {
+        &.collapse[style] {
+            height: auto !important;
+        }
     }
-  }
-  &.nav-third-level {
-    &.collapse[style] {
-      height: auto !important;
+
+    &.nav-third-level {
+        &.collapse[style] {
+            height: auto !important;
+        }
     }
-  }
-  &.nav-fourth-level {
-    &.collapse[style] {
-      height: auto !important;
+
+    &.nav-fourth-level {
+        &.collapse[style] {
+            height: auto !important;
+        }
     }
-  }
-  &.nav-fifth-level {
-    &.collapse[style] {
-      height: auto !important;
+
+    &.nav-fifth-level {
+        &.collapse[style] {
+            height: auto !important;
+        }
     }
-  }
 }
 
-.hp-icon.arrow, .hpe-icon.arrow {
-  float: right;
-  .rotate(270deg);
+.hp-icon.arrow,
+.hpe-icon.arrow {
+    float: right;
+    .rotate(270deg);
 }
 
 .selected {
-  &> a > .hp-icon,   &> a > .hpe-icon {
-    &.arrow {
-      .rotate(180deg);
+    & > a > .hp-icon,
+    & > a > .hpe-icon {
+        &.arrow {
+            .rotate(180deg);
+        }
     }
-  }
 }
 
 .nav-second-level,
 .nav-third-level,
 .nav-fourth-level,
 .nav-fifth-level {
-  li {
-    border-bottom: none !important;
-    border-left: 0 !important;
-  }
+    li {
+        border-bottom: none !important;
+        border-left: 0 !important;
+    }
 }
 
 .nav-second-level {
-  li {
-    a {
-      padding: 5px 10px 5px 10px;
-      padding-left: 52px;
+    li {
+        a {
+            padding: 5px 10px;
+            padding-left: 52px;
+        }
     }
-  }
 }
 
 .nav-third-level {
-  li {
-    a {
-      padding-left: 62px;
+    li {
+        a {
+            padding-left: 62px;
+        }
     }
-  }
 }
 
 .nav-fourth-level {
-  li {
-    a {
-      padding-left: 72px;
+    li {
+        a {
+            padding-left: 72px;
+        }
     }
-  }
 }
 
 .nav-fifth-level {
-  li {
-    a {
-      padding-left: 82px;
+    li {
+        a {
+            padding-left: 82px;
+        }
     }
-  }
 }
 
 .nav-header,
 li.active {
-  -webkit-transition: all 0.5s;
-  -moz-transition: all 0.5s;
-  -o-transition: all 0.5s;
-  transition: all 0.5s;
+    transition: all 0.5s;
 }
 
 .logo-element {
-  height: 47px;
-  width: 111px;
-  margin-top: 26px;
-  margin-bottom: -6px;
-  display: inline-block;
+    height: 47px;
+    width: 111px;
+    margin-top: 26px;
+    margin-bottom: -6px;
+    display: inline-block;
 }
 
 .logo-element-image {
-  height: 47px;
-  width: 47px;
-  display: inline-block;
-  margin-right: 5px;
+    height: 47px;
+    width: 47px;
+    display: inline-block;
+    margin-right: 5px;
 }
 
 .logo-element-text {
-  display: inline-block;
-  font-size: 1.25rem;
-  font-weight: normal;
-  vertical-align: bottom;
+    display: inline-block;
+    font-size: 1.25rem;
+    font-weight: normal;
+    vertical-align: bottom;
 }
 
 .navbar-static-side-dark.navbar-default .nav > li > a {
-  .logo-element-text {
-    color: @navbar-logo-element-text-bg-dark;
-  }
-} 
+    .logo-element-text {
+        color: @navbar-logo-element-text-bg-dark;
+    }
+}
 
 .navbar-static-side-light.navbar-default .nav > li > a,
 .navbar-static-side-dark.navbar-default .nav > li > a {
-  &.logo-element-container {
-    display: flex;
-    align-items: center;
-    padding: 0;
-    &:hover, &:focus {
-      background-color: rgba(0,0,0,0);
-    }
-  }
-}
+    &.logo-element-container {
+        display: flex;
+        align-items: center;
+        padding: 0;
 
+        &:hover,
+        &:focus {
+            background-color: rgba(0, 0, 0, 0);
+        }
+    }
+}
 
 //============================
 //panels and tabs
 //============================
 .panel.blank-panel {
-  background: none;
-  margin: 0;
+    background: none;
+    margin: 0;
 }
 
 .blank-panel {
-  .panel-heading {
-    padding-bottom: 0;
-  }
+    .panel-heading {
+        padding-bottom: 0;
+    }
 }
 
-.panel-heading{
-  padding: 10px 10px;
-
+.panel-heading {
+    padding: 10px;
 }
-.panel-body{
-  padding: 15px 10px;
+
+.panel-body {
+    padding: 15px 10px;
 }
 
 h4 {
-  &.panel-title{
-    font-family: @font-family;
-  }
+    &.panel-title {
+        font-family: @font-family;
+    }
 }
 
 .nav-tabs > li.active > a,
 .nav-tabs > li.active > a:hover,
 .nav-tabs > li.active > a:focus {
-  color: @tabs-color;
-  background-color: @tabs-bg;
-  cursor: default;
+    color: @tabs-color;
+    background-color: @tabs-bg;
+    cursor: default;
 }
 
 .nav {
-  &.nav-tabs {
-    li {
-      background: none;
+    &.nav-tabs {
+        li {
+            background: none;
+        }
     }
-  }
 }
 
 .nav-tabs > li > a {
-  color: lighten(@tabs-color, 15%);
-  border-width: 0px 0px 3px 0px;
-  font-family: @font-family;
-  font-weight: @font-weight-semibold;
-  padding: 8px 20px 0px 20px;
-  cursor: pointer;
-  height: 40px;
+    color: lighten(@tabs-color, 15%);
+    border-width: 0 0 3px;
+    font-family: @font-family;
+    font-weight: @font-weight-semibold;
+    padding: 8px 20px 0;
+    cursor: pointer;
+    height: 40px;
 }
+
 .nav-tabs > li > a {
-  i {
-    margin-right: 0px !important;
-  }
+    i {
+        margin-right: 0 !important;
+    }
 }
+
 .nav-tabs > li > a {
-  i+span {
-    padding-left: 8px;
-  }
+    i + span {
+        padding-left: 8px;
+    }
 }
-.outline-tab
-  {
-  .nav-tabs > li > a {
-    border-width: 1px 1px 2px 1px;
-    border-radius: 4px 4px 0px 0px;
-    &:hover,&:focus{
-      border-bottom-width: 2px;
-      border-bottom-color: @tabs-bg;
-      border-radius: 4px 4px 0px 0px;
-    }
-  }
- }
-.nav-tabs{
-  .tab-title{
-    line-height: 2;
- }
 
- .tab-dropdown {
-    padding: 0px 10px 0px 10px;
-    float: left;
-    margin-bottom: -1px;
-    position: relative;
-    display: block;
-    margin-top: -1px;
+.outline-tab {
+    .nav-tabs > li > a {
+        border-width: 1px 1px 2px;
+        border-radius: 4px 4px 0 0;
 
-    [dropdown-toggle] {
-      padding: 8px 0px 0px 0px;
-      min-width: 50px;
-      color: lighten(@tabs-color, 15%);
-      border-width: 0px 0px 3px 0px;
-      font-family: @font-family;
-      font-weight: @font-weight-semibold;
-      cursor: pointer;
-      height: 40px;
-      font-weight: 600;
-      margin-right: 2px;
-      line-height: 1.42857143;
-      border: 1px solid transparent;
-      border-radius: 4px 4px 0 0;
-      position: relative;
-      display: block;
-      text-align: center;
+        &:hover,
+        &:focus {
+            border-bottom-width: 2px;
+            border-bottom-color: @tabs-bg;
+            border-radius: 4px 4px 0 0;
+        }
     }
-
-    i+.tab-title, button+.tab-title {
-      padding-left: 4px;
-    }
-
-    .tab-option-selected {
-      color: @tabs-dropdown-selected-color;
-      cursor: default;
-      background: none !important;
-    }
-  }
 }
-.body-dark {
-  .nav-tabs {
+
+.nav-tabs {
+    .tab-title {
+        line-height: 2;
+    }
+
     .tab-dropdown {
-      .tab-option-selected {
-        color: @navbar-tab-option-selected-color-dark;
-      }
+        padding: 0 10px;
+        float: left;
+        margin-bottom: -1px;
+        position: relative;
+        display: block;
+        margin-top: -1px;
+
+        [dropdown-toggle] {
+            padding: 8px 0 0;
+            min-width: 50px;
+            color: lighten(@tabs-color, 15%);
+            border-width: 0 0 3px;
+            font-family: @font-family;
+            font-weight: @font-weight-semibold;
+            cursor: pointer;
+            height: 40px;
+            margin-right: 2px;
+            line-height: 1.42857143;
+            border: 1px solid transparent;
+            border-radius: 4px 4px 0 0;
+            position: relative;
+            display: block;
+            text-align: center;
+        }
+
+        i + .tab-title,
+        button + .tab-title {
+            padding-left: 4px;
+        }
+
+        .tab-option-selected {
+            color: @tabs-dropdown-selected-color;
+            cursor: default;
+            background: none !important;
+        }
     }
-  }
 }
 
 .nav-tabs > li > a {
-  &:hover, &:focus {
-    background-color: @tabs-hover-bg;
-    color: @tabs-hover-color;
-    border-color: transparent;
-    border-radius: 0;
-  }
+    &:hover,
+    &:focus {
+        background-color: @tabs-hover-bg;
+        color: @tabs-hover-color;
+        border-color: transparent;
+        border-radius: 0;
+    }
 }
-// minimal-tab style for tab with minimal effects
 
+// minimal-tab style for tab with minimal effects
 .minimal-tab {
-  border-style: none;
+    border-style: none;
 }
 
 .minimal-tab > li {
-  padding: 0px 10px 0px 10px;
+    padding: 0 10px;
 }
+
 .minimal-tab > li > a {
-  padding: 8px 0px 0px 0px;
-  min-width: 50px;
+    padding: 8px 0 0;
+    min-width: 50px;
 }
+
 .minimal-tab > li.active > a,
 .minimal-tab > li.active > a:hover,
 .minimal-tab > li.active > a:focus {
-  border-bottom: 3px solid @tabs-active-border;
-  border-left: none;
-  background-color: @tabs-active-bg;
-  border-right: none;
-  border-top: none;
-  cursor: default;
-  color: @tabs-active-color; 
+    border-bottom: 3px solid @tabs-active-border;
+    border-left: none;
+    background-color: @tabs-active-bg;
+    border-right: none;
+    border-top: none;
+    cursor: default;
+    color: @tabs-active-color;
 }
-//left and right stacked tabs
 
+//left and right stacked tabs
 .tabs-right > .nav-tabs,
-.tabs-left > .nav-tabs ,
+.tabs-left > .nav-tabs,
 .tabs-left > .outline-tab > .nav-tabs,
 .tabs-right > .outline-tab > .nav-tabs {
-  width: 20%;
-  border-bottom: 0;
-  & > li
-  {
-    border-width:0 0 3px 0;
+    width: 20%;
+    border-bottom: 0;
 
-    &.active > a
-    {
-      &,&:hover,&:focus
-      {     border-width:0 0 3px 0;
-        background-color: @tabs-active-bg;
-        border-bottom: 3px solid @tabs-active-border;
-        color: @tabs-active-color;
-        border-left: none;
-        border-right: none;
-        border-top: none;
-        cursor: default;
-      }
+    & > li {
+        border-width: 0 0 3px;
+
+        &.active > a {
+            &:hover,
+            &:focus {
+                border-width: 0 0 3px;
+                background-color: @tabs-active-bg;
+                border-bottom: 3px solid @tabs-active-border;
+                color: @tabs-active-color;
+                border-left: none;
+                border-right: none;
+                border-top: none;
+                cursor: default;
+            }
+        }
+
+        float: none;
+        text-align: left;
+        clear: both;
+
+        & > a {
+            min-width: 50px;
+            border-width: 0 0 3px;
+            display: table;
+            margin-right: 0;
+            margin-bottom: 30px;
+            padding: 10px 0 3px;
+            line-height: normal;
+            height: 30px;
+
+            .tab-title {
+                line-height: normal;
+            }
+
+            &:hover,
+            &:focus {
+                background-color: @tabs-hover-bg;
+                border-color: transparent;
+            }
+
+            &.text-right {
+                float: right;
+            }
+
+            &.text-left {
+                float: left;
+            }
+        }
     }
-    float: none;
-    text-align: left;
-    clear: both;
-    & > a
-    {
-      min-width: 50px;
-      border-width:0 0 3px 0;
-      display: table;
-      margin-right: 0;
-      margin-bottom: 30px;
-      padding: 10px 0px 3px 0px;
-      line-height: normal;
-      height: 30px;
-      .tab-title
-      {
-        line-height: normal;
-      }
-      &:hover,&:focus
-      {
-        background-color: @tabs-hover-bg;
-        border-color: transparent;
-      }
-      &.text-right
-      {
-        float:right;
-      }
-      &.text-left
-      {
-        float:left;
-      }
-    }
-  }
 }
 
-.tab-content
-{
-    & > .tab-pane
-    {
+.tab-content {
+    & > .tab-pane {
         display: none;
     }
-    & > .active
-    {
+
+    & > .active {
         display: block;
     }
 }
 
-
 .tabs-left > .nav-tabs,
 .tabs-left > .outline-tab > .nav-tabs {
-  float: left;
-  margin-right: 19px;
-  border-bottom: none;
+    float: left;
+    margin-right: 19px;
+    border-bottom: none;
 }
 
 .tabs-right > .nav-tabs,
 .tabs-right > .outline-tab > .nav-tabs {
-  float: right;
-  margin-left: 19px;
-  border-bottom: none;
+    float: right;
+    margin-left: 19px;
+    border-bottom: none;
 }
 
 .menu-tab {
-  .menu-tab-btn {
-    margin-right: 10px;
-    &:focus{
-      outline: none;
-      border-color: @accent;
-    }
-  }
-  .dropdown-menu {
-    margin-top: 12px;
-    padding-left: 15px;
-    .arrow {
-      margin-top: -10px;
-      margin-left: -10px;
-      width: 0; 
-      height: 0; 
-      border-left: 10px solid transparent;
-      border-right: 10px solid transparent;
-      border-bottom: 10px solid @tabs-dropdown-arrow-border;
-    }
-    .arrow-inner {
-      margin-left: -9px;
-      border-left: 9px solid transparent;
-      border-right: 9px solid transparent;
-      border-bottom: 10px solid @white;
-    }
-    .content{
-      padding-top: 10px;
-      padding-bottom: 10px;
-      margin-right: 25px;
-      margin-left: 25px;
-      min-width: 100px;
-      li {
-        p {
-          font-family: @font-family;
-          font-weight: @font-weight-semibold;
-          margin-top: 9px;
-          margin-left: 4px;
-          margin-right: 4px;
-          color: @primary;
+    .menu-tab-btn {
+        margin-right: 10px;
+
+        &:focus {
+            outline: none;
+            border-color: @accent;
         }
-        a{
-          display: inline;
-          &:hover {
-            background-color: transparent;
-          }
+    }
+
+    .dropdown-menu {
+        margin-top: 12px;
+        padding-left: 15px;
+
+        .arrow {
+            margin-top: -10px;
+            margin-left: -10px;
+            width: 0;
+            height: 0;
+            border-left: 10px solid transparent;
+            border-right: 10px solid transparent;
+            border-bottom: 10px solid @tabs-dropdown-arrow-border;
         }
-      }
+
+        .arrow-inner {
+            margin-left: -9px;
+            border-left: 9px solid transparent;
+            border-right: 9px solid transparent;
+            border-bottom: 10px solid @white;
+        }
+
+        .content {
+            padding-top: 10px;
+            padding-bottom: 10px;
+            margin-right: 25px;
+            margin-left: 25px;
+            min-width: 100px;
+
+            li {
+                p {
+                    font-family: @font-family;
+                    font-weight: @font-weight-semibold;
+                    margin-top: 9px;
+                    margin-left: 4px;
+                    margin-right: 4px;
+                    color: @primary;
+                }
+
+                a {
+                    display: inline;
+
+                    &:hover {
+                        background-color: transparent;
+                    }
+                }
+            }
+        }
     }
-  }
 }
-
-.body-dark {
-  .dropdown-menu {
-    .arrow {
-      border-bottom: 10px solid rgba(86, 96, 117, 0.7);
-    }
-    .arrow-inner {
-      border-bottom: 10px solid @grey2;
-    }
-  }
-}
-
-
 
 //============================
 //top header navigation styling
 //============================
 .navbar-fixed-top {
-  background: @white;
-  transition-duration: 0.5s;
-  border-bottom: 1px solid @navbar-fixed-top-border !important
+    background: @white;
+    transition-duration: 0.5s;
+    border-bottom: 1px solid @navbar-fixed-top-border !important;
 }
 
 .navbar-static-top {
-  width: 100%;
-  margin-bottom: 0;
-  &.show-search {
-   .navbar-header {
-     padding-top: 0;
-   }
-   .page-heading {
-    padding-top: 6px;
-   }
-   .navbar-form-search {
-    display: inline-block;
-   }
-  }
-
-  &.condensed {
-    min-height: 0;
-  }
-
-  .hp-icon, .hpe-icon {
-    font-size: 1rem;
-  }
-
-  .navbar-header {
     width: 100%;
-    padding-top: 8px;
-    &.top-link {
-      width:~'calc(100% - @{nav-top-link-width} - 50px)';
-    }
-    &.top-link-2 {
-      width:~'calc(100% - @{nav-top-link-width} - @{nav-top-link-width} - 50px)';
-    }
-    &.top-link-dropdown {
-      width:~'calc(100% - @{nav-top-link-width-dropdown} - 50px)';
-    }
-    &.top-link-dropdown-2 {
-      width:~'calc(100% - @{nav-top-link-width-dropdown} - @{nav-top-link-width-dropdown} - 50px)';
-    }
-    &.top-link {
-      &.top-link-dropdown {
-        width:~'calc(100% - @{nav-top-link-width-dropdown} - @{nav-top-link-width} - 50px)';
-      }
-    }
-  }
-  .navbar-right {
-    margin-right: 0;
-    position: absolute;
-    right: 5px;
-  }
-  .navbar-form-search {
-    display: none;
-    color: @navbar-search-color;
-    vertical-align: middle;
-    margin: 12px 0 10px 23px;
-    width: ~'calc(100% - 55px)';
-    .input-group-addon, .form-control {
-      background: none repeat scroll 0 0 rgba(0, 0, 0, 0);
-      border: medium none;
-      font-size: @font-size-md;
-      margin: 0;
-      z-index: @input-group-addon-z-index;
-      .opacity(0.7);
-      line-height: 1.428571429;
+    margin-bottom: 0;
 
+    &.show-search {
+        .navbar-header {
+            padding-top: 0;
+        }
+
+        .page-heading {
+            padding-top: 6px;
+        }
+
+        .navbar-form-search {
+            display: inline-block;
+        }
     }
-    .form-control {
-      display: inline-block;
-      vertical-align: middle;
-      padding-left: 6px;
-      width: ~'calc(100% + 30px)';
-      font-size: 0.9375rem;
-      .opacity(0.7);
-      &::-ms-clear {
+
+    &.condensed {
+        min-height: 0;
+    }
+
+    .hp-icon,
+    .hpe-icon {
+        font-size: 1rem;
+    }
+
+    .navbar-header {
+        width: 100%;
+        padding-top: 8px;
+
+        &.top-link {
+            width: ~'calc(100% - @{nav-top-link-width} - 50px)';
+        }
+
+        &.top-link-2 {
+            width: ~'calc(100% - @{nav-top-link-width} - @{nav-top-link-width} - 50px)';
+        }
+
+        &.top-link-dropdown {
+            width: ~'calc(100% - @{nav-top-link-width-dropdown} - 50px)';
+        }
+
+        &.top-link-dropdown-2 {
+            width: ~'calc(100% - @{nav-top-link-width-dropdown} - @{nav-top-link-width-dropdown} - 50px)';
+        }
+
+        &.top-link {
+            &.top-link-dropdown {
+                width: ~'calc(100% - @{nav-top-link-width-dropdown} - @{nav-top-link-width} - 50px)';
+            }
+        }
+    }
+
+    .navbar-right {
+        margin-right: 0;
+        position: absolute;
+        right: 5px;
+    }
+
+    .navbar-form-search {
         display: none;
-      }
+        color: @navbar-search-color;
+        vertical-align: middle;
+        margin: 12px 0 10px 23px;
+        width: ~'calc(100% - 55px)';
+
+        .input-group-addon,
+        .form-control {
+            background: none repeat scroll 0 0 rgba(0, 0, 0, 0);
+            border: medium none;
+            font-size: @font-size-md;
+            margin: 0;
+            z-index: @input-group-addon-z-index;
+            .opacity(0.7);
+
+            line-height: 1.428571429;
+        }
+
+        .form-control {
+            display: inline-block;
+            vertical-align: middle;
+            padding-left: 6px;
+            width: ~'calc(100% + 30px)';
+            font-size: 0.9375rem;
+            .opacity(0.7);
+
+            &::-ms-clear {
+                display: none;
+            }
+        }
+
+        .form-control,
+        .form-control:focus {
+            outline: 0;
+        }
+
+        .form-control {
+            &:focus {
+                .opacity(1);
+            }
+        }
     }
-    .form-control,
-    .form-control:focus {
-      outline: 0;
-    }
-    .form-control {
-      &:focus {
-        .opacity(1);
-      }
-    }
-  }
 }
 
 //============================
 //Affix Header --- Start
 //============================
 .affix-toolbar {
-  background: @toolbar-bg;
-  position: absolute;
-  width: 100%;
-  padding: 10px 20px;
-  top: 0;
+    background: @toolbar-bg;
+    position: absolute;
+    width: 100%;
+    padding: 10px 20px;
+    top: 0;
 }
 
 .affix-clone {
-  position: static !important;
+    position: static !important;
 }
 
 .affix-element {
-  position: absolute;
-  top: 0;
-  left: 0;
+    position: absolute;
+    top: 0;
+    left: 0;
 }
 
 .hide-navbar {
-  .affix-container {
-    .affix {
-      margin-left: 0;
-      width: 100%;
+    .affix-container {
+        .affix {
+            margin-left: 0;
+            width: 100%;
+        }
     }
-  }
 }
 
 .affix-container {
-  position: relative;
-  min-height: 57px;
-  z-index: @affix-z-index;
-  .affix {
-    position: fixed;
-    top: 0;
-    width: ~'calc(100% - @{sidebar-width})';
+    position: relative;
+    min-height: 57px;
     z-index: @affix-z-index;
-    margin-left: @sidebar-width;
-    box-shadow: @navbar-shadow;
-  }
-  &.toolbar ~ .wrapper-content {
-    padding-top: 10px;
-  }
-  &.toolbar.child-affix {
-    z-index: @affix-z-index;
-  }
-  &.toolbar {
-    z-index: @affix-toolbar-z-index;
-  }
-}
-.body-dark {
-  .affix-container {
+
     .affix {
-      box-shadow: 0px 5px 10px 0px @affix-shadow;
+        position: fixed;
+        top: 0;
+        width: ~ 'calc(100% - @{sidebar-width})';
+        z-index: @affix-z-index;
+        margin-left: @sidebar-width;
+        box-shadow: @navbar-shadow;
     }
-  }
+
+    &.toolbar ~ .wrapper-content {
+        padding-top: 10px;
+    }
+
+    &.toolbar.child-affix {
+        z-index: @affix-z-index;
+    }
+
+    &.toolbar {
+        z-index: @affix-toolbar-z-index;
+    }
 }
+
 .condensed,
 .affix {
-  .navbar-header {
-    padding: 0;
-    .logo-styling,.product-name,.product-styling{
-      display:none;
+    .navbar-header {
+        padding: 0;
+
+        .logo-styling,
+        .product-name,
+        .product-styling {
+            display: none;
+        }
     }
-  }
-  .btn {
-    padding: 5px 10px;
-    font-size: 0.75rem;
-    line-height: 1.5;
-    border-radius: 3px;
-  }
-  input {
-    height: 30px;
-    padding: 5px 10px;
-    font-size: 1.125rem;
-    line-height: 1.5;
-  }
-  .btn-clear {
-    padding: 0 10px 2px 10px;
-  }
-  .breadcrumb {
-    display: inline-block;
-    margin-top: 2px;
-    font-size: 0.9375rem;
-  }
-  .navbar-right {
-    position: absolute;
-    right: 5px;
-  }
-  .heading {
-    display: inline-block;
-    margin: 0;
-    font-size: 0.9375rem;
-  }
-  .dynamic-name-callout {
-    display: none;
-  }
-  .breadcrumb > li {
-    &:last-child {
-      &:after {
+
+    .btn {
+        padding: 5px 10px;
+        font-size: 0.75rem;
+        line-height: 1.5;
+        border-radius: 3px;
+    }
+
+    input {
+        height: 30px;
+        padding: 5px 10px;
+        font-size: 1.125rem;
+        line-height: 1.5;
+    }
+
+    .btn-clear {
+        padding: 0 10px 2px;
+    }
+
+    .breadcrumb {
         display: inline-block;
-      }
+        margin-top: 2px;
+        font-size: 0.9375rem;
     }
-  }
-  .navbar-form-search {
-    display: none;
-    padding: 0;
-    vertical-align: top;
-  }
-  &.show-search {
-    .page-heading {
-      display: none;
+
+    .navbar-right {
+        position: absolute;
+        right: 5px;
     }
-  }
-  .navbar-tabs {
-    display: none;
-  }
+
+    .heading {
+        display: inline-block;
+        margin: 0;
+        font-size: 0.9375rem;
+    }
+
+    .dynamic-name-callout {
+        display: none;
+    }
+
+    .breadcrumb > li {
+        &:last-child {
+            &:after {
+                display: inline-block;
+            }
+        }
+    }
+
+    .navbar-form-search {
+        display: none;
+        padding: 0;
+        vertical-align: top;
+    }
+
+    &.show-search {
+        .page-heading {
+            display: none;
+        }
+    }
+
+    .navbar-tabs {
+        display: none;
+    }
 }
 
 .navbar-tabs {
-  .nav-tabs {
-    height: 50px; 
-    padding-left: 10px;
-    background-color: @navbar-tabs-bg;
-
-    .menu-tab-btn {
-      margin-top: 10px;
-    }
-
-    li {
-      height: 50px;
-
-      a {
+    .nav-tabs {
         height: 50px;
-        padding: 0;
-        line-height: 50px;
+        padding-left: 10px;
+        background-color: @navbar-tabs-bg;
 
-        &:hover { 
-          background-color: transparent;
-        }
-      }
-    }
-    .dropdown-menu {
-      li {
-        height: 30px;
-        a {
-          height: 30px;
-          line-height: 30px
-        }
-      }
-    }
-  }
-
-  &.nav-divider {
-    .nav-tabs {
-      border-bottom: 1px solid @navbar-divider-tabs-border;
-      .menu-tab-btn {
-        margin-top: 10px;
-      }
-    }
-  }
-}
-
-.body-dark {
-  .navbar-tabs {
-    .nav-tabs {
-      background-color: @navbar-tabs-bg-dark;
-
-      li {
-        a {
-          color: @navbar-tabs-item-color-dark;
-
-          &:focus {
-            background-color: @navbar-tabs-item-focus-bg-dark;
-          }
+        .menu-tab-btn {
+            margin-top: 10px;
         }
 
-        &.active {
-          a {
-            color: @navbar-tabs-item-active-bg-dark;
-          }
+        li {
+            height: 50px;
+
+            a {
+                height: 50px;
+                padding: 0;
+                line-height: 50px;
+
+                &:hover {
+                    background-color: transparent;
+                }
+            }
         }
-      }
+
+        .dropdown-menu {
+            li {
+                height: 30px;
+
+                a {
+                    height: 30px;
+                    line-height: 30px;
+                }
+            }
+        }
     }
 
-    .affix-toolbar {
-      background-color: @navbar-tabs-affix-toolbar-bg-dark;
-    }
-    
     &.nav-divider {
-      .nav-tabs {
-        border-bottom: 1px solid @navbar-divider-tabs-border-dark;
-      }
-    }
-    
-    &.integrated-tabs {
-      .nav-tabs {
-        background-color: @navbar-integrated-tabs-bg-dark;
-      }
-    }
-  }
+        .nav-tabs {
+            border-bottom: 1px solid @navbar-divider-tabs-border;
 
+            .menu-tab-btn {
+                margin-top: 10px;
+            }
+        }
+    }
 }
 
 .navbar-tabs.integrated-tabs {
-  .nav-tabs {
-    background-color: @navbar-integrated-tabs-bg;
-    padding-left: 10px;
-    height: 60px;
-
-    .menu-tab-btn {
-      margin-top: 15px;
-    }
-
-    li {
-      height: 100%; 
-
-      a {
+    .nav-tabs {
+        background-color: @navbar-integrated-tabs-bg;
+        padding-left: 10px;
         height: 60px;
-        border: none;
+
+        .menu-tab-btn {
+            margin-top: 15px;
+        }
+
+        li {
+            height: 100%;
+
+            a {
+                height: 60px;
+                border: none;
+                padding: 0;
+                margin: 0;
+                line-height: 60px;
+            }
+
+            &.active {
+                tab-heading {
+                    border-bottom: 3px solid @primary;
+                    padding-bottom: 4px;
+                }
+            }
+        }
+
+        .dropdown-menu {
+            li {
+                height: 30px;
+
+                a {
+                    height: 30px;
+                    line-height: 30px;
+                }
+            }
+        }
+    }
+}
+
+.condensed,
+.affix {
+    .page-heading {
+        position: static;
         padding: 0;
-        margin: 0;   
-        line-height: 60px;
-      }
-
-      &.active {
-        tab-heading {
-          border-bottom: 3px solid @primary;
-          padding-bottom: 4px;
-        }
-      } 
+        display: block;
     }
-    .dropdown-menu {
-      li {
-        height: 30px;
-        a {
-          height: 30px;
-          line-height: 30px
-        }
-      }
-    }
-  }
 }
 
-.condensed, .affix {
-  .page-heading {
-    position: static;
-    padding: 0;
-    display: block;
-  }
-}
-.inputexpanded.affix, .inputexpanded.condensed {
-  .page-heading {
-    display:none;
-  }
+.inputexpanded.affix,
+.inputexpanded.condensed {
+    .page-heading {
+        display: none;
+    }
 }
 
 .inputexpanded {
-  &.affix, &.condensed {
-    .navbar-form-search {
-      display:inline-block;
-      margin : -4px;
-      margin-left: 3px;
+    &.affix,
+    &.condensed {
+        .navbar-form-search {
+            display: inline-block;
+            margin: -4px;
+            margin-left: 3px;
+        }
     }
-  }
 }
 
-.condensed, .affix {
-  .navbar-top-links {
-    .navbar-top-link {
-      &.search {
-        display: inline-block;
-      }
+.condensed,
+.affix {
+    .navbar-top-links {
+        .navbar-top-link {
+            &.search {
+                display: inline-block;
+            }
+        }
     }
-  }
 }
 
 .navbar-static-top {
-  &.affix.affix-element, &.condensed {
-    min-height: 57px;
-    padding: 16px 0 10px 20px;
-  }
+    &.affix.affix-element,
+    &.condensed {
+        min-height: 57px;
+        padding: 16px 0 10px 20px;
+    }
 }
 
-// Deprecated
-.body-dark {
-  .affix-toolbar {
-    background: @affix-toolbar-bg-dark;
-  }
-}
 //============================
 //Affix Header --- End
 //============================
@@ -947,101 +942,102 @@ h4 {
 .nav.navbar-top-links > .open > a,
 .nav.navbar-top-links > .open > a:hover,
 .nav.navbar-top-links > .open > a:focus {
-  cursor: pointer;
-  background-color: darken(@primary, 3%);
+    cursor: pointer;
+    background-color: darken(@primary, 3%);
 }
 
 .navbar-top-links {
-  .navbar-top-link {
-    display: inline-block;
-    width: @nav-top-link-width;
-    &.show-icon-header-btn {
-      display:none;
+    .navbar-top-link {
+        display: inline-block;
+        width: @nav-top-link-width;
+
+        &.show-icon-header-btn {
+            display: none;
+        }
+
+        &.dropdown {
+            width: @nav-top-link-width-dropdown;
+        }
     }
-    &.dropdown {
-      width: @nav-top-link-width-dropdown;
-    }
-  }
 }
 
 .navbar-top-links {
-  .navbar-top-link {
-    &:last-child {
-      margin-right: 15px;
+    .navbar-top-link {
+        &:last-child {
+            margin-right: 15px;
+        }
     }
-  }
 }
 
 .navbar-top-links {
-  .navbar-top-link {
-    a {
-      padding: 10px;
-      font-size: @font-size-md;
+    .navbar-top-link {
+        a {
+            padding: 10px;
+            font-size: @font-size-md;
+        }
     }
-  }
 }
 
 .dropdown-menu {
-  border: medium none;
-  border-radius: 3px;
-  box-shadow: 0 0 3px @dropdown-shadow;
-  color: @dropdown-color;
-  background-color: @dropdown-bg;
-  display: none;
-  float: left;
-  font-size: @font-size-sm;
-  left: 0;
-  list-style: none outside none;
-  padding: 0;
-  position: absolute;
-  text-shadow: none;
-  top: 100%;
-  z-index: @dropdown-menu-z-index;
-  border-radius: 2px;
+    border: medium none;
+    box-shadow: 0 0 3px @dropdown-shadow;
+    color: @dropdown-color;
+    background-color: @dropdown-bg;
+    display: none;
+    float: left;
+    font-size: @font-size-sm;
+    left: 0;
+    list-style: none outside none;
+    padding: 0;
+    position: absolute;
+    text-shadow: none;
+    top: 100%;
+    z-index: @dropdown-menu-z-index;
+    border-radius: 2px;
 
-  li > a {
-    &:hover {
-      text-decoration: none;
-      background-color: @dropdown-hover-bg;
-      color: @dropdown-hover-color;
-    }
-  }
-
-  li.dropdown-indent > a {
-    padding-left: 52px;
-  }
-  
-  a.dropdown-menu-item {
-    display: inline-flex;
-    width: 100%;
-    align-items: baseline;
-
-    .dropdown-menu-icon {
-      flex: 0 0 auto;
-      width: 20px;
-      text-align: center;
-      margin-right: 10px;
+    li > a {
+        &:hover {
+            text-decoration: none;
+            background-color: @dropdown-hover-bg;
+            color: @dropdown-hover-color;
+        }
     }
 
-    .dropdown-menu-text {
-      flex: 1;
-      overflow: hidden;
-      text-overflow: ellipsis;
+    li.dropdown-indent > a {
+        padding-left: 52px;
     }
 
-    .dropdown-menu-right {
-      text-align: right;
+    a.dropdown-menu-item {
+        display: inline-flex;
+        width: 100%;
+        align-items: baseline;
+
+        .dropdown-menu-icon {
+            flex: 0 0 auto;
+            width: 20px;
+            text-align: center;
+            margin-right: 10px;
+        }
+
+        .dropdown-menu-text {
+            flex: 1;
+            overflow: hidden;
+            text-overflow: ellipsis;
+        }
+
+        .dropdown-menu-right {
+            text-align: right;
+        }
+
+        .dropdown-menu-hint {
+            color: @dropdown-menu-hint;
+            font-size: 80%;
+        }
     }
 
-    .dropdown-menu-hint {
-      color: @dropdown-menu-hint;
-      font-size: 80%;
+    .divider {
+        margin: 5px 0;
     }
-  }
-
-  .divider {
-    margin: 5px 0;
-  }
 }
 
 .dropdown-submenu {
@@ -1059,709 +1055,752 @@ h4 {
     display: block;
 }
 
-// Deprecated
-.body-dark {
-  .dropdown-menu {
+.navbar-static-side-hidden,
+.navbar-static-side-container-hidden {
+    display: none;
+}
+
+.dropdown-menu {
     li > a {
-      color: @dropdown-menu-color-dark;
-      &:focus,&:hover {
-        background-color: @dropdown-menu-focus-bg-dark;
-      }
-    }
-  }
-}
-
-.navbar-static-side-hidden, .navbar-static-side-container-hidden {
-  display: none;
-}
-
-.dropdown-menu {
-  li > a {
-    color: inherit;
-    line-height: 25px;
-    padding: 6px 20px;
-    text-align: left;
-    font-weight: normal;
-    font-size: @font-size;
-    display: block;
-  }
-}
-
-.dropdown-menu {
-  li > a {
-    &.font-bold {
-      .font-semibold;
-    }
-  }
-}
-
-.navbar-top-links {
-  .dropdown-menu {
-    li {
-      display: block;
-    }
-  }
-}
-
-.navbar-top-links {
-  .dropdown-menu {
-    li {
-      &:last-child {
-        margin-right: 0;
-      }
-      a {
+        color: inherit;
+        line-height: 25px;
         padding: 6px 20px;
-        min-height: 0;
-        color: @dropdown-color;
+        text-align: left;
+        font-weight: normal;
         font-size: @font-size;
-
-      }
+        display: block;
     }
-  }
 }
 
-.navbar-top-links .dropdown-menu li>span {
-  font-size: @font-size;
-}
-
-.navbar-top-links {
-  .dropdown-menu {
-    .dropdown-header {
-      padding: 3px 20px;
-      margin: 4px
-    }
-  }
-}
-
-.navbar-top-links {
-  .dropdown-menu {
-    li {
-      a {
-        div {
-          white-space: normal;
+.dropdown-menu {
+    li > a {
+        &.font-bold {
+            .font-semibold;
         }
-      }
     }
-  }
 }
 
 .navbar-top-links {
-  .dropdown-menu {
-    width: 310px;
-    min-width: 0;
-  }
+    .dropdown-menu {
+        li {
+            display: block;
+        }
+    }
+}
+
+.navbar-top-links {
+    .dropdown-menu {
+        li {
+            &:last-child {
+                margin-right: 0;
+            }
+
+            a {
+                padding: 6px 20px;
+                min-height: 0;
+                color: @dropdown-color;
+                font-size: @font-size;
+            }
+        }
+    }
+}
+
+.navbar-top-links .dropdown-menu li > span {
+    font-size: @font-size;
+}
+
+.navbar-top-links {
+    .dropdown-menu {
+        .dropdown-header {
+            padding: 3px 20px;
+            margin: 4px;
+        }
+    }
+}
+
+.navbar-top-links {
+    .dropdown-menu {
+        li {
+            a {
+                div {
+                    white-space: normal;
+                }
+            }
+        }
+    }
+}
+
+.navbar-top-links {
+    .dropdown-menu {
+        width: 310px;
+        min-width: 0;
+    }
 }
 
 .count-info {
-  .label {
-    line-height: 12px;
-    padding: 2px 5px;
-    position: absolute;
-    right: 6px;
-    top: 2px;
-  }
+    .label {
+        line-height: 12px;
+        padding: 2px 5px;
+        position: absolute;
+        right: 6px;
+        top: 2px;
+    }
 }
 
- 
 .hide-navbar {
-  & .logo-styling {
-    img {
-      display: none;
-    }
-    &.always-visible {
-      img {
-        padding-left:54px;
-        display: block;
-      }
-    }
-  }
+    & .logo-styling {
+        img {
+            display: none;
+        }
 
-  & .product-name {
-    display: none;
-    &.always-visible {
-      padding-left:54px;
-      display: block;
+        &.always-visible {
+            img {
+                padding-left: 54px;
+                display: block;
+            }
+        }
     }
-  }
 
-  .page-content {
-    position: inherit;
-    margin: 0;
-  }
+    & .product-name {
+        display: none;
 
-  .nav-menu-btn-container {
-    position: relative;
-    width: 0;
-    z-index:@nav-menu-z-index;
-    padding-bottom: 0;
-    a {
-       color: @grey2;
+        &.always-visible {
+            padding-left: 54px;
+            display: block;
+        }
     }
-  }
-  .nav-menu-btn-container-dark{
-    background-color: @navbar-side-container-dark;
-  } 
-  .nav-menu-btn-container-light {
-     background-color: @white;
-  }
-  .navbar-static-top {
-     .navbar-form-search {
-         margin-left: 50px;
-     }
-  }
 
-  .condensed, .affix {
-    .page-heading {
-      margin-left: 30px;
-      margin-top: -1px;
+    .page-content {
+        position: inherit;
+        margin: 0;
     }
-  }
-  .nav-menu-btn-container-top-light {
-    a {
-      color: @grey2;
+
+    .nav-menu-btn-container {
+        position: relative;
+        width: 0;
+        z-index: @nav-menu-z-index;
+        padding-bottom: 0;
+
+        a {
+            color: @grey2;
+        }
     }
-  }
-  .nav-menu-btn-container-top-dark {
-    a {
-      color: @grey2;
+
+    .nav-menu-btn-container-dark {
+        background-color: @navbar-side-container-dark;
     }
-  }
-  .navbar-static-top {
-    .navbar-form-search {
-      .form-control {
-        width: ~'calc(100% - 30px)';
-      }
+
+    .nav-menu-btn-container-light {
+        background-color: @white;
     }
-  }
+
+    .navbar-static-top {
+        .navbar-form-search {
+            margin-left: 50px;
+        }
+    }
+
+    .condensed,
+    .affix {
+        .page-heading {
+            margin-left: 30px;
+            margin-top: -1px;
+        }
+    }
+
+    .nav-menu-btn-container-top-light {
+        a {
+            color: @grey2;
+        }
+    }
+
+    .nav-menu-btn-container-top-dark {
+        a {
+            color: @grey2;
+        }
+    }
+
+    .navbar-static-top {
+        .navbar-form-search {
+            .form-control {
+                width: ~'calc(100% - 30px)';
+            }
+        }
+    }
 }
 
 .navbar-static-side-container {
-  margin-top: 37px;
-  position: fixed;
-  min-height:~'calc(100%-37px)';
-  top: 0;
-  bottom:0;
-  overflow: hidden;
-  width: @sidebar-width;
-  //The z-index of the side menu should be above the toolbar to avoid box-shadow overflow.
-  z-index: @nav-side-z-index;
+    margin-top: 37px;
+    position: fixed;
+    min-height: ~'calc(100%-37px)';
+    top: 0;
+    bottom: 0;
+    overflow: hidden;
+    width: @sidebar-width; //The z-index of the side menu should be above the toolbar to avoid box-shadow overflow.
+    z-index: @nav-side-z-index;
 
-  &:hover {
-    overflow-y:auto;
-  }
-}
-
-.navbar-static-side {
-  width: @sidebar-width;
-}
-
-.navbar-static-side {
-  &:hover {
-    ul {
-      width: initial;
+    &:hover {
+        overflow-y: auto;
     }
-  }
+}
+
+.navbar-static-side {
+    width: @sidebar-width;
+}
+
+.navbar-static-side {
+    &:hover {
+        ul {
+            width: initial;
+        }
+    }
 }
 
 //============================
 //Navigation Menu Toggle Button
 //============================
 .hide-navbar {
-  .nav-menu-btn-container{
-    &.p-nil{
-      padding: 0;
-      .nav-menu-toggle-btn {
-        display: none;
-      }
+    .nav-menu-btn-container {
+        &.p-nil {
+            padding: 0;
+
+            .nav-menu-toggle-btn {
+                display: none;
+            }
+        }
     }
-  }
 }
 
 .nav-menu-btn-container {
-  width: @sidebar-width;
-  position: fixed;
-  line-height: 1.25;
-  height: 37px;
-  float: left;
-  .nav-menu-toggle-btn {
-    position: absolute;
-    top: 19px;
-    left: 25px;
-  }
-  .hp-icon, .hpe-icon {
-    font-size: 1rem;
-  }
-}
-
-.nav-menu-btn-container a{
-  &:hover, &:focus {
-    outline: 0;
-  }
-}
-
-.logo-img{
-  img, svg {
+    width: @sidebar-width;
+    position: fixed;
+    line-height: 1.25;
+    height: 37px;
     float: left;
-    padding-left: 25px;
-    position: relative;
-    top: 50%;
-    transform: translateY(-50%);
-  }
+
+    .nav-menu-toggle-btn {
+        position: absolute;
+        top: 19px;
+        left: 25px;
+    }
+
+    .hp-icon,
+    .hpe-icon {
+        font-size: 1rem;
+    }
+}
+
+.nav-menu-btn-container a {
+    &:hover,
+    &:focus {
+        outline: 0;
+    }
+}
+
+.logo-img {
+    img,
+    svg {
+        float: left;
+        padding-left: 25px;
+        position: relative;
+        top: 50%;
+        transform: translateY(-50%);
+    }
 }
 
 .logo-styling {
-  height: 40px;
-  display: inline-block;
-  position: relative;
-  float: left;
-  .logo-img;
-}
-
-.back-button{
-  .logo-styling {
+    height: 40px;
+    display: inline-block;
+    position: relative;
+    float: left;
     .logo-img;
-    img {
-      padding-left:54px;
+}
+
+.back-button {
+    .logo-styling {
+        .logo-img;
+
+        img {
+            padding-left: 54px;
+        }
     }
-  }
-  .product-name {
-    padding-left:54px;
-  }
-}
 
-.back-button{
-  .product-name {
-    padding-left:54px;
-  }
-  .switch-group {
-   margin-left: 52px !important;
-  }
-}
-
-.back-button{
-.header-content-left{
-  ol{
-    padding-left: 30px;
-  }
-}
-}
-.affix{
-  .header-content-left{
-    ol{
-      padding-left: 0px;
+    .product-name {
+        padding-left: 54px;
     }
-  }
 }
 
-.hide-navbar{
-  .logo-styling {
+.back-button {
+    .product-name {
+        padding-left: 54px;
+    }
+
+    .switch-group {
+        margin-left: 52px !important;
+    }
+}
+
+.back-button {
+    .header-content-left {
+        ol {
+            padding-left: 30px;
+        }
+    }
+}
+
+.affix {
+    .header-content-left {
+        ol {
+            padding-left: 0;
+        }
+    }
+}
+
+.hide-navbar {
+    .logo-styling {
+        display: none;
+
+        &.always-visible {
+            display: inline-block;
+        }
+    }
+}
+
+.header-content-right {
     display: none;
-      &.always-visible {
-        display: inline-block;
-      }
-  }
 }
 
-.header-content-right{
-  display: none;
+.content-panel {
+    .header-content-right {
+        display: block;
+        position: absolute;
+        bottom: 11px;
+        right: 20px;
+        width: 25vw;
+        height: 54px;
+        white-space: nowrap;
+    }
 }
 
-
-.content-panel{
-  .header-content-right{
-    display: block;
-    position: absolute;
-    bottom:11px;
-    right:20px;
-    width: 25vw;
-    height: 54px;
-    white-space: nowrap;
-  }
+.affix {
+    .header-content-right {
+        display: none !important;
+    }
 }
-
-
-.affix{
-  .header-content-right{
-    display: none !important;
-  }
-}
-
 
 @media (min-width: 1024px) {
-  .content-panel&:not(.affix){
-    .heading, .breadcrumb{
-      max-width: 70%;
+    .content-panel&:not(.affix) {
+        .heading,
+        .breadcrumb {
+            max-width: 70%;
+        }
     }
-  }
 }
-
 
 .product-name {
-  float: left;
-  color: @white;
-  font-family: @font-family;
-  font-size: 0.8125rem;
-  line-height: 40px;
-  height: 40px;
-  padding-left: 25px;
+    float: left;
+    color: @white;
+    font-family: @font-family;
+    font-size: 0.8125rem;
+    line-height: 40px;
+    height: 40px;
+    padding-left: 25px;
 }
-
 
 .product-styling {
-  display: block;
-  margin-bottom: 2px;
-  height: 40px;
-  width:100%;
-  line-height: 1;
+    display: block;
+    margin-bottom: 2px;
+    height: 40px;
+    width: 100%;
+    line-height: 1;
 }
 
-.logo-styling+ .product-name {
-  padding-left:6px;
-}
-
-.condensed-panel{
-  .navbar-static-side-container {
-    margin-top: 57px;
-    min-height:~'calc(100%-57px)';
-  }
-  .nav-menu-btn-container,.affix-container .affix{
-    min-height:57px;
-  }
-  .logo-element {
-    height: 47px;
-    width: 111px;
-    margin-top: 9px;
-    display: inline-block;
-  }
-  .logo-element-image {
-    height: 47px;
-    width: 47px;
-    margin-top: 6px;
-    display: inline-block;
-  }
-  .navbar-static-side-dark {
-    .nav-header {
-      height:65px;
-      .nav-header-dark;
-      & .logo-element, & .logo-element-image{
-        background: url(../img/UX-graphic.png) no-repeat;
-        background-size: contain;
-        background-position: center;
-      }
-    }
-  }
-  .navbar-static-side-light
-  {
-    .nav-header {
-      height:65px;
-      .nav-header-light;
-      & .logo-element, & .logo-element-image{
-        background: url(../img/UX-graphic.png) no-repeat; 
-        background-size: contain;
-        background-position: center;
-      }
-    }
-  }
+.logo-styling + .product-name {
+    padding-left: 6px;
 }
 
 .condensed-panel {
-  .navbar-static-top {
-    .navbar-top-links {
-      height: 100%;
-      top: 0px;
-      .navbar-top-link {
-        height: 100%;
-        a {
-          height: 100%;
-          padding: 20px 10px;
-          &.count-info .label {
-              top: 2px;
-          }
-        }
-      }
+    .navbar-static-side-container {
+        margin-top: 57px;
+        min-height: ~'calc(100%-57px)';
     }
-  }
+
+    .nav-menu-btn-container,
+    .affix-container .affix {
+        min-height: 57px;
+    }
+
+    .logo-element {
+        height: 47px;
+        width: 111px;
+        margin-top: 9px;
+        display: inline-block;
+    }
+
+    .logo-element-image {
+        height: 47px;
+        width: 47px;
+        margin-top: 6px;
+        display: inline-block;
+    }
+
+    .navbar-static-side-dark {
+        .nav-header {
+            height: 65px;
+            .nav-header-dark;
+
+            & .logo-element,
+            & .logo-element-image {
+                background: url(../img/UX-graphic.png) no-repeat;
+                background-size: contain;
+                background-position: center;
+            }
+        }
+    }
+
+    .navbar-static-side-light {
+        .nav-header {
+            height: 65px;
+            .nav-header-light;
+
+            & .logo-element,
+            & .logo-element-image {
+                background: url(../img/UX-graphic.png) no-repeat;
+                background-size: contain;
+                background-position: center;
+            }
+        }
+    }
+}
+
+.condensed-panel {
+    .navbar-static-top {
+        .navbar-top-links {
+            height: 100%;
+            top: 0;
+
+            .navbar-top-link {
+                height: 100%;
+
+                a {
+                    height: 100%;
+                    padding: 20px 10px;
+
+                    &.count-info .label {
+                        top: 2px;
+                    }
+                }
+            }
+        }
+    }
 }
 
 .switch-group {
-  background-color: transparent !important;
-  border-color: transparent !important;
-  box-shadow: none !important;
-  font-size: 0.8125rem !important;
-  color: inherit !important;
-  padding: 0 !important;
-  margin-left: 25px !important;
-  display: block;
-  top: -5px;
-  left: 0;
+    background-color: transparent !important;
+    border-color: transparent !important;
+    box-shadow: none !important;
+    font-size: 0.8125rem !important;
+    color: inherit !important;
+    padding: 0 !important;
+    margin-left: 25px !important;
+    display: block;
+    top: -5px;
+    left: 0;
 }
+
 .page-content-navbar-top-dark {
-  .switch-group {
-    color: @white !important;
-  }
-}
-.page-content-navbar-top-light {
-  .switch-group {
-    color: @grey2 !important;
-  }
-}
-.switcher {
-  .switch-group {
-    top: -3px;
-  }
-}
-.switcher {
-  .btn-group {
-    vertical-align: top !important;
-  }
-}
-.switch-group + ul {
-  &.dropdown-menu {
-    white-space: nowrap;
-    top: 14px;
-    padding: 5px 0 5px 0;
-    width: 310px;
-    min-width: 0;
-  }
-}
-.switch-group + ul {
-  &.dropdown-menu {
-    li > a {
-      padding: 3px 20px 3px 20px;
+    .switch-group {
+        color: @white !important;
     }
-  }
 }
+
+.page-content-navbar-top-light {
+    .switch-group {
+        color: @grey2 !important;
+    }
+}
+
+.switcher {
+    .switch-group {
+        top: -3px;
+    }
+}
+
+.switcher {
+    .btn-group {
+        vertical-align: top !important;
+    }
+}
+
+.switch-group + ul {
+    &.dropdown-menu {
+        white-space: nowrap;
+        top: 14px;
+        padding: 5px 0;
+        width: 310px;
+        min-width: 0;
+    }
+}
+
+.switch-group + ul {
+    &.dropdown-menu {
+        li > a {
+            padding: 3px 20px;
+        }
+    }
+}
+
 .hide-navbar .switch-group,
 .hide-navbar .switch-group + ul.dropdown-menu,
-.back-button .switch-group + ul.dropdown-menu
-{
-  margin-left: 50px !important;
+.back-button .switch-group + ul.dropdown-menu {
+    margin-left: 50px !important;
 }
+
 .switch-group + ul.dropdown-menu {
-  margin-left: 25px !important;
+    margin-left: 25px !important;
 }
 
 //============================
 //left navigation animate styling
 //============================
-
 @keyframes navblack {
-  0%   { background-color: @grey2 }
-  80%   { background-color: @grey2 }
-  90% { background-color: transparent }
+    0% {
+        background-color: @grey2;
+    }
+
+    80% {
+        background-color: @grey2;
+    }
+
+    90% {
+        background-color: transparent;
+    }
 }
 
 @keyframes navwhite {
-  0%   { background-color: @white }
-  5%   { background-color: @white }
-  18% { background-color: transparent }
-} 
+    0% {
+        background-color: @white;
+    }
+
+    5% {
+        background-color: @white;
+    }
+
+    18% {
+        background-color: transparent;
+    }
+}
 
 .animate-navbar {
-  .navbar-static-side-container {
-    transition: margin-left 0.4s cubic-bezier(0.4, 0, 0.2, 1);
-  }
+    .navbar-static-side-container {
+        transition: margin-left 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+    }
 
-  .nav-menu-btn-container {
-    transition: width 0.4s cubic-bezier(0.4, 0, 0.2, 1);
-  }
+    .nav-menu-btn-container {
+        transition: width 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+    }
 
-  .page-content {
-    transition: margin-left 0.4s cubic-bezier(0.4, 0, 0.2, 1);
-  }
+    .page-content {
+        transition: margin-left 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+    }
 }
 
 @media (max-width: 500px) {
-  .condensed-panel {
+    .condensed-panel {
+        .page-content-navbar-top-dark {
+            .navbar-static-top {
+                .navbar-top-links {
+                    .open {
+                        .dropdown-menu {
+                            display: none;
+                        }
+                    }
+
+                    .navbar-top-link {
+                        display: none;
+                    }
+
+                    .show-icon-header-btn {
+                        display: block;
+                    }
+                }
+
+                .navbar-icon-header {
+                    display: inline-block;
+                    width: 100%;
+                    height: 40px;
+
+                    .navbar-right {
+                        top: auto;
+                    }
+
+                    .navbar-top-links {
+                        .navbar-top-link {
+                            display: inline-block;
+                        }
+
+                        .open {
+                            .dropdown-menu {
+                                display: block;
+                            }
+                        }
+                    }
+                }
+
+                &.show-search {
+                    .navbar-icon-header {
+                        display: none;
+                    }
+                }
+            }
+        }
+
+        .navbar-static-top {
+            .navbar-icon-header {
+                .navbar-top-links {
+                    a {
+                        height: 56px;
+                    }
+                }
+            }
+
+            .navbar-top-links {
+                .navbar-top-link {
+                    &.show-icon-header-btn {
+                        a {
+                            height: 57px;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     .page-content-navbar-top-dark {
-      .navbar-static-top {
-        .navbar-top-links {
-          .open {
-            .dropdown-menu {
-              display: none;
+        .navbar-static-top {
+            .navbar-top-links {
+                .open {
+                    .dropdown-menu {
+                        width: 220px;
+                    }
+                }
             }
-          }
-          .navbar-top-link {
-            display: none;
-          }
-          .show-icon-header-btn {
-            display: block;
-          }
         }
-        .navbar-icon-header { 
-          display: inline-block;
-          width: 100%; 
-          height: 40px; 
-          .navbar-right {
-            top: auto;
-          }
-          .navbar-top-links {
-            .navbar-top-link {
-              display: inline-block;
-            }
-            .open {
-              .dropdown-menu {
-                display: block;
-              }
-            }
-          }
-        }
-        &.show-search {
-          .navbar-icon-header {
-            display: none;
-          }
-        }
-      }
     }
-    .navbar-static-top {
-      .navbar-icon-header {
-        .navbar-top-links {
-          a {
-            height: 56px;
-          }
-        }
-      }
-      .navbar-top-links {
-        .navbar-top-link {
-          &.show-icon-header-btn {
-            a {
-              height: 57px;
-            }
-          }
-        }
-      }
-    }
-  }
-  .page-content-navbar-top-dark {
-    .navbar-static-top {
-      .navbar-top-links {
-        .open {
-          .dropdown-menu {
-            width: 220px;
-          }
-        }
-      }
-    }
-  }
 }
 
 // Icon header
-
 .navbar-icon-header {
-  width: 100%; 
-  height: 0px;
-  overflow: visible;
+    width: 100%;
+    height: 0;
+    overflow: visible;
 }
 
 .page-content-navbar-top-dark {
-  .navbar-static-top {
-    &.show-search {
-      .navbar-top-link {
-        display: none;
-      }  
+    .navbar-static-top {
+        &.show-search {
+            .navbar-top-link {
+                display: none;
+            }
+        }
     }
-  }
 }
-
 
 /*
   App Navigator
 */
 
-.navbar-static-side-light > .nav > li:nth-child(2),
-.navbar-static-side-dark > .nav > li:nth-child(2) {
-  &.app-navigator {
-    margin-top: 0;
-  }
+.navbar-static-side-light > .nav > li:nth-child(2), .navbar-static-side-dark > .nav > li:nth-child(2) {
+    &.app-navigator {
+        margin-top: 0;
+    }
 }
 
 .navbar-static-side-dark {
-  .nav {
-    li {
-      &.app-navigator {
-        background-color: @navbar-app-navigator-dark-bg;
+    .nav {
+        li {
+            &.app-navigator {
+                background-color: @navbar-app-navigator-dark-bg;
 
-        &:hover {
-          background-color: @navbar-app-navigator-dark-bg;
-          .app-navigator-contents {
-            background-color: rgba(42, 42, 42, 0.2);
-          }
-        }
+                &:hover {
+                    background-color: @navbar-app-navigator-dark-bg;
 
-        .app-navigator-contents {
-          .brand {
-            color: @white;
-          }
+                    .app-navigator-contents {
+                        background-color: rgba(42, 42, 42, 0.2);
+                    }
+                }
+
+                .app-navigator-contents {
+                    .brand {
+                        color: @white;
+                    }
+                }
+            }
         }
-      }
     }
-  }
 }
 
 .nav {
-  li {
-    &.app-navigator {
-      width: 100%;
-      height: 50px;
-      background-color: @body-bg;
+    li {
+        &.app-navigator {
+            width: 100%;
+            height: 50px;
+            background-color: @body-bg;
 
-      &:hover {
-          background-color: @card-hover-bg;        
-      }
+            &:hover {
+                background-color: @card-hover-bg;
+            }
 
-      &+ li:nth-child(2) {
-        margin-top: 0;
-      }
+            & + li:nth-child(2) {
+                margin-top: 0;
+            }
 
-      .app-navigator-contents {
-        display: flex;
-        height: 100%;
-        align-items: center;
-        padding: 0 25px;
-        margin-bottom: 0;
-        cursor: pointer;
-        justify-content: space-between;
+            .app-navigator-contents {
+                display: flex;
+                height: 100%;
+                align-items: center;
+                padding: 0 25px;
+                margin-bottom: 0;
+                cursor: pointer;
+                justify-content: space-between;
 
-        .brand {
-          margin: 0;
-          font-weight: 600;
-          font-size: 1.1rem;
-          color: @grey2;
-          
-          .application {
-            font-weight: 500;
-          }
+                .brand {
+                    margin: 0;
+                    font-weight: 600;
+                    font-size: 1.1rem;
+                    color: @grey2;
 
-          .application-hover {
-            display: none;
-            font-weight: 500;
-          }
+                    .application {
+                        font-weight: 500;
+                    }
+
+                    .application-hover {
+                        display: none;
+                        font-weight: 500;
+                    }
+                }
+
+                .hpe-icon {
+                    display: none;
+                    color: @primary;
+                }
+
+                &:hover {
+                    .application {
+                        display: none;
+                    }
+
+                    .application-hover {
+                        display: inline;
+                    }
+
+                    .hpe-icon {
+                        display: inline;
+                    }
+                }
+            }
         }
-
-        .hpe-icon {
-          display: none;
-          color: @primary;
-        }
-
-        &:hover {
-          
-          .application {
-            display: none;
-          }
-
-          .application-hover {
-            display: inline;
-          }
-
-          .hpe-icon {
-            display: inline;
-          }
-        }
-      }
-
-
     }
-  }
 }
 
 /*
@@ -1769,44 +1808,42 @@ h4 {
 */
 
 .app-navigator-popover {
+    .popover-content {
+        padding: 0;
 
-  .popover-content {
-    padding: 0;
+        .app-navigator-popover-contents {
+            display: flex;
+            flex-direction: column;
+            width: 260px;
 
-    .app-navigator-popover-contents {
-      display: flex;
-      flex-direction: column;
-      width: 260px;
+            .app-navigator-item {
+                display: flex;
+                height: 80px;
+                align-items: center;
+                padding: 0 16px;
+                border-bottom: 1px solid @modal-inset-panel-border;
+                cursor: pointer;
 
-      .app-navigator-item {
-        display: flex;
-        height: 80px;
-        align-items: center;
-        padding: 0 16px;
-        border-bottom: 1px solid @modal-inset-panel-border;
-        cursor: pointer;
+                &:hover {
+                    background-color: @card-hover-bg;
+                }
 
-        &:hover {
-          background-color: @card-hover-bg;
+                &:last-of-type {
+                    border-bottom: none;
+                }
+
+                .app-navigator-item-name {
+                    font-size: 1.1rem;
+                    margin: 0;
+                    color: @grey2;
+                }
+
+                .hpe-icon {
+                    font-size: 1.1rem;
+                    color: @primary;
+                    margin-right: 10px;
+                }
+            }
         }
-
-        &:last-of-type {
-          border-bottom: none;
-        }
-
-        .app-navigator-item-name {
-          font-size: 1.1rem;
-          margin: 0;
-          color: @grey2;
-        }
-
-        .hpe-icon {
-          font-size: 1.1rem;
-          color: @primary;
-          margin-right: 10px;
-        }
-      }
-  }
-
-  }
+    }
 }

--- a/src/styles/notifications.less
+++ b/src/styles/notifications.less
@@ -1,54 +1,45 @@
 .alert-info {
-  color: @alert-info-color;
-  background-color: @alert-info-bg;
-  border: 1px solid @alert-info-border;
+    color: @alert-info-color;
+    background-color: @alert-info-bg;
+    border: 1px solid @alert-info-border;
 }
 
 .alert-info {
-  .alert-link {
-    color: @alert-info-color;
-  }
+    .alert-link {
+        color: @alert-info-color;
+    }
 }
 
 .alert-error {
-  color: @alert-error-color;
-  background-color: @alert-error-bg;
-  border: 1px solid @alert-error-border;
-}
-
-.alert-error {
-  .alert-link {
     color: @alert-error-color;
-  }
+    background-color: @alert-error-bg;
+    border: 1px solid @alert-error-border;
 }
 
-.alert{
-  .close {
-    font-size: 0.875rem;
-    opacity: 0.5;
-    top: 4px;
-    &:focus{
-  	 .aspects-outline;
-  	}
-  }
+.alert-error {
+    .alert-link {
+        color: @alert-error-color;
+    }
 }
 
-.body-dark {
-  .alert {
+.alert {
     .close {
-      text-shadow: 0 1px 0 @notification-alert-shadow;
-      &:focus, &:hover {
-        color: @notification-alert-hover-color-dark;
-      }
-    } 
-  }
+        font-size: 0.875rem;
+        opacity: 0.5;
+        top: 4px;
+
+        &:focus {
+            .aspects-outline;
+        }
+    }
 }
 
-.alert-link{
-  .font-semibold;
-  &:focus{
-	 .aspects-outline;
-  }
+.alert-link {
+    .font-semibold;
+
+    &:focus {
+        .aspects-outline;
+    }
 }
 
 /*
@@ -56,153 +47,152 @@
 */
 
 @-webkit-keyframes fadeInNotification {
-  from {
-    opacity: 0;
-    -webkit-transform: translate3d(0, 30%, 0);
-    transform: translate3d(0, 30%, 0);
-  }
+    from {
+        opacity: 0;
+        -webkit-transform: translate3d(0, 30%, 0);
+        transform: translate3d(0, 30%, 0);
+    }
 
-  to {
-    opacity: 0.9;
-    -webkit-transform: none;
-    transform: none;
-  }
+    to {
+        opacity: 0.9;
+        -webkit-transform: none;
+        transform: none;
+    }
 }
 
 @keyframes fadeInNotification {
-  from {
-    opacity: 0;
-    -webkit-transform: translate3d(0, 30%, 0);
-    transform: translate3d(0, 30%, 0);
-  }
+    from {
+        opacity: 0;
+        -webkit-transform: translate3d(0, 30%, 0);
+        transform: translate3d(0, 30%, 0);
+    }
 
-  to {
-    opacity: 0.9;
-    -webkit-transform: none;
-    transform: none;
-  }
+    to {
+        opacity: 0.9;
+        -webkit-transform: none;
+        transform: none;
+    }
 }
 
 @-webkit-keyframes fadeOutNotification {
-  from {
-    opacity: 0.9;
-  }
+    from {
+        opacity: 0.9;
+    }
 
-  to {
-    opacity: 0;
-    -webkit-transform: scale3d(.97, .97, .97);
-    transform: scale3d(.97, .97, .97);
-  }
+    to {
+        opacity: 0;
+        -webkit-transform: scale3d(0.97, 0.97, 0.97);
+        transform: scale3d(0.97, 0.97, 0.97);
+    }
 }
 
 @keyframes fadeOutNotification {
-  from {
-    opacity: 0.9;
-  }
+    from {
+        opacity: 0.9;
+    }
 
-  to {
-    opacity: 0;
-    -webkit-transform: scale3d(.97, .97, .97);
-    transform: scale3d(.97, .97, .97);
-  }
+    to {
+        opacity: 0;
+        -webkit-transform: scale3d(0.97, 0.97, 0.97);
+        transform: scale3d(0.97, 0.97, 0.97);
+    }
 }
 
 .fadeOutNotification {
-  -webkit-animation-duration: 0.7s;
-  animation-duration: 0.7s;
-  -webkit-animation-fill-mode: both;
-  animation-fill-mode: both;
-  -webkit-animation-name: fadeOutNotification;
-  animation-name: fadeOutNotification;
+    -webkit-animation-duration: 0.7s;
+    animation-duration: 0.7s;
+    -webkit-animation-fill-mode: both;
+    animation-fill-mode: both;
+    -webkit-animation-name: fadeOutNotification;
+    animation-name: fadeOutNotification;
 }
 
 .fadeInNotification {
-  -webkit-animation-duration: 1s;
-  animation-duration: 1s;
-  -webkit-animation-fill-mode: both;
-  animation-fill-mode: both;
-  -webkit-animation-name: fadeInNotification;
-  animation-name: fadeInNotification;
+    -webkit-animation-duration: 1s;
+    animation-duration: 1s;
+    -webkit-animation-fill-mode: both;
+    animation-fill-mode: both;
+    -webkit-animation-name: fadeInNotification;
+    animation-name: fadeInNotification;
 }
 
 .notification-container {
-  position: fixed;
-  z-index: 9999999;
-  top: 12px;
-  right: 12px;
-  width: 300px;
-
-  .notification {
-    position: relative;
+    position: fixed;
+    z-index: 9999999;
+    top: 12px;
+    right: 12px;
     width: 300px;
-    min-height: 67px;
-    background-color: @notification-bg;
-    border-radius: @notification-border-radius;
-    opacity: 0;
-    margin-bottom: 4px;
-    transition: top 500ms ease-in-out;
 
-    .dismiss {
-      position: absolute;
-      color: @notification-color;
-      opacity: 1;
-      font-size: 0.8125rem;
-      right: 5px;
-      top: 3px;
-      cursor: pointer;
-      transition: opacity 0.3s linear;
+    .notification {
+        position: relative;
+        width: 300px;
+        min-height: 67px;
+        background-color: @notification-bg;
+        border-radius: @notification-border-radius;
+        opacity: 0;
+        margin-bottom: 4px;
+        transition: top 500ms ease-in-out;
 
-      &:hover {
-        opacity: 0.8;
-      }
-    }
+        .dismiss {
+            position: absolute;
+            color: @notification-color;
+            opacity: 1;
+            font-size: 0.8125rem;
+            right: 5px;
+            top: 3px;
+            cursor: pointer;
+            transition: opacity 0.3s linear;
 
-    .notification-content {
-      display: table;
-      width: 100%;
-      min-height: 67px;
-
-      .notification-icon {
-        display: table-cell;
-        width: 50px;
-        color: @notification-color;
-        vertical-align: middle;
-        text-align: center;
-        font-size: 1.438rem;
-      }
-
-      .notification-title {
-        color: @notification-color;
-        font-size: @font-size-lg;
-        font-family: @font-family;
-        font-weight: 600;
-        margin-bottom: 3px;
-        word-break: break-word;
-      }
-
-      .notification-text {
-        display: table-cell;
-        vertical-align: middle;
-        padding: 15px 15px 15px 0;
-
-        .notification-label {
-          color: @white;
-          margin: 0;
-          font-size: @font-size-lg;
-          line-height: 20px;
-          word-break: break-word;
+            &:hover {
+                opacity: 0.8;
+            }
         }
 
-        .notification-subtitle {
-          display: block;
-          color: @notification-color;
-          margin-top: 3px;
-          font-size: 0.8125rem;
-          opacity: 0.8;
-          word-break: break-word;
-        }
-      }
-    }
-  }
+        .notification-content {
+            display: table;
+            width: 100%;
+            min-height: 67px;
 
+            .notification-icon {
+                display: table-cell;
+                width: 50px;
+                color: @notification-color;
+                vertical-align: middle;
+                text-align: center;
+                font-size: 1.438rem;
+            }
+
+            .notification-title {
+                color: @notification-color;
+                font-size: @font-size-lg;
+                font-family: @font-family;
+                font-weight: 600;
+                margin-bottom: 3px;
+                word-break: break-word;
+            }
+
+            .notification-text {
+                display: table-cell;
+                vertical-align: middle;
+                padding: 15px 15px 15px 0;
+
+                .notification-label {
+                    color: @white;
+                    margin: 0;
+                    font-size: @font-size-lg;
+                    line-height: 20px;
+                    word-break: break-word;
+                }
+
+                .notification-subtitle {
+                    display: block;
+                    color: @notification-color;
+                    margin-top: 3px;
+                    font-size: 0.8125rem;
+                    opacity: 0.8;
+                    word-break: break-word;
+                }
+            }
+        }
+    }
 }

--- a/src/styles/organization-chart.less
+++ b/src/styles/organization-chart.less
@@ -9,8 +9,8 @@
 
         &.search-option {
             display: flex;
-            box-shadow: 0px 0px 5px #E2E2E2;
-            border-bottom: 1px solid #E2E2E2;
+            box-shadow: 0 0 5px #e2e2e2;
+            border-bottom: 1px solid #e2e2e2;
 
             .organization-chart-hierarchy {
                 flex: 1;
@@ -46,11 +46,11 @@
             left: 0;
             background-color: #fff;
             padding: 5px 20px;
-            
+
             .dropdown-menu {
                 border-radius: 0;
                 border: 1px solid #e5e5e5;
-                box-shadow: 2px 1px 5px 0px #e0e0e0;
+                box-shadow: 2px 1px 5px 0 #e0e0e0;
 
                 li {
                     transition: border-bottom 0s;
@@ -83,16 +83,16 @@
                             margin-bottom: 4px;
 
                             strong {
-                                color: #333333;
+                                color: #333;
                             }
                         }
 
                         .organization-chart-search-item-subtitle {
                             margin: 0;
-                            color: #999999;
+                            color: #999;
 
                             strong {
-                                color: #333333;
+                                color: #333;
                                 font-weight: 500;
                             }
                         }
@@ -106,7 +106,8 @@
         position: relative;
         flex: 1;
 
-        .organization-links, .organization-nodes {
+        .organization-links,
+        .organization-nodes {
             position: absolute;
             width: 100%;
             height: 100%;
@@ -122,7 +123,6 @@
         }
 
         .organization-nodes {
-
             .organization-node {
                 position: absolute;
                 border: 1px solid @organization-chart-node-border;
@@ -131,10 +131,10 @@
                 transform: translateX(-50%);
                 transition: border 0.2s linear, outline 0.2s linear;
                 box-sizing: content-box;
-                outline: 0px solid transparent; 
+                outline: 0 solid transparent;
 
                 &:hover {
-                    border: 1px solid @organization-chart-node-hover-border;  
+                    border: 1px solid @organization-chart-node-hover-border;
                     outline: 1px solid @organization-chart-node-hover-border;
                 }
 
@@ -142,9 +142,9 @@
                     border: 1px solid @organization-chart-node-active-border;
 
                     &:hover {
-                        border: 1px solid @organization-chart-node-hover-border;  
-                        outline: 1px solid @organization-chart-node-hover-border;                  
-                    } 
+                        border: 1px solid @organization-chart-node-hover-border;
+                        outline: 1px solid @organization-chart-node-hover-border;
+                    }
                 }
             }
 
@@ -157,7 +157,7 @@
                 cursor: pointer;
 
                 &:hover {
-                    color: @organization-chart-node-hover-border; 
+                    color: @organization-chart-node-hover-border;
                 }
             }
         }

--- a/src/styles/pages.less
+++ b/src/styles/pages.less
@@ -1,161 +1,151 @@
 // Error Page
 @-webkit-keyframes fadeInDown {
-  0% {
-    opacity: 0;
-    -webkit-transform: translateY(-20px);
-    transform: translateY(-20px);
-  }
-  100% {
-    opacity: 1;
-    -webkit-transform: translateY(0);
-    transform: translateY(0);
-  }
+    0% {
+        opacity: 0;
+        -webkit-transform: translateY(-20px);
+        transform: translateY(-20px);
+    }
+
+    100% {
+        opacity: 1;
+        -webkit-transform: translateY(0);
+        transform: translateY(0);
+    }
 }
 
 @keyframes fadeInDown {
-  0% {
-    opacity: 0;
-    -webkit-transform: translateY(-20px);
-    -ms-transform: translateY(-20px);
-    transform: translateY(-20px);
-  }
-  100% {
-    opacity: 1;
-    -webkit-transform: translateY(0);
-    -ms-transform: translateY(0);
-    transform: translateY(0);
-  }
+    0% {
+        opacity: 0;
+        -webkit-transform: translateY(-20px);
+        -ms-transform: translateY(-20px);
+        transform: translateY(-20px);
+    }
+
+    100% {
+        opacity: 1;
+        -webkit-transform: translateY(0);
+        -ms-transform: translateY(0);
+        transform: translateY(0);
+    }
 }
 
 .error-animate {
-  -webkit-animation-name: fadeInDown;
-  animation-name: fadeInDown;
-  -webkit-animation-duration: 1s;
-  animation-duration: 1s;
+    -webkit-animation-name: fadeInDown;
+    animation-name: fadeInDown;
+    -webkit-animation-duration: 1s;
+    animation-duration: 1s;
 }
 
 .error-documentation {
-  position: absolute;
-  top: 55%;
-  left: 5%;
+    position: absolute;
+    top: 55%;
+    left: 5%;
 }
 
 .middle-box {
-  height: 400px;
-  width: 300px;
-  position: absolute;
-  margin: auto;
-  left: 0;
-  right: 0;
-  top: 0;
-  bottom: 0;
+    height: 400px;
+    width: 300px;
+    position: absolute;
+    margin: auto;
+    left: 0;
+    right: 0;
+    top: 0;
+    bottom: 0;
 
-  h1 {
-    font-size: 10.63rem;
-  }
+    h1 {
+        font-size: 10.63rem;
+    }
 
-  h2 {
-    color: @white;
-  }
+    h2 {
+        color: @white;
+    }
 }
+
 .right-box {
-  height: 100%;
-  width: 320px;
-  position: absolute;
-  right: 0;
-  top: 0;
-  bottom: 0;
-  padding: 25px;
-  text-align: left;
+    height: 100%;
+    width: 320px;
+    position: absolute;
+    right: 0;
+    top: 0;
+    bottom: 0;
+    padding: 25px;
+    text-align: left;
 }
 
 .right-box-dark {
-  box-shadow: -12px 0px 245px 16px rgba(25,25,25,1);
-  background-color: rgba(51,51,51,0.93);;
-  .right-box;
+    box-shadow: -12px 0 245px 16px rgba(25, 25, 25, 1);
+    background-color: rgba(51, 51, 51, 0.93);
+    .right-box;
 }
 
 .right-box-light {
-  box-shadow: -12px 0px 245px 16px rgba(125,125,125,1);
-  background-color: rgba(255,255,255,0.93);
-  .right-box;
+    box-shadow: -12px 0 245px 16px rgba(125, 125, 125, 1);
+    background-color: rgba(255, 255, 255, 0.93);
+    .right-box;
 }
 
 .hpe-login-logo {
-  height: 47px;
-  width: 111px;
+    height: 47px;
+    width: 111px;
 }
 
-.loginscreen-img
-{
-  margin-top: 50px;
+.loginscreen-img {
+    margin-top: 50px;
 }
 
-.login-title
-{
-  font-size: 1.75rem;
-  color:@white;
-  vertical-align:middle;
+.login-title {
+    font-size: 1.75rem;
+    color: @white;
+    vertical-align: middle;
 }
 
-.login-form
-{
-  position:absolute;
-  bottom:0;
-  width:270px;
-  margin-bottom:80px;
+.login-form {
+    position: absolute;
+    bottom: 0;
+    width: 270px;
+    margin-bottom: 80px;
 }
 
-p.no-margin
-{
-  margin:0;
-  padding:0;
+p.no-margin {
+    margin: 0;
+    padding: 0;
 }
 
 .login-logo {
-  height: 28px;
-  margin-right:10px;
-  vertical-align: middle;
+    height: 28px;
+    margin-right: 10px;
+    vertical-align: middle;
 }
 
 .login-title-align {
-  margin-bottom: 20px;
+    margin-bottom: 20px;
 }
-
 
 //Temp dark background float labels
-
-.login-form{
-  .float-label-dark{
-    label{
-      color: darken(@white, 40%) !important;
+.login-form {
+    .float-label-dark {
+        label {
+            color: darken(@white, 40%) !important;
+        }
     }
-  }
 }
 
-.login-form{
-  .float-label-light{
-    label{
-      color: lighten(@grey2, 40%) !important;
+.login-form {
+    .float-label-light {
+        label {
+            color: lighten(@grey2, 40%) !important;
+        }
     }
-  }
 }
 
 .landing-page {
-  box-shadow:5px 5px 10px 5px @grey5;
-  &:hover {
-    box-shadow:7px 7px 17px 7px @grey5;
-  }
-}
-.body-dark {
-  .landing-page {
-    box-shadow:5px 5px 10px 5px @landing-page-shadow;
+    box-shadow: 5px 5px 10px 5px @grey5;
+
     &:hover {
-      box-shadow:7px 7px 17px 7px @landing-page-shadow;
+        box-shadow: 7px 7px 17px 7px @grey5;
     }
-  }
 }
 
-.landing-page-text{
-  padding-top:30px;
+.landing-page-text {
+    padding-top: 30px;
 }

--- a/src/styles/preview-pane.less
+++ b/src/styles/preview-pane.less
@@ -1,45 +1,35 @@
 .preview-pane-right {
-  min-height: 800px;
-  padding: 10px;
-  background: @preview-pane-bg;
-  max-height:885px;
+    min-height: 800px;
+    padding: 10px;
+    background: @preview-pane-bg;
+    max-height: 885px;
 }
-.body-dark {
-  .preview-pane-right {
-	 background: @preview-pane-bg-dark;
-  }
+
+.no-preview-pane-right {
+    min-height: 978px;
+    padding: 10px;
+    background: @preview-pane-bg;
+    margin-bottom: 25px;
 }
-.no-preview-pane-right{
-  min-height: 978px;
-  padding: 10px;
-  background: @preview-pane-bg;
-  margin-bottom:25px;
+
+.preview-pagination {
+    margin-top: 24px;
 }
-.body-dark {
-  .no-preview-pane-right {
-    background: @preview-pane-bg-dark;
-  }
-}
-.preview-pagination{
-  margin-top:24px;
-}
+
 .preview-no-record {
-  text-align: center;
-  font-size: 5rem;
-  margin-top: 200px;
-  color: @preview-pane-message-color;
+    text-align: center;
+    font-size: 5rem;
+    margin-top: 200px;
+    color: @preview-pane-message-color;
 }
-.body-dark {
-  .preview-no-record {
-    background: @preview-pane-bg-dark;
-  }
-}
+
 .preview-pane-listview {
-  height: 1020px;
-  overflow-y: auto;
-  .table-responsive {
-    overflow-y: hidden;
-  }
+    height: 1020px;
+    overflow-y: auto;
+
+    .table-responsive {
+        overflow-y: hidden;
+    }
 }
 
 .preview-pane-shadow {
@@ -49,13 +39,14 @@
     background-color: inherit;
     z-index: 1;
     min-height: inherit;
+
     div {
-      z-index: 2;
-      background: @preview-pane-bg;
-      min-height: inherit;
+        z-index: 2;
+        background: @preview-pane-bg;
+        min-height: inherit;
     }
 }
- 
+
 .preview-pane-shadow:before {
     position: absolute;
     z-index: -1;
@@ -73,62 +64,37 @@
 }
 
 .preview-pane-new-window {
-  color: @preview-pane-new-window-color;
+    color: @preview-pane-new-window-color;
 
-  &:focus {
-    outline-color: @accent;
-  }
-  
-  &:hover {
-    color: @preview-pane-new-window-hover-color;
-  }
-}
+    &:focus {
+        outline-color: @accent;
+    }
 
-.body-dark {
-  .preview-pane-new-window {
-    color: @preview-pane-new-window-color-dark;
     &:hover {
-      color: @preview-pane-new-window-hover-color-dark;
-    }
-  }
-}
-
-.body-dark {
-    .preview-pane-shadow {
-        div {
-          background: @preview-pane-shadow-bg-dark;
-        }
-    }
-    .displayPanel {
-      .preview-pane-shadow {
-        div {
-          background: @preview-pane-shadow-display-panel-bg-dark;
-        }
-      }
+        color: @preview-pane-new-window-hover-color;
     }
 }
-
 
 .preview-pane-window-footer {
-  display: none;    
+    display: none;
 }
 
 .preview-pane-window-contents {
-  display: flex;
-  flex-direction: column;
-  height: 100vh;
-  padding: 0;
-
-  .preview-display {
-    flex: 1;
-    overflow: auto;
-  }
-
-  .preview-pane-window-footer {
     display: flex;
-    justify-content: flex-end;
-    align-items: center;
-    border-top: 1px solid rgba(51, 51, 51, 0.1);
-    padding: 20px 10px;
-  }
+    flex-direction: column;
+    height: 100vh;
+    padding: 0;
+
+    .preview-display {
+        flex: 1;
+        overflow: auto;
+    }
+
+    .preview-pane-window-footer {
+        display: flex;
+        justify-content: flex-end;
+        align-items: center;
+        border-top: 1px solid rgba(51, 51, 51, 0.1);
+        padding: 20px 10px;
+    }
 }

--- a/src/styles/progress.less
+++ b/src/styles/progress.less
@@ -1,358 +1,319 @@
 // Progress Bars
 .progress-bar-secondary,
 .progress-bar-accent {
-  color: @progress-bar-accent-color;
-  background-color: @progress-bar-accent;
-  font-size: @font-size-md;
+    color: @progress-bar-accent-color;
+    background-color: @progress-bar-accent;
+    font-size: @font-size-md;
 }
 
 .progress-bar-width {
-  width: 35%;
+    width: 35%;
 }
 
 .progress-static-text {
-    margin-bottom: 0px;
+    margin-bottom: 0;
     text-align: center;
     color: @progress-bar-color;
 }
 
-.body-dark {
-  .progress-static-text{
-    color: @progress-bar-color-dark;
-  }
+.indicator.ng-animate {
+    -webkit-animation: none 0s;
 }
 
-.indicator.ng-animate{ 
-  -webkit-animation: none 0s;
+.indicator-alt-sm {
+    height: 24px;
 }
 
-.indicator-alt-sm{
-  height:24px
+.indicator-alt {
+    height: 40px;
 }
-.indicator-alt{
-  height:40px
-}
-.indicator-alt-lg{
-  height:120px
+
+.indicator-alt-lg {
+    height: 120px;
 }
 
 .indicator {
-  font-size: 0.2em;
-  position: relative;
-  text-indent: -9999em;
-  border-top: 1.1em solid @progress-bar-accent;
-  border-right: 1.1em solid @progress-bar-accent;
-  border-bottom: 1.1em solid @progress-bar-accent;
-  border-left: 1.1em solid rgba(0, 0, 0, 0);
-  -webkit-transform: translateZ(0);
-  -ms-transform: translateZ(0);
-  transform: translateZ(0);
-  -webkit-animation: load8 1.1s infinite linear;
-  animation: load8 1.1s infinite linear;
+    font-size: 0.2em;
+    position: relative;
+    text-indent: -9999em;
+    border-top: 1.1em solid @progress-bar-accent;
+    border-right: 1.1em solid @progress-bar-accent;
+    border-bottom: 1.1em solid @progress-bar-accent;
+    border-left: 1.1em solid rgba(0, 0, 0, 0);
+    transform: translateZ(0);
+    animation: load8 1.1s infinite linear;
 }
+
 .indicator,
 .indicator:after {
-  border-radius: 50%;
-  width: 10em;
-  height: 10em;
+    border-radius: 50%;
+    width: 10em;
+    height: 10em;
 }
+
 @-webkit-keyframes load8 {
-  0% {
-    -webkit-transform: rotate(0deg);
-    transform: rotate(0deg);
-  }
-  100% {
-    -webkit-transform: rotate(360deg);
-    transform: rotate(360deg);
-  }
+    0% {
+        -webkit-transform: rotate(0deg);
+        transform: rotate(0deg);
+    }
+
+    100% {
+        -webkit-transform: rotate(360deg);
+        transform: rotate(360deg);
+    }
 }
+
 @keyframes load8 {
-  0% {
-    -webkit-transform: rotate(0deg);
-    transform: rotate(0deg);
-  }
-  100% {
-    -webkit-transform: rotate(360deg);
-    transform: rotate(360deg);
-  }
+    0% {
+        -webkit-transform: rotate(0deg);
+        transform: rotate(0deg);
+    }
+
+    100% {
+        -webkit-transform: rotate(360deg);
+        transform: rotate(360deg);
+    }
 }
-.indicator-primary{
+
+.indicator-primary {
     .indicator;
+
     border-top: 1.1em solid @indicator-primary;
     border-right: 1.1em solid @indicator-primary;
     border-bottom: 1.1em solid @indicator-primary;
 }
-.indicator-large{
+
+.indicator-large {
     .indicator;
+
     font-size: 0.4em;
 }
-.indicator-primary-large{
-  .indicator-primary;
-  font-size: 0.4em;
+
+.indicator-primary-large {
+    .indicator-primary;
+
+    font-size: 0.4em;
 }
 
 /* ============================ */
+
 /* Copyright (c) 2016 by Arthur Camara (http://codepen.io/arthurcamara1/pen/LpNwyq) */
+
 /* Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 /* The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 /* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 /* ============================ */
 
 /* ============================ */
+
 /* SPINNER BOUNCE MIDDLE        */
+
 /* ============================ */
 //Indicator used in custom dropdowns
 .spinner, .spinner:before, .spinner:after {
-  width: 2px;
-  height: 10px;
-  background-color: @indicator-accent;
-  border-radius: 2px;
+    width: 2px;
+    height: 10px;
+    background-color: @indicator-accent;
+    border-radius: 2px;
 }
 
 .spinner {
-  display: inline-block;
-  position: relative;
+    display: inline-block;
+    position: relative;
 
-  &:before,&:after{
-	  content: "";
-	  position: absolute;
-	  display: block;
-	  top: 0px;
-  }
-  &:before{
-	left: -4px;
-  }
-  &:after{
-	left: 4px;
-  }
+    &:before, &:after {
+        content: "";
+        position: absolute;
+        display: block;
+        top: 0;
+    }
+
+    &:before {
+        left: -4px;
+    }
+
+    &:after {
+        left: 4px;
+    }
 }
 
 .spinner-hpegreen, .spinner-hpegreen:before, .spinner-hpegreen:after, .spinner-primary, .spinner-primary:before, .spinner-primary:after {
-  background-color: @primary;
+    background-color: @primary;
 }
+
 .spinner-accent, .spinner-accent:before, .spinner-accent:after {
-  background-color: @accent;
+    background-color: @accent;
 }
 
-
-@-webkit-keyframes bounce-middle {
-  0% {
-    height: 2px;
-    margin-top: 4px;
-    margin-bottom: 4px;
-  }
-  50% {
-    height: 10px;
-    margin-top: 0px;
-    margin-bottom: 0px;
-  }
-  100% {
-    height: 2px;
-    margin-top: 4px;
-    margin-bottom: 4px;
-  }
-}
 @keyframes bounce-middle {
-  0% {
-    height: 2px;
-    margin-top: 4px;
-    margin-bottom: 4px;
-  }
-  50% {
-    height: 10px;
-    margin-top: 0px;
-    margin-bottom: 0px;
-  }
-  100% {
-    height: 2px;
-    margin-top: 4px;
-    margin-bottom: 4px;
-  }
+    0% {
+        height: 2px;
+        margin-top: 4px;
+        margin-bottom: 4px;
+    }
+
+    50% {
+        height: 10px;
+        margin-top: 0;
+        margin-bottom: 0;
+    }
+
+    100% {
+        height: 2px;
+        margin-top: 4px;
+        margin-bottom: 4px;
+    }
 }
+
 .spinner-bounce-middle {
-  -webkit-animation: bounce-middle 0.6s ease 0.1s infinite;
-   animation: bounce-middle 0.6s ease 0.1s infinite;
-		  &:before,&:after{
-			  top: 50%;
-			  -webkit-transform: translateY(-5px) translateZ(0);
-			  transform: translateY(-5px) translateZ(0);
-		  }
-		  &:before{
-			-webkit-animation: bounce-middle 0.6s ease 0s infinite;
-			animation: bounce-middle 0.6s ease 0s infinite;
-		  }
-		  &:after{
-			-webkit-animation: bounce-middle 0.6s ease 0.2s infinite;
-			animation: bounce-middle 0.6s ease 0.2s infinite;
-		  }
+    animation: bounce-middle 0.6s ease 0.1s infinite;
+
+    &:before, &:after {
+        top: 50%;
+        transform: translateY(-5px) translateZ(0);
+    }
+
+    &:before {
+        animation: bounce-middle 0.6s ease 0s infinite;
+    }
+
+    &:after {
+        animation: bounce-middle 0.6s ease 0.2s infinite;
+    }
 }
+
 /* ============================ */
+
 /* SPINNER BOUNCE BOTTOM        */
+
 /* ============================ */
-@-webkit-keyframes bounce-bottom {
-  0% {
-    height: 2px;
-    margin-top: 4px;
-  }
-  50% {
-    height: 10px;
-    margin-top: 0px;
-  }
-  100% {
-    height: 2px;
-    margin-top: 4px;
-  }
-}
 @keyframes bounce-bottom {
-  0% {
-    height: 2px;
-    margin-top: 4px;
-  }
-  50% {
-    height: 10px;
-    margin-top: 0px;
-  }
-  100% {
-    height: 2px;
-    margin-top: 4px;
-  }
+    0% {
+        height: 2px;
+        margin-top: 4px;
+    }
+
+    50% {
+        height: 10px;
+        margin-top: 0;
+    }
+
+    100% {
+        height: 2px;
+        margin-top: 4px;
+    }
 }
+
 .spinner-bounce-bottom {
-  -webkit-animation: bounce-bottom 0.6s ease 0.1s infinite;
-  animation: bounce-bottom 0.6s ease 0.1s infinite;
+    animation: bounce-bottom 0.6s ease 0.1s infinite;
 }
+
 .spinner-bounce-bottom:before,
 .spinner-bounce-bottom:after {
-  top: auto;
-  bottom: 0px;
-}
-.spinner-bounce-bottom:before {
-  -webkit-animation: bounce-bottom 0.6s ease 0s infinite;
-  animation: bounce-bottom 0.6s ease 0s infinite;
-}
-.spinner-bounce-bottom:after {
-  -webkit-animation: bounce-bottom 0.6s ease 0.2s infinite;
-  animation: bounce-bottom 0.6s ease 0.2s infinite;
-}
-/* ============================ */
-/* SPINNER BOUNCE TOP        */
-/* ============================ */
-@-webkit-keyframes bounce-top {
-  0% {
-    height: 2px;
-    margin-bottom: 4px;
-  }
-  50% {
-    height: 10px;
-    margin-bottom: 0px;
-  }
-  100% {
-    height: 2px;
-    margin-bottom: 4px;
-  }
-}
-@keyframes bounce-top {
-  0% {
-    height: 2px;
-    margin-bottom: 4px;
-  }
-  50% {
-    height: 10px;
-    margin-bottom: 0px;
-  }
-  100% {
-    height: 2px;
-    margin-bottom: 4px;
-  }
-}
-.spinner-bounce-top {
-  -webkit-animation: bounce-top 0.6s ease 0.1s infinite;
-  animation: bounce-top 0.6s ease 0.1s infinite;
-}
-.spinner-bounce-top:before {
-  -webkit-animation: bounce-top 0.6s ease 0s infinite;
-  animation: bounce-top 0.6s ease 0s infinite;
-}
-.spinner-bounce-top:after {
-  -webkit-animation: bounce-top 0.6s ease 0.2s infinite;
-  animation: bounce-top 0.6s ease 0.2s infinite;
-}
-/* ============================ */
-/* SPINNER BLINK                */
-/* ============================ */
-@-webkit-keyframes glow-hpegreen {
-  0% {
-    background-color: transparent;
-  }
-  50% {
-    background-color: @primary;
-  }
-  100% {
-    background-color: transparent;
-  }
-}
-@keyframes glow-hpegreen {
-  0% {
-    background-color: transparent;
-  }
-  50% {
-    background-color: @primary;
-  }
-  100% {
-    background-color: transparent;
-  }
+    top: auto;
+    bottom: 0;
 }
 
-@-webkit-keyframes glow-accent {
-  0% {
-    background-color: transparent;
-  }
-  50% {
-    background-color: @accent;
-  }
-  100% {
-    background-color: transparent;
-  }
+.spinner-bounce-bottom:before {
+    animation: bounce-bottom 0.6s ease 0s infinite;
 }
+
+.spinner-bounce-bottom:after {
+    animation: bounce-bottom 0.6s ease 0.2s infinite;
+}
+
+/* ============================ */
+
+/* SPINNER BOUNCE TOP        */
+
+/* ============================ */
+@keyframes bounce-top {
+    0% {
+        height: 2px;
+        margin-bottom: 4px;
+    }
+
+    50% {
+        height: 10px;
+        margin-bottom: 0;
+    }
+
+    100% {
+        height: 2px;
+        margin-bottom: 4px;
+    }
+}
+
+.spinner-bounce-top {
+    animation: bounce-top 0.6s ease 0.1s infinite;
+}
+
+.spinner-bounce-top:before {
+    animation: bounce-top 0.6s ease 0s infinite;
+}
+
+.spinner-bounce-top:after {
+    animation: bounce-top 0.6s ease 0.2s infinite;
+}
+
+/* ============================ */
+
+/* SPINNER BLINK                */
+
+/* ============================ */
+@keyframes glow-hpegreen {
+    0% {
+        background-color: transparent;
+    }
+
+    50% {
+        background-color: @primary;
+    }
+
+    100% {
+        background-color: transparent;
+    }
+}
+
 @keyframes glow-accent {
-  0% {
-    background-color: transparent;
-  }
-  50% {
-    background-color: @accent;
-  }
-  100% {
-    background-color: transparent;
-  }
+    0% {
+        background-color: transparent;
+    }
+
+    50% {
+        background-color: @accent;
+    }
+
+    100% {
+        background-color: transparent;
+    }
 }
 
 .spinner-hpegreen, .spinner-primary {
     &.spinner-blink {
-      -webkit-animation: glow-hpegreen 0.6s 0.1s infinite;
-      animation: glow-hpegreen 0.6s 0.1s infinite;
+        animation: glow-hpegreen 0.6s 0.1s infinite;
     }
+
     &.spinner-blink:before {
-      -webkit-animation: glow-hpegreen 0.6s 0s infinite;
-      animation: glow-hpegreen 0.6s 0s infinite;
+        animation: glow-hpegreen 0.6s 0s infinite;
     }
+
     &.spinner-blink:after {
-      -webkit-animation: glow-hpegreen 0.6s 0.2s infinite;
-      animation: glow-hpegreen 0.6s 0.2s infinite;
+        animation: glow-hpegreen 0.6s 0.2s infinite;
     }
 }
 
 .spinner-accent {
     &.spinner-blink {
-      -webkit-animation: glow-accent 0.6s 0.1s infinite;
-      animation: glow-accent 0.6s 0.1s infinite;
+        animation: glow-accent 0.6s 0.1s infinite;
     }
+
     &.spinner-blink:before {
-      -webkit-animation: glow-accent 0.6s 0s infinite;
-      animation: glow-accent 0.6s 0s infinite;
+        animation: glow-accent 0.6s 0s infinite;
     }
+
     &.spinner-blink:after {
-      -webkit-animation: glow-accent 0.6s 0.2s infinite;
-      animation: glow-accent 0.6s 0.2s infinite;
+        animation: glow-accent 0.6s 0.2s infinite;
     }
 }
 

--- a/src/styles/responsive.less
+++ b/src/styles/responsive.less
@@ -1,106 +1,127 @@
 @media (min-width: 768px) {
-  .form-horizontal .control-label {
-    padding-top: 8px;
-  }
+    .form-horizontal .control-label {
+        padding-top: 8px;
+    }
 }
 
-
 @media (max-width: 1023px) {
-  .header-content-right{
-    display: none !important;
-  }
+    .header-content-right {
+        display: none !important;
+    }
 
-  .hidden-navbar {
-      &.hide-navbar {
-        .navbar-static-side {
-          display: block;
-        }
-        .affix-container {
-          .affix {
-            width: 100%;
-            margin-left: 240px;
-           .page-heading, .navbar-form-search {
-               margin-left: 0px;
+    .hidden-navbar {
+        &.hide-navbar {
+            .navbar-static-side {
+                display: block;
             }
-          }
-        }
-        .page-content {
-          margin-left: 240px;
-          width: 100%;
-        }
-        .condensed {
-           .page-heading, .navbar-form-search {
-              margin-left: px;
-           }
-        }
-        .navbar-form-search {
-          margin-left: 20px;
-        }
-      }
-      .navbar-static-side {
-         display: none;
-       }
-       .page-content {
-         margin: 0;
-       }
-       .affix-container {
-        .affix {
-           width: 100%;
-           margin-left: 0;
-           .navbar-form-search {
-               margin-left: 30px;
-           }
-         }
-       }
-       .condensed {
-         .navbar-form-search {
-           margin-left: 30px;
-         }
-       }
-  }
-  .navbar-static-top {
-    .navbar-header {
-      display: inline;
-      float: left;
-      &.top-link {
-        width:~'calc(100% - @{nav-top-link-width-small} - 80px)';
-      }
-      &.top-link-2 {
-        width:~'calc(100% - @{nav-top-link-width-small} - @{nav-top-link-width-small} - 80px)';
-      }
-      &.top-link-dropdown {
-        width:~'calc(100% - @{nav-top-link-width-dropdown} - 80px)';
-      }
-      &.top-link.top-link-dropdown {
-        width:~'calc(100% - @{nav-top-link-width-dropdown} - @{nav-top-link-width-small} - 80px)';
-      }
-      &.top-link-dropdown-2 {
-        width:~'calc(100% - @{nav-top-link-width-dropdown} - @{nav-top-link-width-dropdown})';
-      }
-    }
-    .navbar-right {
-      .dropdown-menu {
-        right: 0;
-        left: auto;
-      }
-    }
-    .navbar-top-links {
-      .navbar-top-link {
-        width: 30px;
-        &.dropdown {
-          width: 40px;
-        }
-      }
-    }
-  }
-  .condensed, .affix {
-    .navbar-form-search {
-      display: none;
-    }
-  }
 
+            .affix-container {
+                .affix {
+                    width: 100%;
+                    margin-left: 240px;
+
+                    .page-heading,
+                    .navbar-form-search {
+                        margin-left: 0;
+                    }
+                }
+            }
+
+            .page-content {
+                margin-left: 240px;
+                width: 100%;
+            }
+
+            .condensed {
+                .page-heading,
+                .navbar-form-search {
+                    margin-left: px;
+                }
+            }
+
+            .navbar-form-search {
+                margin-left: 20px;
+            }
+        }
+
+        .navbar-static-side {
+            display: none;
+        }
+
+        .page-content {
+            margin: 0;
+        }
+
+        .affix-container {
+            .affix {
+                width: 100%;
+                margin-left: 0;
+
+                .navbar-form-search {
+                    margin-left: 30px;
+                }
+            }
+        }
+
+        .condensed {
+            .navbar-form-search {
+                margin-left: 30px;
+            }
+        }
+    }
+
+    .navbar-static-top {
+        .navbar-header {
+            display: inline;
+            float: left;
+
+            &.top-link {
+                width: ~'calc(100% - @{nav-top-link-width-small} - 80px)';
+            }
+
+            &.top-link-2 {
+                width: ~'calc(100% - @{nav-top-link-width-small} - @{nav-top-link-width-small} - 80px)';
+            }
+
+            &.top-link-dropdown {
+                width: ~'calc(100% - @{nav-top-link-width-dropdown} - 80px)';
+            }
+
+            &.top-link.top-link-dropdown {
+                width: ~'calc(100% - @{nav-top-link-width-dropdown} - @{nav-top-link-width-small} - 80px)';
+            }
+
+            &.top-link-dropdown-2 {
+                width: ~'calc(100% - @{nav-top-link-width-dropdown} - @{nav-top-link-width-dropdown})';
+            }
+        }
+
+        .navbar-right {
+            .dropdown-menu {
+                right: 0;
+                left: auto;
+            }
+        }
+
+        .navbar-top-links {
+            .navbar-top-link {
+                width: 30px;
+
+                &.dropdown {
+                    width: 40px;
+                }
+            }
+        }
+    }
+
+    .condensed,
+    .affix {
+        .navbar-form-search {
+            display: none;
+        }
+    }
 }
 
 layout-switcher-container {
-  display: block;
+    display: block;
 }

--- a/src/styles/scroll-bar.less
+++ b/src/styles/scroll-bar.less
@@ -1,197 +1,179 @@
-.jspContainer
-{
-  overflow: hidden;
-  position: relative;
+.jspContainer {
+    overflow: hidden;
+    position: relative;
 }
 
-.hidden-navbar,.hide-navbar {
-  .navbar-static-side-container {
-    .jspContainer {
-      position: static;
+.hidden-navbar,
+.hide-navbar {
+    .navbar-static-side-container {
+        .jspContainer {
+            position: static;
+        }
     }
-  }
 }
 
-.jspPane
-{
-  position: absolute;
-}
-
-.jspVerticalBar
-{
-  position: absolute;
-  top: 0;
-  right: 0;
-  width: 10px;
-  height: 100%;
-  background: transparent;
-}
-
-.jspHorizontalBar
-{
-  position: absolute;
-  bottom: 0;
-  left: 0;
-  width: 100%;
-  height: 10px;
-  background: transparent;
-}
-
-.jspCap
-{
-  display: none;
-}
-
-.jspHorizontalBar {
-  .jspCap {
-    float: left;
-  }
-}
-
-.jspTrack
-{
-  background: transparent;
-  position: relative;
-}
-
-.jspDrag
-{
-  background: @scrollbar-drag-bg;
-  position: relative;
-  top: 0;
-  left: 0;
-  cursor: pointer;
-  border-radius: @scrollbar-drag-border-radius;
-  width:6px;
-  left: 3px;
-
-}
-
-.jspHorizontalBar {
-  .jspTrack, .jspDrag {
-    float: left;
-    height: 100%;
-  }
-}
-
-.jspArrow
-{
-  background: @scrollbar-jsp-arrow-bg;
-  text-indent: -20000px;
-  display: block;
-  cursor: pointer;
-  padding: 0;
-  margin: 0;
-}
-
-.jspArrow {
-  &.jspDisabled {
-    cursor: default;
-    background: @scrollbar-jsp-arrow-disabled-bg;
-  }
+.jspPane {
+    position: absolute;
 }
 
 .jspVerticalBar {
-  .jspArrow {
-    height: 16px;
-    &:focus {
-      outline: none;
-    }
-  }
+    position: absolute;
+    top: 0;
+    right: 0;
+    width: 10px;
+    height: 100%;
+    background: transparent;
 }
 
 .jspHorizontalBar {
-  .jspArrow {
-    width: 16px;
-    float: left;
-    height: 100%;
-  }
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    height: 10px;
+    background: transparent;
 }
 
+.jspCap {
+    display: none;
+}
 
-.jspCorner
-{
-  background: @scrollbar-jsp-corner-bg;
-  float: left;
-  height: 100%;
+.jspHorizontalBar {
+    .jspCap {
+        float: left;
+    }
+}
+
+.jspTrack {
+    background: transparent;
+    position: relative;
+}
+
+.jspDrag {
+    background: @scrollbar-drag-bg;
+    position: relative;
+    top: 0;
+    cursor: pointer;
+    border-radius: @scrollbar-drag-border-radius;
+    width: 6px;
+    left: 3px;
+}
+
+.jspHorizontalBar {
+    .jspTrack,
+    .jspDrag {
+        float: left;
+        height: 100%;
+    }
+}
+
+.jspArrow {
+    background: @scrollbar-jsp-arrow-bg;
+    text-indent: -20000px;
+    display: block;
+    cursor: pointer;
+    padding: 0;
+    margin: 0;
+}
+
+.jspArrow {
+    &.jspDisabled {
+        cursor: default;
+        background: @scrollbar-jsp-arrow-disabled-bg;
+    }
+}
+
+.jspVerticalBar {
+    .jspArrow {
+        height: 16px;
+
+        &:focus {
+            outline: none;
+        }
+    }
+}
+
+.jspHorizontalBar {
+    .jspArrow {
+        width: 16px;
+        float: left;
+        height: 100%;
+    }
+}
+
+.jspCorner {
+    background: @scrollbar-jsp-corner-bg;
+    float: left;
+    height: 100%;
 }
 
 * html {
-  .jspCorner {
-    margin: 0 -3px 0 0;
-  }
+    .jspCorner {
+        margin: 0 -3px 0 0;
+    }
 }
-
 
 .scroll-container {
-  .aspects-outline;
-}
-.navbar-static-side-container {
-  .jspDrag {
-    left:3px;
-    width:7px;
-  }
+    .aspects-outline;
 }
 
-.scroll-pane, .jspScrollable{
-  outline: 0;
+.navbar-static-side-container {
+    .jspDrag {
+        left: 3px;
+        width: 7px;
+    }
+}
+
+.scroll-pane,
+.jspScrollable {
+    outline: 0;
 }
 
 /*
   Infinite Scroll
 */
 
-.body-dark {
-  .infinite-scroll-load-button {
-    background-color: @infinite-scroll-load-button-bg-dark;
-
-    &:hover {
-      background-color: @infinite-scroll-load-button-hover-bg-dark;
-    }
-  }
-}
-
 .infinite-scroll-loading {
-  text-align: left;
-  height: 50px;
-  line-height: 50px;
+    text-align: left;
+    height: 50px;
+    line-height: 50px;
 
-  .spinner {
-    margin-left: 25px;
-    margin-right: 20px;
-  }
+    .spinner {
+        margin-left: 25px;
+        margin-right: 20px;
+    }
 
-  .spinner-text {
-    font-family: 'Source Sans Pro';
-    font-size: 1rem;
-    opacity: 0.6;
-  }
+    .spinner-text {
+        font-family: 'Source Sans Pro';
+        font-size: 1rem;
+        opacity: 0.6;
+    }
 }
 
 .infinite-scroll-load-button {
-  width: 100%;
-  height: 50px;
-  background-color: @infinite-scroll-load-button-bg;
-  cursor: pointer;
-  text-align: center;
-  display: flex;
-  justify-content: center;
-  align-items: center;
+    width: 100%;
+    height: 50px;
+    background-color: @infinite-scroll-load-button-bg;
+    cursor: pointer;
+    text-align: center;
+    display: flex;
+    justify-content: center;
+    align-items: center;
 
-  &:hover {
-    background-color: @infinite-scroll-load-button-hover-bg;
+    &:hover {
+        background-color: @infinite-scroll-load-button-hover-bg;
+
+        .load-button-text {
+            color: @infinite-scroll-load-button-hover-color;
+            border-color: @infinite-scroll-load-button-hover-border;
+        }
+    }
 
     .load-button-text {
-      color: @infinite-scroll-load-button-hover-color;
-      border-color: @infinite-scroll-load-button-hover-border;
+        display: inline-block;
+        font-size: 1.125rem;
+        color: @infinite-scroll-load-button-color;
+        border-bottom: 2px dotted @infinite-scroll-load-button-border;
+        margin: 0;
     }
-  }
-
-  .load-button-text {
-    display: inline-block;
-    font-size: 1.125rem;
-    color: @infinite-scroll-load-button-color;
-    border-bottom: 2px dotted @infinite-scroll-load-button-border;
-    margin: 0;
-  }
 }

--- a/src/styles/search.less
+++ b/src/styles/search.less
@@ -1,87 +1,91 @@
 .el-searchcategories {
-  display: inline-block;
-  position: relative;
-  width: 100%;
-
-  tags-input {
-    .tags {
-        border-color: @form-control-border;
-        -webkit-appearance: inherit;
-
-        &.focused {
-          border-color: @form-control-focus-border;
-          outline: none;
-        }
-
-        .input {
-          &.invalid-tag {
-            color: inherit;
-          }
-        }
-
-        li.tag-item {
-          color: @white;
-          background-color: @accent;
-          border: 1px solid @accent;
-          border-radius: 2px;
-        }
-    }
-  }
-
-  .el-searchcategory-tag {
     display: inline-block;
-    white-space: nowrap;
-    .el-searchcategory-tag-icon {
-      margin-right: 5px;
-      line-height: inherit;
-    }
-    .el-searchcategory-tag-category {
-      opacity: 0.5;
-    }
-    .el-searchcategory-tag-remove {
-      position: absolute;
-      top: 6px;
-      right: 3px;
-      color: @white;
-      font-size: 13px;
-      &:hover {
-        opacity: 0.5;
-      }
-    }
-  }
-
-  .el-searchcategories-dropdown {
-    display: none;
-    position: absolute;
-    top: 100%;
-    left: 0;
+    position: relative;
     width: 100%;
-    z-index: @select-drop-z-index;
-    border: none;
-    border-radius: 2px;
-    background-color: @form-control-bg;
-    box-shadow: 0 0 3px @dropdown-shadow;
 
-    &.open {
-      display: block;
-    }
+    tags-input {
+        .tags {
+            border-color: @form-control-border;
+            -webkit-appearance: inherit;
 
-    ul {
-      padding: 0;
+            &.focused {
+                border-color: @form-control-focus-border;
+                outline: none;
+            }
 
-      .el-searchcategories-dropdown-item {
-        display: list-item;
-        list-style: none;
-        margin: 0;
-        padding: 0 10px;
-        line-height: 24px;
-        cursor: pointer;
+            .input {
+                &.invalid-tag {
+                    color: inherit;
+                }
+            }
 
-        &:focus {
-          outline: none;
-          background-color: @shift-select-selected-light;
+            li.tag-item {
+                color: @white;
+                background-color: @accent;
+                border: 1px solid @accent;
+                border-radius: 2px;
+            }
         }
-      }
     }
-  }
+
+    .el-searchcategory-tag {
+        display: inline-block;
+        white-space: nowrap;
+
+        .el-searchcategory-tag-icon {
+            margin-right: 5px;
+            line-height: inherit;
+        }
+
+        .el-searchcategory-tag-category {
+            opacity: 0.5;
+        }
+
+        .el-searchcategory-tag-remove {
+            position: absolute;
+            top: 6px;
+            right: 3px;
+            color: @white;
+            font-size: 13px;
+
+            &:hover {
+                opacity: 0.5;
+            }
+        }
+    }
+
+    .el-searchcategories-dropdown {
+        display: none;
+        position: absolute;
+        top: 100%;
+        left: 0;
+        width: 100%;
+        z-index: @select-drop-z-index;
+        border: none;
+        border-radius: 2px;
+        background-color: @form-control-bg;
+        box-shadow: 0 0 3px @dropdown-shadow;
+
+        &.open {
+            display: block;
+        }
+
+        ul {
+            padding: 0;
+
+            .el-searchcategories-dropdown-item {
+                display: list-item;
+                list-style: none;
+                margin: 0;
+                padding: 0 10px;
+                line-height: 24px;
+                cursor: pointer;
+
+                &:focus {
+                    outline: none;
+                    background-color: @shift-select-selected-light;
+                }
+            }
+        }
+    }
 }

--- a/src/styles/slider.less
+++ b/src/styles/slider.less
@@ -1,5 +1,4 @@
 .slider {
-
     .track {
         display: flex;
         flex-direction: row;
@@ -30,7 +29,7 @@
                 border-top-right-radius: 2px;
                 border-bottom-right-radius: 2px;
             }
-        } 
+        }
 
         .thumb {
             flex: none;
@@ -74,7 +73,7 @@
 
                     &:before {
                         width: 30px;
-                        transform: translateX(-27%);                        
+                        transform: translateX(-27%);
                     }
                 }
             }
@@ -109,9 +108,7 @@
                     }
                 }
             }
-
         }
-
     }
 
     .tick-container {
@@ -132,20 +129,16 @@
             position: absolute;
 
             &.major {
-                
                 .tick-indicator {
                     height: 8px;
                 }
-
             }
 
             &.minor {
-                
                 .tick-indicator {
                     height: 4px;
                     margin-bottom: 4px;
                 }
-
             }
 
             .tick-indicator {
@@ -163,15 +156,12 @@
             }
         }
     }
-
-    
 }
 
 .slider-chart {
-
     .slider {
         padding-left: 7px;
-        padding-right: 7px; 
+        padding-right: 7px;
         margin-top: -8px;
     }
 
@@ -187,45 +177,45 @@
             display: flex;
             flex-direction: row;
         }
-
     }
 
     .left-overlay {
         position: relative;
-        flex: 1; 
-        top: 0; 
-        left: 0; 
+        flex: 1;
+        top: 0;
+        left: 0;
         height: 100%;
         background: #f9f9f9;
         margin-left: 7px;
         border-right: 1px dotted #909090;
         opacity: 0.8;
+
         &.hide-left-border {
             opacity: 0;
         }
     }
 
     .right-overlay {
-        position: relative; 
+        position: relative;
         flex: 1;
-        top: 0; 
-        right: 0; 
-        height: 100%; 
-        background: #f9f9f9; 
+        top: 0;
+        right: 0;
+        height: 100%;
+        background: #f9f9f9;
         margin-right: 7px;
         border-left: 1px dotted #909090;
         opacity: 0.8;
+
         &.hide-right-border {
             opacity: 0;
         }
     }
 
     .middle-overlay {
-        position: relative; 
+        position: relative;
         flex: 1;
         top: 0;
         height: 100%;
         opacity: 0;
     }
-
 }

--- a/src/styles/tables.less
+++ b/src/styles/tables.less
@@ -1,620 +1,527 @@
-.table>thead>tr>th {
-  border-bottom-width: 1px;
-  .font-semibold;
+.table > thead > tr > th {
+    border-bottom-width: 1px;
+    .font-semibold;
 }
 
-.table>tbody>tr>td {
-  border-top-color: @table-border;
+.table > tbody > tr > td {
+    border-top-color: @table-border;
 }
 
-.table>tbody>tr>th {
-  border-top: 0;
+.table > tbody > tr > th {
+    border-top: 0;
 }
 
-.table>tbody>tr>td {
+.table > tbody > tr > td {
     &.vertical-center-icon {
         vertical-align: middle;
     }
 }
 
-.body-dark {
-  .table>tbody>tr {
-    border-color: @table-border-dark;
-    color: @table-color-dark;
-  }
-}
-
 // ngx-bootstrap - pagination
 .pagination {
-  &>li.page-item {
-    &>a {
-      .btn;
-      .button-secondary;
-      text-align: center;
-      min-width: 45px;
-      padding: 6px 12px;
-      &:hover {
-        .button-secondary-hover;
-      }
+    & > li.page-item {
+        & > a {
+            .btn;
+            .button-secondary;
+
+            text-align: center;
+            min-width: 45px;
+            padding: 6px 12px;
+
+            &:hover {
+                .button-secondary-hover;
+            }
+        }
+
+        &.active > a {
+            .button-primary-active;
+
+            &:hover {
+                .button-primary-hover;
+            }
+
+            &:focus {
+                .button-primary-active;
+            }
+        }
+
+        &.disabled {
+            & > a {
+                .button-secondary-disabled;
+            }
+        }
     }
-    &.active>a {
-      .button-primary-active;
-      &:hover {
-        .button-primary-hover;
-      }
-      &:focus {
-        .button-primary-active;
-      }
-    }
-    &.disabled {
-      &>a {
-        .button-secondary-disabled;
-      }
-    }
-  }
 }
 
 //pagination
 .pagination-details {
-  margin: 20px 0;
-  padding: 6px 12px;
-  vertical-align: top;
-  display: inline-block;
+    margin: 20px 0;
+    padding: 6px 12px;
+    vertical-align: top;
+    display: inline-block;
 }
 
-.pagination>.disabled>span, .pagination>.disabled>a {
-  .button-secondary-disabled;
-  &:hover, &:focus {
+.pagination > .disabled > span,
+.pagination > .disabled > a {
     .button-secondary-disabled;
-  }
+
+    &:hover,
+    &:focus {
+        .button-secondary-disabled;
+    }
 }
 
 .pagination > li {
-  & > a {
-    .button-secondary;
-    min-width: 45px;
-    border-radius: 0px !important;
-    &:hover {
-      .button-secondary-hover;
+    & > a {
+        .button-secondary;
+
+        min-width: 45px;
+        border-radius: 0 !important;
+
+        &:hover {
+            .button-secondary-hover;
+        }
     }
-  }
-  &.active > a {
-    .button-primary-active;
-    &:hover {
-      .button-primary-hover;
+
+    &.active > a {
+        .button-primary-active;
+
+        &:hover {
+            .button-primary-hover;
+        }
+
+        &:focus {
+            .button-primary-active;
+        }
     }
-    &:focus {
-      .button-primary-active;
-    }
-  }
 }
 
 table {
-  &.dataTable {
-    clear: both;
-    margin-top: 6px;
-    margin-bottom: 6px;
-    max-width: none;
-  }
+    &.dataTable {
+        clear: both;
+        margin-top: 6px;
+        margin-bottom: 6px;
+        max-width: none;
+    }
 }
 
 .dataTables_filter {
-  label {
-    float: right;
-    font-weight: normal;
-  }
+    label {
+        float: right;
+        font-weight: normal;
+    }
 }
 
 .dataTables_length {
-  label {
-    float: left;
-    text-align: left;
-    font-weight: normal;
-  }
+    label {
+        float: left;
+        text-align: left;
+        font-weight: normal;
+    }
 }
 
 .dataTables_paginate {
-  float: right;
-  margin: 0;
-  ul {
-    &.pagination {
-      margin: 2px 0;
-      white-space: nowrap;
+    float: right;
+    margin: 0;
+
+    ul {
+        &.pagination {
+            margin: 2px 0;
+            white-space: nowrap;
+        }
     }
-  }
 }
 
 .dataTables_info {
-  padding-top: 8px;
+    padding-top: 8px;
 }
 
 .dataTable {
-  thead {
-    .sorting_asc {
-      background: url('../img/sort_asc.png') no-repeat center right;
+    thead {
+        .sorting_asc {
+            background: url('../img/sort_asc.png') no-repeat center right;
+        }
+
+        .sorting_desc {
+            background: url('../img/sort_desc.png') no-repeat center right;
+        }
+
+        .sorting {
+            background: url('../img/sort.png') no-repeat center right;
+        }
     }
-    .sorting_desc {
-      background: url('../img/sort_desc.png') no-repeat center right;
-    }
-    .sorting {
-      background: url('../img/sort.png') no-repeat center right;
-    }
-  }
 }
 
 // Documentation Grids
 .show-grid {
-  margin: 15px 0;
+    margin: 15px 0;
 }
 
 .show-grid [class^="col-"] {
-  padding-top: 10px;
-  padding-bottom: 10px;
-  border: 1px solid @table-grid-border;
-  background-color: @table-grid-bg !important;
+    padding-top: 10px;
+    padding-bottom: 10px;
+    border: 1px solid @table-grid-border;
+    background-color: @table-grid-bg !important;
 }
-// Deprecated
-.body-dark {
-  .show-grid [class^="col-"] {
-    background-color: @show-grid-bg-dark !important;
-  }
-}
+
 //hover actions
-.table>tbody>tr {
-  &.hover-actions>td {
-    &.item-actions {
-      position: relative;
-    }
-    .list-hover-actions {
-      top: 0;
-      padding: 0;
-      right: 10px;
-      position: absolute;
-      border: 0;
-      opacity:0;
-      width: 100%;
-      white-space: nowrap;
-    }
-  }
-}
-
-.table>tbody>tr {
-  &.hover-actions {
-    &:focus {
-      outline:0;
-    }
-  }
-}
-
-.table>tbody>tr {
-  &.hover-actions {
-    &:focus, &:hover, &.child-focus {
-      background-color: @table-hover-bg;
-      &>td.listview-document-bg {
-        background-color: @table-hover-bg;
-      }
-      &>td .list-hover-actions {
-        opacity: 1;
-      }
-      &.multiple-select-item--selecting{
-        &>td .list-hover-actions {
-          opacity: 0;
+.table > tbody > tr {
+    &.hover-actions > td {
+        &.item-actions {
+            position: relative;
         }
-      }
-    }
-  }
-}
 
-.table-hover > tbody > tr {
-  &:hover {
-    background: @table-hover-bg;
-  }
-}
-
-//Deprecated
-.body-dark {
-  .table > tbody > tr {
-    &.hover-actions {
-      &:focus, &.child-focus {
-        background-color: @table-hover-bg-dark;
-      }
+        .list-hover-actions {
+            top: 0;
+            padding: 0;
+            right: 10px;
+            position: absolute;
+            border: 0;
+            opacity: 0;
+            width: 100%;
+            white-space: nowrap;
+        }
     }
-  }
-  .table-hover>tbody>tr {
-    &:hover {
-      background: @table-hover-bg-dark;
-    }
-  }
-}
-
-.table>tbody>tr {
-  &.hover-actions {
-    &:focus, &.child-focus {
-      background-color: @table-hover-bg;
-      &>td.listview-document-bg {
-        background-color:  @table-hover-bg;
-      }
-    }
-  }
 }
 
 .table > tbody > tr {
-  &.highlight{
-    background-color: @table-hover-bg;
-  }
-  &.hover-actions {
-    &.highlight > td {
-      &.listview-document-bg {
+    &.hover-actions {
+        &:focus {
+            outline: 0;
+        }
+    }
+}
+
+.table > tbody > tr {
+    &.hover-actions {
+        &:focus,
+        &:hover,
+        &.child-focus {
+            background-color: @table-hover-bg;
+
+            & > td.listview-document-bg {
+                background-color: @table-hover-bg;
+            }
+
+            & > td .list-hover-actions {
+                opacity: 1;
+            }
+
+            &.multiple-select-item--selecting {
+                & > td .list-hover-actions {
+                    opacity: 0;
+                }
+            }
+        }
+    }
+}
+
+.table-hover > tbody > tr {
+    &:hover {
+        background: @table-hover-bg;
+    }
+}
+
+.table > tbody > tr {
+    &.hover-actions {
+        &:focus,
+        &.child-focus {
+            background-color: @table-hover-bg;
+
+            & > td.listview-document-bg {
+                background-color: @table-hover-bg;
+            }
+        }
+    }
+}
+
+.table > tbody > tr {
+    &.highlight {
         background-color: @table-hover-bg;
-      }
     }
-  }
-}
 
-.body-dark .table > tbody > tr {
-  &.highlight {
-    background-color: @table-hover-bg-dark;
-  }
-}
-.body-dark {
-  .table > tbody > tr > td {
-    border-top-color: @table-border-dark;
-  }
-  .table > thead > tr > th {
-    border-color: @table-border-dark;
-  }
-  .table-striped>tbody>tr:nth-of-type(odd) {
-    background-color: @table-striped-bg-dark;
-  }
-  .table {
-    &.table-striped > thead > tr > th {
-      border-color: @table-striped-border-dark;
+    &.hover-actions {
+        &.highlight > td {
+            &.listview-document-bg {
+                background-color: @table-hover-bg;
+            }
+        }
     }
-  }
 }
-
 
 .list-hover-actions {
-  position: relative;
-  margin-top: 3px;
-  background-color: @table-hover-bg;
-  box-shadow: -2px 0px 4px @table-hover-bg;
-  a.list-hover-action {
-    display: inline-block;
-    padding: 6px;
-    color: @text-color;
-    opacity: 0.5;
-    &:hover, &:focus, &:active {
-      opacity: 1;
-      color: @text-color;
-    }
-  }
-}
-.body-dark {
-  .list-hover-actions {
-    background-color: @table-hover-bg-dark;
-    box-shadow: none;
+    position: relative;
+    margin-top: 3px;
+    background-color: @table-hover-bg;
+    box-shadow: -2px 0 4px @table-hover-bg;
+
     a.list-hover-action {
-      color: @table-color-dark;
+        display: inline-block;
+        padding: 6px;
+        color: @text-color;
+        opacity: 0.5;
+
+        &:hover,
+        &:focus,
+        &:active {
+            opacity: 1;
+            color: @text-color;
+        }
     }
-  }
 }
 
-.select-link{
-      &:link{
-      color:@primary;
-      border-bottom: 1px dotted @primary;
+.select-link {
+    &:link {
+        color: @primary;
+        border-bottom: 1px dotted @primary;
     }
-    &:hover, &:focus{
-      color: @grey2;
-      border-bottom: 1px solid @primary;
-      outline-color: @accent;
+
+    &:hover,
+    &:focus {
+        color: @grey2;
+        border-bottom: 1px solid @primary;
+        outline-color: @accent;
     }
-    &:active{
-      color: @grey2;
-      border-bottom: 1px solid @grey2;
+
+    &:active {
+        color: @grey2;
+        border-bottom: 1px solid @grey2;
     }
-    &:visited{
-      color: @primary;
-      border-bottom: 1px solid @hyperlink-color;
+
+    &:visited {
+        color: @primary;
+        border-bottom: 1px solid @hyperlink-color;
     }
 }
 
 //multiple-list-select styling
-.multiple-list-select-selecting
-{
-  .multiple-select-link{
-    .select-link;
-  }
+.multiple-list-select-selecting {
+    .multiple-select-link {
+        .select-link;
+    }
 }
 
 .multiple-list-select-selecting {
-  .cancel-btn {
-    line-height: 22px;
-    .button-secondary;
-  }
-}
-
-// Deprecated
-.body-dark {
-  .multiple-list-select-selecting {
-    span {
-      color: @multiple-list-select-color-dark;
-    }
-    .multiple-select-link > span {
-      color: @multiple-select-link-dark;
-      border-bottom: 1px dotted @multiple-select-link-dark;
-      &:hover {
-        border-bottom: 1px solid @multiple-select-link-dark;
-      }
-    }
-  }
-}
-
-.body-dark {
-  .multiple-list-select-selecting, .multiple-select-selecting {
     .cancel-btn {
-      &.btn-link {
-        &:hover {
-          background-color: @multiple-select-selecting-hover-bg-dark;
-        }
-      }
+        line-height: 22px;
+        .button-secondary;
     }
-  }
-}
-.body-dark {
-  .multiple-select-selecting {
-    .cancel-btn.btn-link:hover {
-      background-color: @multiple-select-selecting-hover-bg-dark;
-    }
-  }
 }
 
 .table > tbody > tr.row-selected {
-  background-color: @table-hover-bg;
-  &> td .list-hover-actions {
-    opacity: 1;
-  }
+    background-color: @table-hover-bg;
+
+    & > td .list-hover-actions {
+        opacity: 1;
+    }
 }
 
 .table > tbody > tr.hover-actions:hover > td > .listview-document-bg,
 .table > tbody > tr.hover-actions:focus > td > .listview-document-bg,
-.table > tbody > tr.highlight > td > .listview-document-bg
-{
-  background-color: @document-bg;
+.table > tbody > tr.highlight > td > .listview-document-bg {
+    background-color: @document-bg;
 }
-.table > tbody > tr.single-select-selected-bg > td > .listview-document-bg{
-  background-color: @document-bg;
+
+.table > tbody > tr.single-select-selected-bg > td > .listview-document-bg {
+    background-color: @document-bg;
 }
+
 .table > tbody > tr.multiple-list-select-item--selecting:hover > td.item-actions .list-hover-actions,
 .table > tbody > tr.multiple-list-select-item--selecting > td.item-actions .list-hover-actions {
-  visibility: hidden;
-  opacity: 0;
-}
-.table > tbody > tr > td > .listview-document-bg{
-
-  vertical-align: middle;
+    visibility: hidden;
+    opacity: 0;
 }
 
-.body-dark .table > tbody > tr.multiple-select-item--selecting:hover,
-.body-dark .table > tbody > tr.multiple-select-item--selecting.multiple-select-item--selected {
-  background-color: @table-multiple-select-item-hover-bg-dark;
-
+.table > tbody > tr > td > .listview-document-bg {
+    vertical-align: middle;
 }
 
 //multiple select
 .multiple-select-container {
-  .multiple-select-action {
-    margin-right: 5px;
-  }
-  .multiple-select-error {
-    background-color: darken(@primary, 4%);
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    height: 0;
-    line-height: 34px;
-    color: @white;
-    transition: all 200ms linear;
-    overflow: hidden;
-    .error-text {
-      display: inline-block;
-      padding: 10px 20px;
+    .multiple-select-action {
+        margin-right: 5px;
     }
-    &.show-error {
-      height: 100%;
+
+    .multiple-select-error {
+        background-color: darken(@primary, 4%);
+        position: absolute;
+        top: 0;
+        left: 0;
+        right: 0;
+        height: 0;
+        line-height: 34px;
+        color: @white;
+        transition: all 200ms linear;
+        overflow: hidden;
+
+        .error-text {
+            display: inline-block;
+            padding: 10px 20px;
+        }
+
+        &.show-error {
+            height: 100%;
+        }
     }
-  }
 }
 
 .multiple-select-selecting {
-  .btn {
-    vertical-align: baseline;
-  }
-  .btn-sm {
-    margin-top: 2px;
-    margin-bottom: 2px;
-  }
-  .multiple-select-link {
-    .select-link;
-    vertical-align: text-top;
-  }
-  .cancel-btn {
-    line-height: 22px;
-    .button-secondary;
-  }
+    .btn {
+        vertical-align: baseline;
+    }
+
+    .btn-sm {
+        margin-top: 2px;
+        margin-bottom: 2px;
+    }
+
+    .multiple-select-link {
+        .select-link;
+
+        vertical-align: text-top;
+    }
+
+    .cancel-btn {
+        line-height: 22px;
+        .button-secondary;
+    }
 }
 
 .multiple-select-checkbox-table {
-  .multiple-select-checkbox {
-    margin-bottom: 0;
-    .el-checkbox {
-      position: absolute;
-      display: none;
+    .multiple-select-checkbox {
+        margin-bottom: 0;
+
+        .el-checkbox {
+            position: absolute;
+            display: none;
+        }
+
+        .el-checkbox-content {
+            margin-left: 0;
+            transition: padding 100ms linear;
+        }
     }
-    .el-checkbox-content {
-      margin-left: 0;
-      transition: padding 100ms linear;
-    }
-  }
 }
 
 //multiple select item
 //disable hover actions
-.table>tbody>tr.multiple-select-item--selecting { 
-  td:first-child{
-    position: relative;
-    transition: padding 100ms linear;
-    padding-left: 39px;
-    
-    &:before {
-      position: absolute;
-      background: url(../img/blue_checkboxes.png) no-repeat;
-      background-position: 0px 0;
-      height: 22px;
-      width: 22px;
-      left: 8px;
-      top: 9px;
-      display: block;
-      content: "";
-      
-    }
-    &:hover {
-      &:before {
-        background-position: -24px 0;
-      }
-    }
-    &.multiple-select-checkbox-table{
-      padding-left: 8px; 
-      .multiple-select-checkbox{
-        .el-checkbox {
-          display: inline-flex;
+.table > tbody > tr.multiple-select-item--selecting {
+    td:first-child {
+        position: relative;
+        transition: padding 100ms linear;
+        padding-left: 39px;
+
+        &:before {
+            position: absolute;
+            background: url(../img/blue_checkboxes.png) no-repeat;
+            background-position: 0 0;
+            height: 22px;
+            width: 22px;
+            left: 8px;
+            top: 9px;
+            display: block;
+            content: "";
         }
-        .el-checkbox-content{
-          padding-left: 31px;
-        }
-      }
-      &:before {
-        display: none;
-      }
-    }
-  }
-  &.multiple-select-item--selected {
-    td:first-child:before {
-      background-position: -48px 0;
-    }
-  }
-  &>td.listview-document-bg,
-  &:hover>td.listview-document-bg {
-    background-color: transparent;
-  }
-  &:hover, 
-  &.multiple-select-item--selected {
-    background-color: @table-hover-bg;
-    cursor: pointer;
-    &>td.item-actions .list-hover-actions {
-      visibility: hidden;
-      opacity: 0;
-    }
-  }
-}
-.body-dark {
-  .table > tbody > tr {
-    &.multiple-select-item--selecting {
-      td {
-        &:first-child {
-          &:before {
-            background-position: -600px 0;
-          }
-        }
-      }
-      &.multiple-select-item--selected {
-        td {
-          &:first-child {
+
+        &:hover {
             &:before {
-              background-position: -576px 0;
+                background-position: -24px 0;
             }
-          }
         }
-      }
+
+        &.multiple-select-checkbox-table {
+            padding-left: 8px;
+
+            .multiple-select-checkbox {
+                .el-checkbox {
+                    display: inline-flex;
+                }
+
+                .el-checkbox-content {
+                    padding-left: 31px;
+                }
+            }
+
+            &:before {
+                display: none;
+            }
+        }
     }
-  }
+
+    &.multiple-select-item--selected {
+        td:first-child:before {
+            background-position: -48px 0;
+        }
+    }
+
+    & > td.listview-document-bg,
+    &:hover > td.listview-document-bg {
+        background-color: transparent;
+    }
+
+    &:hover,
+    &.multiple-select-item--selected {
+        background-color: @table-hover-bg;
+        cursor: pointer;
+
+        & > td.item-actions .list-hover-actions {
+            visibility: hidden;
+            opacity: 0;
+        }
+    }
 }
+
 //shift/ctrl select item
 //disable hover actions
-.table>tbody>tr.shift-select-selected-bg {
-  background-color: @shift-select-selected-light;
-  &>td.item-actions .list-hover-actions {
+.table > tbody > tr.shift-select-selected-bg {
     background-color: @shift-select-selected-light;
-    box-shadow: none;
-  }
-  &:hover, &:focus, &.child-focus{
-    background-color: @shift-select-selected-hover-light;
-    &>td.item-actions .list-hover-actions {
-      background-color: @shift-select-selected-hover-light;
-      box-shadow: none;
-    }
-  }
 
-}
-.body-dark {
-  .table > tbody > tr.shift-select-selected-bg {
-    background-color: @shift-select-selected-dark;
-    &>td.item-actions .list-hover-actions {
-      background-color: @shift-select-selected-dark;
-      box-shadow: none;
-    }
-    &:hover, &:focus, &.child-focus{
-      background-color: @shift-select-selected-hover-dark;
-      &>td.item-actions .list-hover-actions {
-        background-color: @shift-select-selected-hover-dark;
+    & > td.item-actions .list-hover-actions {
+        background-color: @shift-select-selected-light;
         box-shadow: none;
-      }
     }
-  }
+
+    &:hover,
+    &:focus,
+    &.child-focus {
+        background-color: @shift-select-selected-hover-light;
+
+        & > td.item-actions .list-hover-actions {
+            background-color: @shift-select-selected-hover-light;
+            box-shadow: none;
+        }
+    }
 }
 
 .affix-toolbar {
-  &.multiple-select-mode {
-    background: @white;
-  }
-}
-.body-dark {
-  .affix-toolbar {
     &.multiple-select-mode {
-      background: @affix-toolbar-multiple-select-mode-bg-dark;
+        background: @white;
     }
-  }
 }
+
 .affix {
-  .multiple-select-selecting {
-    .btn-sm {
-      margin-top: 0px;
-      margin-bottom: 0px;
+    .multiple-select-selecting {
+        .btn-sm {
+            margin-top: 0;
+            margin-bottom: 0;
+        }
     }
-  }
 }
 
 .multiple-select-selecting {
-  .multiple-list-select-selecting{
-    .btn{
-      vertical-align: middle;
+    .multiple-list-select-selecting {
+        .btn {
+            vertical-align: middle;
+        }
     }
-  }
-}
-.selecting-text{
-  vertical-align: text-top;
 }
 
-.body-dark {
-  .selecting-text{
-    color: @selecting-text-color-dark;
-  }
+.selecting-text {
+    vertical-align: text-top;
 }
 
 .table-responsive {
-   border: none;
+    border: none;
 }
 
 .horizontal-scrollbar {
@@ -624,18 +531,11 @@ table {
 }
 
 .table-header-dark {
-  th {
-    color: @grey2;
-    text-transform: uppercase;
-    font-size: 0.875rem;
-  }
-}
-.body-dark {
-  .table-header-dark {
     th {
-      color: @table-header-color-dark;
+        color: @grey2;
+        text-transform: uppercase;
+        font-size: 0.875rem;
     }
-  }
 }
 
 .listview-page-icon {
@@ -646,31 +546,30 @@ table {
 }
 
 .listview-text-emphasis {
-  color: @grey2;
+    color: @grey2;
 }
 
 // Fixed Header Table
-
-
 .scrollableContainer {
     position: relative;
     padding-top: 35px;
     overflow: hidden;
 
     .headerSpacer {
-       position: absolute;
-       top: 0;
-       right: 0;
-       left: 0;
+        position: absolute;
+        top: 0;
+        right: 0;
+        left: 0;
     }
+
     th {
-     .orderWrapper {
-       position: absolute;
-       top: 0;
-       right: 2px;
-       cursor: pointer;
-       font-size: 0.625rem;
-     }
+        .orderWrapper {
+            position: absolute;
+            top: 0;
+            right: 2px;
+            cursor: pointer;
+            font-size: 0.625rem;
+        }
     }
 }
 
@@ -678,125 +577,117 @@ table {
     height: 100%;
     overflow-x: auto;
     overflow-y: auto;
+
     /*  the implementation of this is still quite buggy; specifically, it doesn't like the
         absolutely positioned headers within
     -webkit-overflow-scrolling: touch;  */
-
-
     table {
-      overflow-x: hidden;
-      overflow-y: auto;
-      margin-bottom: 0;
-      width: 100%;
-      border: none;
-      /*border-collapse: separate;*/
+        overflow-x: hidden;
+        overflow-y: auto;
+        margin-bottom: 0;
+        width: 100%;
+        border: none;
 
-      th {
-        padding: 0 !important;
-        border: none !important;
-        min-width: 40px;
+        /*border-collapse: separate;*/
+        th {
+            padding: 0 !important;
+            border: none !important;
+            min-width: 40px;
 
-        .box {
-          padding: 0 8px;
-          padding-right: 11px;    /*  order icon width*/
-          height: 100%;
+            .box {
+                padding: 0 8px;
+                padding-right: 11px;
 
-          > .row {
-            height: 100%;
-          }
-        }
-      }
-      .th-inner {
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
-        position: absolute;
-        top: 0;
-        height: 36px;
-        line-height: 36px;
-        border-bottom: 1px solid @table-border;
+                /*  order icon width*/
+                height: 100%;
 
-        .ng-scope {
-          display: block;
-          overflow: hidden;
-          text-overflow: ellipsis;
+                > .row {
+                    height: 100%;
+                }
+            }
         }
 
-        .condensed {
-          padding: 0 3px;
-        }
-      }
-      tbody {
-        tr {
-         td:first-child {
-          border-left: none;
-         }
-          td:last-child {
-           border-right: none;
-          }
-          td {
-            border-bottom: 1px solid @table-border;
+        .th-inner {
             overflow: hidden;
             text-overflow: ellipsis;
-          }
-        }
-        tr:first-child td {
-          border-top: none;
-        }
-      }
-    }
-}
+            white-space: nowrap;
+            position: absolute;
+            top: 0;
+            height: 36px;
+            line-height: 36px;
+            border-bottom: 1px solid @table-border;
 
-.body-dark {
-  .scrollArea {
-    table {
-      tbody {
-        tr {
-          td {
-            border-bottom-color: @table-border-dark;
-          }
+            .ng-scope {
+                display: block;
+                overflow: hidden;
+                text-overflow: ellipsis;
+            }
+
+            .condensed {
+                padding: 0 3px;
+            }
         }
-      }
-      .th-inner {
-        border-bottom-color: @table-border-dark;
-      }
+
+        tbody {
+            tr {
+                td:first-child {
+                    border-left: none;
+                }
+
+                td:last-child {
+                    border-right: none;
+                }
+
+                td {
+                    border-bottom: 1px solid @table-border;
+                    overflow: hidden;
+                    text-overflow: ellipsis;
+                }
+            }
+
+            tr:first-child td {
+                border-top: none;
+            }
+        }
     }
-  }
 }
 
 /*  to hack fix firefox border issue    */
+
 @-moz-document url-prefix() {
-    .scrollArea table th .box{
+    .scrollArea table th .box {
         border-left: none;
     }
 }
 
 .scrollableContainer {
-  .scaler {
-    position: absolute;
-    top: 0px;
-    width: 2px;
-    height: 100%;
-  }
-  th {
-    .resize-rod {
-      position: absolute;
-      top: 0;
-      right: 0;
-      cursor: col-resize;
-      width: 4px;
-      height: 100%;
+    .scaler {
+        position: absolute;
+        top: 0;
+        width: 2px;
+        height: 100%;
     }
-  }
+
+    th {
+        .resize-rod {
+            position: absolute;
+            top: 0;
+            right: 0;
+            cursor: col-resize;
+            width: 4px;
+            height: 100%;
+        }
+    }
 }
 
 .scrollable-resizing {
-  .scrollableContainer {
-    cursor: col-resize;
-    -moz-user-select: none;
-    -webkit-user-select: none;
-    -ms-user-select: none;
-  }
+    .scrollableContainer {
+        cursor: col-resize;
+        -moz-user-select: none;
+        -webkit-user-select: none;
+        -ms-user-select: none;
+        user-select: none;
+    }
 }
 
 .sortableHeader {
@@ -808,116 +699,136 @@ table {
     float: left;
 }
 
-
 .sorter-header-sm {
-  .sortableHeader {
-    font-size: 0.875rem;
-  }
-  .sortableHeaderIcon {
-    padding-bottom: 3px;
-  }
-  &.multiSortHeader {
-    .multiSortTitle {
-      font-size: 0.875rem;
+    .sortableHeader {
+        font-size: 0.875rem;
     }
-    .multiSortNumber {
-      font-size: 0.875rem;
-    }
+
     .sortableHeaderIcon {
-      padding-top: 5px;
+        padding-bottom: 3px;
     }
-  }
+
+    &.multiSortHeader {
+        .multiSortTitle {
+            font-size: 0.875rem;
+        }
+
+        .multiSortNumber {
+            font-size: 0.875rem;
+        }
+
+        .sortableHeaderIcon {
+            padding-top: 5px;
+        }
+    }
 }
 
 .sorter-header-md {
-  .sortableHeader {
-    font-size: 1rem;
-  }
-  .sortableHeaderIcon {
-    padding-bottom: 1px;
-  }
-  &.multiSortHeader {
-    .multiSortTitle {
-      font-size: 1rem;
+    .sortableHeader {
+        font-size: 1rem;
     }
-    .multiSortNumber {
-      font-size: 1rem;
-    }
+
     .sortableHeaderIcon {
-      padding-top: 5px;
+        padding-bottom: 1px;
     }
-  }
+
+    &.multiSortHeader {
+        .multiSortTitle {
+            font-size: 1rem;
+        }
+
+        .multiSortNumber {
+            font-size: 1rem;
+        }
+
+        .sortableHeaderIcon {
+            padding-top: 5px;
+        }
+    }
 }
 
 .sorter-header-lg {
-  .sortableHeader {
-    font-size: 1.125rem;
-  }
-  .sortableHeaderIcon {
-    padding-top: 2px;
-  }
-  &.multiSortHeader {
-    .multiSortTitle {
-      font-size: 1.125rem;
+    .sortableHeader {
+        font-size: 1.125rem;
     }
-    .multiSortNumber {
-      font-size: 1.125rem;
-    }
+
     .sortableHeaderIcon {
-      padding-top: 6px;
+        padding-top: 2px;
     }
-  }
+
+    &.multiSortHeader {
+        .multiSortTitle {
+            font-size: 1.125rem;
+        }
+
+        .multiSortNumber {
+            font-size: 1.125rem;
+        }
+
+        .sortableHeaderIcon {
+            padding-top: 6px;
+        }
+    }
 }
 
 .scrollable-header-sm {
-  .sortableHeader {
-    font-size: 0.875rem;
-  }
-  .sortableHeaderIcon {
-    padding-bottom: 3px;
-  }
-  .multiSortTitle {
-    font-size: 0.875rem;
-  }
-  .multiSortNumber {
-    font-size: 0.875rem;
-  }
+    .sortableHeader {
+        font-size: 0.875rem;
+    }
+
+    .sortableHeaderIcon {
+        padding-bottom: 3px;
+    }
+
+    .multiSortTitle {
+        font-size: 0.875rem;
+    }
+
+    .multiSortNumber {
+        font-size: 0.875rem;
+    }
 }
 
 .scrollable-header-md {
-  .sortableHeader {
-    font-size: 1rem;
-  }
-  .sortableHeaderIcon {
-    padding-bottom: 2px;
-  }
-  .multiSortTitle {
-    font-size: 1rem;
-  }
-  .multiSortNumber {
-    font-size: 1rem;
-  }
+    .sortableHeader {
+        font-size: 1rem;
+    }
+
+    .sortableHeaderIcon {
+        padding-bottom: 2px;
+    }
+
+    .multiSortTitle {
+        font-size: 1rem;
+    }
+
+    .multiSortNumber {
+        font-size: 1rem;
+    }
 }
 
 .scrollable-header-lg {
-  .sortableHeader {
-    font-size: 1.125rem;
-  }
-  .sortableHeaderIcon {
-    padding-bottom: 2px;
-  }
-  .multiSortTitle {
-    font-size: 1.125rem;
-  }
-  .multiSortNumber {
-    font-size: 1.125rem;
-  }
+    .sortableHeader {
+        font-size: 1.125rem;
+    }
+
+    .sortableHeaderIcon {
+        padding-bottom: 2px;
+    }
+
+    .multiSortTitle {
+        font-size: 1.125rem;
+    }
+
+    .multiSortNumber {
+        font-size: 1.125rem;
+    }
 }
 
 .sortableHeaderIcon {
-  display: inline-block;
-  width: 18px;
-  vertical-align: middle;
+    display: inline-block;
+    width: 18px;
+    vertical-align: middle;
 }
 
 .multiSortTitle {
@@ -930,285 +841,291 @@ table {
     line-height: 28px;
 }
 
-.multiSortHeader{
-  &:hover {
-    .multiSortNumber{
-      display: inline-block;
-      opacity: 1;
-      transition: 0.5s;
+.multiSortHeader {
+    &:hover {
+        .multiSortNumber {
+            display: inline-block;
+            opacity: 1;
+            transition: 0.5s;
+        }
     }
-  }
-  .header {
-    padding-bottom: 0px;
-  }
 
-  .sortableHeaderIcon {
-    float: left;
-  }
+    .header {
+        padding-bottom: 0;
+    }
+
+    .sortableHeaderIcon {
+        float: left;
+    }
 }
 
-.multiSortNumber{
-  opacity: 0;
-  width: 18px;
-  float: right;
+.multiSortNumber {
+    opacity: 0;
+    width: 18px;
+    float: right;
 }
 
 .multiSortContainer {
-  width: 36px;
-  display: inline-block;
-  height: 22px;
+    width: 36px;
+    display: inline-block;
+    height: 22px;
 }
 
 .fixed-layout {
-  table-layout: fixed;
+    table-layout: fixed;
 }
 
 .no-cell-overflow {
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
 }
 
 .table-col-icon {
-  width: 65px;
-  min-width: 65px;
-  max-width: 65px;
-  .no-cell-overflow;
+    width: 65px;
+    min-width: 65px;
+    max-width: 65px;
+    .no-cell-overflow;
 }
 
 .table-col-xs {
-  width: 5%;
-  min-width: 5%;
-  max-width: 5%;
-  .no-cell-overflow;
+    width: 5%;
+    min-width: 5%;
+    max-width: 5%;
+    .no-cell-overflow;
 }
 
 .table-col-sm {
-  width: 10%;
-  min-width: 10%;
-  max-width: 10%;
-  .no-cell-overflow;
+    width: 10%;
+    min-width: 10%;
+    max-width: 10%;
+    .no-cell-overflow;
 }
 
 .table-col-md {
-  width: 20%;
-  min-width: 20%;
-  max-width: 20%;
-  .no-cell-overflow;
+    width: 20%;
+    min-width: 20%;
+    max-width: 20%;
+    .no-cell-overflow;
 }
 
 .table-col-lg {
-  width: 30%;
-  min-width: 30%;
-  max-width: 30%;
-  .no-cell-overflow;
+    width: 30%;
+    min-width: 30%;
+    max-width: 30%;
+    .no-cell-overflow;
 }
 
 .table-col-xl {
-  width: 40%;
-  min-width: 40%;
-  max-width: 40%;
-  .no-cell-overflow;
+    width: 40%;
+    min-width: 40%;
+    max-width: 40%;
+    .no-cell-overflow;
 }
 
 .expand-input {
-  .dropdown-menu {
-    width: 35%;
-    box-shadow: 0px 0px 3px @dropdown-menu-shadow;
-    border-radius: 0px;
-    line-height: 16px;
-    margin: 4px;
-    li{
-      a{
-      width: 100%;
-      border-radius: 0px;
-      line-height: 16px;
-      margin: 0px;
-      padding: 3px 12px;
-      }
-      a:hover, a:focus, a:active {
-        color: @text-color;
-        background: @dropdown-menu-hover-bg;
-      }
+    .dropdown-menu {
+        width: 35%;
+        box-shadow: 0 0 3px @dropdown-menu-shadow;
+        border-radius: 0;
+        line-height: 16px;
+        margin: 4px;
+
+        li {
+            a {
+                width: 100%;
+                border-radius: 0;
+                line-height: 16px;
+                margin: 0;
+                padding: 3px 12px;
+            }
+
+            a:hover,
+            a:focus,
+            a:active {
+                color: @text-color;
+                background: @dropdown-menu-hover-bg;
+            }
+        }
     }
-  }
 }
 
 .expand-input {
-  .dropdown-menu {
-    .active{
-      a:hover, a:focus, a{
-        color: @text-color;
-        background: @dropdown-menu-hover-bg;
-      }
+    .dropdown-menu {
+        .active {
+            a:hover,
+            a:focus,
+            a {
+                color: @text-color;
+                background: @dropdown-menu-hover-bg;
+            }
+        }
     }
-  }
 }
 
 .search-toolbar-icon {
-  display: inline-block;
-  width: 40px;
-  height: 34px;
-  .hpe-icon {
-    font-size: 1.5rem;
-    padding: 4px;
-    margin-left: 2px;
-  }
+    display: inline-block;
+    width: 40px;
+    height: 34px;
+
+    .hpe-icon {
+        font-size: 1.5rem;
+        padding: 4px;
+        margin-left: 2px;
+    }
 }
 
-.search-toolbar-icon:hover, .search-toolbar-icon:focus {
-  cursor: pointer;
-  backgound: none !important;
+.search-toolbar-icon:hover,
+.search-toolbar-icon:focus {
+    cursor: pointer;
+    background: none !important;
 }
 
 .search-toolbar-input {
-  border-top: none !important;
-  border-right: none !important;
-  border-left: none !important;
+    border-top: none !important;
+    border-right: none !important;
+    border-left: none !important;
 }
 
 //sortDirectionToggle
 .sort-direction-toggle {
-  p {
-    float: left;
-    padding: 6px;
-    margin-bottom: 0;
-  }
-  .sort-icon {
-    height: 34px;
-    margin-right: 1px;
-    float: right;
-    padding: 6px;
-    padding-top: 10px;
-    cursor: pointer;
+    p {
+        float: left;
+        padding: 6px;
+        margin-bottom: 0;
+    }
 
-    &:hover, &:focus {
-      background: @table-sort-hover-bg;
-    }
-    &:focus {
-      outline-style: solid;
-      outline-width: 1px;
-      outline-color: @table-sort-focus-outline;
-    }
-  }
-}
-
-.body-dark {
-  .sort-direction-toggle {
-    p{
-      color: @table-color-dark;
-    }
     .sort-icon {
-      &:hover, &:focus {
-        background: @table-sort-hover-bg-dark;
-      }
+        height: 34px;
+        margin-right: 1px;
+        float: right;
+        padding: 6px;
+        padding-top: 10px;
+        cursor: pointer;
+
+        &:hover,
+        &:focus {
+            background: @table-sort-hover-bg;
+        }
+
+        &:focus {
+            outline: 1px solid @table-sort-focus-outline;
+        }
     }
-  }
 }
 
 //Table Row Headers
 .detail-row-header {
-  white-space: nowrap;
-  .title {
-    line-height: 1;
-    display: inline-block;
-    max-width: 100%;
-  }
-  .sort {
-    display: none;
-  }
-  &.sort {
+    white-space: nowrap;
+
     .title {
-      max-width: ~'calc(100% - 60px)';
+        line-height: 1;
+        display: inline-block;
+        max-width: 100%;
     }
+
     .sort {
-      display: inline;
-      pointer-events: none;
-      max-width: 42px;
-      i {
-        vertical-align: top;
-      }
-      .number {
-        transition: 0.5s;
-        opacity: 0;
-        width: 18px;
+        display: none;
+    }
+
+    &.sort {
+        .title {
+            max-width: ~'calc(100% - 60px)';
+        }
+
+        .sort {
+            display: inline;
+            pointer-events: none;
+            max-width: 42px;
+
+            i {
+                vertical-align: top;
+            }
+
+            .number {
+                transition: 0.5s;
+                opacity: 0;
+                width: 18px;
+                display: inline;
+            }
+        }
+    }
+
+    .filter {
         display: inline;
-      }
+        width: 18px;
+
+        i {
+            vertical-align: top;
+            color: @primary;
+
+            span {
+                height: inherit;
+                width: inherit;
+                display: block;
+            }
+        }
     }
-  }
-  .filter {
-    display: inline;
-    width: 18px;
-    i {
-      vertical-align: top;
-      color: @primary;
-      span {
-        height: inherit;
-        width: inherit;
-        display: block;
-      }
-    }
-  }
 }
 
 .scrollArea {
-  table {
-    .detail-row-header {
-      .sort {
-        i {
-          vertical-align: baseline;
+    table {
+        .detail-row-header {
+            .sort {
+                i {
+                    vertical-align: baseline;
+                }
+            }
+
+            .filter {
+                display: inline-flex;
+
+                i {
+                    display: inline-block;
+                    vertical-align: baseline;
+                }
+            }
         }
-      }
-      .filter {
-        display: inline-flex;
-        i {
-          display: inline-block;
-          vertical-align: baseline;
-        }
-      }
     }
-  }
 }
 
-
 th {
-  &:hover {
-    .detail-row-header {
-      &.sort {
-        .sort {
-          .number {
-            opacity: 1;
-            transition: 0.5s;
-          }
+    &:hover {
+        .detail-row-header {
+            &.sort {
+                .sort {
+                    .number {
+                        opacity: 1;
+                        transition: 0.5s;
+                    }
+                }
+            }
         }
-      }
     }
-  }
 }
 
 .detail-row-header-popover {
-  width: 300px;
-  max-width: none;
-  .popover-content, .popover-title {
-    padding: 5px; 
-  }
+    width: 300px;
+    max-width: none;
+
+    .popover-content,
+    .popover-title {
+        padding: 5px;
+    }
 }
 
 /*
   Integrated Table Control
 */
+
 .integrated-table {
-
-  tbody {
-
-    tr {
-      &:focus {
-        background-color: #f5f5f5;
-      }
+    tbody {
+        tr {
+            &:focus {
+                background-color: #f5f5f5;
+            }
+        }
     }
-
-  }
-
 }
 
 /*
@@ -1216,27 +1133,29 @@ th {
  */
 
 .ux-fixed-header-table {
-  display: flex;
-  flex-direction: column;
+    display: flex;
+    flex-direction: column;
 
-  thead, tbody {
-      display: block;
+    thead,
+    tbody {
+        display: block;
 
-      tr {
-          display: flex;
+        tr {
+            display: flex;
 
-          th, td {
-              display: block;
-              flex: 1;
-              overflow: hidden;
-              text-overflow: ellipsis;
-          }
-      }
-  }
+            th,
+            td {
+                display: block;
+                flex: 1;
+                overflow: hidden;
+                text-overflow: ellipsis;
+            }
+        }
+    }
 
-  tbody {
-      overflow-y: scroll;
-      min-height: 1px;
-      margin-top: -1px;
-  }
+    tbody {
+        overflow-y: scroll;
+        min-height: 1px;
+        margin-top: -1px;
+    }
 }

--- a/src/styles/tags-input.less
+++ b/src/styles/tags-input.less
@@ -1,202 +1,207 @@
+tags-input {
+    display: block;
+}
+
+tags-input *,
+tags-input *:before,
+tags-input *:after {
+    -moz-box-sizing: border-box;
+    -webkit-box-sizing: border-box;
+    box-sizing: border-box;
+}
 
 tags-input {
-  display: block;
-}
-tags-input *, tags-input *:before, tags-input *:after {
-  -moz-box-sizing: border-box;
-  -webkit-box-sizing: border-box;
-  box-sizing: border-box;
-}
-tags-input {
-  .host {
-    position: relative;
-    margin-top: 5px;
-    margin-bottom: 5px;
-    height: auto;
-  }
-}
-tags-input {
-  .host {
-    &:active {
-      outline: none;
+    .host {
+        position: relative;
+        margin-top: 5px;
+        margin-bottom: 5px;
+        height: auto;
     }
-  }
-}
-
-.body-dark {
-  tags-input .tags .tag-item {
-    border: 1px solid @tag-input-tag-border-dark;
-    background-color: @tag-input-tag-bg-dark;
-    color: @tag-input-tag-color-dark;
-  }
 }
 
 tags-input {
-  .tags {
-    -moz-appearance: textfield;
-    -webkit-appearance: textfield;
-    padding: 1px;
-    overflow: hidden;
-    word-wrap: break-word;
-    cursor: text;
-    border: 1px solid @tag-input-border;
-    height: auto;
-    padding-top: 2px;
-    .tag-list {
-      margin: 0;
-      padding: 0;
-      list-style-type: none;
-    }
-    .tag-item {
-      margin: 2px 0 2px 6px;
-      padding: 5px 20px 3px 5px;
-      display: list-item;
-      float: left;
-      font: @font-size-lg @font-family;
-      font-weight: 400;
-      height: 25px;
-      line-height: 13px;
-      border: 1px solid @tag-input-tag-border;
-      background-color: @tag-input-tag-bg;
-      color: @tag-input-tag-color;
-      position: relative;
-      border-radius: @tag-input-tag-border-radius;
-      cursor: default;
-      list-style: none;
-      white-space: pre;
-      
-      .remove-button {
-        margin: 1px 0px 0px 5px;
-        padding: 0;
-        border: none;
-        cursor: pointer;
-        vertical-align: middle;
-        font: bold 16px Arial, sans-serif;
-        color: @tag-item-remove-button-color;
-        position: absolute;
-        top: 6px;
-        right: 3px;
-        display: block;
-        width: 12px;
-        height: 12px;
-        background: url('../img/chosen-sprite.png') -42px 1px no-repeat;
-        font-size: 0.0625rem;
-
-        &:hover {
-          background-position: -42px -10px;
-        }
-
+    .host {
         &:active {
-          color: @tag-item-remove-button-active-color;
+            outline: none;
         }
-      }
     }
-    .tag-item.selected {
-      background-color: @tag-input-tag-active-bg;
-      border: 1px solid @tag-input-tag-active-border;
-      color:@tag-input-tag-active-color;
-    }
-    .input {
-      border: 0;
-      outline: none;
-      margin: 2px;
-      padding: 0;
-      padding-left: 5px;
-      float: left;
-      height: 26px;
-      font: @font-size-lg @font-family;
-      background-color: transparent;
+}
 
-      &.invalid-tag {
-        color: @tag-input-invalid;
-      }
-    }
-  }
-  &.ng-invalid {
+tags-input {
     .tags {
-      border-color: @tag-input-invalid;
-    }
-  }
-  .autocomplete {
-    margin-top: 5px;
-    position: absolute;
-    padding: 5px 0;
-    z-index: 999;
-    width: 100%;
-    max-height: 280px;
-    background-color: @tag-input-autocomplete-bg;
-    border: 1px solid @tag-input-autocomplete-border;
+        -moz-appearance: textfield;
+        -webkit-appearance: textfield;
+        padding: 1px;
+        overflow: hidden;
+        word-wrap: break-word;
+        cursor: text;
+        border: 1px solid @tag-input-border;
+        height: auto;
+        padding-top: 2px;
 
-    .suggestion-list {
-      margin: 0;
-      padding: 0;
-      list-style-type: none;
-      position: relative;
-    }
-
-    .suggestion-item {
-      padding: 5px 10px;
-      cursor: pointer;
-      white-space: nowrap;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      font: 16px @font-family, Helvetica, Arial, sans-serif;
-      color: @tag-input-autocomplete-color;
-      background-color: @tag-input-autocomplete-bg;
-
-      &.selected {
-        color: @tag-input-autocomplete-active-color;
-        background-color: @tag-input-autocomplete-active-bg;
-
-        em {
-          color: @tag-input-autocomplete-active-color;
-          background-color: @tag-input-autocomplete-active-bg;
+        .tag-list {
+            margin: 0;
+            padding: 0;
+            list-style-type: none;
         }
-      }
-      em {
-        font: normal bold 16px @font-family;
-        color: @tag-input-autocomplete-color;
-        background-color: @tag-input-autocomplete-bg;
-        text-decoration: underline;
-      }
+
+        .tag-item {
+            margin: 2px 0 2px 6px;
+            padding: 5px 20px 3px 5px;
+            display: list-item;
+            float: left;
+            font: @font-size-lg @font-family;
+            font-weight: 400;
+            height: 25px;
+            line-height: 13px;
+            border: 1px solid @tag-input-tag-border;
+            background-color: @tag-input-tag-bg;
+            color: @tag-input-tag-color;
+            position: relative;
+            border-radius: @tag-input-tag-border-radius;
+            cursor: default;
+            list-style: none;
+            white-space: pre;
+
+            .remove-button {
+                margin: 1px 0 0 5px;
+                padding: 0;
+                border: none;
+                cursor: pointer;
+                vertical-align: middle;
+                font: bold 16px Arial, sans-serif;
+                color: @tag-item-remove-button-color;
+                position: absolute;
+                top: 6px;
+                right: 3px;
+                display: block;
+                width: 12px;
+                height: 12px;
+                background: url('../img/chosen-sprite.png') -42px 1px no-repeat;
+                font-size: 0.0625rem;
+
+                &:hover {
+                    background-position: -42px -10px;
+                }
+
+                &:active {
+                    color: @tag-item-remove-button-active-color;
+                }
+            }
+        }
+
+        .tag-item.selected {
+            background-color: @tag-input-tag-active-bg;
+            border: 1px solid @tag-input-tag-active-border;
+            color: @tag-input-tag-active-color;
+        }
+
+        .input {
+            border: 0;
+            outline: none;
+            margin: 2px;
+            padding: 0;
+            padding-left: 5px;
+            float: left;
+            height: 26px;
+            font: @font-size-lg @font-family;
+            background-color: transparent;
+
+            &.invalid-tag {
+                color: @tag-input-invalid;
+            }
+        }
     }
-  }
+
+    &.ng-invalid {
+        .tags {
+            border-color: @tag-input-invalid;
+        }
+    }
+
+    .autocomplete {
+        margin-top: 5px;
+        position: absolute;
+        padding: 5px 0;
+        z-index: 999;
+        width: 100%;
+        max-height: 280px;
+        background-color: @tag-input-autocomplete-bg;
+        border: 1px solid @tag-input-autocomplete-border;
+
+        .suggestion-list {
+            margin: 0;
+            padding: 0;
+            list-style-type: none;
+            position: relative;
+        }
+
+        .suggestion-item {
+            padding: 5px 10px;
+            cursor: pointer;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            font: 16px @font-family, Helvetica, Arial, sans-serif;
+            color: @tag-input-autocomplete-color;
+            background-color: @tag-input-autocomplete-bg;
+
+            &.selected {
+                color: @tag-input-autocomplete-active-color;
+                background-color: @tag-input-autocomplete-active-bg;
+
+                em {
+                    color: @tag-input-autocomplete-active-color;
+                    background-color: @tag-input-autocomplete-active-bg;
+                }
+            }
+
+            em {
+                font: normal bold 16px @font-family;
+                color: @tag-input-autocomplete-color;
+                background-color: @tag-input-autocomplete-bg;
+                text-decoration: underline;
+            }
+        }
+    }
 }
 
 tags-input .tags .input::-ms-clear {
-  display: none;
+    display: none;
 }
 
 tags-input[disabled] {
-  .host:focus {
-    outline: none;
-  }
-  .tags {
-    background-color: @tag-input-disabled-bg;
-    cursor: default;
+    .host:focus {
+        outline: none;
+    }
 
-    .tag-item {
-      opacity: 0.65;
-
-      .remove-button {
+    .tags {
+        background-color: @tag-input-disabled-bg;
         cursor: default;
 
-        &:active {
-          color: @tag-input-disabled-color;
+        .tag-item {
+            opacity: 0.65;
+
+            .remove-button {
+                cursor: default;
+
+                &:active {
+                    color: @tag-input-disabled-color;
+                }
+            }
         }
-      }
+
+        .input {
+            background-color: @tag-input-disabled-bg;
+            cursor: default;
+        }
     }
-    .input {
-      background-color: @tag-input-disabled-bg;
-      cursor: default;
-    }
-  }
 }
 
 .tags-text-bold {
-  font-weight: bold;
+    font-weight: bold;
 }
 
 .tags-text-small {
-  font-size: 0.75rem;
+    font-size: 0.75rem;
 }

--- a/src/styles/theme.less
+++ b/src/styles/theme.less
@@ -2,599 +2,677 @@
 //Left navigation container styling
 //============================
 .navbar-static-side-container-dark {
-  background-color: @navbar-side-container-dark;
+    background-color: @navbar-side-container-dark;
 }
 
 .navbar-static-side-container-light {
- background-color: @navbar-side-container-light;
- .nav-header-dark {
-  border-bottom: 0;
- }
+    background-color: @navbar-side-container-light;
+
+    .nav-header-dark {
+        border-bottom: 0;
+    }
 }
 
 //============================
 //Left navigation styling
 //============================
-
 .navbar-static-side-dark {
-  &> .nav > li:nth-child(2) {
-    margin-top: 25px;
-  }
-  background-color: @navbar-side-container-dark;
-  .nav > li > a {
-    color: @grey5;
-    font-weight:300;
-  }
-  .nav-fourth-level, .nav-fifth-level {
-      &>li > a {
-        color: @nav-fifth-level-color-dark;
-      }
-   }
-  .nav > li.active > a {
-    color: @white;
-    .font-semibold;
-  }
-  &.navbar-default .nav > li > a {
-    &:hover {
-      background-color: lighten(@navbar-side-container-dark, 5%);
-      color: @white;
-   }
-   &:focus {
-     color: @white;
-     background-color: lighten(@navbar-side-container-dark, 5%);
-   }
-  }
-   .nav > li {
-    &.active {
-      border-left: 4px solid darken(@primary, 5%);
+    & > .nav > li:nth-child(2) {
+        margin-top: 25px;
     }
-   }
-   .logo-element, .logo-element-image {
-     color: @white;
-   }
-   .nav-header-dark {
-     box-shadow: 0px 5px 10px 0px rgba(255,255,255,0.05);
-   }
+
+    background-color: @navbar-side-container-dark;
+
+    .nav > li > a {
+        color: @grey5;
+        font-weight: 300;
+    }
+
+    .nav-fourth-level,
+    .nav-fifth-level {
+        & > li > a {
+            color: @nav-fifth-level-color-dark;
+        }
+    }
+
+    .nav > li.active > a {
+        color: @white;
+        .font-semibold;
+    }
+
+    &.navbar-default .nav > li > a {
+        &:hover {
+            background-color: lighten(@navbar-side-container-dark, 5%);
+            color: @white;
+        }
+
+        &:focus {
+            color: @white;
+            background-color: lighten(@navbar-side-container-dark, 5%);
+        }
+    }
+
+    .nav > li {
+        &.active {
+            border-left: 4px solid darken(@primary, 5%);
+        }
+    }
+
+    .logo-element,
+    .logo-element-image {
+        color: @white;
+    }
+
+    .nav-header-dark {
+        box-shadow: 0 5px 10px 0 rgba(255, 255, 255, 0.05);
+    }
 }
 
 .navbar-static-side-light {
-  &> .nav > li:nth-child(2) {
-    margin-top: 25px;
-  }
-  background-color: @navbar-side-container-light;
-  .nav > li > a {
-    color: @grey2;
-    font-weight: 400;
-  }
-  .nav-fourth-level, .nav-fifth-level {
-   &>li > a {
-     color: @nav-fifth-level-color;
-   }
-  }
-  .nav > li {
-    &.active > a {
-      .font-semibold;
+    & > .nav > li:nth-child(2) {
+        margin-top: 25px;
     }
-  }
-  &.navbar-default {
+
+    background-color: @navbar-side-container-light;
+
     .nav > li > a {
-      &:hover {
-        background-color: darken(@navbar-side-container-light, 4%);
         color: @grey2;
-      }
-      &:focus {
+        font-weight: 400;
+    }
+
+    .nav-fourth-level,
+    .nav-fifth-level {
+        & > li > a {
+            color: @nav-fifth-level-color;
+        }
+    }
+
+    .nav > li {
+        &.active > a {
+            .font-semibold;
+        }
+    }
+
+    &.navbar-default {
+        .nav > li > a {
+            &:hover {
+                background-color: darken(@navbar-side-container-light, 4%);
+                color: @grey2;
+            }
+
+            &:focus {
+                color: @grey2;
+                background-color: darken(@navbar-side-container-light, 4%);
+            }
+        }
+    }
+
+    .nav > li {
+        &.active {
+            border-left: 4px solid @navbar-side-active-border;
+        }
+    }
+
+    .logo-element,
+    .logo-element-image {
         color: @grey2;
-		    background-color: darken(@navbar-side-container-light, 4%);
-      }
     }
-  }
-   .nav > li {
-    &.active {
-      border-left: 4px solid @navbar-side-active-border;
+
+    .nav-header-light {
+        box-shadow: 0 5px 10px 0 rgba(51, 51, 51, 0.05);
     }
-   }
-   .logo-element, .logo-element-image {
-     color: @grey2;
-   }
-  .nav-header-light {
-    box-shadow: 0px 5px 10px 0px rgba(51,51,51,0.05);
-  }
 }
 
 //============================
 //Left header navigation styling
 //============================
-
-
 .nav-header-dark {
-  background-color: @navbar-menu-btn-container-bg-dark;
-  color : @white;
-  transition: all 0s ease 0s;
-  .logo-element, .logo-element-image {
-    background: url(../img/UX-graphic.png) no-repeat;
-    background-size: contain;
-    background-position: center;
-  }
+    background-color: @navbar-menu-btn-container-bg-dark;
+    color: @white;
+    transition: all 0s ease 0s;
+
+    .logo-element,
+    .logo-element-image {
+        background: url(../img/UX-graphic.png) no-repeat;
+        background-size: contain;
+        background-position: center;
+    }
 }
 
 .nav-header-light {
-  background-color: @navbar-menu-btn-container-bg-light;
-  color : @grey2;
-  transition: all 0s ease 0s;
-  .logo-element, .logo-element-image {
-    background: url(../img/UX-graphic.png) no-repeat;
-    background-size: contain;
-    background-position: center;
-  }
+    background-color: @navbar-menu-btn-container-bg-light;
+    color: @grey2;
+    transition: all 0s ease 0s;
+
+    .logo-element,
+    .logo-element-image {
+        background: url(../img/UX-graphic.png) no-repeat;
+        background-size: contain;
+        background-position: center;
+    }
 }
 
 //============================
 //Navigation Menu Toggle Button
 //============================
-
 .nav-menu-btn-container-dark {
- background-color: @navbar-menu-btn-container-bg-dark;
- a{
-   color: @white;
- }
+    background-color: @navbar-menu-btn-container-bg-dark;
 
- &:hover, &:focus {
-  color: @white;
- }
+    a {
+        color: @white;
+    }
+
+    &:hover,
+    &:focus {
+        color: @white;
+    }
 }
 
 .nav-menu-btn-container-light {
- background-color: @navbar-menu-btn-container-bg-light;
- a{
-   color: @grey2;
- }
-  &:hover, &:focus {
-   color: @grey2;
-  }
+    background-color: @navbar-menu-btn-container-bg-light;
+
+    a {
+        color: @grey2;
+    }
+
+    &:hover,
+    &:focus {
+        color: @grey2;
+    }
 }
 
 //============================
 // Top Header
 //============================
 .page-content-navbar-top-dark {
-  .navbar-static-top {
-   border-left: 1px solid rgba(255,255,255,0.05);
-   &.condensed {
-    box-shadow:none;
-   }
-   background-color: @navbar-bg-dark;
-    .navbar-form-search {
-      .placeholder(@white);
-      .form-control {
-        &:focus {
-          -webkit-text-fill-color: @white;
-          box-shadow: 0 0 0px 1000px @navbar-bg-dark inset;
-          color: @white;
-        }
-      }
+    .navbar-static-top {
+        border-left: 1px solid rgba(255, 255, 255, 0.05);
 
-     .expanded {
-         input {
-           border-bottom: 1px solid @navbar-search-expanded-border !important;
-         }
-         .input-group-btn {
-          .btn {
-            border-bottom: 1px solid @navbar-search-expanded-btn-border;
-          }
-         }
-       }
-    .expand-input {
-      .input-group-btn {
-        .btn {
-          color: @white;
+        &.condensed {
+            box-shadow: none;
         }
-       }
-      .input-group-addon {
-        a {
-          color: @white;
+
+        background-color: @navbar-bg-dark;
+
+        .navbar-form-search {
+            .placeholder(@white);
+
+            .form-control {
+                &:focus {
+                    -webkit-text-fill-color: @white;
+                    box-shadow: 0 0 0 1000px @navbar-bg-dark inset;
+                    color: @white;
+                }
+            }
+
+            .expanded {
+                input {
+                    border-bottom: 1px solid @navbar-search-expanded-border !important;
+                }
+
+                .input-group-btn {
+                    .btn {
+                        border-bottom: 1px solid @navbar-search-expanded-btn-border;
+                    }
+                }
+            }
+
+            .expand-input {
+                .input-group-btn {
+                    .btn {
+                        color: @white;
+                    }
+                }
+
+                .input-group-addon {
+                    a {
+                        color: @white;
+                    }
+                }
+            }
         }
-       }
-     }
+
+        .primary-bg {
+            background-color: @navbar-bg-dark;
+            color: @white;
+        }
+
+        .nav {
+            &.navbar-right {
+                & > li > a {
+                    color: @white;
+                    padding: 20px 10px;
+                    height: 57px;
+                }
+            }
+        }
+
+        .nav.navbar-top-links > li > a:hover,
+        .nav.navbar-top-links > li > a:focus,
+        .nav.navbar-top-links > .open > a,
+        .nav.navbar-top-links > .open > a:hover,
+        .nav.navbar-top-links > .open > a:focus {
+            background-color: lighten(@navbar-bg-dark, 10%);
+        }
+
+        .navbar-top-links {
+            .navbar-top-link {
+                color: @white;
+            }
+        }
     }
-    .primary-bg {
-      background-color: @navbar-bg-dark;
-      color: @white;
-    }
-    .nav {
-      &.navbar-right {
-       &> li > a {
-           color: @white;
-           padding: 20px 10px;
-           height: 57px;
-         }
-       }
-    }
-    .nav.navbar-top-links > li > a:hover,
-    .nav.navbar-top-links > li > a:focus,
-    .nav.navbar-top-links > .open > a,
-    .nav.navbar-top-links > .open > a:hover,
-    .nav.navbar-top-links > .open > a:focus {
-       background-color: lighten(@navbar-bg-dark, 10%);
-    }
-    .navbar-top-links {
-      .navbar-top-link {
-        color: @white;
-      }
-    }
-  }
 }
 
 .page-content-navbar-top-light {
-  .navbar-static-top {
-   border-left: 1px solid rgba(51,51,51,0.05);
-   box-shadow: 0px 5px 10px rgba(51,51,51,0.05);
-   &.condensed {
-       box-shadow:none;
-   }
-   background-color: @navbar-bg-light;
-   .navbar-form-search {
-     .form-control {
-       .placeholder(@grey2);
-       &:focus {
-        -webkit-text-fill-color: @grey2;
-        color: @grey2;
-       }
-     }
-    .expanded {
-       input {
-         border-bottom: 1px solid rgba(51,51,51,0.5) !important;
-       }
-       .input-group-btn {
-        .btn {
-          border-bottom: 1px solid rgba(51,51,51,0.6);
+    .navbar-static-top {
+        border-left: 1px solid rgba(51, 51, 51, 0.05);
+        box-shadow: 0 5px 10px rgba(51, 51, 51, 0.05);
+
+        &.condensed {
+            box-shadow: none;
         }
-       }
-     }
-    .expand-input {
-      .input-group-btn {
-        .btn {
-          color: @grey2;
-        }
-       }
-      .input-group-addon {
-        a {
-          color: @grey2;
-        }
-       }
-     }
-   }
-   .primary-bg {
-     background-color: @navbar-bg-light;
-     color: @grey2;
-   }
-   .nav {
-    &.navbar-right {
-      &> li > a {
-        color: @grey2;
-        padding: 20px 10px;
-        height: 57px;
-      }
-    }
-   }
-  .nav.navbar-top-links > li > a:hover,
-  .nav.navbar-top-links > li > a:focus,
-  .nav.navbar-top-links > .open > a,
-  .nav.navbar-top-links > .open > a:hover,
-  .nav.navbar-top-links > .open > a:focus {
-    background-color: darken(@navbar-bg-light, 3%);
-  }
-  .navbar-top-links {
-    .navbar-top-link {
-      color: @grey2;
-    }
-  }
-  .navbar-top-links {
-      .navbar-top-link {
-        &.help {
-          margin-right: 0;
-          .count-info {
-            padding: 20px 10px;
-            height: 57px;
-            white-space: nowrap;
-            &:hover, &:focus {
-              cursor: pointer;
-              background-color: darken(@navbar-bg-light, 3%);
+
+        background-color: @navbar-bg-light;
+
+        .navbar-form-search {
+            .form-control {
+                .placeholder(@grey2);
+
+                &:focus {
+                    -webkit-text-fill-color: @grey2;
+                    color: @grey2;
+                }
             }
-          }
+
+            .expanded {
+                input {
+                    border-bottom: 1px solid rgba(51, 51, 51, 0.5) !important;
+                }
+
+                .input-group-btn {
+                    .btn {
+                        border-bottom: 1px solid rgba(51, 51, 51, 0.6);
+                    }
+                }
+            }
+
+            .expand-input {
+                .input-group-btn {
+                    .btn {
+                        color: @grey2;
+                    }
+                }
+
+                .input-group-addon {
+                    a {
+                        color: @grey2;
+                    }
+                }
+            }
         }
-        .helpCenter {
-          margin-top: 25px;
+
+        .primary-bg {
+            background-color: @navbar-bg-light;
+            color: @grey2;
         }
-      }
+
+        .nav {
+            &.navbar-right {
+                & > li > a {
+                    color: @grey2;
+                    padding: 20px 10px;
+                    height: 57px;
+                }
+            }
+        }
+
+        .nav.navbar-top-links > li > a:hover,
+        .nav.navbar-top-links > li > a:focus,
+        .nav.navbar-top-links > .open > a,
+        .nav.navbar-top-links > .open > a:hover,
+        .nav.navbar-top-links > .open > a:focus {
+            background-color: darken(@navbar-bg-light, 3%);
+        }
+
+        .navbar-top-links {
+            .navbar-top-link {
+                color: @grey2;
+            }
+        }
+
+        .navbar-top-links {
+            .navbar-top-link {
+                &.help {
+                    margin-right: 0;
+
+                    .count-info {
+                        padding: 20px 10px;
+                        height: 57px;
+                        white-space: nowrap;
+
+                        &:hover,
+                        &:focus {
+                            cursor: pointer;
+                            background-color: darken(@navbar-bg-light, 3%);
+                        }
+                    }
+                }
+
+                .helpCenter {
+                    margin-top: 25px;
+                }
+            }
+        }
     }
-  }
 }
 
 .hidden-navbar.hide-navbar {
- //============================
- //Left navigation container styling
- //============================
- .navbar-static-side-container-dark {
-   background-color: @navbar-side-container-dark;
- }
-
- .navbar-static-side-container-light {
-  .nav-menu-btn-container-light {
-    padding-top: 15px;
-  }
-  background-color: @navbar-side-container-light;
-  .nav-header-dark {
-   border-bottom: 0;
-  }
- }
-
- //============================
- //Left navigation styling
- //============================
-
- .navbar-static-side-dark {
-   &> .nav > li:nth-child(2) {
-     margin-top: 25px;
-   }
-   background-color: @navbar-side-container-dark;
-   .nav > li > a {
-     color: @grey5;
-     font-weight:300;
-   }
-   .nav-fourth-level, .nav-fifth-level {
-    &>li > a {
-      color: @nav-fifth-level-color-dark;
+    //============================
+    //Left navigation container styling
+    //============================
+    .navbar-static-side-container-dark {
+        background-color: @navbar-side-container-dark;
     }
-   }
-   .nav > li.active > a {
-     color: @white;
-     font-weight: 500;
-   }
-   &.navbar-default .nav > li > a {
-     &:hover {
-       background-color: lighten(@navbar-side-container-dark, 5%);
-       color: @white;
-    }
-    &:focus {
-      background-color: lighten(@navbar-side-container-dark, 5%);
-      color: @white;
-    }
-   }
-    .nav > li.active {
-      border-left: 4px solid darken(@primary, 5%);
-    }
-    .logo-element, .logo-element-image {
-      color: @white;
-    }
-    .nav-header-dark {
-      box-shadow: 0px 10px 10px 0px rgba(255,255,255,0.05);
-    }
- }
 
-.navbar-static-side-light {
-   &> .nav > li:nth-child(2) {
-     margin-top: 25px;
-   }
-   background-color: @navbar-side-container-light;
-   .nav > li > a {
-     color: @grey2;
-     font-weight: 400;
-   }
-   .nav > li.active > a {
-     font-weight: 600;
-   }
-   &.navbar-default .nav > li > a {
-     &:hover {
-       background-color: darken(@navbar-side-container-light, 4%);
-       color: @grey2;
-     }
-     &:focus {
-       background-color: darken(@navbar-side-container-light, 4%);
-       color: @grey2;
-     }
-   }
-    .nav > li.active {
-      border-left: 4px solid @navbar-side-active-border;
-    }
-    .logo-element, .logo-element-image {
-      color: @grey2;
-    }
-   .nav-header-light {
-     box-shadow: 0px 10px 10px 0px rgba(51,51,51,0.05);
-   }
- }
+    .navbar-static-side-container-light {
+        .nav-menu-btn-container-light {
+            padding-top: 15px;
+        }
 
- //============================
- //Navigation Menu Toggle Button
- //============================
+        background-color: @navbar-side-container-light;
 
-.nav-menu-btn-container-dark {
-  background-color: @grey2;
-}
+        .nav-header-dark {
+            border-bottom: 0;
+        }
+    } //============================
+    //Left navigation styling
+    //============================
+    .navbar-static-side-dark {
+        & > .nav > li:nth-child(2) {
+            margin-top: 25px;
+        }
 
-.nav-menu-btn-container-light {
-  background-color: @navbar-menu-btn-container-bg-light;
-  a{
-    color: @grey2;
-  }
-   &:hover, &:focus {
-    color: @grey2;
-   }
- }
+        background-color: @navbar-side-container-dark;
 
- //============================
- // Top Header
- //============================
-.page-content-navbar-top-dark {
-   .navbar-static-top {
-    border-left: 1px solid rgba(255,255,255,0.05);
-    &.condensed {
-     box-shadow:none;
-    }
-    background-color: @grey2;
-     .navbar-form-search {
-       .placeholder(@white);
-       .form-control {
-         &:focus {
-           -webkit-text-fill-color: @white;
-           box-shadow: 0 0 0px 1000px @navbar-bg-dark inset;
-           color: @white;
-         }
-       }
+        .nav > li > a {
+            color: @grey5;
+            font-weight: 300;
+        }
 
-      .expanded {
-          input {
-            border-bottom: 1px solid rgba(255,255,255,0.5) !important;
-          }
-          .input-group-btn {
-            .btn {
-              border-bottom: 1px solid rgba(255,255,255,0.6);
+        .nav-fourth-level,
+        .nav-fifth-level {
+            & > li > a {
+                color: @nav-fifth-level-color-dark;
             }
-          }
         }
-    .expand-input {
-      .input-group-btn {
-        .btn {
-          color: @white;
+
+        .nav > li.active > a {
+            color: @white;
+            font-weight: 500;
         }
-      }
-      .input-group-addon {
-        a {
-          color: @white;
+
+        &.navbar-default .nav > li > a {
+            &:hover {
+                background-color: lighten(@navbar-side-container-dark, 5%);
+                color: @white;
+            }
+
+            &:focus {
+                background-color: lighten(@navbar-side-container-dark, 5%);
+                color: @white;
+            }
         }
-      }
-    }
-     }
-     .primary-bg {
-       background-color: @grey2;
-       color: @white;
-     }
-     .nav {
-      &.navbar-right {
-        &> li > a {
+
+        .nav > li.active {
+            border-left: 4px solid darken(@primary, 5%);
+        }
+
+        .logo-element,
+        .logo-element-image {
             color: @white;
         }
-      }
-     }
-     .nav.navbar-top-links > li > a:hover,
-     .nav.navbar-top-links > li > a:focus,
-     .nav.navbar-top-links > .open > a,
-     .nav.navbar-top-links > .open > a:hover,
-     .nav.navbar-top-links > .open > a:focus {
-        background-color: lighten(@navbar-bg-dark, 10%);
-     }
-     .navbar-top-links {
-      .navbar-top-link {
-        color: @white;
-      }
-     }
-   }
- }
 
-.page-content-navbar-top-light {
-   .navbar-static-top {
-    border-left: 1px solid rgba(51,51,51,0.05);
-    box-shadow: 0px 10px 10px rgba(51,51,51,0.05);
-    &.condensed {
-        box-shadow:none;
+        .nav-header-dark {
+            box-shadow: 0 10px 10px 0 rgba(255, 255, 255, 0.05);
+        }
     }
-    background-color: @navbar-bg-light;
-    .navbar-form-search {
-      .form-control {
-        .placeholder(@grey2);
-        &:focus {
-         -webkit-text-fill-color: @grey2;
-         color: @white;
+
+    .navbar-static-side-light {
+        & > .nav > li:nth-child(2) {
+            margin-top: 25px;
         }
-      }
-     .expanded {
-        input {
-          border-bottom: 1px solid rgba(51,51,51,0.5) !important;
+
+        background-color: @navbar-side-container-light;
+
+        .nav > li > a {
+            color: @grey2;
+            font-weight: 400;
         }
-        .input-group-btn {
-          .btn {
-            border-bottom: 1px solid rgba(51,51,51,0.6);
-          }
+
+        .nav > li.active > a {
+            font-weight: 600;
         }
-      }
-     .expand-input {
-       .input-group-btn {
-        .btn {
-          color: @grey2;
+
+        &.navbar-default .nav > li > a {
+            &:hover {
+                background-color: darken(@navbar-side-container-light, 4%);
+                color: @grey2;
+            }
+
+            &:focus {
+                background-color: darken(@navbar-side-container-light, 4%);
+                color: @grey2;
+            }
         }
-      }
-       .input-group-addon {
+
+        .nav > li.active {
+            border-left: 4px solid @navbar-side-active-border;
+        }
+
+        .logo-element,
+        .logo-element-image {
+            color: @grey2;
+        }
+
+        .nav-header-light {
+            box-shadow: 0 10px 10px 0 rgba(51, 51, 51, 0.05);
+        }
+    } //============================
+    //Navigation Menu Toggle Button
+    //============================
+    .nav-menu-btn-container-dark {
+        background-color: @grey2;
+    }
+
+    .nav-menu-btn-container-light {
+        background-color: @navbar-menu-btn-container-bg-light;
+
         a {
-          color: @grey2;
+            color: @grey2;
         }
-      }
-     }
+
+        &:hover,
+        &:focus {
+            color: @grey2;
+        }
+    } //============================
+    // Top Header
+    //============================
+    .page-content-navbar-top-dark {
+        .navbar-static-top {
+            border-left: 1px solid rgba(255, 255, 255, 0.05);
+
+            &.condensed {
+                box-shadow: none;
+            }
+
+            background-color: @grey2;
+
+            .navbar-form-search {
+                .placeholder(@white);
+
+                .form-control {
+                    &:focus {
+                        -webkit-text-fill-color: @white;
+                        box-shadow: 0 0 0 1000px @navbar-bg-dark inset;
+                        color: @white;
+                    }
+                }
+
+                .expanded {
+                    input {
+                        border-bottom: 1px solid rgba(255, 255, 255, 0.5) !important;
+                    }
+
+                    .input-group-btn {
+                        .btn {
+                            border-bottom: 1px solid rgba(255, 255, 255, 0.6);
+                        }
+                    }
+                }
+
+                .expand-input {
+                    .input-group-btn {
+                        .btn {
+                            color: @white;
+                        }
+                    }
+
+                    .input-group-addon {
+                        a {
+                            color: @white;
+                        }
+                    }
+                }
+            }
+
+            .primary-bg {
+                background-color: @grey2;
+                color: @white;
+            }
+
+            .nav {
+                &.navbar-right {
+                    & > li > a {
+                        color: @white;
+                    }
+                }
+            }
+
+            .nav.navbar-top-links > li > a:hover,
+            .nav.navbar-top-links > li > a:focus,
+            .nav.navbar-top-links > .open > a,
+            .nav.navbar-top-links > .open > a:hover,
+            .nav.navbar-top-links > .open > a:focus {
+                background-color: lighten(@navbar-bg-dark, 10%);
+            }
+
+            .navbar-top-links {
+                .navbar-top-link {
+                    color: @white;
+                }
+            }
+        }
     }
-    .primary-bg {
-      background-color: @navbar-bg-light;
-      color: @grey2;
+
+    .page-content-navbar-top-light {
+        .navbar-static-top {
+            border-left: 1px solid rgba(51, 51, 51, 0.05);
+            box-shadow: 0 10px 10px rgba(51, 51, 51, 0.05);
+
+            &.condensed {
+                box-shadow: none;
+            }
+
+            background-color: @navbar-bg-light;
+
+            .navbar-form-search {
+                .form-control {
+                    .placeholder(@grey2);
+
+                    &:focus {
+                        -webkit-text-fill-color: @grey2;
+                        color: @white;
+                    }
+                }
+
+                .expanded {
+                    input {
+                        border-bottom: 1px solid rgba(51, 51, 51, 0.5) !important;
+                    }
+
+                    .input-group-btn {
+                        .btn {
+                            border-bottom: 1px solid rgba(51, 51, 51, 0.6);
+                        }
+                    }
+                }
+
+                .expand-input {
+                    .input-group-btn {
+                        .btn {
+                            color: @grey2;
+                        }
+                    }
+
+                    .input-group-addon {
+                        a {
+                            color: @grey2;
+                        }
+                    }
+                }
+            }
+
+            .primary-bg {
+                background-color: @navbar-bg-light;
+                color: @grey2;
+            }
+
+            .nav {
+                &.navbar-right {
+                    & > li > a {
+                        color: @grey2;
+                    }
+                }
+            }
+
+            .nav.navbar-top-links > li > a:hover,
+            .nav.navbar-top-links > li > a:focus,
+            .nav.navbar-top-links > .open > a,
+            .nav.navbar-top-links > .open > a:hover,
+            .nav.navbar-top-links > .open > a:focus {
+                background-color: darken(@navbar-bg-light, 3%);
+            }
+
+            .navbar-top-links {
+                .navbar-top-link {
+                    color: @grey2;
+                }
+            }
+        }
     }
-    .nav {
-      &.navbar-right {
-       &> li > a {
-           color: @grey2;
-         }
-      }
-    }
-   .nav.navbar-top-links > li > a:hover,
-   .nav.navbar-top-links > li > a:focus,
-   .nav.navbar-top-links > .open > a,
-   .nav.navbar-top-links > .open > a:hover,
-   .nav.navbar-top-links > .open > a:focus {
-     background-color: darken(@navbar-bg-light, 3%);
-   }
-   .navbar-top-links {
-    .navbar-top-link {
-      color: @grey2;
-    }
-   }
-   }
- }
 }
 
- //============================
- // Center Panel
- //============================
-
-.body-dark {
-  background: @body-bg-dark;
-  .page-content {
-    background: @body-bg-dark;
-    .navbar-static-top {
-      box-shadow: none;
-    }
-    .hpebox-title, .hpebox-content, .ebox-title, .ebox-content {
-       background: @ebox-title-bg-dark;
-       color: @ebox-title-color-dark;
-    }
-    .hpebox-content, .ebox-content {
-      border-color: @ebox-border-dark;
-    }
-  }
-  hr {
-    border-top: 1px solid @hr-dark-border;
-  }
-}
-
+//============================
+// Center Panel
+//============================
 .body-light {
-  background: @body-bg;
-  .page-content {
     background: @body-bg;
-    .hpebox-title, .hpebox-content, .ebox-title, .ebox-content {
-      background: @ebox-title-bg;
-      color: @text-color;
+
+    .page-content {
+        background: @body-bg;
+
+        .hpebox-title,
+        .hpebox-content,
+        .ebox-title,
+        .ebox-content {
+            background: @ebox-title-bg;
+            color: @text-color;
+        }
+
+        .hpebox-content,
+        .ebox-content {
+            border-color: @ebox-border;
+        }
     }
-    .hpebox-content, .ebox-content {
-      border-color: @ebox-border;
-    }
-   }
 }
-
-
-
-

--- a/src/styles/timeline.less
+++ b/src/styles/timeline.less
@@ -2,357 +2,329 @@
     padding: 0;
     list-style: none;
     position: relative;
-  
+
     &:before {
-      top: 0;
-      bottom: 0;
-      position: absolute;
-      content: " ";
-      width: 2px;
-      background-color: @timeline-color;
-      left: 50%;
-      margin-left: -1.5px;
-    }
-  
-    li {
-      margin-bottom: 20px;
-      position: relative;
-  
-      .timeline-footer {
-        margin-top: 10px;
-        padding: 10px 0;
-      }
-  
-      .timeline-title {
-        margin-top: 0;
-      }
-    }
-  }
-  
-  .body-dark {
-    .timeline {
-      &:before {
-        background-color: @timeline-bg-dark;
-      }
-    }
-  }
-  .timeline {
-  
-    &.hp-timeline-down-arrow {
-      
-      &:after:extend(.hpe-chevron-down:before) {
-        font-family: 'hpe-icons';
+        top: 0;
+        bottom: 0;
         position: absolute;
-        color: @timeline-color;
-        left: 56px;
-        bottom: -9px;
-        transform: translateX(-0.5px);
-      }
-    }
-  }
-  
-  .body-dark {
-    .timeline {
-      &.hp-timeline-down-arrow {
-        &:after {
-          color: @timeline-arrow-color-dark;
-        }
-      }
-    }
-  }
-  .timeline {
-    li {
-      timeline-badge {
-        &.critical {
-          background-color: @timeline-badge-critical !important;
-        }
-        &.success {
-          background-color: @timeline-badge-success !important;
-        }
-        &.warning {
-          background-color: @timeline-badge-warning !important;
-        }
-        &.info, &.accent {
-          background-color: @timeline-badge-accent !important;
-        }
-        &.primary {
-          background-color: @timeline-badge-primary !important;
-        }
-        &.alternate1 {
-          background-color: @timeline-badge-alternate1 !important;
-        }
-        &.alternate2 {
-          background-color: @timeline-badge-alternate2 !important;
-        }
-        &.alternate3 {
-          background-color: @timeline-badge-alternate3 !important;
-        }
-        &.vibrant1 {
-          background-color: @timeline-badge-vibrant1 !important;
-        }
-        &.vibrant2 {
-          background-color: @timeline-badge-vibrant2 !important;
-        }
-        &.grey1 {
-          background-color: @timeline-badge-grey1 !important;
-        }
-        &.grey2 {
-          background-color: @timeline-badge-grey2 !important;
-        }
-        &.grey3 {
-          background-color: @timeline-badge-grey3 !important;
-        }
-        &.grey4 {
-          background-color: @timeline-badge-grey4 !important;
-        }
-        &.grey5 {
-          background-color: @timeline-badge-grey5 !important;
-        }
-      }
-    }
-  }
-  
-  .timeline {
-    li {
-      timeline-panel> * {
-        margin: 0;
-      }
-    }
-  }
-  
-  .timeline {
-    li {
-      timeline-panel {
-        background-color: @timeline-panel-bg;
-        float: left;
-        border: 1px solid @timeline-panel-border;
-        border-radius: 2px;
-        padding: 12px;
-        position: relative;
-        -webkit-box-shadow: @timeline-panel-shadow;
-        box-shadow: @timeline-panel-shadow;
-      }
-    }
-  }
-  
-  .body-dark {
-    .timeline {
-      li {
-        timeline-panel {
-          background-color: @timeline-panel-bg-dark;
-          border: 1px solid @timeline-panel-border-dark !important;
-          -webkit-box-shadow: 0 1px 6px @timeline-panel-shadow-dark !important;
-          box-shadow: 0 1px 6px @timeline-panel-shadow-dark !important;
-        }
-      }
-    }
-  }
-  
-  .timeline {
-    li {
-      timeline-panel {
-        &:before {
-          position: absolute;
-          top: 40px;
-          right: -8px;
-          display: inline-block;
-          border-top: 8px solid transparent;
-          border-left: 8px solid @timeline-panel-border;
-          border-right: 0 solid @timeline-panel-border;
-          border-bottom: 8px solid transparent;
-          content: " ";
-        }
-      }
-    }
-  }
-  
-  .body-dark {
-    .timeline {
-      li {
-        timeline-panel {
-          &:before {
-            border-left: 8px solid @timeline-panel-border-dark;
-            border-right: 0 solid @timeline-panel-border-dark;
-          }
-        }
-      }
-    }
-  }
-  
-  .timeline {
-    li {
-      timeline-panel {
-        &:after {
-          position: absolute;
-          top: 41px;
-          right: -14px;
-          display: inline-block;
-          border-top: 7px solid transparent;
-          border-left: 7px solid @timeline-panel-bg;
-          border-right: 0 solid @timeline-panel-bg;
-          border-bottom: 7px solid transparent;
-          content: " ";
-        }
-      }
-    }
-  }
-  
-  .body-dark {
-    .timeline {
-      li {
-        timeline-panel {
-          &:after {
-            border-left: 7px solid @timeline-panel-bg-dark;
-            border-right: 0 solid @timeline-panel-bg-dark;
-          }
-        }
-      }
-    }
-  }
-  
-  .timeline {
-    li {
-      timeline-badge {
-        color: @timeline-badge-color;
-        width: 100px;
-        max-width: 100px;
-        max-height: 100px;
-        line-height: 25px;
-        font-size: 0.9em;
-        text-align: center;
-        position: absolute;
-        top: 26px;
+        content: " ";
+        width: 2px;
+        background-color: @timeline-color;
         left: 50%;
-        margin-left: -25px;
-        padding: 0 15px 0 15px;
-        background-color: @timeline-bg;
-        z-index: 100;
-        border-radius: 1.25em;
-      }
+        margin-left: -1.5px;
     }
-  }
-  
-  .timeline {
+
     li {
-      &.timeline-inverted {
-        timeline-panel {
-          float: right;
-          &:before {
-            border-left-width: 0;
-            border-right-width: 8px;
-            left: -8px;
-            right: auto;
-          }
-          :after {
-            border-left-width: 0;
-            border-right-width: 8px;
-            left: -7px;
-            right: auto;
-          }
+        margin-bottom: 20px;
+        position: relative;
+
+        .timeline-footer {
+            margin-top: 10px;
+            padding: 10px 0;
         }
-      }
+
+        .timeline-title {
+            margin-top: 0;
+        }
     }
-  }
-  
-  .timeline-heading {
+}
+
+.timeline {
+    &.hp-timeline-down-arrow {
+        &:after {
+            font-family: 'hpe-icons';
+            position: absolute;
+            color: @timeline-color;
+            left: 56px;
+            bottom: -9px;
+            transform: translateX(-0.5px);
+            &:extend(.hpe-chevron-down:before);
+        }
+    }
+}
+
+.timeline {
+    li {
+        timeline-badge {
+            &.critical {
+                background-color: @timeline-badge-critical !important;
+            }
+
+            &.success {
+                background-color: @timeline-badge-success !important;
+            }
+
+            &.warning {
+                background-color: @timeline-badge-warning !important;
+            }
+
+            &.info,
+            &.accent {
+                background-color: @timeline-badge-accent !important;
+            }
+
+            &.primary {
+                background-color: @timeline-badge-primary !important;
+            }
+
+            &.alternate1 {
+                background-color: @timeline-badge-alternate1 !important;
+            }
+
+            &.alternate2 {
+                background-color: @timeline-badge-alternate2 !important;
+            }
+
+            &.alternate3 {
+                background-color: @timeline-badge-alternate3 !important;
+            }
+
+            &.vibrant1 {
+                background-color: @timeline-badge-vibrant1 !important;
+            }
+
+            &.vibrant2 {
+                background-color: @timeline-badge-vibrant2 !important;
+            }
+
+            &.grey1 {
+                background-color: @timeline-badge-grey1 !important;
+            }
+
+            &.grey2 {
+                background-color: @timeline-badge-grey2 !important;
+            }
+
+            &.grey3 {
+                background-color: @timeline-badge-grey3 !important;
+            }
+
+            &.grey4 {
+                background-color: @timeline-badge-grey4 !important;
+            }
+
+            &.grey5 {
+                background-color: @timeline-badge-grey5 !important;
+            }
+        }
+    }
+}
+
+.timeline {
+    li {
+        timeline-panel > * {
+            margin: 0;
+        }
+    }
+}
+
+.timeline {
+    li {
+        timeline-panel {
+            background-color: @timeline-panel-bg;
+            float: left;
+            border: 1px solid @timeline-panel-border;
+            border-radius: 2px;
+            padding: 12px;
+            position: relative;
+            -webkit-box-shadow: @timeline-panel-shadow;
+            box-shadow: @timeline-panel-shadow;
+        }
+    }
+}
+
+.timeline {
+    li {
+        timeline-panel {
+            &:before {
+                position: absolute;
+                top: 40px;
+                right: -8px;
+                display: inline-block;
+                border-top: 8px solid transparent;
+                border-left: 8px solid @timeline-panel-border;
+                border-right: 0 solid @timeline-panel-border;
+                border-bottom: 8px solid transparent;
+                content: " ";
+            }
+        }
+    }
+}
+
+.timeline {
+    li {
+        timeline-panel {
+            &:after {
+                position: absolute;
+                top: 41px;
+                right: -14px;
+                display: inline-block;
+                border-top: 7px solid transparent;
+                border-left: 7px solid @timeline-panel-bg;
+                border-right: 0 solid @timeline-panel-bg;
+                border-bottom: 7px solid transparent;
+                content: " ";
+            }
+        }
+    }
+}
+
+.timeline {
+    li {
+        timeline-badge {
+            color: @timeline-badge-color;
+            width: 100px;
+            max-width: 100px;
+            max-height: 100px;
+            line-height: 25px;
+            font-size: 0.9em;
+            text-align: center;
+            position: absolute;
+            top: 26px;
+            left: 50%;
+            margin-left: -25px;
+            padding: 0 15px;
+            background-color: @timeline-bg;
+            z-index: 100;
+            border-radius: 1.25em;
+        }
+    }
+}
+
+.timeline {
+    li {
+        &.timeline-inverted {
+            timeline-panel {
+                float: right;
+
+                &:before {
+                    border-left-width: 0;
+                    border-right-width: 8px;
+                    left: -8px;
+                    right: auto;
+                }
+
+                :after {
+                    border-left-width: 0;
+                    border-right-width: 8px;
+                    left: -7px;
+                    right: auto;
+                }
+            }
+        }
+    }
+}
+
+.timeline-heading {
     .hp-icon,
     .hpe-icon {
-      margin-right: 4px;
-      vertical-align: -1px;
+        margin-right: 4px;
+        vertical-align: -1px;
     }
-  }
-  
-  .timeline {
+}
+
+.timeline {
     li {
-      &:before,
-      &:after {
-        content: " ";
-        display: table;
-      }
+        &:before,
+        &:after {
+            content: " ";
+            display: table;
+        }
     }
-  }
-  
-  .timeline {
+}
+
+.timeline {
     li {
-      &:after {
-        clear: both;
-      }
+        &:after {
+            clear: both;
+        }
     }
-  }
-  
-  @media only screen and (min-width: 768px) {
+}
+
+@media only screen and (min-width: 768px) {
     timeline[side="right"] ul.timeline:before {
-      left: 64px;
+        left: 64px;
     }
+
     timeline[side="alternate"] ul.timeline:before {
-      left: ~'calc(50% + 25px)';
+        left: ~'calc(50% + 25px)';
     }
+
     ul.timeline li timeline-panel {
-      width: ~'calc(100% - 135px)';
-      width: ~'-moz-calc(100% - 135px)';
-      width: ~'-webkit-calc(100% - 135px)';
+        width: ~'calc(100% - 135px)';
+        width: ~'-moz-calc(100% - 135px)';
+        width: ~'-webkit-calc(100% - 135px)';
     }
-  }
-  
-  @media only screen and (min-width: 768px) {
+}
+
+@media only screen and (min-width: 768px) {
     ul.timeline timeline-event[side="right"] li timeline-badge {
-      left: 15px;
-      margin-left: 0;
-      top: 36px;
+        left: 15px;
+        margin-left: 0;
+        top: 36px;
     }
+
     ul.timeline timeline-event[side="right"] li timeline-panel {
-      width: ~'calc(100% - 135px)';
-      width: ~'-moz-calc(100% - 135px)';
-      width: ~'-webkit-calc(100% - 135px)';
+        width: ~'calc(100% - 135px)';
+        width: ~'-moz-calc(100% - 135px)';
+        width: ~'-webkit-calc(100% - 135px)';
     }
+
     ul.timeline timeline-event[side="right"] li timeline-panel {
-      float: right;
+        float: right;
     }
+
     ul.timeline timeline-event[side="right"] li timeline-panel:before {
-      border-left-width: 0;
-      border-right-width: 8px;
-      left: -8px;
-      right: auto;
-      top: 40px;
+        border-left-width: 0;
+        border-right-width: 8px;
+        left: -8px;
+        right: auto;
+        top: 40px;
     }
+
     ul.timeline timeline-event[side="right"] li timeline-panel:after {
-      border-left-width: 0;
-      border-right-width: 8px;
-      right: auto;
-      left: -7px;
-      top: 41px;
+        border-left-width: 0;
+        border-right-width: 8px;
+        right: auto;
+        left: -7px;
+        top: 41px;
     }
-  }
-  
-  @media only screen and (max-width: 767px) {
+}
+
+@media only screen and (max-width: 767px) {
     ul.timeline:before {
-      left: 64px;
+        left: 64px;
     }
+
     ul.timeline li timeline-panel {
-      width: ~'calc(100% - 135px) !important';
-      width: ~'-moz-calc(100% - 135px) !important';
-      width: ~'-webkit-calc(100% - 135px) !important';
+        width: ~'calc(100% - 135px) !important';
+        width: ~'-moz-calc(100% - 135px) !important';
+        width: ~'-webkit-calc(100% - 135px) !important';
     }
+
     ul.timeline li timeline-badge {
-      left: 15px;
-      margin-left: 0;
-      top: 36px;
+        left: 15px;
+        margin-left: 0;
+        top: 36px;
     }
+
     ul.timeline li timeline-panel {
-      float: right;
+        float: right;
     }
+
     ul.timeline li timeline-panel:before {
-      border-left-width: 0;
-      border-right-width: 8px;
-      left: -8px;
-      right: auto;
-      top: 40px;
+        border-left-width: 0;
+        border-right-width: 8px;
+        left: -8px;
+        right: auto;
+        top: 40px;
     }
+
     ul.timeline li timeline-panel:after {
-      border-left-width: 0;
-      border-right-width: 8px;
-      right: auto;
-      left: -7px;
-      top: 41px;
+        border-left-width: 0;
+        border-right-width: 8px;
+        right: auto;
+        left: -7px;
+        top: 41px;
     }
-  }
+}

--- a/src/styles/tree-views.less
+++ b/src/styles/tree-views.less
@@ -110,8 +110,8 @@
     tree-node-expander {
         .toggle-children-wrapper {
             display: block;
-            padding: 0px 3px 5px 1px;
-            
+            padding: 0 3px 5px 1px;
+
             .toggle-children {
                 background-image: none;
                 font-family: 'hpe-icons';

--- a/src/styles/typography.less
+++ b/src/styles/typography.less
@@ -1,297 +1,282 @@
-@font-face{
+@font-face {
     font-family: 'Source Sans Pro';
     font-weight: 200;
     font-style: normal;
     font-stretch: normal;
-    src: url('../fonts/SourceSansPro-ExtraLight.otf') format('opentype')
-         url('../fonts/SourceSansPro-ExtraLight.woff') format('woff');
+    src: url('../fonts/SourceSansPro-ExtraLight.otf') format('opentype') url('../fonts/SourceSansPro-ExtraLight.woff') format('woff');
 }
 
-@font-face{
+@font-face {
     font-family: 'Source Sans Pro';
     font-weight: 300;
     font-style: normal;
     font-stretch: normal;
-    src: url('../fonts/SourceSansPro-Light.otf') format('opentype'),
-         url('../fonts/SourceSansPro-Light.woff') format('woff');
+    src: url('../fonts/SourceSansPro-Light.otf') format('opentype'), url('../fonts/SourceSansPro-Light.woff') format('woff');
 }
 
-@font-face{
+@font-face {
     font-family: 'Source Sans Pro';
     font-weight: 400;
     font-style: normal;
     font-stretch: normal;
-    src: url('../fonts/SourceSansPro-Regular.otf') format('opentype'),
-         url('../fonts/SourceSansPro-Regular.woff') format('woff');
+    src: url('../fonts/SourceSansPro-Regular.otf') format('opentype'), url('../fonts/SourceSansPro-Regular.woff') format('woff');
 }
 
-@font-face{
+@font-face {
     font-family: 'Source Sans Pro';
     font-weight: 600;
     font-style: normal;
     font-stretch: normal;
-    src: url('../fonts/SourceSansPro-Semibold.otf') format('opentype'),
-         url('../fonts/SourceSansPro-Semibold.woff') format('woff');
+    src: url('../fonts/SourceSansPro-Semibold.otf') format('opentype'), url('../fonts/SourceSansPro-Semibold.woff') format('woff');
 }
 
-@font-face{
+@font-face {
     font-family: 'Source Sans Pro';
     font-weight: 700;
     font-style: normal;
     font-stretch: normal;
-    src: url('../fonts/SourceSansPro-Bold.otf') format('opentype'),
-         url('../fonts/SourceSansPro-Bold.woff') format('woff');
+    src: url('../fonts/SourceSansPro-Bold.otf') format('opentype'), url('../fonts/SourceSansPro-Bold.woff') format('woff');
 }
 
-@font-face{
+@font-face {
     font-family: 'Source Sans Pro';
     font-weight: 900;
     font-style: normal;
     font-stretch: normal;
-    src: url('../fonts/SourceSansPro-Black.otf') format('opentype'),
-         url('../fonts/SourceSansPro-Black.woff') format('woff');
+    src: url('../fonts/SourceSansPro-Black.otf') format('opentype'), url('../fonts/SourceSansPro-Black.woff') format('woff');
 }
 
-@font-face{
+@font-face {
     font-family: 'Source Sans Pro';
     font-weight: 200;
     font-style: italic;
     font-stretch: normal;
-    src: url('../fonts/SourceSansPro-ExtraLightIt.woff') format('woff'),
-         url('../fonts/SourceSansPro-ExtraLightIt.otf') format('opentype');
+    src: url('../fonts/SourceSansPro-ExtraLightIt.woff') format('woff'), url('../fonts/SourceSansPro-ExtraLightIt.otf') format('opentype');
 }
 
-@font-face{
+@font-face {
     font-family: 'Source Sans Pro';
     font-weight: 400;
     font-style: italic;
     font-stretch: normal;
-    src: url('../fonts/SourceSansPro-It.woff') format('woff'),
-         url('../fonts/SourceSansPro-It.otf') format('opentype');
+    src: url('../fonts/SourceSansPro-It.woff') format('woff'), url('../fonts/SourceSansPro-It.otf') format('opentype');
 }
 
-@font-face{
+@font-face {
     font-family: 'Source Sans Pro';
     font-weight: 600;
     font-style: italic;
     font-stretch: normal;
-    src: url('../fonts/SourceSansPro-SemiboldIt.woff') format('woff'),
-         url('../fonts/SourceSansPro-SemiboldIt.otf') format('opentype');
+    src: url('../fonts/SourceSansPro-SemiboldIt.woff') format('woff'), url('../fonts/SourceSansPro-SemiboldIt.otf') format('opentype');
 }
 
-@font-face{
+@font-face {
     font-family: 'Source Sans Pro';
     font-weight: 700;
     font-style: italic;
     font-stretch: normal;
-    src: url('../fonts/SourceSansPro-BoldIt.woff') format('woff'),
-         url('../fonts/SourceSansPro-BoldIt.otf') format('opentype');
+    src: url('../fonts/SourceSansPro-BoldIt.woff') format('woff'), url('../fonts/SourceSansPro-BoldIt.otf') format('opentype');
 }
 
-@font-face{
+@font-face {
     font-family: 'Source Sans Pro';
     font-weight: 900;
     font-style: italic;
     font-stretch: normal;
-    src: url('../fonts/SourceSansPro-BlackIt.woff') format('woff'),
-         url('../fonts/SourceSansPro-BlackIt.otf') format('opentype');
+    src: url('../fonts/SourceSansPro-BlackIt.woff') format('woff'), url('../fonts/SourceSansPro-BlackIt.otf') format('opentype');
 }
 
 .font-regular {
-  font-family: @font-family;
-  font-weight: @font-weight;
-  font-style: normal;
+    font-family: @font-family;
+    font-weight: @font-weight;
+    font-style: normal;
 }
 
 .font-light {
- font-family: @font-family;
- font-weight: @font-weight-light;
- font-style: normal;
-}
-
-.font-semibold, .font-bold{
-  font-family: @font-family;
-  font-weight: @font-weight-semibold;
-}
-
-small{
-  font-weight: 300;
-}
-
-h1, h2, h3, h4, h5, h6 {
-  color: @headings-color;
-  font-family: @headings-font-family;
-  font-weight: @font-weight-light;
-}
-
-h1{
-  font-size: @font-size-h1;
-  font-weight: @font-weight-h1;
-
-  small{
-    font-size: 60%;
-    margin-left: 10px;
-    font-weight: @font-weight-light;
-  }
-}
-
-h2{
-  font-size: @font-size-h2;
-  font-weight: @font-weight-h2;
-
-  small{
-    font-size: 65%;
-    margin-left: 8px;
-    font-weight: @font-weight-light;
-  }
-}
-
-h3{
-  font-size: @font-size-h3;
-  font-weight: @font-weight-h3;
-
-  small{
-    font-size: 70%;
-    margin-left: 5px;
-    font-weight: @font-weight-light;
-  }
-}
-
-h4{
-  font-size: @font-size-h4;
-  font-weight: @font-weight-h4;
-
-  small{
     font-family: @font-family;
     font-weight: @font-weight-light;
-    font-size: 100%;
-    margin-left: 3px;
-  }
+    font-style: normal;
 }
 
-h5{
-  font-size: @font-size-h5;
-  font-weight: @font-weight-h5;
-  
-  small{
+.font-semibold,
+.font-bold {
     font-family: @font-family;
+    font-weight: @font-weight-semibold;
+}
+
+small {
+    font-weight: 300;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+    color: @headings-color;
+    font-family: @headings-font-family;
     font-weight: @font-weight-light;
-    font-size: 100%;
-    margin-left: 3px;
-  }
+}
+
+h1 {
+    font-size: @font-size-h1;
+    font-weight: @font-weight-h1;
+
+    small {
+        font-size: 60%;
+        margin-left: 10px;
+        font-weight: @font-weight-light;
+    }
+}
+
+h2 {
+    font-size: @font-size-h2;
+    font-weight: @font-weight-h2;
+
+    small {
+        font-size: 65%;
+        margin-left: 8px;
+        font-weight: @font-weight-light;
+    }
+}
+
+h3 {
+    font-size: @font-size-h3;
+    font-weight: @font-weight-h3;
+
+    small {
+        font-size: 70%;
+        margin-left: 5px;
+        font-weight: @font-weight-light;
+    }
+}
+
+h4 {
+    font-size: @font-size-h4;
+    font-weight: @font-weight-h4;
+
+    small {
+        font-family: @font-family;
+        font-weight: @font-weight-light;
+        font-size: 100%;
+        margin-left: 3px;
+    }
+}
+
+h5 {
+    font-size: @font-size-h5;
+    font-weight: @font-weight-h5;
+
+    small {
+        font-family: @font-family;
+        font-weight: @font-weight-light;
+        font-size: 100%;
+        margin-left: 3px;
+    }
 }
 
 h6 {
-  font-size: @font-size-h6;
-  font-weight: @font-weight-h6;
+    font-size: @font-size-h6;
+    font-weight: @font-weight-h6;
 }
 
 p {
-  font-size: @font-size;
+    font-size: @font-size;
 }
 
 b {
-  font-weight: @font-weight-bold;
+    font-weight: @font-weight-bold;
 }
-
 
 /* COLORED TEXT */
 
-
 .text-primary {
-  color: @primary;
+    color: @primary;
 }
 
-.text-secondary, .text-accent {
-  color: @accent;
+.text-secondary,
+.text-accent {
+    color: @accent;
 }
 
 .text-alternate1 {
-  color: @alternate1;
+    color: @alternate1;
 }
 
 .text-alternate2 {
-  color: @alternate2;
+    color: @alternate2;
 }
 
 .text-alternate3 {
-  color: @alternate3;
+    color: @alternate3;
 }
 
 .text-vibrant1 {
-  color: @vibrant1;
+    color: @vibrant1;
 }
 
 .text-vibrant2 {
-  color: @vibrant2;
+    color: @vibrant2;
 }
 
-.text-alert, .text-error, .text-warning {
-  color: @critical;
+.text-alert,
+.text-error,
+.text-warning {
+    color: @critical;
 }
 
 .text-success {
-  color: @ok;
+    color: @ok;
 }
 
-.text-white{
-  color:@white !important;
+.text-white {
+    color: @white !important;
 }
-.text-black{
-  color:@grey2 !important;
+
+.text-black {
+    color: @grey2 !important;
 }
+
 .text-muted {
-  color: #888888;
+    color: #888;
 }
 
 .alignment-box {
-  border: 1px solid darken(@white,10%);
-  padding: 10px;
+    border: 1px solid darken(@white, 10%);
+    padding: 10px;
 }
 
 .v-separator {
-  display: inline-block;
-  border-right: 1px solid @v-separator-border;
-  box-shadow: 1px 0px 0px @v-separator-shadow;
-  height: 25px;
-  margin-right: 4px;
-  vertical-align: middle;
+    display: inline-block;
+    border-right: 1px solid @v-separator-border;
+    box-shadow: 1px 0 0 @v-separator-shadow;
+    height: 25px;
+    margin-right: 4px;
+    vertical-align: middle;
 }
 
-.body-dark {
-  .v-separator {
-    border-right: 1px solid @v-separator-border-dark;
-    box-shadow: 1px 0px 0px @v-separator-shadow-dark;
-  }
-}
-.body-dark {
-	.well {
-		background: @well-bg-dark;
-		border: 1px solid @well-border-dark;
-	}
-}
-
-
-.affix-toolbar-condensed .v-separator, .affix .v-separator {
- height: 20px;
+.affix-toolbar-condensed .v-separator,
+.affix .v-separator {
+    height: 20px;
 }
 
 .pos-absolute {
- position: absolute !important;
+    position: absolute !important;
 }
 
-strong{
-  .font-semibold;
+strong {
+    .font-semibold;
 }
 
 .align-right {
- float: right;
+    float: right;
 }
 
 .align-left {
-  float: left;
+    float: left;
 }
 
 .inline-block {
-  display: inline-block;
+    display: inline-block;
 }

--- a/src/styles/utilities.less
+++ b/src/styles/utilities.less
@@ -1,453 +1,512 @@
 //=================
 //helper classes
 //=================
-.clickable{
-  cursor: pointer;
+.clickable {
+    cursor: pointer;
 }
-
 
 //=================
 //font classes
 //=================
 .font-bold {
-  font-weight: 600;
+    font-weight: 600;
 }
+
 .font-size-small {
-  font-size: @font-size-sm;
+    font-size: @font-size-sm;
 }
+
 //================
 //text alignment
 //================
-.text-center{
-  text-align: center;
-}
-.text-left{
-  text-align: left;
-}
-.text-right{
-  text-align: right;
-}
-.text-justify{
-  text-align: justify;
+.text-center {
+    text-align: center;
 }
 
+.text-left {
+    text-align: left;
+}
+
+.text-right {
+    text-align: right;
+}
+
+.text-justify {
+    text-align: justify;
+}
 
 //================
 //background-color
 //================
 .navigation-white-bg {
-  background-color: @white !important;
+    background-color: @white !important;
 }
-.listview-document-th{
-  width: 35px;
+
+.listview-document-th {
+    width: 35px;
 }
-.listview-document-bg {  
-  color: darken(@grey4,10%);
-  background-color:@listview-document-bg;
+
+.listview-document-bg {
+    color: darken(@grey4, 10%);
+    background-color: @listview-document-bg;
 }
 
 //=================
 //display classes
 //=================
-.block{
-  display:block;
+.block {
+    display: block;
 }
-.inline{
-  display:inline;
+
+.inline {
+    display: inline;
 }
 
 //=================
 //margin classes
 //=================
-
 // --- 4 sides
 //nill - 0 - no margin
 .m-nil {
-  .m-t-nil;
-  .m-r-nil;
-  .m-b-nil;
-  .m-l-nil;
+    .m-t-nil;
+    .m-r-nil;
+    .m-b-nil;
+    .m-l-nil;
 }
 
 //EXTRA extra small
 .m-xxs {
-  .m-t-xxs;
-  .m-r-xxs;
-  .m-b-xxs;
-  .m-l-xxs;
+    .m-t-xxs;
+    .m-r-xxs;
+    .m-b-xxs;
+    .m-l-xxs;
 }
 
 // extra small
 .m-xs {
-  .m-t-xs;
-  .m-r-xs;
-  .m-b-xs;
-  .m-l-xs;
+    .m-t-xs;
+    .m-r-xs;
+    .m-b-xs;
+    .m-l-xs;
 }
 
 //small margin
 .m-sm {
-  .m-t-sm;
-  .m-r-sm;
-  .m-b-sm;
-  .m-l-sm;
+    .m-t-sm;
+    .m-r-sm;
+    .m-b-sm;
+    .m-l-sm;
 }
 
 //normal margin
 .m {
-  .m-t;
-  .m-r;
-  .m-b;
-  .m-l;
+    .m-t;
+    .m-r;
+    .m-b;
+    .m-l;
 }
+
 //medium margin
 .m-md {
-  .m-t-md;
-  .m-r-md;
-  .m-b-md;
-  .m-l-md;
+    .m-t-md;
+    .m-r-md;
+    .m-b-md;
+    .m-l-md;
 }
 
 //large margin
 .m-lg {
-  .m-t-lg;
-  .m-r-lg;
-  .m-b-lg;
-  .m-l-lg;
+    .m-t-lg;
+    .m-r-lg;
+    .m-b-lg;
+    .m-l-lg;
 }
 
 //extra large margin
 .m-xl {
-  .m-t-xl;
-  .m-r-xl;
-  .m-b-xl;
-  .m-l-xl;
+    .m-t-xl;
+    .m-r-xl;
+    .m-b-xl;
+    .m-l-xl;
 }
 
 // --- individual sides
 //nill - 0 - no margin
 .m-t-nil {
-  margin-top: @spacing-nil;
-}
-.m-r-nil {
-  margin-right: @spacing-nil;
-}
-.m-b-nil {
-  margin-bottom: @spacing-nil;
-}
-.m-l-nil {
-  margin-left: @spacing-nil;
+    margin-top: @spacing-nil;
 }
 
+.m-r-nil {
+    margin-right: @spacing-nil;
+}
+
+.m-b-nil {
+    margin-bottom: @spacing-nil;
+}
+
+.m-l-nil {
+    margin-left: @spacing-nil;
+}
 
 //EXTRA extra small
 .m-t-xxs {
-  margin-top: @spacing-xxsTopBottom;
+    margin-top: @spacing-xxsTopBottom;
 }
+
 .m-r-xxs {
-  margin-right: @spacing-xxsRightLeft;
+    margin-right: @spacing-xxsRightLeft;
 }
+
 .m-b-xxs {
-  margin-bottom: @spacing-xxsTopBottom;
+    margin-bottom: @spacing-xxsTopBottom;
 }
+
 .m-l-xxs {
-  margin-left: @spacing-xxsRightLeft;
+    margin-left: @spacing-xxsRightLeft;
 }
 
 //extra small
 .m-t-xs {
-  margin-top: @spacing-xs;
+    margin-top: @spacing-xs;
 }
+
 .m-r-xs {
-  margin-right: @spacing-xs;
+    margin-right: @spacing-xs;
 }
+
 .m-b-xs {
-  margin-bottom: @spacing-xs;
+    margin-bottom: @spacing-xs;
 }
+
 .m-l-xs {
-  margin-left: @spacing-xs;
+    margin-left: @spacing-xs;
 }
 
 //small margin
 .m-t-sm {
-  margin-top: @spacing-sm;
+    margin-top: @spacing-sm;
 }
+
 .m-r-sm {
-  margin-right: @spacing-sm !important;
+    margin-right: @spacing-sm !important;
 }
+
 .m-b-sm {
-  margin-bottom: @spacing-sm;
+    margin-bottom: @spacing-sm;
 }
+
 .m-l-sm {
-  margin-left: @spacing-sm;
+    margin-left: @spacing-sm;
 }
 
 //normal margin
 .m-t {
-  margin-top: @spacing;
+    margin-top: @spacing;
 }
+
 .m-r {
-  margin-right: @spacing;
+    margin-right: @spacing;
 }
+
 .m-b {
-  margin-bottom: @spacing;
+    margin-bottom: @spacing;
 }
+
 .m-l {
-  margin-left: @spacing;
+    margin-left: @spacing;
 }
 
 //medium margin
 .m-t-md {
-  margin-top: @spacing-md;
+    margin-top: @spacing-md;
 }
+
 .m-r-md {
-  margin-right: @spacing-md;
+    margin-right: @spacing-md;
 }
+
 .m-b-md {
-  margin-bottom: @spacing-md;
+    margin-bottom: @spacing-md;
 }
+
 .m-l-md {
-  margin-left: @spacing-md;
+    margin-left: @spacing-md;
 }
 
 //large margin
 .m-t-lg {
-  margin-top: @spacing-lg;
+    margin-top: @spacing-lg;
 }
+
 .m-r-lg {
-  margin-right: @spacing-lg;
+    margin-right: @spacing-lg;
 }
+
 .m-b-lg {
-  margin-bottom: @spacing-lg;
+    margin-bottom: @spacing-lg;
 }
+
 .m-l-lg {
-  margin-left: @spacing-lg;
+    margin-left: @spacing-lg;
 }
 
 //extra large margin
 .m-t-xl {
-  margin-top: @spacing-xl;
+    margin-top: @spacing-xl;
 }
+
 .m-r-xl {
-  margin-right: @spacing-xl;
+    margin-right: @spacing-xl;
 }
+
 .m-b-xl {
-  margin-bottom: @spacing-xl;
+    margin-bottom: @spacing-xl;
 }
+
 .m-l-xl {
-  margin-left: @spacing-xl;
+    margin-left: @spacing-xl;
 }
 
 //=================
 //padding classes
 //=================
-
 // --- 4 sides
 //nill - 0 - no padding
 .p-nil {
-  .p-t-nil;
-  .p-r-nil;
-  .p-b-nil;
-  .p-l-nil;
+    .p-t-nil;
+    .p-r-nil;
+    .p-b-nil;
+    .p-l-nil;
 }
 
 //EXTRA extra small
 .p-xxs {
-  .p-t-xxs;
-  .p-r-xxs;
-  .p-b-xxs;
-  .p-l-xxs;
+    .p-t-xxs;
+    .p-r-xxs;
+    .p-b-xxs;
+    .p-l-xxs;
 }
 
 // extra small
 .p-xs {
-  .p-t-xs;
-  .p-r-xs;
-  .p-b-xs;
-  .p-l-xs;
+    .p-t-xs;
+    .p-r-xs;
+    .p-b-xs;
+    .p-l-xs;
 }
 
 //small padding
 .p-sm {
-  .p-t-sm;
-  .p-r-sm;
-  .p-b-sm;
-  .p-l-sm;
+    .p-t-sm;
+    .p-r-sm;
+    .p-b-sm;
+    .p-l-sm;
 }
 
 //normal padding
 .p {
-  .p-t;
-  .p-r;
-  .p-b;
-  .p-l;
+    .p-t;
+    .p-r;
+    .p-b;
+    .p-l;
 }
+
 //medium padding
 .p-md {
-  .p-t-md;
-  .p-r-md;
-  .p-b-md;
-  .p-l-md;
+    .p-t-md;
+    .p-r-md;
+    .p-b-md;
+    .p-l-md;
 }
 
 //large padding
 .p-lg {
-  .p-t-lg;
-  .p-r-lg;
-  .p-b-lg;
-  .p-l-lg;
+    .p-t-lg;
+    .p-r-lg;
+    .p-b-lg;
+    .p-l-lg;
 }
 
 //extra large padding
 .p-xl {
-  .p-t-xl;
-  .p-r-xl;
-  .p-b-xl;
-  .p-l-xl;
+    .p-t-xl;
+    .p-r-xl;
+    .p-b-xl;
+    .p-l-xl;
 }
 
 // --- individual sides
 //nill - 0 - no padding
 .p-t-nil {
-  padding-top: @spacing-nil;
-}
-.p-r-nil {
-  padding-right: @spacing-nil;
-}
-.p-b-nil {
-  padding-bottom: @spacing-nil;
-}
-.p-l-nil {
-  padding-left: @spacing-nil;
+    padding-top: @spacing-nil;
 }
 
+.p-r-nil {
+    padding-right: @spacing-nil;
+}
+
+.p-b-nil {
+    padding-bottom: @spacing-nil;
+}
+
+.p-l-nil {
+    padding-left: @spacing-nil;
+}
 
 //EXTRA extra small
 .p-t-xxs {
-  padding-top: @spacing-xxsTopBottom;
-}
-.p-r-xxs {
-  padding-right: @spacing-xxsRightLeft;
-}
-.p-b-xxs {
-  padding-bottom: @spacing-xxsTopBottom;
-}
-.p-l-xxs {
-  padding-left: @spacing-xxsRightLeft;
+    padding-top: @spacing-xxsTopBottom;
 }
 
+.p-r-xxs {
+    padding-right: @spacing-xxsRightLeft;
+}
+
+.p-b-xxs {
+    padding-bottom: @spacing-xxsTopBottom;
+}
+
+.p-l-xxs {
+    padding-left: @spacing-xxsRightLeft;
+}
 
 .p-t-xs {
-  padding-top: @spacing-xs;
+    padding-top: @spacing-xs;
 }
+
 .p-r-xs {
-  padding-right: @spacing-xs;
+    padding-right: @spacing-xs;
 }
+
 .p-b-xs {
-  padding-bottom: @spacing-xs;
+    padding-bottom: @spacing-xs;
 }
+
 .p-l-xs {
-  padding-left: @spacing-xs;
+    padding-left: @spacing-xs;
 }
 
 //small padding
 .p-t-sm {
-  padding-top: @spacing-sm;
+    padding-top: @spacing-sm;
 }
+
 .p-r-sm {
-  padding-right: @spacing-sm;
+    padding-right: @spacing-sm;
 }
+
 .p-b-sm {
-  padding-bottom: @spacing-sm;
+    padding-bottom: @spacing-sm;
 }
+
 .p-l-sm {
-  padding-left: @spacing-sm;
+    padding-left: @spacing-sm;
 }
 
 //normal padding
 .p-t {
-  padding-top: @spacing;
+    padding-top: @spacing;
 }
+
 .p-r {
-  padding-right: @spacing;
+    padding-right: @spacing;
 }
+
 .p-b {
-  padding-bottom: @spacing;
+    padding-bottom: @spacing;
 }
+
 .p-l {
-  padding-left: @spacing;
+    padding-left: @spacing;
 }
 
 //medium padding
 .p-t-md {
-  padding-top: @spacing-md;
+    padding-top: @spacing-md;
 }
+
 .p-r-md {
-  padding-right: @spacing-md;
+    padding-right: @spacing-md;
 }
+
 .p-b-md {
-  padding-bottom: @spacing-md;
+    padding-bottom: @spacing-md;
 }
+
 .p-l-md {
-  padding-left: @spacing-md;
+    padding-left: @spacing-md;
 }
 
 //large padding
 .p-t-lg {
-  padding-top: @spacing-lg;
+    padding-top: @spacing-lg;
 }
+
 .p-r-lg {
-  padding-right: @spacing-lg;
+    padding-right: @spacing-lg;
 }
+
 .p-b-lg {
-  padding-bottom: @spacing-lg;
+    padding-bottom: @spacing-lg;
 }
+
 .p-l-lg {
-  padding-left: @spacing-lg;
+    padding-left: @spacing-lg;
 }
 
 //extra large padding
 .p-t-xl {
-  padding-top: @spacing-xl;
-}
-.p-r-xl {
-  padding-right: @spacing-xl;
-}
-.p-b-xl {
-  padding-bottom: @spacing-xl;
-}
-.p-l-xl {
-  padding-left: @spacing-xl;
+    padding-top: @spacing-xl;
 }
 
+.p-r-xl {
+    padding-right: @spacing-xl;
+}
+
+.p-b-xl {
+    padding-bottom: @spacing-xl;
+}
+
+.p-l-xl {
+    padding-left: @spacing-xl;
+}
 
 //=================
 //Global classes
 //=================
 .no-borders {
-  border: none !important;
+    border: none !important;
 }
+
 .no-top-border {
-  border-top: 0 !important;
-}
-.no-margin{
-  .m-nil !important;
+    border-top: 0 !important;
 }
 
-.no-padding{
-  .p-nil !important;
+.no-margin {
+    .m-nil !important;
 }
 
-.no-wrap{
-  white-space: nowrap;
+.no-padding {
+    .p-nil !important;
+}
+
+.no-wrap {
+    white-space: nowrap;
 }
 
 //===============
 //Angular
 //==============
-[ng\:cloak],[ng-cloak],[data-ng-cloak],[x-ng-cloak],.ng-cloak,.x-ng-cloak,.ng-hide:not(.ng-hide-animate){
-  display:none !important;
+[ng\:cloak],
+[ng-cloak],
+[data-ng-cloak],
+[x-ng-cloak],
+.ng-cloak,
+.x-ng-cloak,
+.ng-hide:not(.ng-hide-animate) {
+    display: none !important;
 }
-ng\:form{
-  display:block;
+
+ng\:form {
+    display: block;
 }

--- a/src/styles/wizard.less
+++ b/src/styles/wizard.less
@@ -1,277 +1,259 @@
 .wizard,
 .tabcontrol {
-  display: block;
-  width: 100%;
-  overflow: hidden;
-  a {
-    outline: 0;
-  }
-  & > .steps, .actions {
-    ul {
-      list-style: none !important;
-      padding: 0;
-      margin: 0;
-      & > li{
-        display: block;
-        padding: 0;
-      }
-    }
-  }
-  & > .actions {
-    ul {
-      margin-bottom: 5px;
-    }
-  }
-  & > .steps {
-    .current-info {
-      position: absolute;
-      left: -999em;
-    }
-  }
-  & > .content > .title {
-    position: absolute;
-    left: -999em;
-  }
-}
+    display: block;
+    width: 100%;
+    overflow: hidden;
 
+    a {
+        outline: 0;
+    }
+
+    & > .steps,
+    .actions {
+        ul {
+            list-style: none !important;
+            padding: 0;
+            margin: 0;
+
+            & > li {
+                display: block;
+                padding: 0;
+            }
+        }
+    }
+
+    & > .actions {
+        ul {
+            margin-bottom: 5px;
+        }
+    }
+
+    & > .steps {
+        .current-info {
+            position: absolute;
+            left: -999em;
+        }
+    }
+
+    & > .content > .title {
+        position: absolute;
+        left: -999em;
+    }
+}
 
 /*
 Wizard
 */
+
 .wizard {
-  & > .steps {
-    position: relative;
-    display: block;
-    width: 100%;
-  }
-  &.vertical > .steps {
-    display: inline;
-    float: left;
-    width: 30%;
-  }
+    & > .steps {
+        position: relative;
+        display: block;
+        width: 100%;
+    }
+
+    &.vertical > .steps {
+        display: inline;
+        float: left;
+        width: 30%;
+    }
 }
 
-.wizard > .steps > ul > li
-{
-  width: 25%;
+.wizard > .steps > ul > li {
+    width: 25%;
 }
 
 .wizard > .steps > ul > li,
-.wizard > .actions > ul > li
-{
-  float: left;
+.wizard > .actions > ul > li {
+    float: left;
 }
 
-.wizard.vertical > .steps > ul > li
-{
-  float: none;
-  width: 100%;
+.wizard.vertical > .steps > ul > li {
+    float: none;
+    width: 100%;
 }
 
 .wizard > .steps a,
 .wizard > .steps a:hover,
 .wizard > .steps a:active {
-  display: block;
-  width: auto;
-  margin: 0 0.5em 0.5em;
-  padding: 8px;
-  text-decoration: none;
-
-  -webkit-border-radius: @btn-border-radius;
-  -moz-border-radius: @btn-border-radius;
-  border-radius: @btn-border-radius;
+    display: block;
+    width: auto;
+    margin: 0 0.5em 0.5em;
+    padding: 8px;
+    text-decoration: none;
+    -webkit-border-radius: @btn-border-radius;
+    -moz-border-radius: @btn-border-radius;
+    border-radius: @btn-border-radius;
 }
 
 .wizard > .steps .disabled a,
 .wizard > .steps .disabled a:hover,
-.wizard > .steps .disabled a:active
-{
-  background: @wizard-steps-disabled-bg;
-  color: @wizard-steps-disabled-color;
-  cursor: default;
-}
-
-.body-dark .wizard > .steps .disabled a,
-.body-dark .wizard > .steps .disabled a:hover,
-.body-dark .wizard > .steps .disabled a:active
-{
-  background: @wizard-steps-disabled-bg-dark;
+.wizard > .steps .disabled a:active {
+    background: @wizard-steps-disabled-bg;
+    color: @wizard-steps-disabled-color;
+    cursor: default;
 }
 
 .wizard > .steps .current a,
 .wizard > .steps .current a:hover,
-.wizard > .steps .current a:active
-{
-  background: @wizard-step-active-bg;
-  color: @wizard-step-active-color;
-  cursor: default;
+.wizard > .steps .current a:active {
+    background: @wizard-step-active-bg;
+    color: @wizard-step-active-color;
+    cursor: default;
 }
 
 .wizard > .steps .done a,
 .wizard > .steps .done a:hover,
-.wizard > .steps .done a:active
-{
-  background: @wizard-step-complete-bg;
-  .opacity(@wizard-step-complete-opacity);
-  color: @wizard-step-complete-color;
+.wizard > .steps .done a:active {
+    background: @wizard-step-complete-bg;
+    .opacity(@wizard-step-complete-opacity);
+
+    color: @wizard-step-complete-color;
 }
 
 .wizard > .steps .error a,
 .wizard > .steps .error a:hover,
-.wizard > .steps .error a:active
-{
-  background: @wizard-step-error-bg;
-  color: @wizard-step-error-color;
+.wizard > .steps .error a:active {
+    background: @wizard-step-error-bg;
+    color: @wizard-step-error-color;
 }
 
-.wizard > .content
-{
-  background: @wizard-content-bg;
-  display: block;
-  margin: 5px 5px 10px 5px;
-  min-height: 120px;
-  overflow: hidden;
-  position: relative;
-  width: auto;
-
-  -webkit-border-radius: @btn-border-radius;
-  -moz-border-radius: @btn-border-radius;
-  border-radius: @btn-border-radius;
+.wizard > .content {
+    background: @wizard-content-bg;
+    display: block;
+    margin: 5px 5px 10px;
+    min-height: 120px;
+    overflow: hidden;
+    position: relative;
+    width: auto;
+    -webkit-border-radius: @btn-border-radius;
+    -moz-border-radius: @btn-border-radius;
+    border-radius: @btn-border-radius;
 }
 
 .wizard-big.wizard > .content {
-  min-height: 320px;
-}
-.wizard.vertical > .content
-{
-  display: inline;
-  float: left;
-  margin: 0 2.5% 0.5em 2.5%;
-  width: 65%;
+    min-height: 320px;
 }
 
-.wizard > .content > .body
-{
-  width: 100%;
-  padding: 20px;
+.wizard.vertical > .content {
+    display: inline;
+    float: left;
+    margin: 0 2.5% 0.5em;
+    width: 65%;
 }
 
-.wizard > .content > .body > iframe
-{
-  border: 0 none;
-  width: 100%;
-  height: 100%;
+.wizard > .content > .body {
+    width: 100%;
+    padding: 20px;
 }
 
-.body-dark .wizard > .content {
-  background: @wizard-content-bg-dark;
+.wizard > .content > .body > iframe {
+    border: 0 none;
+    width: 100%;
+    height: 100%;
 }
 
-
-.wizard > .actions
-{
-  position: relative;
-  display: block;
-  text-align: right;
-  width: 100%;
+.wizard > .actions {
+    position: relative;
+    display: block;
+    text-align: right;
+    width: 100%;
 }
 
-.wizard.vertical > .actions
-{
-  display: inline;
-  float: right;
-  margin: 0 2.5%;
-  width: 95%;
+.wizard.vertical > .actions {
+    display: inline;
+    float: right;
+    margin: 0 2.5%;
+    width: 95%;
 }
 
-.wizard > .actions > ul
-{
-  display: inline-block;
-  text-align: right;
+.wizard > .actions > ul {
+    display: inline-block;
+    text-align: right;
 }
 
-.wizard > .actions > ul > li
-{
-  margin: 0 0.5em;
+.wizard > .actions > ul > li {
+    margin: 0 0.5em;
 }
 
-.wizard.vertical > .actions > ul > li
-{
-  margin: 0 0 0 1em;
+.wizard.vertical > .actions > ul > li {
+    margin: 0 0 0 1em;
 }
 
 /*
   Marquee Wizard
 */
+
 .marquee-wizard-modal {
-  height: 520px;
+    height: 520px;
 }
 
 .marquee-wizard-steps {
-  width: 100%;
-  list-style-type: none;
-  padding: 0;
-  margin-top: 30px;
+    width: 100%;
+    list-style-type: none;
+    padding: 0;
+    margin-top: 30px;
 
-  .marquee-wizard-step {
-    padding: 8px 20px;
-    cursor: default;
-    transition: background-color 0.3s linear;
-    
-    &.visited:hover {
-      cursor: pointer;
-      background-color: @marquee-wizard-step-hover-bg;
-    }
+    .marquee-wizard-step {
+        padding: 8px 20px;
+        cursor: default;
+        transition: background-color 0.3s linear;
 
-    &.active{
-      background-color: @marquee-wizard-step-active-bg;
-
-      &:hover {
-        background-color: @marquee-wizard-step-active-hover-bg;
-      }
-
-      .step-label {
-        color: @marquee-wizard-step-active-color;
-      }
-    }
-
-    &.error {
-      background: @marquee-wizard-step-error-bg;
-      &.visited:hover {
-        cursor: pointer;
-        background: @marquee-wizard-step-error-bg;
-      }
-    }
-
-    .step-label {
-      display: table;
-      width: 100%;
-      color: @marquee-wizard-step-color;
-
-      .step-title {
-        display: table-cell;
-
-        .title {
-          font-family: @font-family;
-          font-weight: @font-weight-light;
-          font-size: 1.125rem; 
+        &.visited:hover {
+            cursor: pointer;
+            background-color: @marquee-wizard-step-hover-bg;
         }
-      }
 
-      .step-complete {
-        display: table-cell;
-        width: 15px;
-        color: @marquee-wizard-step-complete-color;
-      }
+        &.active {
+            background-color: @marquee-wizard-step-active-bg;
+
+            &:hover {
+                background-color: @marquee-wizard-step-active-hover-bg;
+            }
+
+            .step-label {
+                color: @marquee-wizard-step-active-color;
+            }
+        }
+
+        &.error {
+            background: @marquee-wizard-step-error-bg;
+
+            &.visited:hover {
+                cursor: pointer;
+                background: @marquee-wizard-step-error-bg;
+            }
+        }
+
+        .step-label {
+            display: table;
+            width: 100%;
+            color: @marquee-wizard-step-color;
+
+            .step-title {
+                display: table-cell;
+
+                .title {
+                    font-family: @font-family;
+                    font-weight: @font-weight-light;
+                    font-size: 1.125rem;
+                }
+            }
+
+            .step-complete {
+                display: table-cell;
+                width: 15px;
+                color: @marquee-wizard-step-complete-color;
+            }
+        }
     }
-  }
 }
 
 .marquee-wizard-user {
-  background: url(../img/IconUser.png) no-repeat;
-  height: 48px;
+    background: url(../img/IconUser.png) no-repeat;
+    height: 48px;
 }
 
 .marquee-wizard-text {
-  color: @marquee-wizard-color;
+    color: @marquee-wizard-color;
 }


### PR DESCRIPTION
- Removing Dark Styling (anything under .body-dark)
- Making existing styles follow stylelint rules - fixing formatting, missing semicolons, removing some < IE 10 vendor specific prefixes
- Adding grunt task to lint the stylesheets now (with the exception of the icons as that stylesheet is autogenerated)