### PR TITLE
EL-2969 - Card Tabs

### DIFF
--- a/configs/webpack.docs.prod.config.js
+++ b/configs/webpack.docs.prod.config.js
@@ -55,10 +55,6 @@ module.exports = {
                 })
             },
             {
-                test: /\.json$/,
-                use: 'json-loader'
-            },
-            {
                 test: /\.md$/,
                 use: ['html-loader', 'markdown-code-highlight-loader']
             },

--- a/docs/app/data/components-page.json
+++ b/docs/app/data/components-page.json
@@ -1588,8 +1588,30 @@
                 },
                 {
                     "title": "Card Tabs",
+                    "component": "ComponentsCardTabsComponent",
+                    "version": "Angular",
+                    "usage": [{
+                        "title": "Selector",
+                        "content": "ux-card-tabset"
+                    },
+                    {
+                        "title": "Selector",
+                        "content": "ux-card-tab"
+                    },
+                    {
+                        "title": "Selector",
+                        "content": "[uxCardTabContent]"
+                    },
+                    {
+                        "title": "Module",
+                        "content": "CardTabsModule"
+                    }]
+                },
+                {
+                    "title": "Card Tabs",
                     "component": "ComponentsCardTabsNg1Component",
-                    "version": "AngularJS"
+                    "version": "AngularJS",
+                    "deprecated": true
                 }
             ]
         },

--- a/docs/app/pages/components/components-sections/tabs/card-tabs/card-tabs.component.html
+++ b/docs/app/pages/components/components-sections/tabs/card-tabs/card-tabs.component.html
@@ -1,0 +1,71 @@
+<ux-card-tabset [position]="position">
+
+    <ux-card-tab class="card" *ngFor="let tab of tabs">
+        <h3 class="card-title">{{ tab.title }}</h3>
+        
+        <div class="card-image" [ngClass]="tab.image"></div>
+        
+        <h3 class="card-value">{{ tab.value }}<small>{{ tab.unit }}</small></h3>
+        <h4 class="card-subtitle">{{ tab.subtitle }}</h4>
+
+        <ng-template uxCardTabContent>
+            <h4>{{ tab.title }}</h4>
+            <p>{{ tab.content }}</p>
+        </ng-template>
+    </ux-card-tab>
+
+</ux-card-tabset>
+
+<hr>
+
+<div class="row uxd-customize-example">
+    <div class="col-md-12">
+        <accordion>
+            <accordion-group class="accordion-chevron" heading="Customize Example...">
+                <div class="row uxd-customize-row">
+                    <div class="col-md-4 col-sm-12">
+                        <label>Position</label>
+                        <ux-radio-button [(value)]="position" option="top">top</ux-radio-button>
+                        <ux-radio-button [(value)]="position" option="bottom">bottom</ux-radio-button>
+                    </div>
+                </div>
+            </accordion-group>
+        </accordion>
+    </div>
+</div>
+
+<p>
+    Card tabs are defined inside a <code>ux-card-tabset</code> component using a <code>ux-card-tab</code> component.
+    Inside the <code>ux-card-tab</code> component insert any content you want to display in the card.
+</p>
+<p>
+    Also inside the <code>ux-card-tab</code> component an element with a <code>uxCardTabContent</code> directive should be defined which will contain
+    the content that will be shown when that card is selected.
+</p>
+
+<p>
+    If the <code>ux-card-tabset</code> has more cards than can be displayed in the space available arrow buttons will appear
+    to allow the user to scroll through all the cards.
+</p>
+
+<p>
+    The following can be used to configure the appearance of the card tabs:
+</p>
+
+<uxd-api-properties tableTitle="Inputs">
+    <tr uxd-api-property name="position" type="string" defaultValue="top">
+        Defines whether the tab content should appear above or below the cards. The possible values are <code>top</code> and <code>bottom</code>.
+    </tr>
+</uxd-api-properties>
+
+<tabset>
+    <tab heading="HTML">
+        <uxd-snippet [content]="snippets.compiled.appHtml"></uxd-snippet>
+    </tab>
+    <tab heading="TypeScript">
+        <uxd-snippet [content]="snippets.compiled.appTs"></uxd-snippet>
+    </tab>
+    <tab heading="CSS">
+        <uxd-snippet [content]="snippets.compiled.appCss"></uxd-snippet>
+    </tab>
+</tabset>

--- a/docs/app/pages/components/components-sections/tabs/card-tabs/card-tabs.component.less
+++ b/docs/app/pages/components/components-sections/tabs/card-tabs/card-tabs.component.less
@@ -1,0 +1,51 @@
+.card-title {
+    color: #333;
+    font-size: 17px;
+    margin: 3px 0 14px;
+    font-weight: 400;
+}
+
+.card-value {
+    text-align: center;
+    font-size: 26px;
+    color: #686868;
+    margin: 0;
+    padding: 5px 0;
+    font-weight: 400;
+}
+
+.card-subtitle {
+    text-align: center;
+    color: #b8b8b8;
+    margin: 0;
+    font-weight: 400;
+    font-size: 15px;
+}
+
+.card-image {
+    width: 100%;
+    height: 60px;
+    background-repeat: no-repeat;
+    background-size: contain;
+    background-position: center;
+
+    &.card-image-1 {
+        background-image: url('../../../../../assets/img/card-img1.png');
+    }
+
+    &.card-image-2 {
+        background-image: url('../../../../../assets/img/card-img2.png');
+    }
+
+    &.card-image-3 {
+        background-image: url('../../../../../assets/img/card-img3.png');
+    }
+
+    &.card-image-4 {
+        background-image: url('../../../../../assets/img/card-img4.png');
+    }
+
+    &.card-image-5 {
+        background-image: url('../../../../../assets/img/card-img5.png');
+    }
+}

