### PR TITLE
Store icon colour in NotificationRef object. Not overloading the exis…

### DIFF
--- a/src/components/notification/notification.module.ts
+++ b/src/components/notification/notification.module.ts
@@ -2,10 +2,12 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { NotificationListComponent } from './notification-list.component';
 import { NotificationService } from './notification.service';
+import { ColorServiceModule } from '../../services/color/index';
 
 @NgModule({
     imports: [
-        CommonModule
+        CommonModule,
+        ColorServiceModule
     ],
     exports: [
         NotificationListComponent

--- a/src/components/notification/notification.service.ts
+++ b/src/components/notification/notification.service.ts
@@ -9,7 +9,8 @@ export class NotificationService {
         duration: 4,
         height: 100,
         spacing: 10,
-        backgroundColor: '#7b63a3'
+        backgroundColor: '#7b63a3',
+        iconColor: '#7b63a3'
     };
 
     direction: NotificationListDirection = 'above';
@@ -27,7 +28,8 @@ export class NotificationService {
             visible: true,
             height: options.height,
             spacing: options.spacing,
-            backgroundColor: options.backgroundColor
+            backgroundColor: options.backgroundColor,
+            iconColor: options.iconColor
         };
 
         const notifications = this.notifications$.getValue();
@@ -70,14 +72,16 @@ export interface NotificationRef {
     visible?: boolean;
     height?: number;
     spacing?: number;
-    backgroundColor: string;
+    backgroundColor?: string;
+    iconColor?: string;
 }
 
 export interface NotificationOptions {
     duration?: number;
     height?: number;
     spacing?: number;
-    backgroundColor: string;
+    backgroundColor?: string;
+    iconColor?: string;
 }
 
 export type NotificationListDirection = 'above' | 'below';

--- a/src/components/notification/notification.service.ts
+++ b/src/components/notification/notification.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, TemplateRef } from '@angular/core';
 import { BehaviorSubject } from 'rxjs/BehaviorSubject';
+import { ColorService } from '../../services/color/index';
 
 @Injectable()
 export class NotificationService {
@@ -9,8 +10,8 @@ export class NotificationService {
         duration: 4,
         height: 100,
         spacing: 10,
-        backgroundColor: '#7b63a3',
-        iconColor: '#7b63a3'
+        backgroundColor: this._colorService.getColor('accent').toHex(),
+        iconColor: this._colorService.getColor('accent').toHex()
     };
 
     direction: NotificationListDirection = 'above';
@@ -62,6 +63,9 @@ export class NotificationService {
     dismissAll(): void {
         this.notifications$.getValue().forEach(notificationRef => notificationRef.visible = false);
         this.notifications$.next(this.notifications$.getValue());        
+    }
+
+    constructor(private _colorService: ColorService) {
     }
 }
 


### PR DESCRIPTION
…ting 'backgroundColor' property as the MF documentation refers to the 'iconColor' property in the Notification Configuration object.

https://jira.autonomy.com/browse/EL-3000