### PR TITLE
Fixing infinite scroll issue for victor

### DIFF
--- a/src/ng1/directives/infiniteScroll/infiniteScroll.controller.js
+++ b/src/ng1/directives/infiniteScroll/infiniteScroll.controller.js
@@ -30,7 +30,7 @@ export class InfiniteScrollController {
         this.$interval = safeInterval.create($scope);
 
         // private variables
-        this._query = null;
+        this._query = this._query || null;
         this._subscriptions = [];
 
         // set some default values if required


### PR DESCRIPTION
There was a chance the setter (which sets this._query) was getting called before the constructor. Currently the constructor sets this._query to null initially which could cause the search query to be missing when the page is loaded.

Added a minor change to only set the initial value if one hasn't already been set.