### PR TITLE
Fixing QA/Acceptance Comments

### DIFF
--- a/docs/app/pages/components/components-sections/tables/selection/selection.component.html
+++ b/docs/app/pages/components/components-sections/tables/selection/selection.component.html
@@ -1,4 +1,4 @@
-<table class="table">
+<table class="table table-hover">
     <thead>
         <tr>
             <th></th>

--- a/docs/app/pages/components/components-sections/tables/selection/snippets/app.html
+++ b/docs/app/pages/components/components-sections/tables/selection/snippets/app.html
@@ -1,4 +1,4 @@
-<table class="table">
+<table class="table table-hover">
     <thead>
         <tr>
             <th></th>

--- a/e2e/tests/components/page-header/page-header.e2e-spec.ts
+++ b/e2e/tests/components/page-header/page-header.e2e-spec.ts
@@ -226,4 +226,30 @@ describe('Page Header Tests', () => {
     // check the selected text
     expect(await page.selected.getText()).toBe('Daily View');
   });
+
+  it('should not deselect child items when the parent item is clicked again', async () => {
+
+    // enable autoselect
+    await page.autoselectButton.click();
+
+    // click the second menu item
+    await page.pageHeader2.$$('.horizontal-navigation-button').get(1).click();
+
+    // get the required elements
+    const secondaryNavigation: ElementFinder = await page.getSecondaryNavigation();
+    const tabset = await secondaryNavigation.$('.nav-tabs');
+    const tabs: ElementArrayFinder = await tabset.$$('li');
+
+    // click the second item
+    await tabs[1].click();
+
+    // check the selected text
+    expect(await page.selected.getText()).toBe('Weekly View');
+
+    // click the second menu item again
+    await page.pageHeader2.$$('.horizontal-navigation-button').get(1).click();
+
+    // check the selected text has not changed
+    expect(await page.selected.getText()).toBe('Weekly View');
+  });
 });

--- a/src/components/page-header/page-header.service.ts
+++ b/src/components/page-header/page-header.service.ts
@@ -29,6 +29,11 @@ export class PageHeaderService implements OnDestroy {
             return;
         }
 
+        // if we are in secondary navigation mode and we click a parent - dont deselect the child
+        if (this.secondary$.getValue() === true && this.isParentOf(this.selected$.getValue(), item)) {
+            return;
+        }
+
         // deselect all current items
         this.deselectAll();
 
@@ -95,6 +100,22 @@ export class PageHeaderService implements OnDestroy {
             // check if it has any parents
             this.selectParents(item.parent);
         }
+    }
+
+    private isParentOf(node: PageHeaderNavigation, parent: PageHeaderNavigation): boolean {
+        
+        // if there are no parents return false
+        if (!node || !node.parent) {
+            return false;
+        }
+
+        // if the parent is the match we are looking for return true
+        if (node.parent === parent) {
+            return true;
+        }
+
+        // if there are potentially grandparents then check them too
+        return this.isParentOf(node.parent, parent);
     }
 }
 


### PR DESCRIPTION
- Selection example missing hover styling on rows (added .table-hover class)
- Masthead if you click the "Showcase" tab when one of its children are currently selected it will deselect the child. This no longer happens and added a test to cover this case