--- a/docs/app/pages/components/components-sections/tabs/card-tabs/card-tabs.component.ts
+++ b/docs/app/pages/components/components-sections/tabs/card-tabs/card-tabs.component.ts
@@ -1,0 +1,78 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { BaseDocumentationSection } from '../../../../../components/base-documentation-section/base-documentation-section';
+import { DocumentationSectionComponent } from '../../../../../decorators/documentation-section-component';
+import { IPlunk } from '../../../../../interfaces/IPlunk';
+import { IPlunkProvider } from '../../../../../interfaces/IPlunkProvider';
+
+@Component({
+    selector: 'uxd-components-card-tabs',
+    templateUrl: './card-tabs.component.html',
+    styleUrls: ['./card-tabs.component.less'],
+    changeDetection: ChangeDetectionStrategy.OnPush
+})
+@DocumentationSectionComponent('ComponentsCardTabsComponent')
+export class ComponentsCardTabsComponent extends BaseDocumentationSection implements IPlunkProvider {
+
+    plunk: IPlunk = {
+        files: {
+            'app.component.html': this.snippets.raw.appHtml,
+            'app.component.ts': this.snippets.raw.appTs,
+            'app.component.css': this.snippets.raw.appCss,
+        },
+        modules: [
+            {
+                imports: ['CardTabsModule', 'RadioButtonModule'],
+                library: '@ux-aspects/ux-aspects'
+            },
+            {
+                imports: ['AccordionModule'],
+                library: 'ngx-bootstrap/accordion',
+                forRoot: true
+            }
+        ]
+    };
+
+    position: string = 'top';
+
+    tabs = [{
+        title: 'Archive Totals',
+        image: 'card-image-1',
+        value: 637,
+        unit: 'GB',
+        subtitle: '63% licensed storage used',
+        content: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam cursus volutpat eros, in varius nibh ultrices a. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Aliquam pellentesque vel augue nec pellentesque. Nullam sollicitudin pulvinar lectus, non eleifend mauris finibus vitae. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.'
+    }, {
+        title: 'Data Processed',
+        image: 'card-image-2',
+        value: 1.3,
+        unit: 'GB',
+        subtitle: 'processed this month',
+        content: 'Vestibulum faucibus porttitor ligula, vitae sollicitudin tellus efficitur quis. Duis sit amet sollicitudin dui. Praesent mauris tortor, dignissim sit amet convallis et, sollicitudin et risus. Phasellus eget tortor eu est egestas suscipit et eget ante. Vivamus eget ultricies felis. Ut dolor justo, finibus vel metus quis, hendrerit malesuada justo. Donec est nibh, suscipit non feugiat eget, rutrum sed ipsum.'
+    }, {
+        title: 'Data Retention',
+        image: 'card-image-3',
+        value: 242,
+        unit: 'GB',
+        subtitle: '39% data on hold',
+        content: 'Mauris sit amet condimentum lorem. Aliquam at ante sed quam volutpat ornare. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Nam congue posuere eros sed egestas. Cras gravida viverra ipsum vel porta. Ut at hendrerit velit. Fusce est est, vehicula vel elementum et, ultricies at leo.'
+    }, {
+        title: 'Users',
+        image: 'card-image-4',
+        value: 195,
+        unit: null,
+        subtitle: '76 logged in',
+        content: 'In hac habitasse platea dictumst. Donec ut nunc mauris. Suspendisse lobortis viverra neque vitae cursus. Proin tempus arcu erat, eu sollicitudin neque efficitur interdum. Cras bibendum eget sapien sit amet hendrerit. Phasellus non dictum urna. Sed fermentum nisl nec turpis euismod lobortis. Pellentesque porta ligula at auctor tempus. Suspendisse non augue nec libero posuere tempus quis nec lectus. Sed non nisl velit.'
+    }, {
+        title: 'Audit Trail',
+        image: 'card-image-5',
+        value: null,
+        unit: null,
+        subtitle: 'activity (last 7 days)',
+        content: 'Fusce tempus aliquet tristique. Cras mollis cursus eros, ac tincidunt arcu aliquet sed. Fusce magna nisl, euismod eget mattis ut, convallis sit amet mi. Sed tempor nunc ac blandit pretium. Aliquam ut luctus augue. Etiam luctus felis nisi. Cras a ante nec nulla mattis dignissim. Vivamus placerat faucibus ultricies. Aliquam in efficitur elit, nec egestas odio.'
+    }];
+
+    constructor() {
+        super(require.context('./snippets/', false, /\.(html|css|js|ts)$/));
+    }
+
+}

