### PR TITLE
EL-2973 - Side inset splitter QA fixes

### DIFF
--- a/src/styles/splitter.less
+++ b/src/styles/splitter.less
@@ -72,9 +72,7 @@
 
 .ux-splitter-toggle-btn {
     position: absolute;
-    display: flex;
-    justify-content: center;
-    align-items: center;
+    padding: 4px 6px;
 
     &.right,
     &.left {


### PR DESCRIPTION
- Fixing icon alignment all browsers

- Note: The animation in IE is an issue with the angular-split library, I tried visiting their example page: https://bertrandg.github.io/angular-split/#/examples/split-transitons in IE and was getting the same issue. I have raised an issue on the library github regarding this issue: https://github.com/bertrandg/angular-split/issues/103