### PR TITLE
Fixing dragula plunker issue

### DIFF
--- a/docs/app/services/plunker/templates/config_js.txt
+++ b/docs/app/services/plunker/templates/config_js.txt
@@ -41,6 +41,7 @@ System.config({
     'ng2-charts': 'https://unpkg.com/ng2-charts/bundles/ng2-charts.umd.min.js',
     'ng2-file-upload': 'https://unpkg.com/ng2-file-upload/bundles/ng2-file-upload.umd.js',
     'angular-split': 'https://unpkg.com/angular-split/bundles/angular-split.umd.js',
+    'dragula': 'https://unpkg.com/dragula/dragula.js',
 
     // ngx-bootstrap aliases
     'ngx-bootstrap/accordion': 'https://unpkg.com/ngx-bootstrap/bundles/ngx-bootstrap.umd.min.js',

--- a/ng-package.json
+++ b/ng-package.json
@@ -5,7 +5,8 @@
     "lib": {
       "entryFile": "./index.ts",
       "externals": {
-        "@angular/upgrade/static": "./node_modules/@angular/upgrade/bundles/upgrade-static.umd.js"
+        "@angular/upgrade/static": "./node_modules/@angular/upgrade/bundles/upgrade-static.umd.js",
+        "dragula": "dragula"
       }
     }
   }

--- a/src/directives/reorderable/dragula.ts
+++ b/src/directives/reorderable/dragula.ts
@@ -1,0 +1,5 @@
+// WORKAROUND: ng-packagr issue - https://github.com/dherges/ng-packagr/issues/163
+import * as dragulaNamespace from 'dragula';
+import { Drake } from 'dragula';
+
+export const dragula: (containers?: any, options?: any) => Drake = (dragulaNamespace as any).default || dragulaNamespace;

--- a/src/directives/reorderable/reorderable.directive.ts
+++ b/src/directives/reorderable/reorderable.directive.ts
@@ -2,9 +2,7 @@ import { Directive, Input, ElementRef, OnInit, ContentChildren, QueryList, OnDes
 import { Drake } from 'dragula';
 import { ReorderableHandleDirective } from './reorderable-handle.directive';
 import { ReorderableModelDirective } from './reorderable-model.directive';
-
-// WORKAROUND: ng-packagr issue: https://github.com/dherges/ng-packagr/issues/163
-const dragula = require('dragula');
+import { dragula } from './dragula';
 
 @Directive({
     selector: '[uxReorderable]'


### PR DESCRIPTION
Turns out ng-packagr keeps `require` statements dynamic so I had to use a different workaround to allow us to use the dragula library. Should work as expected now.