### PR TITLE
EL-3027 - Fixing spark chart issues

### DIFF
--- a/src/components/spark/spark.component.ts
+++ b/src/components/spark/spark.component.ts
@@ -1,10 +1,11 @@
-import { Component, Input } from '@angular/core';
+import { Component, Input, ChangeDetectionStrategy } from '@angular/core';
 import { ColorService } from '../../services/color/index';
 import { ColorIdentifier } from '../../index';
 
 @Component({
     selector: 'ux-spark',
-    templateUrl: './spark.component.html'
+    templateUrl: './spark.component.html',
+    changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class SparkComponent {
 
@@ -21,7 +22,6 @@ export class SparkComponent {
     private _trackColor: string;
     private _theme: ColorIdentifier = 'primary';    
     private _barColor: string | string[] = [];
-
     
     @Input() 
     set theme(value: string) {
@@ -62,7 +62,7 @@ export class SparkComponent {
         const values = Array.isArray(value) ? value : [value];
 
         // get the total value of all lines
-        let total = Math.max(values.reduce((previous, current) => previous + current, 0), 100);
+        const total = Math.max(values.reduce((previous, current) => previous + current, 0), 100);
 
         // figure out the percentages for each spark line
         this.values = values.map(val => (val / total) * 100);

--- a/src/ng1/directives/spark/spark.directive.js
+++ b/src/ng1/directives/spark/spark.directive.js
@@ -4,7 +4,7 @@ export default function SparkDirective() {
         template: require("./spark.html"),
         controller: "SparkCtrl as sc",
         scope: {
-            type: "=",
+            type: "=?",
             value: "=",
             fillheight: "=",
             label: "=inlineLabel",

--- a/src/ng1/directives/spark/spark.html
+++ b/src/ng1/directives/spark/spark.html
@@ -9,7 +9,7 @@
                 <div class="align-right inline-block" ng-if="sc.topRightLabel" ng-bind-html="sc.topRightLabel" class="text-right"></div>
             </div>
             <div class="spark" ng-class="[ 'inline', sc.type ]" ng-style="sc.styles" tooltip="{{sc.sparkTooltip}}">
-                <div class="progress-bar fill" ng-repeat="bar in sc.values" aria-valuenow="{{sc.value}}" aria-valuemin="0"
+                <div class="progress-bar fill" ng-repeat="bar in sc.values track by $index" aria-valuenow="{{sc.value}}" aria-valuemin="0"
                      aria-valuemax="100" ng-style="{ width: (bar < 100 ? bar : 100) + '%', backgroundColor: sc.barColor[$index]}"
                      aria-valuetext="sc.label"></div>
             </div>
@@ -26,7 +26,7 @@
             <div class="align-right inline-block" ng-if="sc.topRightLabel" ng-bind-html="sc.topRightLabel" class="text-right"></div>
         </div>
         <div class="spark" ng-class="sc.type" ng-style="{height: sc.fillheight + 'px', backgroundColor: sc.trackColor}" tooltip="{{sc.sparkTooltip}}">
-            <div class="progress-bar fill" ng-repeat="bar in sc.values" aria-valuenow="{{sc.value}}" aria-valuemin="0"
+            <div class="progress-bar fill" ng-repeat="bar in sc.values track by $index" aria-valuenow="{{sc.value}}" aria-valuemin="0"
                  aria-valuemax="100" ng-style="{width: (bar < 100 ? bar : 100) + '%', backgroundColor: sc.barColor[$index]}" 
                  aria-valuetext="sc.top-left-label"></div>
         </div>

--- a/src/services/color/color.service.ts
+++ b/src/services/color/color.service.ts
@@ -105,7 +105,7 @@ export class ColorService {
         return value;
     }
 
-    resolveColorName(value: string): string {
+    resolveColorName(value: string = ''): string {
         return value.replace(/\s+/g, '-').toLowerCase();
     }
 }


### PR DESCRIPTION
JIRA: https://jira.autonomy.com/browse/EL-3027

- Angular JS spark chart throws an error when a multi spark chart has two values the same. Now fixed
- Error thrown when type property not specified - made this optional as it is not always application now we support multi spark charts
- Made Angular Spark chart to use OnPush change detection
- Added default value to color service to prevent errors