### PR TITLE
EL-2970 - Expanding textarea migration

### DIFF
--- a/docs/app/data/components-page.json
+++ b/docs/app/data/components-page.json
@@ -535,8 +535,24 @@
                 },
                 {
                     "title": "Expanding Text Area",
+                    "component": "ComponentsExpandingTextAreaComponent",
+                    "version": "Angular",
+                    "usage": [
+                        {
+                            "title": "Selector",
+                            "content": "[uxAutoGrow]"
+                        },
+                        {
+                            "title": "Module",
+                            "content": "AutoGrowModule"
+                        }
+                    ]
+                },
+                {
+                    "title": "Expanding Text Area",
                     "component": "ComponentsExpandingTextAreaNg1Component",
-                    "version": "AngularJS"
+                    "version": "AngularJS",
+                    "deprecated": true
                 },
                 {
                     "title": "Toggle Switch",

--- a/docs/app/pages/components/components-sections/input-controls/expanding-text-area/expanding-text-area.component.html
+++ b/docs/app/pages/components/components-sections/input-controls/expanding-text-area/expanding-text-area.component.html
@@ -1,0 +1,28 @@
+<div class="row">
+    <div class="col-md-6 col-xs-12">
+        <textarea uxAutoGrow class="form-control expanding-textarea-demo" rows="1" placeholder="Enter text"></textarea>
+    </div>
+</div>
+
+<hr>
+
+<p>
+    Expanding textareas have the same functionality as regular textareas however with the additional feature that they can
+    grow in height as more content is added to them.
+</p>
+
+<p>
+    To set a limit on how large the textarea can grow add a <code>max-height</code> using CSS.
+    If the content becomes larger than the max height a vertical scrollbar will appear.
+</p>
+
+<p>To create an expanding textarea use the <code>uxAutoGrow</code> directive.</p>
+
+<tabset>
+    <tab heading="HTML">
+        <uxd-snippet [content]="this.snippets.compiled.appHtml"></uxd-snippet>
+    </tab>
+    <tab heading="CSS">
+        <uxd-snippet [content]="this.snippets.compiled.appCss"></uxd-snippet>
+    </tab>
+</tabset>

--- a/docs/app/pages/components/components-sections/input-controls/expanding-text-area/expanding-text-area.component.less
+++ b/docs/app/pages/components/components-sections/input-controls/expanding-text-area/expanding-text-area.component.less
@@ -1,0 +1,3 @@
+.expanding-textarea-demo {
+    max-height: 87px;
+}

--- a/docs/app/pages/components/components-sections/input-controls/expanding-text-area/expanding-text-area.component.ts
+++ b/docs/app/pages/components/components-sections/input-controls/expanding-text-area/expanding-text-area.component.ts
@@ -1,0 +1,34 @@
+import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { DocumentationSectionComponent } from '../../../../../decorators/documentation-section-component';
+import { BaseDocumentationSection } from '../../../../../components/base-documentation-section/base-documentation-section';
+import { IPlunkProvider } from '../../../../../interfaces/IPlunkProvider';
+import { IPlunk } from '../../../../../interfaces/IPlunk';
+
+@Component({
+    selector: 'uxd-expanding-text-area',
+    templateUrl: './expanding-text-area.component.html',
+    styleUrls: ['./expanding-text-area.component.less'],
+    changeDetection: ChangeDetectionStrategy.OnPush
+})
+@DocumentationSectionComponent('ComponentsExpandingTextAreaComponent')
+export class ComponentsExpandingTextAreaComponent extends BaseDocumentationSection implements IPlunkProvider {
+    
+    plunk: IPlunk = {
+        files: {
+            'app.component.html': this.snippets.raw.appHtml,
+            'app.component.ts': this.snippets.raw.appTs,
+            'app.component.css': this.snippets.raw.appCss,
+        },
+        modules: [
+            {
+                imports: ['AutoGrowModule'],
+                library: '@ux-aspects/ux-aspects'
+            }
+        ]
+    };
+
+    constructor() {
+        super(require.context('./snippets/', false, /\.(html|css|js|ts)$/));
+    }
+
+}

--- a/docs/app/pages/components/components-sections/input-controls/expanding-text-area/snippets/app.css
+++ b/docs/app/pages/components/components-sections/input-controls/expanding-text-area/snippets/app.css
@@ -1,0 +1,3 @@
+.expanding-textarea-demo {
+    max-height: 87px;
+}

--- a/docs/app/pages/components/components-sections/input-controls/expanding-text-area/snippets/app.html
+++ b/docs/app/pages/components/components-sections/input-controls/expanding-text-area/snippets/app.html
@@ -1,0 +1,5 @@
+<div class="row">
+    <div class="col-md-6 col-xs-12">
+        <textarea uxAutoGrow class="form-control expanding-textarea-demo" rows="1" placeholder="Enter text"></textarea>
+    </div>
+</div>

--- a/docs/app/pages/components/components-sections/input-controls/expanding-text-area/snippets/app.html
+++ b/docs/app/pages/components/components-sections/input-controls/expanding-text-area/snippets/app.html
@@ -1,5 +1,8 @@
 <div class="row">
     <div class="col-md-6 col-xs-12">
-        <textarea uxAutoGrow class="form-control expanding-textarea-demo" rows="1" placeholder="Enter text"></textarea>
+        <textarea uxAutoGrow 
+                  class="form-control expanding-textarea-demo" 
+                  rows="1" placeholder="Enter text">
+        </textarea>
     </div>
 </div>

--- a/docs/app/pages/components/components-sections/input-controls/expanding-text-area/snippets/app.ts
+++ b/docs/app/pages/components/components-sections/input-controls/expanding-text-area/snippets/app.ts
@@ -1,0 +1,10 @@
+import { Component } from '@angular/core';
+
+@Component({
+    selector: 'app',
+    templateUrl: './app.component.html',
+    styleUrls: ['./app.component.css'],
+})
+export class AppComponent {
+
+}

--- a/docs/app/pages/components/components-sections/input-controls/input-controls.module.ts
+++ b/docs/app/pages/components/components-sections/input-controls/input-controls.module.ts
@@ -7,7 +7,7 @@ import { DocumentationComponentsModule } from '../../../../components/components
 import { ResolverService, DocumentationPage } from '../../../../services/resolver/resolver.service';
 import { DocumentationCategoryComponent } from '../../../../components/documentation-category/documentation-category.component';
 
-import { CheckboxModule, ToggleSwitchModule, RadioButtonModule, ColorServiceModule, SliderModule, TagInputModule, TypeaheadModule, NumberPickerModule } from '../../../../../../src/index';
+import { CheckboxModule, ToggleSwitchModule, RadioButtonModule, ColorServiceModule, SliderModule, TagInputModule, TypeaheadModule, NumberPickerModule, AutoGrowModule } from '../../../../../../src/index';
 import { TabsModule } from 'ngx-bootstrap/tabs';
 import { WrappersModule } from '../../../../wrappers/wrappers.module';
 
@@ -29,6 +29,7 @@ import { ComponentsTagsNg1Component } from './tags-ng1/tags-ng1.component';
 import { ComponentsToggleSwitchComponent } from './toggleswitch/toggleswitch.component';
 import { ComponentsToggleSwitchNg1Component } from './toggle-switch-ng1/toggle-switch-ng1.component';
 import { ComponentsNumberPickerComponent } from './number-picker/number-picker.component';
+import { ComponentsExpandingTextAreaComponent } from './expanding-text-area/expanding-text-area.component';
 
 const SECTIONS = [
     ComponentsCheckboxComponent,
@@ -49,6 +50,7 @@ const SECTIONS = [
     ComponentsToggleSwitchComponent,
     ComponentsToggleSwitchNg1Component,
     ComponentsNumberPickerComponent,
+    ComponentsExpandingTextAreaComponent
 ];
 
 const ROUTES = [
@@ -77,6 +79,7 @@ const ROUTES = [
         FormsModule,
         NumberPickerModule,
         ColorServiceModule,
+        AutoGrowModule,
         DocumentationComponentsModule,
         RouterModule.forChild(ROUTES),
         ReactiveFormsModule,

--- a/e2e/pages/app/app.module.ts
+++ b/e2e/pages/app/app.module.ts
@@ -62,6 +62,10 @@ const ROUTES: Routes = [
         loadChildren: './dropdowns/dropdowns.module#DropdownsTestPageModule'
     },
     {
+        path: 'expanding-text-area',
+        loadChildren: './expanding-text-area/expanding-text-area.module#ExpandingTextAreaModule'
+    },
+    {
         path: 'facet-check-list',
         loadChildren:
             './facet-check-list/facet-check-list.module#FacetCheckListTestPageModule'

--- a/e2e/pages/app/expanding-text-area/expanding-text-area.module.ts
+++ b/e2e/pages/app/expanding-text-area/expanding-text-area.module.ts
@@ -1,0 +1,21 @@
+import { NgModule } from '@angular/core';
+import { RouterModule } from '@angular/router';
+import { AutoGrowModule } from '../../../../dist';
+
+import { ExpandingTextAreaTestPageComponent } from './expanding-text-area.testpage.component';
+
+@NgModule({
+    imports: [
+        AutoGrowModule,
+        RouterModule.forChild([
+            {
+                path: '',
+                component: ExpandingTextAreaTestPageComponent
+            }
+        ])
+    ],
+    exports: [],
+    declarations: [ExpandingTextAreaTestPageComponent],
+    providers: [],
+})
+export class ExpandingTextAreaModule { }

--- a/e2e/pages/app/expanding-text-area/expanding-text-area.testpage.component.html
+++ b/e2e/pages/app/expanding-text-area/expanding-text-area.testpage.component.html
@@ -1,0 +1,5 @@
+<div class="row">
+    <div class="col-md-6 col-xs-12">
+        <textarea uxAutoGrow class="form-control expanding-textarea-demo" rows="1" placeholder="Enter text"></textarea>
+    </div>
+</div>

--- a/e2e/pages/app/expanding-text-area/expanding-text-area.testpage.component.less
+++ b/e2e/pages/app/expanding-text-area/expanding-text-area.testpage.component.less
@@ -1,0 +1,3 @@
+.expanding-textarea-demo {
+    max-height: 83px;
+}

--- a/e2e/pages/app/expanding-text-area/expanding-text-area.testpage.component.ts
+++ b/e2e/pages/app/expanding-text-area/expanding-text-area.testpage.component.ts
@@ -1,0 +1,10 @@
+import { Component } from '@angular/core';
+
+@Component({
+    selector: 'app-expanding-text-area',
+    templateUrl: './expanding-text-area.testpage.component.html',
+    styleUrls: ['./expanding-text-area.testpage.component.less']
+})
+export class ExpandingTextAreaTestPageComponent {
+
+}

--- a/e2e/tests/components/expanding-text-area/expanding-text-area.e2e-spec.ts
+++ b/e2e/tests/components/expanding-text-area/expanding-text-area.e2e-spec.ts
@@ -1,0 +1,59 @@
+import { ExpandingTextAreaPage } from './expanding-text-area.po.spec';
+
+describe('Expanding Text Area Tests', () => {
+
+  let page: ExpandingTextAreaPage;
+
+  const height: number = 33;
+
+  beforeEach(() => {
+    page = new ExpandingTextAreaPage();
+    page.getPage();
+  });
+
+  it('should have correct initial states', async () => {
+    expect(await page.getHeight()).toBe(height);
+    expect(await page.getText()).toBe('');
+  });
+
+  it('should not grow when one line has been entered', async () => {
+    expect(await page.getHeight()).toBe(height);
+    expect(await page.getText()).toBe('');
+
+    await page.setText('A single line of text');
+
+    expect(await page.getHeight()).toBe(height);
+    expect(await page.getText()).toBe('A single line of text');
+  });
+
+  it('should grow when two lines has been entered', async () => {
+    expect(await page.getHeight()).toBe(height);
+    expect(await page.getText()).toBe('');
+
+    await page.setText('A first line of text\nA second line of text');
+
+    expect(await page.getHeight()).toBe(58);
+    expect(await page.getText()).toBe('A first line of text\nA second line of text');
+  });
+
+  it('should grow when three lines have been entered', async () => {
+    expect(await page.getHeight()).toBe(height);
+    expect(await page.getText()).toBe('');
+
+    await page.setText('A first line of text\nA second line of text\nA third line of text');
+
+    expect(await page.getHeight()).toBe(83);
+    expect(await page.getText()).toBe('A first line of text\nA second line of text\nA third line of text');
+  });
+
+  it('should not grow when four lines have been entered', async () => {
+    expect(await page.getHeight()).toBe(height);
+    expect(await page.getText()).toBe('');
+
+    await page.setText('A first line of text\nA second line of text\nA third line of text\nA fourth line of text');
+
+    expect(await page.getHeight()).toBe(83);
+    expect(await page.getText()).toBe('A first line of text\nA second line of text\nA third line of text\nA fourth line of text');
+  });
+
+});

--- a/e2e/tests/components/expanding-text-area/expanding-text-area.po.spec.ts
+++ b/e2e/tests/components/expanding-text-area/expanding-text-area.po.spec.ts
@@ -1,0 +1,22 @@
+import { browser, by, element } from 'protractor';
+
+export class ExpandingTextAreaPage {
+        
+    textarea = element(by.tagName('textarea'));
+
+    getPage(): void {
+        browser.get('#/expanding-text-area');
+    }
+
+    async setText(text: string): Promise<void> {
+        return await this.textarea.sendKeys(text);
+    }
+
+    async getText(): Promise<string> {
+        return await this.textarea.getAttribute('value');
+    }
+
+    async getHeight(): Promise<number> {
+        return (await this.textarea.getSize()).height;
+    }
+}

--- a/src/directives/auto-grow/auto-grow.directive.ts
+++ b/src/directives/auto-grow/auto-grow.directive.ts
@@ -1,0 +1,45 @@
+import { AfterViewInit, Directive, ElementRef, HostListener, Renderer2 } from '@angular/core';
+
+@Directive({
+  selector: '[uxAutoGrow]'
+})
+export class AutoGrowDirective implements AfterViewInit {
+
+  constructor(private _elementRef: ElementRef, private _renderer: Renderer2) {
+    // ensure this is a textarea or else throw error
+    if (_elementRef.nativeElement.tagName.toLowerCase() !== 'textarea') {
+      throw new Error('uxAutoGrow directive can only be used on <textarea> elements.');
+    }
+  }
+
+  ngAfterViewInit(): void {
+    this.update();
+  }
+
+  @HostListener('input')
+  update(): void {
+
+    // get computed style of element
+    const { paddingTop, paddingBottom } = getComputedStyle(this._elementRef.nativeElement);
+
+    // perform sizing
+    this._renderer.setStyle(this._elementRef.nativeElement, 'overflowY', 'hidden');
+    this._renderer.setStyle(this._elementRef.nativeElement, 'height', 'auto');
+
+    // get the new total height and element height
+    const { scrollHeight } = this._elementRef.nativeElement;
+    const { maxHeight } = getComputedStyle(this._elementRef.nativeElement);
+
+    // determine what the maximum allowed height is
+    const maximum = !isNaN(parseFloat(maxHeight)) ? parseFloat(maxHeight) : Infinity;
+
+    // if there is a max height specifed we want to show the scrollbars
+    if (maximum < scrollHeight) {
+      this._renderer.setStyle(this._elementRef.nativeElement, 'overflowY', 'auto');
+      this._renderer.setStyle(this._elementRef.nativeElement, 'height', maximum + 'px');
+    } else {
+      this._renderer.setStyle(this._elementRef.nativeElement, 'height', scrollHeight + 'px');
+    }
+  }
+
+}

--- a/src/directives/auto-grow/auto-grow.module.ts
+++ b/src/directives/auto-grow/auto-grow.module.ts
@@ -1,0 +1,9 @@
+import { NgModule } from '@angular/core';
+
+import { AutoGrowDirective } from './auto-grow.directive';
+
+@NgModule({
+    exports: [AutoGrowDirective],
+    declarations: [AutoGrowDirective]
+})
+export class AutoGrowModule { }

--- a/src/directives/auto-grow/index.ts
+++ b/src/directives/auto-grow/index.ts
@@ -1,0 +1,2 @@
+export * from './auto-grow.module';
+export * from './auto-grow.directive';

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,6 +35,7 @@ export * from './components/wizard/index';
 /*
   Export Directives
 */
+export * from './directives/auto-grow/index';
 export * from './directives/drag/index';
 export * from './directives/fixed-header-table/index';
 export * from './directives/focus-if/index';


### PR DESCRIPTION
- Created new Angular directive
- Added documentation section and deprecated old section
- Added protractor tests

Old component had two attributes which I have removed:
- max lines - This is better just set using css as that gives more flexibility eg, flexbox and % etc..
- disable return - This was fairly useless before as you could paste stuff in that had multiple lines. In the rare case that they would want this, this should be handled using ngModel rather than part of this directive.