--- a/docs/app/pages/components/components-sections/tabs/card-tabs/snippets/app.css
+++ b/docs/app/pages/components/components-sections/tabs/card-tabs/snippets/app.css
@@ -1,0 +1,51 @@
+.card-title {
+    color: #333;
+    font-size: 17px;
+    margin: 3px 0 14px;
+    font-weight: 400;
+}
+
+.card-value {
+    text-align: center;
+    font-size: 26px;
+    color: #686868;
+    margin: 0;
+    padding: 5px 0;
+    font-weight: 400;
+}
+
+.card-subtitle {
+    text-align: center;
+    color: #b8b8b8;
+    margin: 0;
+    font-weight: 400;
+    font-size: 15px;
+}
+
+.card-image {
+    width: 100%;
+    height: 60px;
+    background-repeat: no-repeat;
+    background-size: contain;
+    background-position: center;
+}
+
+.card-image.card-image-1 {
+    background-image: url("https://uxaspects.github.io/UXAspects/assets/img/card-img1.png");
+}
+
+.card-image.card-image-2 {
+    background-image: url("https://uxaspects.github.io/UXAspects/assets/img/card-img2.png");
+}
+
+.card-image.card-image-3 {
+    background-image: url("https://uxaspects.github.io/UXAspects/assets/img/card-img3.png");
+}
+
+.card-image.card-image-4 {
+    background-image: url("https://uxaspects.github.io/UXAspects/assets/img/card-img4.png");
+}
+
+.card-image.card-image-5 {
+    background-image: url("https://uxaspects.github.io/UXAspects/assets/img/card-img5.png");
+}

--- a/docs/app/pages/components/components-sections/tabs/card-tabs/snippets/app.html
+++ b/docs/app/pages/components/components-sections/tabs/card-tabs/snippets/app.html
@@ -1,0 +1,35 @@
+<ux-card-tabset [position]="position">
+
+    <ux-card-tab class="card" *ngFor="let tab of tabs">
+        <h3 class="card-title">{{ tab.title }}</h3>
+        
+        <div class="card-image" [ngClass]="tab.image"></div>
+        
+        <h3 class="card-value">{{ tab.value }}<small>{{ tab.unit }}</small></h3>
+        <h4 class="card-subtitle">{{ tab.subtitle }}</h4>
+
+        <ng-template uxCardTabContent>
+            <h4>{{ tab.title }}</h4>
+            <p>{{ tab.content }}</p>
+        </ng-template>
+    </ux-card-tab>
+
+</ux-card-tabset>
+
+<hr>
+
+<div class="row uxd-customize-example">
+    <div class="col-md-12">
+        <accordion>
+            <accordion-group class="accordion-chevron" heading="Customize Example...">
+                <div class="row uxd-customize-row">
+                    <div class="col-md-4 col-sm-12">
+                        <label>Position</label>
+                        <ux-radio-button [(value)]="position" option="top">top</ux-radio-button>
+                        <ux-radio-button [(value)]="position" option="bottom">bottom</ux-radio-button>
+                    </div>
+                </div>
+            </accordion-group>
+        </accordion>
+    </div>
+</div>

--- a/docs/app/pages/components/components-sections/tabs/card-tabs/snippets/app.ts
+++ b/docs/app/pages/components/components-sections/tabs/card-tabs/snippets/app.ts
@@ -1,0 +1,49 @@
+import { Component } from '@angular/core';
+
+@Component({
+    selector: 'app',
+    templateUrl: './app.component.html',
+    styleUrls: ['./app.component.css']
+})
+export class AppComponent {
+
+    position: string = 'top';
+
+    tabs = [{
+        title: 'Archive Totals',
+        image: 'card-image-1',
+        value: 637,
+        unit: 'GB',
+        subtitle: '63% licensed storage used',
+        content: 'Lorem ipsum dolor sit amet...'
+    }, {
+        title: 'Data Processed',
+        image: 'card-image-2',
+        value: 1.3,
+        unit: 'GB',
+        subtitle: 'processed this month',
+        content: 'Vestibulum faucibus porttitor...'
+    }, {
+        title: 'Data Retention',
+        image: 'card-image-3',
+        value: 242,
+        unit: 'GB',
+        subtitle: '39% data on hold',
+        content: 'Mauris sit amet condimentum lorem...'
+    }, {
+        title: 'Users',
+        image: 'card-image-4',
+        value: 195,
+        unit: null,
+        subtitle: '76 logged in',
+        content: 'In hac habitasse platea dictumst...'
+    }, {
+        title: 'Audit Trail',
+        image: 'card-image-5',
+        value: null,
+        unit: null,
+        subtitle: 'activity (last 7 days)',
+        content: 'Fusce tempus aliquet tristique...'
+    }];
+
+}

--- a/docs/app/pages/components/components-sections/tabs/tabs.module.ts
+++ b/docs/app/pages/components/components-sections/tabs/tabs.module.ts
@@ -1,21 +1,26 @@
-import { NgModule, ComponentFactoryResolver } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ComponentFactoryResolver, NgModule } from '@angular/core';
 import { RouterModule } from '@angular/router';
+import { AccordionModule } from 'ngx-bootstrap/accordion';
+import { TabsModule } from 'ngx-bootstrap/tabs';
+import { CardTabsModule, RadioButtonModule } from '../../../../../../src';
 import { DocumentationComponentsModule } from '../../../../components/components.module';
-import { ResolverService, DocumentationPage } from '../../../../services/resolver/resolver.service';
 import { DocumentationCategoryComponent } from '../../../../components/documentation-category/documentation-category.component';
