### PR TITLE
Added "forest green"

### DIFF
--- a/src/services/color/color.service.ts
+++ b/src/services/color/color.service.ts
@@ -301,6 +301,7 @@ export const colorSets = {
             'copper': '#e57828',
             'amber': '#ffc002',
             'leaf-green': '#118c4f',
+            'forest-green': '#00645a',
             'primary': '#0073e7',
             'accent': '#7425ad',
             'secondary': '#ffffff',


### PR DESCRIPTION
This does not appear in the color palette, but is referred to in the Family Logos section: http://everythingux.net/styleguide/corporate-brand/families-product-icons/

https://jira.autonomy.com/browse/EL-2748