### PR TITLE
EL-3010 - Dashboard Infinite Loop fix

### DIFF
--- a/src/components/dashboard/dashboard.service.ts
+++ b/src/components/dashboard/dashboard.service.ts
@@ -207,6 +207,10 @@ export class DashboardService {
                 return;
             }
 
+            if (column === 0 && widget.colSpan > this.options.columns) {
+                throw new Error('Dashboard widgets have a colSpan greater than the max number of dashboard columns!');
+            }
+
             position++;
         }
     }


### PR DESCRIPTION
Added safety check to ensure the widgets are not wider than the number of columns in the dashboard.

Previously this would have resulted in an infinite loop, crashing the page - now it throws an exception with a useful message indicating how to resolve the issue