### PR TITLE
EL-2942 - Hierarchy bar firefox fix

### DIFF
--- a/e2e/tests/components/hierarchy-bar/hierarchy-bar.e2e-spec.ts
+++ b/e2e/tests/components/hierarchy-bar/hierarchy-bar.e2e-spec.ts
@@ -45,7 +45,7 @@ describe('Hierarchy Bar Tests', () => {
         expect(JSON.stringify(titles)).toBe(JSON.stringify(['Leroy Rose', 'Lilly Shaw']));
     });
 
-    it('should display children in popover', async () => {
+    it('should have selected the correct node on popover click', async () => {
         await page.selectPopoverNode(0, 0);
 
         expect(await page.getSelectedNodeTitle()).toBe('Leroy Rose');
@@ -102,7 +102,7 @@ describe('Hierarchy Bar Tests', () => {
         const titles = await page.getOverflowNodeTitles();
         
         // expect there to be nodes in the overflow popover
-        expect(JSON.stringify(titles)).toBe(JSON.stringify(['Theresa Chandler', 'Lilly Shaw']));
+        expect(JSON.stringify(titles)).toBe(JSON.stringify(['Theresa Chandler']));
 
         // increase browser size
         await browser.driver.manage().window().setSize(1000, 700);

--- a/e2e/tests/components/hierarchy-bar/hierarchy-bar.po.spec.ts
+++ b/e2e/tests/components/hierarchy-bar/hierarchy-bar.po.spec.ts
@@ -24,8 +24,9 @@ export class HierarchyBarPage {
 
     async clickNode(index: number): Promise<void> {
         const node: ElementFinder = await this.getNode(index);
+        const content: ElementFinder = await node.$('.hierarchy-bar-node-content');
 
-        await node.click();
+        await content.click();
     }
 
     async nodeHasChildren(index: number): Promise<boolean> {

--- a/src/components/hierarchy-bar/hierarchy-bar.component.html
+++ b/src/components/hierarchy-bar/hierarchy-bar.component.html
@@ -19,13 +19,11 @@
     </div>
 
     <div #nodeElement class="hierarchy-bar-node"
-         tabindex="0"
-         role="button"
-         *ngFor="let node of hierarchyBar.nodes$ | async"
-         [attr.aria-label]="node.title"
-         (keydown.enter)="hierarchyBar.selectNode(node)">
+         *ngFor="let node of hierarchyBar.nodes$ | async">
 
-        <div class="hierarchy-bar-node-content" (click)="hierarchyBar.selectNode(node)">
+        <button class="hierarchy-bar-node-content"
+                [attr.aria-label]="node.title"
+                (click)="hierarchyBar.selectNode(node)">
 
             <!-- Show an icon if specifed -->
             <img class="hierarchy-bar-node-icon" *ngIf="node.icon" [src]="node.icon" alt="Hierarchy Bar Icon">
@@ -33,10 +31,10 @@
             <!-- Show the name of the current node -->
             <span class="hierarchy-bar-node-title">{{ node.title }}</span>
 
-        </div>
+        </button>
 
         <!-- Show a dropdown arrow if there are children -->
-        <span *ngIf="node.children"
+        <button *ngIf="node.children"
               #popover="bs-popover"
               aria-label="Show children"
               role="button"
@@ -47,9 +45,8 @@
               container="body"
               [outsideClick]="true"
               containerClass="hierarchy-bar-popover"
-              tabindex="0"
-              (keydown.enter)="popover.show(); $event.stopPropagation()">
-        </span>
+              tabindex="0">
+        </button>
 
     </div>
 

--- a/src/components/hierarchy-bar/hierarchy-bar.component.html
+++ b/src/components/hierarchy-bar/hierarchy-bar.component.html
@@ -18,10 +18,12 @@
         . . .
     </div>
 
-    <button #nodeElement class="hierarchy-bar-node"
-            *ngFor="let node of hierarchyBar.nodes$ | async"
-            [attr.aria-label]="node.title"
-            (keydown.enter)="hierarchyBar.selectNode(node)">
+    <div #nodeElement class="hierarchy-bar-node"
+         tabindex="0"
+         role="button"
+         *ngFor="let node of hierarchyBar.nodes$ | async"
+         [attr.aria-label]="node.title"
+         (keydown.enter)="hierarchyBar.selectNode(node)">
 
         <div class="hierarchy-bar-node-content" (click)="hierarchyBar.selectNode(node)">
 
@@ -49,7 +51,7 @@
               (keydown.enter)="popover.show(); $event.stopPropagation()">
         </span>
 
-    </button>
+    </div>
 
 </main>
 

--- a/src/components/hierarchy-bar/hierarchy-bar.component.less
+++ b/src/components/hierarchy-bar/hierarchy-bar.component.less
@@ -44,12 +44,6 @@ ux-hierarchy-bar {
         margin-top: 5px;
         margin-bottom: 5px;
         cursor: pointer;
-        border: none;
-        background: transparent;
-
-        &:focus {
-            .aspects-outline;
-        }
 
         &:last-of-type {
             .hierarchy-bar-node-title {
@@ -62,6 +56,13 @@ ux-hierarchy-bar {
     .hierarchy-bar-node-content {
         display: inline-flex;
         align-items: center;
+        border: none;
+        background: transparent;
+        padding: 0;
+
+        &:focus {
+            .aspects-outline;
+        }
     }
 
     .hierarchy-bar-node-icon {
@@ -79,6 +80,9 @@ ux-hierarchy-bar {
         color: @organization-chart-hierarchy-bar-arrow;
         margin-left: 5px;
         transition: color 250ms ease-in-out;
+        border: none;
+        background: transparent;
+        padding: 0;
 
         &:hover {
             color: @primary;


### PR DESCRIPTION
- Firefox doesn't seem to like having elements with a click event as a child of a button. Replaced it will a div with a tabindex