### PR TITLE
Removing fixed ngx-bootstrap version to allow newer versions

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -32,7 +32,7 @@
     "chart.js": "~2.6.0",
     "ng2-charts": "^1.6.0",
     "ng2-file-upload": "^1.3.0",
-    "ngx-bootstrap": "^2.0.0-beta.8",
+    "ngx-bootstrap": "^2.0.0",
     "angular-tree-component": "^5.2.0",
     "bootstrap": "^3.3.7"
   },

--- a/src/package.json
+++ b/src/package.json
@@ -32,7 +32,7 @@
     "chart.js": "~2.6.0",
     "ng2-charts": "^1.6.0",
     "ng2-file-upload": "^1.3.0",
-    "ngx-bootstrap": "2.0.0-beta.8",
+    "ngx-bootstrap": "^2.0.0-beta.8",
     "angular-tree-component": "^5.2.0",
     "bootstrap": "^3.3.7"
   },


### PR DESCRIPTION
In response to the issue Thomas was having on slack I have relaxed the ngx-bootstrap version requirement to prevent multiple versions of it being installed.

His app depended on ngx-bootstrap "^2.0.0-beta.8" which was installing version 2.0.2. The ux-aspects package depended on "2.0.0-beta.8" exact - so it was installing multiple versions causing StaticInjectorErrors in a production build