### PR TITLE
Updating dragula plunker url

### DIFF
--- a/docs/app/services/plunker/templates/config_js.txt
+++ b/docs/app/services/plunker/templates/config_js.txt
@@ -41,7 +41,7 @@ System.config({
     'ng2-charts': 'https://unpkg.com/ng2-charts/bundles/ng2-charts.umd.min.js',
     'ng2-file-upload': 'https://unpkg.com/ng2-file-upload/bundles/ng2-file-upload.umd.js',
     'angular-split': 'https://unpkg.com/angular-split/bundles/angular-split.umd.js',
-    'dragula': 'https://unpkg.com/dragula/dragula.js',
+    'dragula': 'https://unpkg.com/dragula/dist/dragula.js',
 
     // ngx-bootstrap aliases
     'ngx-bootstrap/accordion': 'https://unpkg.com/ngx-bootstrap/bundles/ngx-bootstrap.umd.min.js',


### PR DESCRIPTION
Updated the dragula plunker link to use the prebuilt version of the library.


**Ignore my comments below - seems to have resolved itself by now**


Note Im currently getting errors in plunker eg:

![image](https://user-images.githubusercontent.com/20795331/37835090-3cfc9e9a-2ea7-11e8-8104-ef930c5c897a.png)

This is not related to this ticket - if you look in the released site the plunkers are also currently not working. This is an issue with unpkg.com - this happened one time before and resolved itself after a short while.

To test plunker is working you can temporarily edit the config to specify the exact version of any packages giving errors, eg:

```
'@angular/core': 'https://unpkg.com/@angular/core@5.2.9/bundles/core.umd.js',
```