-
-import { ComponentsTabsNg1Component } from './tabs-ng1/tabs-ng1.component';
+import { DocumentationPage, ResolverService } from '../../../../services/resolver/resolver.service';
+import { WrappersModule } from '../../../../wrappers/wrappers.module';
+import { ComponentsCardTabsNg1Component } from './card-tabs-ng1/card-tabs-ng1.component';
+import { ComponentsCardTabsComponent } from './card-tabs/card-tabs.component';
 import { ComponentsDetailedTabExampleNg1Component } from './detailed-tab-example-ng1/detailed-tab-example-ng1.component';
 import { ComponentsStackedTabsNg1Component } from './stacked-tabs-ng1/stacked-tabs-ng1-component';
-import { ComponentsCardTabsNg1Component } from './card-tabs-ng1/card-tabs-ng1.component';
-import { WrappersModule } from '../../../../wrappers/wrappers.module';
-import { TabsModule } from 'ngx-bootstrap/tabs';
+import { ComponentsTabsNg1Component } from './tabs-ng1/tabs-ng1.component';
+
 
 const SECTIONS = [
     ComponentsTabsNg1Component,
     ComponentsDetailedTabExampleNg1Component,
     ComponentsStackedTabsNg1Component,
-    ComponentsCardTabsNg1Component
+    ComponentsCardTabsNg1Component,
+    ComponentsCardTabsComponent
 ];
 
 const ROUTES = [
@@ -30,8 +35,12 @@ const ROUTES = [
 
 @NgModule({
     imports: [
+        CommonModule,
         WrappersModule,
         TabsModule,
+        CardTabsModule,
+        RadioButtonModule,
+        AccordionModule.forRoot(),
         DocumentationComponentsModule,
         RouterModule.forChild(ROUTES)
     ],

--- a/e2e/pages/app/app.module.ts
+++ b/e2e/pages/app/app.module.ts
@@ -35,6 +35,10 @@ const ROUTES: Routes = [
             './buttons-radio-buttons/buttons-radio-buttons.module#ButtonsRadioButtonsTestPageModule'
     },
     {
+        path: 'card-tabs',
+        loadChildren: './card-tabs/card-tabs.module#CardTabsTestPageModule'
+    },
+    {
         path: 'checkboxes',
         loadChildren: './checkbox/checkbox.module#CheckboxTestPageModule'
     },

--- a/e2e/pages/app/card-tabs/card-tabs.module.ts
+++ b/e2e/pages/app/card-tabs/card-tabs.module.ts
@@ -1,0 +1,20 @@
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { RouterModule } from '@angular/router';
+import { CardTabsModule } from '../../../../dist';
+import { CardTabsTestPageComponent } from './card-tabs.testpage.component';
+
+@NgModule({
+    imports: [
+        CommonModule,
+        CardTabsModule,
+        RouterModule.forChild([
+            {
+                path: '',
+                component: CardTabsTestPageComponent
+            }
+        ])
+    ],
+    declarations: [CardTabsTestPageComponent]
+})
+export class CardTabsTestPageModule { }

--- a/e2e/pages/app/card-tabs/card-tabs.testpage.component.html
+++ b/e2e/pages/app/card-tabs/card-tabs.testpage.component.html
@@ -1,0 +1,15 @@
+<div class="card-container">
+    <ux-card-tabset [position]="position">
+
+        <ux-card-tab class="card" *ngFor="let tab of tabs">
+            <h3 class="card-title">{{ tab.title }}</h3>
+
+            <ng-template uxCardTabContent>
+                <p>{{ tab.content }}</p>
+            </ng-template>
+        </ux-card-tab>
+
+    </ux-card-tabset>
+</div>
+
+<button class="btn button-primary" (click)="position = 'bottom'">Set Position Bottom</button>

--- a/e2e/pages/app/card-tabs/card-tabs.testpage.component.less
+++ b/e2e/pages/app/card-tabs/card-tabs.testpage.component.less
@@ -1,0 +1,3 @@
+.card-container {
+    max-width: 600px;
+}

--- a/e2e/pages/app/card-tabs/card-tabs.testpage.component.ts
+++ b/e2e/pages/app/card-tabs/card-tabs.testpage.component.ts
@@ -1,0 +1,28 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-card-tabs',
+  templateUrl: './card-tabs.testpage.component.html',
+  styleUrls: ['./card-tabs.testpage.component.less'],
+})
+export class CardTabsTestPageComponent {
+
+    position: string = 'top';
+
+    tabs = [{
+        title: 'Tab Title 1',
+        content: 'Tab 1 Content'
+    }, {
+        title: 'Tab Title 2',
+        content: 'Tab 2 Content'
+    }, {
+        title: 'Tab Title 3',
+        content: 'Tab 3 Content'
+    }, {
+        title: 'Tab Title 4',
+        content: 'Tab 4 Content'
+    }, {
+        title: 'Tab Title 5',
+        content: 'Tab 5 Content'
+    }];
+}

--- a/e2e/tests/components/card-tabs/card-tabs.e2e-spec.ts
+++ b/e2e/tests/components/card-tabs/card-tabs.e2e-spec.ts
@@ -1,0 +1,116 @@
+import { Key, browser } from 'protractor';
+import { CardTabsPage } from './card-tabs.po.spec';
+
+describe('Card Tab Tests', () => {
+
+  let page: CardTabsPage;
+
+  beforeEach(() => {
+    page = new CardTabsPage();
+    page.getPage();
+  });
+
+  it('should have correct initial states', async () => {
+
+    // only the first tab should be selected initially
+    expect(await page.getTabSelected(0)).toBe(true);
+    expect(await page.getTabSelected(1)).toBe(false);
+    expect(await page.getTabSelected(2)).toBe(false);
+    expect(await page.getTabSelected(3)).toBe(false);
+    expect(await page.getTabSelected(4)).toBe(false);
+
+    // the initial position should be 'top'
+    expect(await page.getPosition()).toBe('top');
+
+    // expect the tab content to be correct
+    expect(await page.getTabContent()).toBe('Tab 1 Content');
+  });
+
+  it('should select a card on click', async () => {
+
+    // the first tab should initially be selected
+    expect(await page.getTabSelected(0)).toBe(true);
+    expect(await page.getTabSelected(1)).toBe(false);
+
+    // get the tab element
+    const tab = await page.getTab(1);
+
+    // click on the tab
+    await tab.click();
+
+    // the secpnd tab to be selected
+    expect(await page.getTabSelected(0)).toBe(false);
+    expect(await page.getTabSelected(1)).toBe(true);
+
+    // expect the tab content to be updated
+    expect(await page.getTabContent()).toBe('Tab 2 Content');
+  });
+
+  it('should select a card on enter', async () => {
+
+    // the first tab should initially be selected
+    expect(await page.getTabSelected(0)).toBe(true);
+    expect(await page.getTabSelected(1)).toBe(false);
+
+    // tab to the second card
+    await browser.actions().sendKeys(Key.TAB).sendKeys(Key.TAB).sendKeys(Key.ENTER).perform();
+
+    // the secpnd tab to be selected
+    expect(await page.getTabSelected(0)).toBe(false);
+    expect(await page.getTabSelected(1)).toBe(true);
+
+    // expect the tab content to be updated
+    expect(await page.getTabContent()).toBe('Tab 2 Content');
+  });
+
+  it('should show more items on next button click', async () => {
+
+    // initial scroll position should be 0
+    expect(await page.getScrollPosition()).toBe(0);
+    
+    // scroll to next page
+    await page.nextBtn.click();
+
+    // wait for the animations to finish
+    await browser.sleep(500);
+
+    // get the scroll position now
+    expect(await page.getScrollPosition()).toBe(-400);  
+  });
+
+  it('should be able to scroll back again', async () => {
+
+    // initial scroll position should be 0
+    expect(await page.getScrollPosition()).toBe(0);
+    
+    // scroll to next page
+    await page.nextBtn.click();
+
+    // wait for the animations to finish
+    await browser.sleep(500);
+
+    // get the scroll position now
+    expect(await page.getScrollPosition()).toBe(-400);
+    
+    // scroll to next page
+    await page.previousBtn.click();
+
+    // wait for the animations to finish
+    await browser.sleep(500);
+
+    // get the scroll position now
+    expect(await page.getScrollPosition()).toBe(0);
+  });
+
+  it('should be able to change the position', async () => {
+
+    // get the current position
+    expect(await page.getPosition()).toBe('top');
+
+    await page.positionBtn.click();
+
+    // get the current position
+    expect(await page.getPosition()).toBe('bottom');
+  });
+
+});

--- a/e2e/tests/components/card-tabs/card-tabs.po.spec.ts
+++ b/e2e/tests/components/card-tabs/card-tabs.po.spec.ts
@@ -1,0 +1,42 @@
+import { browser, $, $$, ElementFinder, ElementArrayFinder } from 'protractor';
+
+export class CardTabsPage {
+
+    tabset = $('ux-card-tabset');
+    tabs = $$('ux-card-tab');
+    content = $('.card-tab-content');
+    cardlist = $('.card-tabs-list');
+
+    previousBtn = $('.card-tabs-paging-btn-previous');
+    nextBtn = $('.card-tabs-paging-btn-next');
+    positionBtn = $('.button-primary');
+
+    getPage(): void {
+        browser.get('#/card-tabs');
+    }
+
+    async getTab(index: number): Promise<ElementFinder> {
+        return await this.tabs.get(index);
+    }
+
+    async getTabContent(): Promise<string> {
+        return await this.content.getText();
+    }
+
+    async getTabSelected(index: number): Promise<boolean> {
+        const tab: ElementFinder = await this.getTab(index);
+        const classes = await tab.getAttribute('class');
+
+        return classes.includes('active');
+    }
+
+    async getPosition(): Promise<string> {
+        return await this.tabset.getAttribute('class');
+    }
+
+    async getScrollPosition(): Promise<number> {
+        const styles = await this.cardlist.getAttribute('style');
+        return parseInt(styles.substring(styles.indexOf('translateX(') + 'translateX('.length, styles.indexOf('px')));
+    }
+}
+

--- a/src/components/card-tabs/card-tab/card-tab-content.directive.ts
+++ b/src/components/card-tabs/card-tab/card-tab-content.directive.ts
@@ -1,0 +1,6 @@
+import { Directive } from '@angular/core';
+
+@Directive({
+  selector: '[uxCardTabContent]'
+})
+export class CardTabContentDirective { }

--- a/src/components/card-tabs/card-tab/card-tab.component.html
+++ b/src/components/card-tabs/card-tab/card-tab.component.html
@@ -1,0 +1,1 @@
+<ng-content></ng-content>

--- a/src/components/card-tabs/card-tab/card-tab.component.less
+++ b/src/components/card-tabs/card-tab/card-tab.component.less
@@ -1,0 +1,73 @@
+ux-card-tab {
+    position: relative;
+    display: inline-block;
+    width: 190px;
+    height: 170px;
+    background-color: @card-tab-bg;
+    box-shadow: @card-tab-border 0 1px 8px;
+    cursor: pointer;
+    margin: 5px;
+    border: 1px solid @card-tab-border;
+    transition: border 500ms linear;
+    padding: 7px 9px;
+    outline: none;
+
+    &:hover,
+    &:focus {
+        border-color: @card-tab-hover-border;
+    }
+
+    &.active {
+        border-color: @card-tab-active-border;
+
+        &:before,
+        &:after {
+            content: '';
+            border: solid transparent;
+            height: 0;
+            width: 0;
+            position: absolute;
+            pointer-events: none;
+        }
+
+        &.top {
+            &:before,
+            &:after {
+                bottom: 100%;
+                left: 50%;
+            }
+
+            &:before {
+                border-top-color: @card-tab-active-border;
+                margin-left: -10px;
+                border-width: 10px;
+            }
+
+            &:after {
+                border-top-color: @card-tab-bg;
+                margin-left: -9px;
+                border-width: 9px;
+            }
+        }
+
+        &.bottom {
+            &:before,
+            &:after {
+                top: 100%;
+                left: 50%;
+            }
+
+            &:before {
+                border-top-color: @card-tab-active-border;
+                margin-left: -10px;
+                border-width: 10px;
+            }
+
+            &:after {
+                border-top-color: @card-tab-bg;
+                margin-left: -9px;
+                border-width: 9px;
+            }
+        }
+    }
+}

--- a/src/components/card-tabs/card-tab/card-tab.component.ts
+++ b/src/components/card-tabs/card-tab/card-tab.component.ts
@@ -1,0 +1,48 @@
+import { ChangeDetectionStrategy, Component, ContentChild, ElementRef, HostBinding, HostListener, OnDestroy, OnInit, TemplateRef } from '@angular/core';
+import { Subscription } from 'rxjs/Subscription';
+import { CardTabsService } from '../card-tabs.service';
+import { CardTabContentDirective } from './card-tab-content.directive';
+
+@Component({
+  selector: 'ux-card-tab',
+  templateUrl: './card-tab.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  host: {
+    tabindex: '0'
+  }
+})
+export class CardTabComponent implements OnInit, OnDestroy {
+
+  @HostBinding('class') position: string = 'top';
+  @HostBinding('class.active') active: boolean = false;
+
+  @ContentChild(CardTabContentDirective, { read: TemplateRef }) content: TemplateRef<any>;
+
+  private _subscription = new Subscription();
+
+  constructor(private _tabService: CardTabsService, public elementRef: ElementRef) {
+
+    // subscribe to the various values
+    const active$ = _tabService.tab$.subscribe(tab => this.active = tab === this);
+    const direction$ = _tabService.position.subscribe(position => this.position = position);
+
+    // keep a collection of all subscriptions
+    this._subscription.add(active$);
+    this._subscription.add(direction$);
+  }
+
+  ngOnInit(): void {
+    this._tabService.initialise(this);
+  }
+
+  ngOnDestroy(): void {
+    this._subscription.unsubscribe();
+  }
+
+  @HostListener('click')
+  @HostListener('keydown.enter')
+  select(): void {
+    this._tabService.select(this);
+  }
+
+}

--- a/src/components/card-tabs/card-tabs.module.ts
+++ b/src/components/card-tabs/card-tabs.module.ts
@@ -1,0 +1,16 @@
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { ResizeModule } from '../../directives/resize';
+import { CardTabContentDirective } from './card-tab/card-tab-content.directive';
+import { CardTabComponent } from './card-tab/card-tab.component';
+import { CardTabsetComponent } from './card-tabset/card-tabset.component';
+
+@NgModule({
+  imports: [
+    CommonModule,
+    ResizeModule
+  ],
+  declarations: [CardTabsetComponent, CardTabComponent, CardTabContentDirective],
+  exports: [CardTabsetComponent, CardTabComponent, CardTabContentDirective]
+})
+export class CardTabsModule { }

--- a/src/components/card-tabs/card-tabs.service.ts
+++ b/src/components/card-tabs/card-tabs.service.ts
@@ -1,0 +1,34 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs/BehaviorSubject';
+import { CardTabComponent } from './card-tab/card-tab.component';
+
+@Injectable()
+export class CardTabsService {
+
+  tab$ = new BehaviorSubject<CardTabComponent>(null);
+  position = new BehaviorSubject<string>('top');
+
+  /**
+   * Each tab will call this when it is initialised.
+   * This allows us to initially select the first tab
+   */
+  initialise(tab: CardTabComponent): void {
+    if (!this.tab$.getValue()) {
+      this.select(tab);
+    }
+  }
+
+  /**
+   * Select the tab
+   */
+  select(tab: CardTabComponent): void {
+    this.tab$.next(tab);
+  }
+
+  /**
+   * Set the position of the tab content
+   */
+  setPosition(position: string): void {
+    this.position.next(position);
+  }
+}

--- a/src/components/card-tabs/card-tabset/card-tabset.component.html
+++ b/src/components/card-tabs/card-tabset/card-tabset.component.html
@@ -1,0 +1,18 @@
+<div class="card-tab-content" *ngIf="(tab$ | async); let tab">
+    <ng-container [ngTemplateOutlet]="tab.content"></ng-container>
+</div>
+
+<div class="card-tabs">
+
+    <button class="card-tabs-paging-btn card-tabs-paging-btn-previous" (click)="previous()" *ngIf="offset < bounds.lower">
+        <i class="hpe-icon hpe-previous"></i>
+    </button>
+
+    <div class="card-tabs-list" #list (uxResize)="resize($event)" [style.transform]="'translateX(' + offset + 'px)'">
+        <ng-content></ng-content>
+    </div>
+
+    <button class="card-tabs-paging-btn card-tabs-paging-btn-next" (click)="next()" *ngIf="offset > bounds.upper">
+        <i class="hpe-icon hpe-next"></i>
+    </button>
+</div>

--- a/src/components/card-tabs/card-tabset/card-tabset.component.less
+++ b/src/components/card-tabs/card-tabset/card-tabset.component.less
@@ -1,0 +1,51 @@
+ux-card-tabset {
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+
+    &.bottom {
+        flex-direction: column-reverse;
+    }
+
+    .card-tabs {
+        position: relative;
+        white-space: nowrap;
+        overflow: hidden;
+        padding: 4px 0;
+    }
+
+    .card-tabs-list {
+        position: relative;
+        transition: transform 250ms ease-in-out;
+    }
+
+    .card-tabs-paging-btn {
+        position: absolute;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        width: 30px;
+        height: 30px;
+        top: 50%;
+        transform: translateY(-50%);
+        color: @card-tab-pagination-color;
+        cursor: pointer;
+        background-color: @card-tab-pagination-bg;
+        border-radius: 50%;
+        transition: background-color 250ms linear;
+        border: none;
+        z-index: 2;
+
+        &:hover {
+            background-color: @card-tab-pagination-hover-bg;
+        }
+    }
+
+    .card-tabs-paging-btn-previous {
+        left: 10px;
+    }
+
+    .card-tabs-paging-btn-next {
+        right: 10px;
+    }
+}

--- a/src/components/card-tabs/card-tabset/card-tabset.component.ts
+++ b/src/components/card-tabs/card-tabset/card-tabset.component.ts
@@ -1,0 +1,101 @@
+import { Component, ElementRef, HostBinding, Input, OnDestroy, ViewChild } from '@angular/core';
+import { Observable } from 'rxjs/Observable';
+import { Subscription } from 'rxjs/Subscription';
+import { distinctUntilChanged, filter } from 'rxjs/operators';
+import { ResizeDimensions } from '../../../directives/resize';
+import { CardTabComponent } from '../card-tab/card-tab.component';
+import { CardTabsService } from '../card-tabs.service';
+
+@Component({
+  selector: 'ux-card-tabset',
+  templateUrl: './card-tabset.component.html',
+  providers: [CardTabsService]
+})
+export class CardTabsetComponent implements OnDestroy {
+
+  @HostBinding('class')
+  @Input() set position(direction: string) {
+    this._tabService.setPosition(direction);
+  }
+
+  get position(): string {
+    return this._tabService.position.getValue();
+  }
+
+  @ViewChild('list') list: ElementRef;
+
+  offset: number = 0;
+  tab$: Observable<CardTabComponent> = this._tabService.tab$;
+
+  width: number;
+  innerWidth: number;
+  bounds: CardTabsBounds = { lower: 0, upper: 0 };
+
+  private _subscription: Subscription;
+
+  constructor(private _tabService: CardTabsService) {
+    this._subscription = _tabService.tab$.pipe(filter(tab => tab !== null), distinctUntilChanged())
+      .subscribe(this.moveIntoView.bind(this));
+  }
+
+  ngOnDestroy(): void {
+    this._subscription.unsubscribe();
+  }
+
+  resize(dimensions: ResizeDimensions): void {
+    this.width = dimensions.width;
+    this.innerWidth = this.list.nativeElement.scrollWidth;
+
+    this.bounds.lower = 0;
+    this.bounds.upper = -(this.innerWidth - this.width);
+  }
+
+  previous(): void {
+    this.offset += this.width;
+
+    // ensure it remains within the allowed bounds
+    this.offset = Math.min(this.offset, this.bounds.lower);
+  }
+
+  next(): void {
+    this.offset -= this.width;
+
+    // ensure it remains within the allowed bounds
+    this.offset = Math.max(this.offset, this.bounds.upper);
+  }
+
+  private moveIntoView(tab: CardTabComponent): void {
+
+    // if we dont have the dimensions we cant check
+    if (!this.width || !this.innerWidth) {
+      return;
+    }
+
+    // get the element from the component
+    const element = tab.elementRef.nativeElement as HTMLElement;
+
+    // get the current element bounds
+    const { offsetLeft, offsetWidth } = element;
+    const { marginLeft, marginRight } = getComputedStyle(element);
+
+    // calculate the visible area
+    const viewportStart = Math.abs(this.offset);
+    const viewportEnd = viewportStart + this.width;
+    const cardWidth = parseFloat(marginLeft) + offsetWidth + parseFloat(marginRight);
+
+    // if we need to move to the left - figure out how much
+    if (offsetLeft < viewportStart) {
+      this.offset -= (offsetLeft - parseFloat(marginLeft)) - viewportStart;
+    }
+    
+    // if we need to move to the right - figure out how much
+    if ((offsetLeft + cardWidth) > viewportEnd) {
+      this.offset -= (offsetLeft + cardWidth) - viewportEnd;
+    }
+  }
+}
+
+export interface CardTabsBounds {
+  lower: number;
+  upper: number;
+}

--- a/src/components/card-tabs/index.ts
+++ b/src/components/card-tabs/index.ts
@@ -1,0 +1,4 @@
+export * from './card-tabs.module';
+export * from './card-tabset/card-tabset.component';
+export * from './card-tab/card-tab.component';
+export * from './card-tab/card-tab-content.directive';

--- a/src/directives/resize/resize.directive.ts
+++ b/src/directives/resize/resize.directive.ts
@@ -1,20 +1,28 @@
-import { Directive, Output, EventEmitter, ElementRef, Input, NgZone, OnInit } from '@angular/core';
-import { ResizeService, ResizeDimensions } from './resize.service';
+import { Directive, ElementRef, EventEmitter, Input, NgZone, OnDestroy, OnInit, Output } from '@angular/core';
+import { Subscription } from 'rxjs/Subscription';
 import { debounceTime } from 'rxjs/operators/debounceTime';
+import { ResizeDimensions, ResizeService } from './resize.service';
 
 @Directive({
-    selector: '[uxResize]'
+    selector: '[uxResize]',
+    providers: [ResizeService]
 })
-export class ResizeDirective implements OnInit {
+export class ResizeDirective implements OnInit, OnDestroy {
 
     @Input() throttle: number = 0;
     @Output() uxResize: EventEmitter<ResizeDimensions> = new EventEmitter<ResizeDimensions>();
 
+    private _subscription: Subscription;
+
     constructor(private _elementRef: ElementRef, private _resizeService: ResizeService, private _ngZone: NgZone) { }
 
     ngOnInit(): void {
-        this._resizeService.addResizeListener(this._elementRef.nativeElement)
+        this._subscription = this._resizeService.addResizeListener(this._elementRef.nativeElement)
             .pipe(debounceTime(this.throttle))
             .subscribe((event: ResizeDimensions) => this._ngZone.run(() => this.uxResize.emit(event)));
+    }
+
+    ngOnDestroy(): void {
+        this._subscription.unsubscribe();
     }
 }

--- a/src/directives/resize/resize.service.ts
+++ b/src/directives/resize/resize.service.ts
@@ -8,16 +8,14 @@ import { fromEvent } from 'rxjs/observable/fromEvent';
 export class ResizeService implements OnDestroy {
 
     private _renderer: Renderer2;
-    private _subscription: Subscription;
+    private _subscription = new Subscription();
 
     constructor(rendererFactory: RendererFactory2) {
         this._renderer = rendererFactory.createRenderer(null, null);
     }
 
     ngOnDestroy(): void {
-        if (this._subscription) {
-            this._subscription.unsubscribe();
-        }
+        this._subscription.unsubscribe();
     }
 
     addResizeListener(nativeElement: HTMLElement): BehaviorSubject<ResizeDimensions> {
@@ -63,8 +61,8 @@ export class ResizeService implements OnDestroy {
             const attachListener = () => {
 
                 // watch for any future resizes
-                this._subscription = fromEvent(iframe.contentWindow, 'resize').subscribe((event: ResizeDimensions) => 
-                    subject.next({ width: nativeElement.offsetWidth, height: nativeElement.offsetHeight }));
+                this._subscription.add(fromEvent(iframe.contentWindow, 'resize').subscribe((event: ResizeDimensions) => 
+                    subject.next({ width: nativeElement.offsetWidth, height: nativeElement.offsetHeight })));
             };
 
             if (iframeDoc.readyState === 'complete') {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@
   Export Components
 */
 export * from './components/breadcrumbs/index';
+export * from './components/card-tabs/index';
 export * from './components/checkbox/index';
 export * from './components/column-sorting/index';
 export * from './components/dashboard/index';

--- a/src/styles/ux-aspects.less
+++ b/src/styles/ux-aspects.less
@@ -52,6 +52,8 @@
 // Import Component Stylesheets
 
 @import "../components/checkbox/checkbox.component.less";
+@import "../components/card-tabs/card-tabset/card-tabset.component.less";
+@import "../components/card-tabs/card-tab/card-tab.component.less";
 @import "../components/column-sorting/column-sorting.component.less";
 @import "../components/date-time-picker/date-time-picker.component.less";
 @import "../components/date-time-picker/day-view/day-view.component.less";


### PR DESCRIPTION
- Migrated Card Tabs
- Added Documentation & plunker
- Deprecated AngularJS section
- Added e2e tests

Additionally:
- Updated our dev webpack config, my incremental builds were really slow and freezing up a lot. I realised our dev config was not using the official Angular webpack loader, so I have changed it to now use them seeing decent improvements. It now also matches the production build and our MF webpack configs. Also removed json-loader config as this is now built into webpack since v2

- The resize service and resize directive got a few tweaks:
    - Added destroy functions to unsubscribe correctly
    - Changed service to use BehaviorSubject rather than Subject and set initial sizes earlier - this ensures we get the size faster and the event will always fire initially - as before there was a small chance it would not fire initially
    - Added scoped service to the uxResize directive. This will allow the scoped service to be disposed when the uxResize directive is destroyed freeing up some memory.