### PR TITLE
EL-2969 - Card Tabs - Fixing QA Issues

### DIFF
--- a/docs/app/pages/components/components-sections/tabs/card-tabs-ng1/card-tabs-ng1.component.less
+++ b/docs/app/pages/components/components-sections/tabs/card-tabs-ng1/card-tabs-ng1.component.less
@@ -1,0 +1,49 @@
+.cardTab {
+    padding: 7px 9px;
+}
+
+.cardTab .cardTitle {
+    color: #333;
+    font-size: 17px;
+}
+
+.cardTab .cardValue {
+    text-align: center;
+    font-size: 26px;
+    color: #686868;
+    margin: 0;
+}
+
+.cardTab .cardSubtitle {
+    text-align: center;
+    color: #b8b8b8;
+    margin-bottom: 0;
+}
+
+.cardTab .cardImg {
+    width: 100%;
+    height: 60px;
+    background-repeat: no-repeat;
+    background-size: contain;
+    background-position: center;
+}
+
+.cardTab .cardImg.img1 {
+    background-image: url('../../../../../assets/img/card-img1.png');
+}
+
+.cardTab .cardImg.img2 {
+    background-image: url('../../../../../assets/img/card-img2.png');
+}
+
+.cardTab .cardImg.img3 {
+    background-image: url('../../../../../assets/img/card-img3.png');
+}
+
+.cardTab .cardImg.img4 {
+    background-image: url('../../../../../assets/img/card-img4.png');
+}
+
+.cardTab .cardImg.img5 {
+    background-image: url('../../../../../assets/img/card-img5.png');
+}

--- a/docs/app/pages/components/components-sections/tabs/card-tabs-ng1/card-tabs-ng1.component.ts
+++ b/docs/app/pages/components/components-sections/tabs/card-tabs-ng1/card-tabs-ng1.component.ts
@@ -1,12 +1,14 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
-import { DocumentationSectionComponent } from '../../../../../decorators/documentation-section-component';
-import { ICodePenProvider } from '../../../../../interfaces/ICodePenProvider';
-import { ICodePen } from '../../../../../interfaces/ICodePen';
+import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
 import { BaseDocumentationSection } from '../../../../../components/base-documentation-section/base-documentation-section';
+import { DocumentationSectionComponent } from '../../../../../decorators/documentation-section-component';
+import { ICodePen } from '../../../../../interfaces/ICodePen';
+import { ICodePenProvider } from '../../../../../interfaces/ICodePenProvider';
 
 @Component({
     selector: 'uxd-components-card-tabs-ng1',
     templateUrl: './card-tabs-ng1.component.html',
+    styleUrls: ['./card-tabs-ng1.component.less'],
+    encapsulation: ViewEncapsulation.None,
     changeDetection: ChangeDetectionStrategy.OnPush
 })
 @DocumentationSectionComponent('ComponentsCardTabsNg1Component')

--- a/docs/styles.less
+++ b/docs/styles.less
@@ -911,60 +911,6 @@ tr.dragging .reorderable-controls .reorder-drag {
 }
 
 /*
-    Card Tabs
-*/
-
-.cardTab {
-    padding: 7px 9px;
-}
-
-.cardTab .cardTitle {
-    color: #333;
-    font-size: 17px;
-}
-
-.cardTab .cardValue {
-    text-align: center;
-    font-size: 26px;
-    color: #686868;
-    margin: 0;
-}
-
-.cardTab .cardSubtitle {
-    text-align: center;
-    color: #b8b8b8;
-    margin-bottom: 0;
-}
-
-.cardTab .cardImg {
-    width: 100%;
-    height: 60px;
-    background-repeat: no-repeat;
-    background-size: contain;
-    background-position: center;
-}
-
-.cardTab .cardImg.img1 {
-    background-image: url("./app/assets/img/card-img1.png");
-}
-
-.cardTab .cardImg.img2 {
-    background-image: url("./app/assets/img/card-img2.png");
-}
-
-.cardTab .cardImg.img3 {
-    background-image: url("./app/assets/img/card-img3.png");
-}
-
-.cardTab .cardImg.img4 {
-    background-image: url("./app/assets/img/card-img4.png");
-}
-
-.cardTab .cardImg.img5 {
-    background-image: url("./app/assets/img/card-img5.png");
-}
-
-/*
     Overflow Tooltip
 */
 

--- a/src/components/card-tabs/card-tabset/card-tabset.component.html
+++ b/src/components/card-tabs/card-tabset/card-tabset.component.html
@@ -2,7 +2,7 @@
     <ng-content></ng-content>
 </div>
 
-<div class="card-tabs">
+<div class="card-tabs" #tabs>
 
     <button class="card-tabs-paging-btn card-tabs-paging-btn-previous" aria-label="Previous Tabs" (click)="previous()" *ngIf="offset < bounds.lower">
         <i class="hpe-icon hpe-previous"></i>
@@ -18,6 +18,7 @@
             [class.active]="tab.active$ | async"
             [attr.aria-selected]="tab.active$ | async"
             (click)="select(tab, card)"
+            (focus)="tabs.scrollLeft = 0"
             (keydown.enter)="select(tab, card)">
 
             <ng-container [ngTemplateOutlet]="tab.content"></ng-container>

--- a/src/components/card-tabs/card-tabset/card-tabset.component.less
+++ b/src/components/card-tabs/card-tabset/card-tabset.component.less
@@ -110,6 +110,10 @@ ux-card-tabset {
         border: none;
         z-index: 2;
 
+        &:focus {
+            outline: 1px dotted @card-tab-active-border;
+        }
+
         &:hover {
             background-color: @card-tab-pagination-hover-bg;
         }


### PR DESCRIPTION
- Missing Images - images were getting corrupted when processed by both the file-loader and extract-text-webpack-plugin. Moved them to a component stylesheet which resolves this issue.

- IE tab issue - IE was scrolling the element into view even though there is no scrollbars. The only workaround I could come up with was once any tab gains focus it ensures the scroll position is set to 0.

- Focus issue - for some reason firefox just wouldn't show the outline as usual. Had to style the outline manually to make it consistent across all browser.