### PR TITLE
EL-3060 - WCAG Page Header

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -41,6 +41,7 @@ module.exports = function (grunt) {
 
     // Tasks with larger chains of events
     grunt.registerTask('build', ['cleanup', 'lint', 'library', 'scripts', 'iconset', 'styles', 'documentation:build', 'minify', 'assets', 'licenses', 'execute:shim']);
+    grunt.registerTask('build:library', ['cleanup', 'lint', 'library', 'scripts', 'iconset', 'styles', 'minify', 'assets', 'licenses', 'execute:shim']);
     grunt.registerTask('releasebuild', ['build', 'compress:bower']);
 
     // default task will run dev environment

--- a/configs/webpack.docs.dev.config.js
+++ b/configs/webpack.docs.dev.config.js
@@ -231,7 +231,7 @@ module.exports = {
     stats: {
         colors: true,
         reasons: true
-    },    
+    },
 
     devServer: {
         https: {

--- a/docs/app/pages/components/components-sections/page-header/page-header/page-header.component.html
+++ b/docs/app/pages/components/components-sections/page-header/page-header/page-header.component.html
@@ -103,6 +103,9 @@
 <uxd-api-properties tableTitle="PageHeaderIconMenu">
     <tr uxd-api-property name="icon" type="string" required="true">
     </tr>
+    <tr uxd-api-property name="label" type="string">
+        Description of the purpose of the icon menu, including its badge, for assistive technologies.
+    </tr>
     <tr uxd-api-property name="badge" type="string | number">
     </tr>
     <tr uxd-api-property name="select" type="(menu: PageHeaderIconMenu) => void" required="true">
@@ -137,8 +140,8 @@
 <hr>
 
 <p>
-    Additionally you can add custom menu items to the top right of the page header by using the <code>uxPageHeaderCustomMenu</code> 
-    structural directive as content of the <code>ux-page-header</code> component. This is used to define templates for menu items and 
+    Additionally you can add custom menu items to the top right of the page header by using the <code>uxPageHeaderCustomMenu</code>
+    structural directive as content of the <code>ux-page-header</code> component. This is used to define templates for menu items and
     you can add custom click behavior.
 </p>
 
@@ -151,7 +154,7 @@
     <tab heading="HTML">
         <uxd-snippet language="html" [content]="snippets.compiled.appHtml"></uxd-snippet>
     </tab>
-    
+
     <tab heading="TypeScript">
         <uxd-snippet language="javascript" [content]="snippets.compiled.appTs"></uxd-snippet>
     </tab>

--- a/docs/app/pages/components/components-sections/page-header/page-header/page-header.component.html
+++ b/docs/app/pages/components/components-sections/page-header/page-header/page-header.component.html
@@ -102,15 +102,19 @@
 
 <uxd-api-properties tableTitle="PageHeaderIconMenu">
     <tr uxd-api-property name="icon" type="string" required="true">
+        The name of an icon from <a routerLink="/css/icons" fragment="ux-icons">UX Aspects Icons</a>.
     </tr>
     <tr uxd-api-property name="label" type="string">
         Description of the purpose of the icon menu, including its badge, for assistive technologies.
     </tr>
     <tr uxd-api-property name="badge" type="string | number">
+        Content to display in a raised badge over the icon.
     </tr>
     <tr uxd-api-property name="select" type="(menu: PageHeaderIconMenu) => void" required="true">
+        Action to execute when the icon is clicked.
     </tr>
     <tr uxd-api-property name="dropdown" type="PageHeaderIconMenuDropdownItem[]">
+        Items to display as a dropdown menu.
     </tr>
 </uxd-api-properties>
 

--- a/docs/app/pages/components/components-sections/page-header/page-header/page-header.component.ts
+++ b/docs/app/pages/components/components-sections/page-header/page-header/page-header.component.ts
@@ -32,9 +32,16 @@ export class ComponentsPageHeaderComponent extends BaseDocumentationSection impl
 
     condensed: boolean = false;
 
-    crumbs: Breadcrumb[] = [{
-        title: 'Archive'
-    }];
+    crumbs: Breadcrumb[] = [
+        {
+            title: 'Archive',
+            onClick: () => {}
+        },
+        {
+            title: '2017',
+            onClick: () => {}
+        }
+    ];
 
     items: PageHeaderNavigationItem[] = [
         {

--- a/docs/app/pages/components/components-sections/page-header/page-header/page-header.component.ts
+++ b/docs/app/pages/components/components-sections/page-header/page-header/page-header.component.ts
@@ -69,6 +69,7 @@ export class ComponentsPageHeaderComponent extends BaseDocumentationSection impl
     iconMenus: PageHeaderIconMenu[] = [
         {
             icon: 'hpe-notification',
+            label: 'Notifications. 3 new items.',
             badge: 3,
             dropdown: [
                 {
@@ -92,6 +93,7 @@ export class ComponentsPageHeaderComponent extends BaseDocumentationSection impl
         },
         {
             icon: 'hpe-actions',
+            label: 'Actions',
             dropdown: [
                 {
                     header: true,

--- a/docs/app/pages/components/components-sections/page-header/page-header/snippets/app.ts
+++ b/docs/app/pages/components/components-sections/page-header/page-header/snippets/app.ts
@@ -9,9 +9,16 @@ export class AppComponent {
 
     condensed: boolean = false;
 
-    crumbs: Breadcrumb[] = [{
-        title: 'Archive'
-    }];
+    crumbs: Breadcrumb[] = [
+        {
+            title: 'Archive',
+            onClick: () => {}
+        },
+        {
+            title: '2017',
+            onClick: () => {}
+        }
+    ];
 
     items: PageHeaderNavigationItem[] = [
         {
@@ -46,6 +53,7 @@ export class AppComponent {
     iconMenus: PageHeaderIconMenu[] = [
         {
             icon: 'hpe-notification',
+            label: 'Notifications. 3 new items.',
             badge: 3,
             dropdown: [
                 {
@@ -69,6 +77,7 @@ export class AppComponent {
         },
         {
             icon: 'hpe-actions',
+            label: 'Actions',
             dropdown: [
                 {
                     header: true,

--- a/e2e/tests/components/page-header/page-header.po.spec.ts
+++ b/e2e/tests/components/page-header/page-header.po.spec.ts
@@ -1,11 +1,11 @@
 import { browser, element, by, ElementFinder, protractor } from 'protractor';
 
 export class PageHeaderPage {
-        
+
     getPage(): void {
         browser.get('#/page-header');
     }
-    
+
     pageHeader1 = element(by.id('pageHeader1'));
     pageHeader2 = element(by.id('pageHeader2'));
     selected = element(by.id('selected'));
@@ -15,9 +15,9 @@ export class PageHeaderPage {
     alignCenterButton = element(by.id('align-center'));
     alignRightButton = element(by.id('align-right'));
     autoselectButton = element(by.id('autoselect'));
-    
+
     condensed = false;
-    
+
     confirmClassExists(item: ElementFinder, soughtClass: string) {
         return item.getAttribute('class').then(function(classes: string) {
             var allClasses = classes.split(' ');
@@ -28,16 +28,16 @@ export class PageHeaderPage {
             }
         });
     }
-    
+
     confirmPageHeaderIsCondensed() {
         return this.confirmClassExists(this.pageHeader1, 'page-header-condensed');
     }
-    
+
     toggleTheHeader() {
         this.toggleButton.click();
         this.condensed = !this.condensed;
     }
-    
+
     // The expanded and condensed forms of most of the locators used here are the same except for the first
     // two elements. This function will return an ElementFinder for the first two elements which may then be
     // passed to the other functions, avoiding duplication of code.
@@ -56,107 +56,107 @@ export class PageHeaderPage {
         return this.pageHeader1.$('div.page-header-details').$('div.page-header-state-container').$('div.page-header-title-container').
                $('ux-breadcrumbs').$('ol.breadcrumb').$$('li').get(index).getText();
     }
-    
+
     getABreadcrumbWhenCondensed(index: number) {
         return this.pageHeader1.$('div.page-header-condensed-content').$('div.page-header-breadcrumbs').
                $('ux-breadcrumbs').$('ol.breadcrumb').$$('li').get(index).getText();
     }
-    
+
     confirmApplicationLogoIsPresent() {
         return this.getContainerElement(this.condensed).then(function(elem: ElementFinder) {
             return elem.$('div.page-header-navigation').$('ux-page-header-horizontal-navigation').
-                   $$('ux-page-header-horizontal-navigation-item').get(0).$('div.horizontal-navigation-button').
+                   $$('ux-page-header-horizontal-navigation-item').get(0).$('.horizontal-navigation-button').
                    $('span.hpe-home').isPresent();
         });
     }
-    
+
     getApplicationLogoText() {
         return this.getContainerElement(this.condensed).then(function(elem: ElementFinder) {
             return elem.$('div.page-header-navigation').$('ux-page-header-horizontal-navigation').
-                   $$('ux-page-header-horizontal-navigation-item').get(0).$('div.horizontal-navigation-button').
+                   $$('ux-page-header-horizontal-navigation-item').get(0).$('.horizontal-navigation-button').
                    $('span.navigation-item-label').getText();
         });
     }
-    
+
     confirmDropdownIsPresent() {
         return this.getContainerElement(this.condensed).then(function(elem: ElementFinder) {
             return elem.$('div.page-header-navigation').$('ux-page-header-horizontal-navigation').
-                   $$('ux-page-header-horizontal-navigation-item').get(1).$('div.horizontal-navigation-button').
+                   $$('ux-page-header-horizontal-navigation-item').get(1).$('.horizontal-navigation-button').
                    $('span.hpe-analytics').isPresent();
         });
     }
-    
+
     openDropdown() {
         this.getContainerElement(this.condensed).then(function(elem: ElementFinder) {
             elem.$('div.page-header-navigation').$('ux-page-header-horizontal-navigation').
-            $$('ux-page-header-horizontal-navigation-item').get(1).$('div.horizontal-navigation-button').click();
+            $$('ux-page-header-horizontal-navigation-item').get(1).$('.horizontal-navigation-button').click();
         });
     }
-    
+
     confirmDropdownIsOpened() {
         return this.getContainerElement(this.condensed).then(function(elem: ElementFinder) {
             return elem.$('div.page-header-navigation').$('ux-page-header-horizontal-navigation').
-                   $$('ux-page-header-horizontal-navigation-item').get(1).$('div.horizontal-navigation-button.open').isPresent();
+                   $$('ux-page-header-horizontal-navigation-item').get(1).$('.horizontal-navigation-button.open').isPresent();
         });
     }
-    
+
     getFirstDropdownMenuItem(index: number) {
         return browser.element(by.css('body')).$$('bs-dropdown-container').get(0).$('div.dropdown').$('div.dropdown-menu').
                    $$('ux-page-header-horizontal-navigation-dropdown-item').get(index).$('div').$('a.dropdown-item').$('span.dropdown-item-title').getText();
     }
-    
+
     displaySecondDropdownMenu() {
         browser.actions().mouseMove(browser.element(by.css('body')).$$('bs-dropdown-container').get(0).$('div.dropdown').$('div.dropdown-menu').
                    $$('ux-page-header-horizontal-navigation-dropdown-item').get(1)).perform();
     }
-    
+
     getSecondDropdownMenuItem(index: number) {
         return browser.element(by.css('body')).$$('bs-dropdown-container').get(1).$('div.dropdown').$('ul.dropdown-menu').
                    $$('li').get(index).$('a.dropdown-item').$('span.dropdown-item-title').getText();
     }
-    
+
     confirmNotificationIconIsPresent() {
         return this.getContainerElement(this.condensed).then(function(elem: ElementFinder) {
             return elem.$('div.page-header-icon-menus').$$('ux-page-header-icon-menu').get(0).$('div.page-header-icon-menu').
                    $('a.page-header-icon-menu-button').$('i.hpe-notification').isPresent();
         });
     }
-    
+
     openNotifications() {
         this.getContainerElement(this.condensed).then(function(elem: ElementFinder) {
             elem.$('div.page-header-icon-menus').$$('ux-page-header-icon-menu').get(0).$('div.page-header-icon-menu').
                  $('a.page-header-icon-menu-button').click();
         });
     }
-    
+
     confirmNotificationsAreDisplayed() {
         return this.getContainerElement(this.condensed).then(function(elem: ElementFinder) {
             return elem.$('div.page-header-icon-menus').$$('ux-page-header-icon-menu').get(0).
                    $('div.page-header-icon-menu').$('ul.dropdown-menu').$$('li').count();
         });
     }
-    
+
     confirmActionsIconIsPresent() {
         return this.getContainerElement(this.condensed).then(function(elem: ElementFinder) {
             return elem.$('div.page-header-icon-menus').$$('ux-page-header-icon-menu').get(1).$('div.page-header-icon-menu').
                    $('a.page-header-icon-menu-button').$('i.hpe-actions').isPresent();
         });
     }
-    
+
     openActions() {
         this.getContainerElement(this.condensed).then(function(elem: ElementFinder) {
             elem.$('div.page-header-icon-menus').$$('ux-page-header-icon-menu').get(1).$('div.page-header-icon-menu').
                  $('a.page-header-icon-menu-button').click();
         });
     }
-    
+
     confirmActionsAreDisplayed() {
         return this.getContainerElement(this.condensed).then(function(elem: ElementFinder) {
             return elem.$('div.page-header-icon-menus').$$('ux-page-header-icon-menu').get(1).
                    $('div.page-header-icon-menu').$('ul.dropdown-menu').$$('li').count();
         });
     }
-    
+
     async getSecondaryNavigation(): Promise<ElementFinder> {
         return await this.pageHeader2.$('.page-header-secondary');
     }

--- a/src/components/breadcrumbs/breadcrumbs.component.html
+++ b/src/components/breadcrumbs/breadcrumbs.component.html
@@ -1,16 +1,19 @@
-<ol class="breadcrumb">
-    <li *ngFor="let crumb of crumbs">
+<nav aria-label="Breadcrumb">
+    <ol class="breadcrumb">
+        <li *ngFor="let crumb of crumbs">
 
-        <!-- If there is a router link then use a tag -->
-        <a *ngIf="crumb.routerLink"
-           [routerLink]="crumb.routerLink" 
-           [fragment]="crumb.fragment" 
-           [queryParams]="crumb.queryParams" 
-           (click)="clickCrumb($event, crumb)">
+            <!-- If there is a router link then use a tag -->
+            <a *ngIf="crumb.routerLink || crumb.onClick"
+                tabindex="0"
+                [routerLink]="crumb.routerLink"
+                [fragment]="crumb.fragment"
+                [queryParams]="crumb.queryParams"
+                (click)="clickCrumb($event, crumb)">
                 {{ crumb.title }}
-        </a>
+            </a>
 
-        <!-- If there is not router link then display text in a span -->
-        <span *ngIf="!crumb.routerLink">{{ crumb.title }}</span>
-    </li>
-</ol>
+            <!-- If there is not router link then display text in a span -->
+            <span *ngIf="!crumb.routerLink && !crumb.onClick">{{ crumb.title }}</span>
+        </li>
+    </ol>
+</nav>

--- a/src/components/page-header/icon-menu/icon-menu.component.html
+++ b/src/components/page-header/icon-menu/icon-menu.component.html
@@ -1,6 +1,6 @@
 <div class="page-header-icon-menu" dropdown dropdownToggle placement="bottom right">
 
-    <a class="page-header-icon-menu-button" (click)="select(menu)">
+    <a role="button" class="page-header-icon-menu-button" (click)="select(menu)">
         <i class="hpe-icon" [ngClass]="menu.icon"></i>
         <span class="label label-primary" *ngIf="menu?.badge">{{ menu.badge }}</span>
     </a>

--- a/src/components/page-header/icon-menu/icon-menu.component.html
+++ b/src/components/page-header/icon-menu/icon-menu.component.html
@@ -37,6 +37,7 @@
                 class="dropdown-item"
                 tabindex="-1"
                 (click)="select(dropdown)"
+                (keydown)="keydownHandler(dropdown, $event)"
                 uxMenuNavigationItem>
 
                 <i class="hpe-icon hp-fw text-muted" [ngClass]="dropdown.icon"></i>

--- a/src/components/page-header/icon-menu/icon-menu.component.html
+++ b/src/components/page-header/icon-menu/icon-menu.component.html
@@ -1,20 +1,48 @@
-<div class="page-header-icon-menu" dropdown dropdownToggle placement="bottom right">
+<div class="page-header-icon-menu"
+    dropdown
+    placement="bottom right"
+    [(isOpen)]="isOpen">
 
-    <a role="button" class="page-header-icon-menu-button" (click)="select(menu)">
+    <a role="button"
+        class="page-header-icon-menu-button"
+        [attr.aria-label]="menu.label"
+        aria-haspopup="true"
+        tabindex="0"
+        (click)="select(menu)"
+        dropdownToggle
+        uxMenuNavigationToggle
+        #menuNavigationToggle="uxMenuNavigationToggle"
+        [(menuOpen)]="isOpen">
+
         <i class="hpe-icon" [ngClass]="menu.icon"></i>
-        <span class="label label-primary" *ngIf="menu?.badge">{{ menu.badge }}</span>
+        <span class="label label-primary" *ngIf="menu?.badge" aria-hidden="true">{{ menu.badge }}</span>
+
     </a>
 
-    <ul *dropdownMenu class="dropdown-menu" role="menu">
+    <ul *dropdownMenu
+        class="dropdown-menu"
+        role="menu"
+        uxMenuNavigation
+        [toggleButton]="menuNavigationToggle">
 
-        <li role="menuitem" *ngFor="let dropdown of menu?.dropdown" [class.dropdown-header]="dropdown.header" [class.dropdown-divider]="dropdown.divider">
+        <li *ngFor="let dropdown of menu?.dropdown"
+            role="none"
+            [class.dropdown-header]="dropdown.header"
+            [class.dropdown-divider]="dropdown.divider">
 
             <span class="font-bold" *ngIf="dropdown.header">{{ dropdown.title }}</span>
 
-            <a class="dropdown-item" *ngIf="!dropdown.header" (click)="select(dropdown)">
+            <a *ngIf="!dropdown.header"
+                role="menuitem"
+                class="dropdown-item"
+                tabindex="-1"
+                (click)="select(dropdown)"
+                uxMenuNavigationItem>
+
                 <i class="hpe-icon hp-fw text-muted" [ngClass]="dropdown.icon"></i>
                 {{ dropdown.title }}
                 <span class="pull-right text-muted small" *ngIf="dropdown.subtitle">{{ dropdown.subtitle }}</span>
+
             </a>
         </li>
 

--- a/src/components/page-header/icon-menu/icon-menu.component.less
+++ b/src/components/page-header/icon-menu/icon-menu.component.less
@@ -3,19 +3,28 @@ ux-page-header-icon-menu {
     cursor: pointer;
 
     .page-header-icon-menu {
-        position: relative;
         display: inline-flex;
-        justify-content: center;
-        align-items: center;
+        position: relative;
         width: 40px;
-        transition: background-color 0.3s ease-in-out;
-
-        &:hover {
-            background-color: rgba(247, 247, 247, 0.1);
-        }
 
         .page-header-icon-menu-button {
+            display: inline-flex;
+            justify-content: center;
+            align-items: center;
+            position: relative;
+            width: 100%;
+            height: 100%;
             color: #fff;
+            transition: background-color 0.3s ease-in-out;
+
+            &:hover,
+            &:focus {
+                background-color: rgba(247, 247, 247, 0.1);
+            }
+
+            &:focus {
+                .aspects-outline;
+            }
         }
     }
 
@@ -41,6 +50,10 @@ ux-page-header-icon-menu {
                 padding: 6px 20px;
                 min-height: 0;
                 font-size: 1rem;
+
+                &:focus {
+                    .aspects-outline;
+                }
             }
         }
 

--- a/src/components/page-header/icon-menu/icon-menu.component.ts
+++ b/src/components/page-header/icon-menu/icon-menu.component.ts
@@ -9,6 +9,8 @@ export class PageHeaderIconMenuComponent {
 
     @Input() menu: PageHeaderIconMenu;
 
+    isOpen: boolean;
+
     select(item: PageHeaderIconMenu | PageHeaderIconMenuDropdownItem) {
         if (item.select) {
             item.select.call(item, item);

--- a/src/components/page-header/icon-menu/icon-menu.component.ts
+++ b/src/components/page-header/icon-menu/icon-menu.component.ts
@@ -1,5 +1,6 @@
-import { Component, Input } from '@angular/core';
+import { Component, Input, ViewChild } from '@angular/core';
 import { PageHeaderIconMenu, PageHeaderIconMenuDropdownItem } from '../page-header.component';
+import { MenuNavigationToggleDirective } from '../../../directives/menu-navigation/menu-navigation-toggle.directive';
 
 @Component({
     selector: 'ux-page-header-icon-menu',
@@ -11,9 +12,27 @@ export class PageHeaderIconMenuComponent {
 
     isOpen: boolean;
 
+    @ViewChild('menuNavigationToggle')
+    menuNavigationToggle: MenuNavigationToggleDirective;
+
     select(item: PageHeaderIconMenu | PageHeaderIconMenuDropdownItem) {
         if (item.select) {
             item.select.call(item, item);
+        }
+
+        this.isOpen = false;
+    }
+
+    keydownHandler(item: PageHeaderIconMenu | PageHeaderIconMenuDropdownItem, event: KeyboardEvent): void {
+
+        switch (event.key) {
+            case 'Enter':
+            case ' ':
+                this.select(item);
+                this.menuNavigationToggle.focus();
+                event.preventDefault();
+                event.stopPropagation();
+                break;
         }
     }
 }

--- a/src/components/page-header/icon-menu/icon-menu.component.ts
+++ b/src/components/page-header/icon-menu/icon-menu.component.ts
@@ -1,6 +1,6 @@
 import { Component, Input, ViewChild } from '@angular/core';
-import { PageHeaderIconMenu, PageHeaderIconMenuDropdownItem } from '../page-header.component';
 import { MenuNavigationToggleDirective } from '../../../directives/menu-navigation/menu-navigation-toggle.directive';
+import { PageHeaderIconMenu, PageHeaderIconMenuDropdownItem } from '../page-header.component';
 
 @Component({
     selector: 'ux-page-header-icon-menu',

--- a/src/components/page-header/navigation/navigation-dropdown-item/navigation-dropdown-item.component.html
+++ b/src/components/page-header/navigation/navigation-dropdown-item/navigation-dropdown-item.component.html
@@ -1,19 +1,74 @@
-<div role="menu-item" dropdown [isOpen]="dropdownOpen" container="body" placement="right" [isDisabled]="!item.children" (mouseenter)="hoverStart()"
-    (mouseleave)="hoverLeave()" #subMenu="bs-dropdown">
+<div *ngIf="item.children && item.children.length > 0"
+    dropdown
+    #subMenu="bs-dropdown"
+    [isOpen]="dropdownOpen"
+    container="body"
+    placement="right"
+    (mouseenter)="hoverStart()"
+    (mouseleave)="hoverLeave()">
 
-    <!-- Show the menu item and the arrow if there are children -->
-    <a class="dropdown-item" tabindex="0" [class.selected]="item.selected" (keyup.enter)="select(item); subMenu.toggle()" (click)="select(item)">
+    <a role="menuitem"
+        #button
+        class="dropdown-item"
+        [class.selected]="item.selected"
+        dropdownToggle
+        aria-haspopup="true"
+        [attr.aria-expanded]="dropdownOpen"
+        [attr.aria-selected]="item.selected"
+        tabindex="-1"
+        (click)="select(item)"
+        (keyup)="submenuKeyupHandler($event)">
+
         <span class="dropdown-item-title">{{ item.title }}</span>
-        <span class="dropdown-item-icon hpe-icon hpe-next" *ngIf="item.children"></span>
+        <span class="dropdown-item-icon hpe-icon hpe-next"></span>
+
     </a>
 
-    <!-- Allow another level of menu items -->
-    <ul *dropdownMenu class="dropdown-menu horizontal-navigation-dropdown-submenu" role="menu" (mouseenter)="hoverStart()" (mouseleave)="hoverLeave()">
+    <ul *dropdownMenu
+        role="menu"
+        class="dropdown-menu horizontal-navigation-dropdown-submenu"
+        uxMenuNavigation
+        #menuNavigation="uxMenuNavigation"
+        menuOrigin="left"
+        (navigatedOut)="dropdownOpen = false; button.focus();"
+        (mouseenter)="hoverStart()"
+        (mouseleave)="hoverLeave()">
 
-        <li role="menuitem" *ngFor="let subItem of item.children" (click)="select(subItem, item)" (keyup.enter)="select(subItem)">
-            <a class="dropdown-item" tabindex="0" [class.selected]="subItem.selected">
+        <li *ngFor="let subItem of item.children" role="none">
+
+            <a role="menuitem"
+                class="dropdown-item"
+                [class.selected]="subItem.selected"
+                uxMenuNavigationItem
+                [attr.aria-selected]="subItem.selected"
+                tabindex="-1"
+                (click)="select(subItem, item)"
+                (keyup)="keyupHandler($event, subItem)">
+
                 <span class="dropdown-item-title">{{ subItem.title }}</span>
+
             </a>
+
         </li>
     </ul>
+
+</div>
+
+<div *ngIf="!item.children || item.children.length === 0"
+    (mouseenter)="hoverStart()"
+    (mouseleave)="hoverLeave()">
+
+    <a role="menuitem"
+        #button
+        class="dropdown-item"
+        [class.selected]="item.selected"
+        [attr.aria-selected]="item.selected"
+        tabindex="-1"
+        (click)="select(item)"
+        (keyup)="keyupHandler($event, item)">
+
+        <span class="dropdown-item-title">{{ item.title }}</span>
+
+    </a>
+
 </div>

--- a/src/components/page-header/navigation/navigation-dropdown-item/navigation-dropdown-item.component.html
+++ b/src/components/page-header/navigation/navigation-dropdown-item/navigation-dropdown-item.component.html
@@ -8,16 +8,18 @@
     (mouseleave)="hoverLeave()">
 
     <a role="menuitem"
-        #button
         class="dropdown-item"
         [class.selected]="item.selected"
-        dropdownToggle
         aria-haspopup="true"
         [attr.aria-expanded]="dropdownOpen"
         [attr.aria-selected]="item.selected"
         tabindex="-1"
-        (click)="select(item)"
-        (keyup)="submenuKeyupHandler($event)">
+        #button
+        dropdownToggle
+        uxMenuNavigationToggle
+        #menuNavigationToggle="uxMenuNavigationToggle"
+        [(menuOpen)]="dropdownOpen"
+        [keys]="['Enter', ' ', 'ArrowRight']">
 
         <span class="dropdown-item-title">{{ item.title }}</span>
         <span class="dropdown-item-icon hpe-icon hpe-next"></span>
@@ -27,23 +29,23 @@
     <ul *dropdownMenu
         role="menu"
         class="dropdown-menu horizontal-navigation-dropdown-submenu"
+        (mouseenter)="hoverStart()"
+        (mouseleave)="hoverLeave()"
         uxMenuNavigation
         #menuNavigation="uxMenuNavigation"
-        menuOrigin="left"
-        (navigatedOut)="dropdownOpen = false; button.focus();"
-        (mouseenter)="hoverStart()"
-        (mouseleave)="hoverLeave()">
+        [toggleButton]="menuNavigationToggle"
+        toggleButtonPosition="left">
 
         <li *ngFor="let subItem of item.children" role="none">
 
             <a role="menuitem"
                 class="dropdown-item"
                 [class.selected]="subItem.selected"
-                uxMenuNavigationItem
                 [attr.aria-selected]="subItem.selected"
                 tabindex="-1"
                 (click)="select(subItem, item)"
-                (keyup)="keyupHandler($event, subItem)">
+                (keydown)="keydownHandler($event, subItem)"
+                uxMenuNavigationItem>
 
                 <span class="dropdown-item-title">{{ subItem.title }}</span>
 
@@ -65,7 +67,7 @@
         [attr.aria-selected]="item.selected"
         tabindex="-1"
         (click)="select(item)"
-        (keyup)="keyupHandler($event, item)">
+        (keydown)="keydownHandler($event, item)">
 
         <span class="dropdown-item-title">{{ item.title }}</span>
 

--- a/src/components/page-header/navigation/navigation-dropdown-item/navigation-dropdown-item.component.html
+++ b/src/components/page-header/navigation/navigation-dropdown-item/navigation-dropdown-item.component.html
@@ -19,7 +19,7 @@
         uxMenuNavigationToggle
         #menuNavigationToggle="uxMenuNavigationToggle"
         [(menuOpen)]="dropdownOpen"
-        [keys]="['Enter', ' ', 'ArrowRight']">
+        menuPosition="right">
 
         <span class="dropdown-item-title">{{ item.title }}</span>
         <span class="dropdown-item-icon hpe-icon hpe-next"></span>

--- a/src/components/page-header/navigation/navigation-dropdown-item/navigation-dropdown-item.component.ts
+++ b/src/components/page-header/navigation/navigation-dropdown-item/navigation-dropdown-item.component.ts
@@ -1,10 +1,9 @@
-import { Component, EventEmitter, Input, OnDestroy, Output, ViewChild, ElementRef } from '@angular/core';
+import { Component, ElementRef, Input, OnDestroy, ViewChild } from '@angular/core';
 import { Subject } from 'rxjs/Subject';
 import { Subscription } from 'rxjs/Subscription';
 import { debounceTime } from 'rxjs/operators';
-import { PageHeaderNavigationDropdownItem } from '../navigation.component';
 import { PageHeaderService } from '../../page-header.service';
-import { MenuNavigationToggleDirective } from '../../../../directives/menu-navigation/menu-navigation-toggle.directive';
+import { PageHeaderNavigationDropdownItem } from '../navigation.component';
 
 @Component({
     selector: 'ux-page-header-horizontal-navigation-dropdown-item',

--- a/src/components/page-header/navigation/navigation-dropdown-item/navigation-dropdown-item.component.ts
+++ b/src/components/page-header/navigation/navigation-dropdown-item/navigation-dropdown-item.component.ts
@@ -69,19 +69,13 @@ export class PageHeaderNavigationDropdownItemComponent implements OnDestroy {
 
     keydownHandler(event: KeyboardEvent, item: PageHeaderNavigationDropdownItem): void {
 
-        let handled = false;
-
         switch (event.key) {
             case 'Enter':
             case ' ':
                 this.select(item);
-                handled = true;
+                event.preventDefault();
+                event.stopPropagation();
                 break;
-        }
-
-        if (handled) {
-            event.preventDefault();
-            event.stopPropagation();
         }
     }
 }

--- a/src/components/page-header/navigation/navigation-dropdown-item/navigation-dropdown-item.component.ts
+++ b/src/components/page-header/navigation/navigation-dropdown-item/navigation-dropdown-item.component.ts
@@ -4,7 +4,7 @@ import { Subscription } from 'rxjs/Subscription';
 import { debounceTime } from 'rxjs/operators';
 import { PageHeaderNavigationDropdownItem } from '../navigation.component';
 import { PageHeaderService } from '../../page-header.service';
-import { MenuNavigationDirective } from '../../../../directives/menu-navigation/index';
+import { MenuNavigationToggleDirective } from '../../../../directives/menu-navigation/menu-navigation-toggle.directive';
 
 @Component({
     selector: 'ux-page-header-horizontal-navigation-dropdown-item',
@@ -17,9 +17,6 @@ export class PageHeaderNavigationDropdownItemComponent implements OnDestroy {
 
     @ViewChild('button')
     button: ElementRef;
-
-    @ViewChild('menuNavigation')
-    menuNavigation: MenuNavigationDirective;
 
     dropdownOpen: boolean = false;
 
@@ -70,7 +67,7 @@ export class PageHeaderNavigationDropdownItemComponent implements OnDestroy {
         this.dropdownOpen = false;
     }
 
-    keyupHandler(event: KeyboardEvent, item: PageHeaderNavigationDropdownItem): void {
+    keydownHandler(event: KeyboardEvent, item: PageHeaderNavigationDropdownItem): void {
 
         let handled = false;
 
@@ -78,28 +75,6 @@ export class PageHeaderNavigationDropdownItemComponent implements OnDestroy {
             case 'Enter':
             case ' ':
                 this.select(item);
-                handled = true;
-                break;
-        }
-
-        if (handled) {
-            event.preventDefault();
-            event.stopPropagation();
-        }
-    }
-
-    submenuKeyupHandler(event: KeyboardEvent): void {
-
-        let handled = false;
-
-        switch (event.key) {
-            case 'Enter':
-            case ' ':
-            case 'ArrowRight':
-                this.dropdownOpen = true;
-                setTimeout(() => {
-                    this.menuNavigation.focusFirst();
-                });
                 handled = true;
                 break;
         }

--- a/src/components/page-header/navigation/navigation-dropdown-item/navigation-dropdown-item.component.ts
+++ b/src/components/page-header/navigation/navigation-dropdown-item/navigation-dropdown-item.component.ts
@@ -1,20 +1,28 @@
-import { Component, EventEmitter, Input, OnDestroy, Output } from '@angular/core';
+import { Component, EventEmitter, Input, OnDestroy, Output, ViewChild, ElementRef } from '@angular/core';
 import { Subject } from 'rxjs/Subject';
 import { Subscription } from 'rxjs/Subscription';
 import { debounceTime } from 'rxjs/operators';
 import { PageHeaderNavigationDropdownItem } from '../navigation.component';
 import { PageHeaderService } from '../../page-header.service';
+import { MenuNavigationDirective } from '../../../../directives/menu-navigation/index';
 
 @Component({
     selector: 'ux-page-header-horizontal-navigation-dropdown-item',
+    exportAs: 'ux-page-header-horizontal-navigation-dropdown-item',
     templateUrl: './navigation-dropdown-item.component.html'
 })
 export class PageHeaderNavigationDropdownItemComponent implements OnDestroy {
 
     @Input() item: PageHeaderNavigationDropdownItem;
-    
+
+    @ViewChild('button')
+    button: ElementRef;
+
+    @ViewChild('menuNavigation')
+    menuNavigation: MenuNavigationDirective;
+
     dropdownOpen: boolean = false;
-    
+
     private _subscription: Subscription;
     private _hover$: Subject<boolean> = new Subject<boolean>();
 
@@ -22,6 +30,13 @@ export class PageHeaderNavigationDropdownItemComponent implements OnDestroy {
 
         // subscribe to stream with a debounce (a small debounce is all that is required)
         this._subscription = this._hover$.pipe(debounceTime(1)).subscribe(visible => this.dropdownOpen = visible);
+
+        // Close submenus when selected item changes
+        this._subscription.add(
+            _pageHeaderService.selected$.subscribe(() => {
+                this.dropdownOpen = false;
+            })
+        );
     }
 
     ngOnDestroy(): void {
@@ -39,6 +54,10 @@ export class PageHeaderNavigationDropdownItemComponent implements OnDestroy {
         this._pageHeaderService.select(item);
     }
 
+    focus(): void {
+        this.button.nativeElement.focus();
+    }
+
     hoverStart() {
         this._hover$.next(true);
     }
@@ -49,5 +68,45 @@ export class PageHeaderNavigationDropdownItemComponent implements OnDestroy {
 
     close() {
         this.dropdownOpen = false;
+    }
+
+    keyupHandler(event: KeyboardEvent, item: PageHeaderNavigationDropdownItem): void {
+
+        let handled = false;
+
+        switch (event.key) {
+            case 'Enter':
+            case ' ':
+                this.select(item);
+                handled = true;
+                break;
+        }
+
+        if (handled) {
+            event.preventDefault();
+            event.stopPropagation();
+        }
+    }
+
+    submenuKeyupHandler(event: KeyboardEvent): void {
+
+        let handled = false;
+
+        switch (event.key) {
+            case 'Enter':
+            case ' ':
+            case 'ArrowRight':
+                this.dropdownOpen = true;
+                setTimeout(() => {
+                    this.menuNavigation.focusFirst();
+                });
+                handled = true;
+                break;
+        }
+
+        if (handled) {
+            event.preventDefault();
+            event.stopPropagation();
+        }
     }
 }

--- a/src/components/page-header/navigation/navigation-item/navigation-item.component.html
+++ b/src/components/page-header/navigation/navigation-item/navigation-item.component.html
@@ -1,24 +1,55 @@
-<div class="horizontal-navigation-button"
+<div *ngIf="item.children && item.children.length > 0 && !(secondary$ | async)"
     dropdown
-    dropdownToggle
-    placement="bottom left"
-    [isDisabled]="!item?.children || (secondary$ | async)"
-    tabindex="0"
-    container="body"
     #menu="bs-dropdown"
-    (keyup.enter)="menu.toggle()"
-    [class.selected]="item?.selected"
+    [(isOpen)]="isOpen"
+    container="body"
+    placement="bottom left">
+
+    <button role="menuitem"
+        #button
+        class="horizontal-navigation-button"
+        [class.selected]="item.selected"
+        [class.open]="isOpen"
+        dropdownToggle
+        aria-haspopup="true"
+        [attr.aria-expanded]="isOpen"
+        [attr.aria-selected]="item.selected"
+        (click)="select()"
+        (keyup)="keyupHandler($event)">
+
+        <span class="hpe-icon navigation-item-icon" *ngIf="item.icon" [ngClass]="item?.icon"></span>
+        <span class="navigation-item-label">{{ item?.title }}</span>
+        <span class="hpe-icon hpe-down"></span>
+
+    </button>
+
+    <div *dropdownMenu
+        role="menu"
+        class="dropdown-menu horizontal-navigation-dropdown-menu"
+        uxMenuNavigation
+        #menuNavigation="uxMenuNavigation"
+        menuOrigin="top"
+        (navigatedOut)="isOpen = false; button.focus();">
+
+        <div *ngFor="let item of item?.children" uxMenuNavigationItem (activated)="dropdownItem.focus()">
+            <ux-page-header-horizontal-navigation-dropdown-item
+                #dropdownItem="ux-page-header-horizontal-navigation-dropdown-item"
+                [item]="item">
+            </ux-page-header-horizontal-navigation-dropdown-item>
+        </div>
+
+    </div>
+
+</div>
+
+<button *ngIf="!item.children || item.children.length === 0 || (secondary$ | async)"
+    role="menuitem"
+    class="horizontal-navigation-button"
+    [class.selected]="item.selected"
+    [attr.aria-selected]="item.selected"
     (click)="select()">
 
     <span class="hpe-icon navigation-item-icon" *ngIf="item.icon" [ngClass]="item?.icon"></span>
     <span class="navigation-item-label">{{ item?.title }}</span>
-    <span class="hpe-icon hpe-down" *ngIf="item?.children && !(secondary$ | async)"></span>
 
-    <div *dropdownMenu class="dropdown-menu horizontal-navigation-dropdown-menu" role="menu">
-        <ux-page-header-horizontal-navigation-dropdown-item
-            *ngFor="let item of item?.children"
-            [item]="item">
-        </ux-page-header-horizontal-navigation-dropdown-item>
-    </div>
-
-</div>
+</button>

--- a/src/components/page-header/navigation/navigation-item/navigation-item.component.html
+++ b/src/components/page-header/navigation/navigation-item/navigation-item.component.html
@@ -6,16 +6,16 @@
     placement="bottom left">
 
     <button role="menuitem"
-        #button
         class="horizontal-navigation-button"
         [class.selected]="item.selected"
         [class.open]="isOpen"
-        dropdownToggle
         aria-haspopup="true"
         [attr.aria-expanded]="isOpen"
         [attr.aria-selected]="item.selected"
-        (click)="select()"
-        (keyup)="keyupHandler($event)">
+        dropdownToggle
+        uxMenuNavigationToggle
+        #button="uxMenuNavigationToggle"
+        [(menuOpen)]="isOpen">
 
         <span class="hpe-icon navigation-item-icon" *ngIf="item.icon" [ngClass]="item?.icon"></span>
         <span class="navigation-item-label">{{ item?.title }}</span>
@@ -27,9 +27,8 @@
         role="menu"
         class="dropdown-menu horizontal-navigation-dropdown-menu"
         uxMenuNavigation
-        #menuNavigation="uxMenuNavigation"
-        menuOrigin="top"
-        (navigatedOut)="isOpen = false; button.focus();">
+        [toggleButton]="button"
+        toggleButtonPosition="top">
 
         <div *ngFor="let item of item?.children" uxMenuNavigationItem (activated)="dropdownItem.focus()">
             <ux-page-header-horizontal-navigation-dropdown-item

--- a/src/components/page-header/navigation/navigation-item/navigation-item.component.less
+++ b/src/components/page-header/navigation/navigation-item/navigation-item.component.less
@@ -4,7 +4,6 @@ ux-page-header-horizontal-navigation-item {
         display: block;
         padding: 17px;
         border: none;
-        outline: none;
         color: @page-header-nav-color;
         background-color: @page-header-bg;
         cursor: pointer;
@@ -28,6 +27,10 @@ ux-page-header-horizontal-navigation-item {
         &:focus {
             color: @page-header-nav-active-color;
             background-color: @page-header-nav-active-bg;
+        }
+
+        &:focus {
+            .aspects-outline;
         }
 
         &.active,
@@ -56,12 +59,15 @@ ux-page-header-horizontal-navigation-item {
         color: @page-header-nav-dropdown-color;
         padding: 8px 10px 8px 20px;
         min-width: 200px;
-        outline: none;
 
         &:hover,
         &:focus {
             background-color: @page-header-nav-dropdown-hover-bg;
             color: @page-header-nav-dropdown-hover-color;
+        }
+
+        &:focus {
+            .aspects-outline;
         }
 
         .dropdown-item-title {

--- a/src/components/page-header/navigation/navigation-item/navigation-item.component.less
+++ b/src/components/page-header/navigation/navigation-item/navigation-item.component.less
@@ -3,10 +3,11 @@ ux-page-header-horizontal-navigation-item {
         position: relative;
         display: block;
         padding: 17px;
+        border: none;
+        outline: none;
         color: @page-header-nav-color;
         background-color: @page-header-bg;
         cursor: pointer;
-        outline: none;
         white-space: nowrap;
 
         .navigation-item-icon {

--- a/src/components/page-header/navigation/navigation-item/navigation-item.component.ts
+++ b/src/components/page-header/navigation/navigation-item/navigation-item.component.ts
@@ -6,7 +6,7 @@ import { Subscription } from 'rxjs/Subscription';
 import { PageHeaderService } from '../../page-header.service';
 import { PageHeaderNavigationDropdownItemComponent } from '../navigation-dropdown-item/navigation-dropdown-item.component';
 import { PageHeaderNavigationItem } from '../navigation.component';
-import { MenuNavigationDirective } from '../../../../directives/menu-navigation/index';
+import { MenuNavigationToggleDirective } from '../../../../directives/menu-navigation/menu-navigation-toggle.directive';
 
 @Component({
     selector: 'ux-page-header-horizontal-navigation-item',
@@ -14,9 +14,8 @@ import { MenuNavigationDirective } from '../../../../directives/menu-navigation/
 })
 export class PageHeaderNavigationItemComponent implements OnInit, OnDestroy {
 
-    @ViewChild('button') button: ElementRef;
+    @ViewChild('button') button: MenuNavigationToggleDirective;
     @ViewChild('menu') menu: BsDropdownDirective;
-    @ViewChild('menuNavigation') menuNavigation: MenuNavigationDirective;
     @ViewChildren(PageHeaderNavigationDropdownItemComponent) dropdowns: QueryList<PageHeaderNavigationDropdownItemComponent>;
 
     @Input() item: PageHeaderNavigationItem;
@@ -35,12 +34,12 @@ export class PageHeaderNavigationItemComponent implements OnInit, OnDestroy {
     ngOnInit() {
 
         // Close submenus when selected item changes
-        this._subscription = this._pageHeaderService.selected$.subscribe(() => {
-            if (this.isOpen) {
+        this._subscription = this._pageHeaderService.selected$.subscribe((next) => {
+            if (next && this.isOpen) {
                 this.isOpen = false;
 
                 // If menu was closed, keep focus on the toggle button
-                this.button.nativeElement.focus();
+                this.button.focus();
             }
         });
 
@@ -64,26 +63,5 @@ export class PageHeaderNavigationItemComponent implements OnInit, OnDestroy {
 
         // otherwise select the current item
         this._pageHeaderService.select(this.item);
-    }
-
-    keyupHandler(event: KeyboardEvent): void {
-
-        let handled = false;
-
-        switch (event.key) {
-            case 'Enter':
-            case 'ArrowDown':
-                this.isOpen = true;
-                setTimeout(() => {
-                    this.menuNavigation.focusFirst();
-                });
-                handled = true;
-                break;
-        }
-
-        if (handled) {
-            event.preventDefault();
-            event.stopPropagation();
-        }
     }
 }

--- a/src/components/page-header/navigation/navigation-item/navigation-item.component.ts
+++ b/src/components/page-header/navigation/navigation-item/navigation-item.component.ts
@@ -1,10 +1,12 @@
-import { Component, ElementRef, Input, OnDestroy, OnInit, QueryList, ViewChild, ViewChildren } from '@angular/core';
+import { Component, ElementRef, Input, OnDestroy, OnInit, QueryList, ViewChild, ViewChildren, HostListener, Inject } from '@angular/core';
+import { DOCUMENT } from '@angular/platform-browser';
 import { BsDropdownDirective } from 'ngx-bootstrap/dropdown';
 import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 import { Subscription } from 'rxjs/Subscription';
 import { PageHeaderService } from '../../page-header.service';
 import { PageHeaderNavigationDropdownItemComponent } from '../navigation-dropdown-item/navigation-dropdown-item.component';
 import { PageHeaderNavigationItem } from '../navigation.component';
+import { MenuNavigationDirective } from '../../../../directives/menu-navigation/index';
 
 @Component({
     selector: 'ux-page-header-horizontal-navigation-item',
@@ -12,19 +14,41 @@ import { PageHeaderNavigationItem } from '../navigation.component';
 })
 export class PageHeaderNavigationItemComponent implements OnInit, OnDestroy {
 
+    @ViewChild('button') button: ElementRef;
     @ViewChild('menu') menu: BsDropdownDirective;
+    @ViewChild('menuNavigation') menuNavigation: MenuNavigationDirective;
     @ViewChildren(PageHeaderNavigationDropdownItemComponent) dropdowns: QueryList<PageHeaderNavigationDropdownItemComponent>;
-    
+
     @Input() item: PageHeaderNavigationItem;
-    
+
     secondary$: BehaviorSubject<boolean> = this._pageHeaderService.secondary$;
-    
+
+    isOpen: boolean;
+
     private _subscription: Subscription;
 
-    constructor(public elementRef: ElementRef, private _pageHeaderService: PageHeaderService) { }
+    constructor(
+        public elementRef: ElementRef,
+        private _pageHeaderService: PageHeaderService
+    ) { }
 
     ngOnInit() {
-        this._subscription = this.menu.onHidden.subscribe(() => this.dropdowns.forEach(dropdown => dropdown.close()));
+
+        // Close submenus when selected item changes
+        this._subscription = this._pageHeaderService.selected$.subscribe(() => {
+            if (this.isOpen) {
+                this.isOpen = false;
+
+                // If menu was closed, keep focus on the toggle button
+                this.button.nativeElement.focus();
+            }
+        });
+
+        if (this.menu) {
+            this._subscription.add(
+                this.menu.onHidden.subscribe(() => this.dropdowns.forEach(dropdown => dropdown.close()))
+            );
+        }
     }
 
     ngOnDestroy(): void {
@@ -33,12 +57,33 @@ export class PageHeaderNavigationItemComponent implements OnInit, OnDestroy {
 
     select() {
 
-        // if the item has children then do nothing at this stage 
+        // if the item has children then do nothing at this stage
         if (this.item.children && this._pageHeaderService.secondary$.getValue() === false) {
             return;
         }
 
         // otherwise select the current item
         this._pageHeaderService.select(this.item);
+    }
+
+    keyupHandler(event: KeyboardEvent): void {
+
+        let handled = false;
+
+        switch (event.key) {
+            case 'Enter':
+            case 'ArrowDown':
+                this.isOpen = true;
+                setTimeout(() => {
+                    this.menuNavigation.focusFirst();
+                });
+                handled = true;
+                break;
+        }
+
+        if (handled) {
+            event.preventDefault();
+            event.stopPropagation();
+        }
     }
 }

--- a/src/components/page-header/navigation/navigation-item/navigation-item.component.ts
+++ b/src/components/page-header/navigation/navigation-item/navigation-item.component.ts
@@ -1,12 +1,11 @@
-import { Component, ElementRef, Input, OnDestroy, OnInit, QueryList, ViewChild, ViewChildren, HostListener, Inject } from '@angular/core';
-import { DOCUMENT } from '@angular/platform-browser';
+import { Component, ElementRef, Input, OnDestroy, OnInit, QueryList, ViewChild, ViewChildren } from '@angular/core';
 import { BsDropdownDirective } from 'ngx-bootstrap/dropdown';
 import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 import { Subscription } from 'rxjs/Subscription';
+import { MenuNavigationToggleDirective } from '../../../../directives/menu-navigation/menu-navigation-toggle.directive';
 import { PageHeaderService } from '../../page-header.service';
 import { PageHeaderNavigationDropdownItemComponent } from '../navigation-dropdown-item/navigation-dropdown-item.component';
 import { PageHeaderNavigationItem } from '../navigation.component';
-import { MenuNavigationToggleDirective } from '../../../../directives/menu-navigation/menu-navigation-toggle.directive';
 
 @Component({
     selector: 'ux-page-header-horizontal-navigation-item',

--- a/src/components/page-header/navigation/navigation.component.ts
+++ b/src/components/page-header/navigation/navigation.component.ts
@@ -8,17 +8,20 @@ import { PageHeaderNavigationItemComponent } from './navigation-item/navigation-
 
 @Component({
     selector: 'ux-page-header-horizontal-navigation',
-    templateUrl: './navigation.component.html'
+    templateUrl: './navigation.component.html',
+    host: {
+        'role': 'menubar'
+    }
 })
 export class PageHeaderNavigationComponent implements AfterViewInit, OnDestroy {
-    
+
     @ViewChildren(PageHeaderNavigationItemComponent) menuItems: QueryList<PageHeaderNavigationItemComponent>;
-    
+
     items$: BehaviorSubject<PageHeaderNavigationItem[]> = this._pageHeaderService.items$;
     indicatorVisible: boolean = false;
     indicatorX: number = 0;
     indicatorWidth: number = 0;
-    
+
     private _subscription = new Subscription();
 
     constructor(elementRef: ElementRef, resizeService: ResizeService, private _pageHeaderService: PageHeaderService) {
@@ -39,14 +42,14 @@ export class PageHeaderNavigationComponent implements AfterViewInit, OnDestroy {
         setTimeout(() => {
             // find the selected item
             const selected = this.menuItems.find(item => item.item.selected);
-    
+
             // determine whether or not to show the indicator
             this.indicatorVisible = !!selected;
-    
+
             // set the width of the indicator to match the width of the navigation item
             if (selected) {
                 const styles = getComputedStyle(selected.elementRef.nativeElement);
-    
+
                 this.indicatorX = selected.elementRef.nativeElement.offsetLeft;
                 this.indicatorWidth = parseInt(styles.getPropertyValue('width'));
             }
@@ -66,7 +69,7 @@ export interface PageHeaderNavigationItem {
 
 export interface PageHeaderNavigationDropdownItem {
     title: string;
-    selected?: boolean;    
+    selected?: boolean;
     select?: (item: PageHeaderNavigationDropdownItem) => void;
     children?: PageHeaderNavigationDropdownItem[];
     parent?: PageHeaderNavigation;

--- a/src/components/page-header/page-header.component.html
+++ b/src/components/page-header/page-header.component.html
@@ -1,13 +1,13 @@
-<div class="ux-page-header" [class.page-header-condensed]="condensed">
+<div class="ux-page-header" [class.page-header-condensed]="condensed" role="banner">
 
     <!-- Display Upper Section when not condensed -->
     <div class="page-header-actions" *ngIf="!condensed">
 
-        <div class="page-header-logo-container" [hidden]="!logo">
+        <div class="page-header-logo-container" role="presentation" [hidden]="!logo">
             <img [attr.src]="logo" class="page-header-logo">
         </div>
 
-        <div class="page-header-navigation" [ngClass]="alignment">
+        <div class="page-header-navigation" [ngClass]="alignment" role="navigation" aria-label="Primary Navigation">
 
             <!-- The Top Navigation Options -->
             <ux-page-header-horizontal-navigation></ux-page-header-horizontal-navigation>
@@ -23,9 +23,9 @@
     <!-- Display Lower Section When Not Condensed -->
     <div class="page-header-details" *ngIf="!condensed">
 
-        <div class="page-header-state-container">
+        <div class="page-header-state-container" role="navigation">
 
-            <div *ngIf="backVisible == true" class="page-header-back-button" (click)="goBack()">
+            <div *ngIf="backVisible == true" class="page-header-back-button" (click)="goBack()" aria-label="Go Back">
                 <span class="hpe-icon hpe-previous text-primary"></span>
             </div>
 
@@ -43,11 +43,11 @@
     <!-- Display This Section Optimized for Condensed Mode -->
     <div class="page-header-condensed-content" *ngIf="condensed">
 
-        <div class="page-header-breadcrumbs">
+        <div class="page-header-breadcrumbs" role="navigation">
             <ux-breadcrumbs [crumbs]="crumbs"></ux-breadcrumbs>
         </div>
 
-        <div class="page-header-navigation" [ngClass]="alignment">
+        <div class="page-header-navigation" [ngClass]="alignment" role="navigation" aria-label="Primary Navigation">
 
             <!-- The Top Navigation Options -->
             <ux-page-header-horizontal-navigation></ux-page-header-horizontal-navigation>
@@ -62,10 +62,10 @@
 
 </div>
 
-<div class="page-header-secondary" [ngClass]="secondaryNavigationAlignment" *ngIf="secondaryNavigation && (selectedRoot$ | async)">
-    <ul class="nav nav-tabs" role="tablist" *ngIf="(selectedRoot$ | async)?.children; let children">
-        <li role="presentation" *ngFor="let child of children" [class.active]="child === (selected$ | async)">
-            <a role="tab" (click)="select(child)">{{ child.title }}</a>
+<div class="page-header-secondary" [ngClass]="secondaryNavigationAlignment" role="navigation" *ngIf="secondaryNavigation && (selectedRoot$ | async)">
+    <ul class="nav nav-tabs" role="tablist" aria-label="Secondary Navigation" *ngIf="(selectedRoot$ | async)?.children; let children">
+        <li *ngFor="let child of children" [class.active]="child === (selected$ | async)" role="none">
+            <a role="tab" [attr.aria-selected]="child === (selected$ | async)" (click)="select(child)">{{ child.title }}</a>
         </li>
     </ul>
 </div>

--- a/src/components/page-header/page-header.component.html
+++ b/src/components/page-header/page-header.component.html
@@ -13,7 +13,7 @@
             <ux-page-header-horizontal-navigation></ux-page-header-horizontal-navigation>
         </div>
 
-        <div class="page-header-icon-menus">
+        <div class="page-header-icon-menus" role="toolbar">
             <ng-container *ngFor="let menu of customMenus" [ngTemplateOutlet]="menu"></ng-container>
 
             <ux-page-header-icon-menu *ngFor="let menu of iconMenus" [menu]="menu"></ux-page-header-icon-menu>
@@ -25,9 +25,9 @@
 
         <div class="page-header-state-container" role="navigation">
 
-            <div *ngIf="backVisible == true" class="page-header-back-button" (click)="goBack()" aria-label="Go Back">
+            <button *ngIf="backVisible === true" class="page-header-back-button" (click)="goBack()" aria-label="Go Back">
                 <span class="hpe-icon hpe-previous text-primary"></span>
-            </div>
+            </button>
 
             <div class="page-header-title-container">
 
@@ -53,7 +53,7 @@
             <ux-page-header-horizontal-navigation></ux-page-header-horizontal-navigation>
         </div>
 
-        <div class="page-header-icon-menus">
+        <div class="page-header-icon-menus" role="toolbar">
             <ng-container *ngFor="let menu of customMenus" [ngTemplateOutlet]="menu"></ng-container>
             <ux-page-header-icon-menu *ngFor="let menu of iconMenus" [menu]="menu"></ux-page-header-icon-menu>
         </div>

--- a/src/components/page-header/page-header.component.less
+++ b/src/components/page-header/page-header.component.less
@@ -64,8 +64,10 @@ ux-page-header {
                     width: 28px;
                     margin-top: 16px;
                     margin-right: 2px;
+                    border: none;
                     justify-content: center;
                     align-items: center;
+                    background-color: transparent;
                     cursor: pointer;
                     transition: background-color 0.3s ease-in-out;
 

--- a/src/components/page-header/page-header.component.less
+++ b/src/components/page-header/page-header.component.less
@@ -71,8 +71,13 @@ ux-page-header {
                     cursor: pointer;
                     transition: background-color 0.3s ease-in-out;
 
-                    &:hover {
+                    &:hover,
+                    &:focus {
                         background-color: @page-header-back-button-hover-bg;
+                    }
+
+                    &:focus {
+                        .aspects-outline;
                     }
 
                     & > * {

--- a/src/components/page-header/page-header.component.ts
+++ b/src/components/page-header/page-header.component.ts
@@ -1,8 +1,7 @@
 import { Component, ContentChildren, EventEmitter, Input, OnDestroy, OnInit, Output, QueryList, TemplateRef } from '@angular/core';
 import { BehaviorSubject } from 'rxjs/BehaviorSubject';
-import { Observable } from 'rxjs/Observable';
 import { Subscription } from 'rxjs/Subscription';
-import { filter, map, distinctUntilChanged } from 'rxjs/operators';
+import { distinctUntilChanged, filter, map } from 'rxjs/operators';
 import { ColorService } from '../../services/color/index';
 import { Breadcrumb } from '../breadcrumbs/index';
 import { PageHeaderCustomMenuDirective } from './custom-menu/custom-menu.directive';

--- a/src/components/page-header/page-header.component.ts
+++ b/src/components/page-header/page-header.component.ts
@@ -25,7 +25,7 @@ export class PageHeaderComponent implements OnInit, OnDestroy {
     @Input() backVisible: boolean = true;
     @Input() secondaryNavigationAlignment: string = 'center';
     @Input() secondaryNavigationAutoselect: boolean = false;
-    
+
     @Input() set items(items: PageHeaderNavigationItem[]) {
         this._pageHeaderService.setItems(items);
     }
@@ -81,7 +81,7 @@ export class PageHeaderComponent implements OnInit, OnDestroy {
     ngOnInit(): void {
         this._subscription = this.selectedRoot$.pipe(
             distinctUntilChanged(),
-            filter(() => this.secondaryNavigation && this.secondaryNavigationAutoselect), 
+            filter(() => this.secondaryNavigation && this.secondaryNavigationAutoselect),
             filter((item: PageHeaderNavigation) => item && item.children && item.children.length > 0),
             map(item => item.children[0])
         ).subscribe(item => this.select(item));
@@ -102,6 +102,7 @@ export class PageHeaderComponent implements OnInit, OnDestroy {
 
 export interface PageHeaderIconMenu {
     icon: string;
+    label?: string;
     badge?: number | string;
     select?: (menu: PageHeaderIconMenu) => void;
     dropdown?: PageHeaderIconMenuDropdownItem[];

--- a/src/components/page-header/page-header.module.ts
+++ b/src/components/page-header/page-header.module.ts
@@ -11,6 +11,7 @@ import { PageHeaderNavigationDropdownItemComponent } from './navigation/navigati
 import { PageHeaderCustomMenuDirective } from './custom-menu/custom-menu.directive';
 import { ResizeModule } from '../../directives/resize/index';
 import { ColorServiceModule } from '../../services/color/index';
+import { MenuNavigationModule } from '../../directives/menu-navigation/index';
 
 @NgModule({
     imports: [
@@ -18,13 +19,14 @@ import { ColorServiceModule } from '../../services/color/index';
         BreadcrumbsModule,
         ColorServiceModule,
         ResizeModule,
+        MenuNavigationModule,
         BsDropdownModule.forRoot()
     ],
-    exports: [ 
+    exports: [
         PageHeaderComponent,
-        PageHeaderCustomMenuDirective 
+        PageHeaderCustomMenuDirective
     ],
-    declarations: [ 
+    declarations: [
         PageHeaderComponent,
         PageHeaderIconMenuComponent,
         PageHeaderCustomMenuDirective,

--- a/src/directives/menu-navigation/index.ts
+++ b/src/directives/menu-navigation/index.ts
@@ -1,0 +1,3 @@
+export * from './menu-navigation-item.directive';
+export * from './menu-navigation.directive';
+export * from './menu-navigation.module';

--- a/src/directives/menu-navigation/menu-navigation-item.directive.ts
+++ b/src/directives/menu-navigation/menu-navigation-item.directive.ts
@@ -1,6 +1,6 @@
-import { Directive, ElementRef, EventEmitter, HostListener, Output, OnDestroy } from '@angular/core';
-import { MenuNavigationService } from './menu-navigation.service';
+import { Directive, ElementRef, EventEmitter, OnDestroy, Output } from '@angular/core';
 import { Subscription } from 'rxjs/Subscription';
+import { MenuNavigationService } from './menu-navigation.service';
 
 @Directive({
     selector: '[uxMenuNavigationItem]'

--- a/src/directives/menu-navigation/menu-navigation-item.directive.ts
+++ b/src/directives/menu-navigation/menu-navigation-item.directive.ts
@@ -1,0 +1,34 @@
+import { Directive, ElementRef, EventEmitter, HostListener, Output, OnDestroy } from '@angular/core';
+import { MenuNavigationService } from './menu-navigation.service';
+import { Subscription } from 'rxjs/Subscription';
+
+@Directive({
+    selector: '[uxMenuNavigationItem]'
+})
+export class MenuNavigationItemDirective implements OnDestroy {
+
+    @Output()
+    activated = new EventEmitter();
+
+    private _subscription: Subscription;
+
+    constructor(
+        private _service: MenuNavigationService,
+        private _elementRef: ElementRef
+    ) {
+        this._subscription = _service.active$.subscribe((next) => {
+            if (next === this) {
+                this.setActive();
+            }
+        });
+    }
+
+    ngOnDestroy(): void {
+        this._subscription.unsubscribe();
+    }
+
+    setActive(): void {
+        this._elementRef.nativeElement.focus();
+        this.activated.emit();
+    }
+}

--- a/src/directives/menu-navigation/menu-navigation-toggle.directive.ts
+++ b/src/directives/menu-navigation/menu-navigation-toggle.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, Input, HostListener, EventEmitter, Output, ElementRef } from '@angular/core';
+import { Directive, ElementRef, EventEmitter, HostListener, Input, Output } from '@angular/core';
 
 @Directive({
     selector: '[uxMenuNavigationToggle]',

--- a/src/directives/menu-navigation/menu-navigation-toggle.directive.ts
+++ b/src/directives/menu-navigation/menu-navigation-toggle.directive.ts
@@ -17,7 +17,7 @@ export class MenuNavigationToggleDirective {
     }
 
     @Input()
-    keys = ['Enter', 'ArrowDown'];
+    menuPosition: 'top' | 'right' | 'bottom' | 'left' = 'bottom';
 
     @Output()
     menuOpenChange = new EventEmitter<boolean>();
@@ -35,7 +35,7 @@ export class MenuNavigationToggleDirective {
     @HostListener('keydown', ['$event'])
     keydownHandler(event: KeyboardEvent): void {
 
-        if (this.keys.find((k) => k === event.key)) {
+        if (this.isKeyMatch(event.key)) {
 
             // Open the menu
             this.menuOpen = true;
@@ -48,5 +48,31 @@ export class MenuNavigationToggleDirective {
             event.preventDefault();
             event.stopPropagation();
         }
+    }
+
+    private isKeyMatch(key: string): boolean {
+        switch (key) {
+            case 'Enter':
+            case ' ':
+                return true;
+
+            case 'ArrowUp':
+            case 'Up':
+                return this.menuPosition === 'top';
+
+            case 'ArrowDown':
+            case 'Down':
+                return this.menuPosition === 'bottom';
+
+            case 'ArrowLeft':
+            case 'Left':
+                return this.menuPosition === 'left';
+
+            case 'ArrowRight':
+            case 'Right':
+                return this.menuPosition === 'right';
+        }
+
+        return false;
     }
 }

--- a/src/directives/menu-navigation/menu-navigation-toggle.directive.ts
+++ b/src/directives/menu-navigation/menu-navigation-toggle.directive.ts
@@ -1,0 +1,52 @@
+import { Directive, Input, HostListener, EventEmitter, Output, ElementRef } from '@angular/core';
+
+@Directive({
+    selector: '[uxMenuNavigationToggle]',
+    exportAs: 'uxMenuNavigationToggle'
+})
+export class MenuNavigationToggleDirective {
+
+    @Input()
+    get menuOpen(): boolean {
+        return this._menuOpen;
+    }
+
+    set menuOpen(value: boolean) {
+        this._menuOpen = value;
+        this.menuOpenChange.emit(value);
+    }
+
+    @Input()
+    keys = ['Enter', 'ArrowDown'];
+
+    @Output()
+    menuOpenChange = new EventEmitter<boolean>();
+
+    keyEnter = new EventEmitter<void>();
+
+    private _menuOpen: boolean;
+
+    constructor(private _elementRef: ElementRef) { }
+
+    focus(): void {
+        this._elementRef.nativeElement.focus();
+    }
+
+    @HostListener('keydown', ['$event'])
+    keydownHandler(event: KeyboardEvent): void {
+
+        if (this.keys.find((k) => k === event.key)) {
+
+            // Open the menu
+            this.menuOpen = true;
+
+            // Allow the menu to init, then send the event to give it focus
+            setTimeout(() => {
+                this.keyEnter.emit();
+            });
+
+            event.preventDefault();
+            event.stopPropagation();
+        }
+    }
+}

--- a/src/directives/menu-navigation/menu-navigation.directive.ts
+++ b/src/directives/menu-navigation/menu-navigation.directive.ts
@@ -1,0 +1,164 @@
+import { Directive, ContentChildren, QueryList, AfterContentInit, HostListener, ElementRef, Inject, Output, EventEmitter, Input } from '@angular/core';
+import { DOCUMENT } from '@angular/platform-browser';
+import { MenuNavigationItemDirective } from './menu-navigation-item.directive';
+import { MenuNavigationService } from './menu-navigation.service';
+
+@Directive({
+    selector: '[uxMenuNavigation]',
+    exportAs: 'uxMenuNavigation',
+    providers: [MenuNavigationService]
+})
+export class MenuNavigationDirective implements AfterContentInit {
+
+    @Input()
+    menuOrigin: 'top' | 'right' | 'bottom' | 'left' = 'top';
+
+    @Output()
+    navigatedOut = new EventEmitter<KeyboardEvent>();
+
+    @ContentChildren(MenuNavigationItemDirective, { descendants: true })
+    items: QueryList<MenuNavigationItemDirective>;
+
+    get activeIndex(): number {
+        return this._itemsOrdered.indexOf(this._service.active$.value);
+    }
+
+    private _itemsOrdered: MenuNavigationItemDirective[];
+    private _document: Document;
+
+    constructor(
+        private _service: MenuNavigationService,
+        private _elementRef: ElementRef,
+        @Inject(DOCUMENT) document: any
+    ) {
+        this._document = document;
+    }
+
+    ngAfterContentInit(): void {
+        this.items.changes.subscribe(() => {
+            this._itemsOrdered = this.items.toArray();
+        });
+
+        this._itemsOrdered = this.items.toArray();
+    }
+
+    focusFirst(): void {
+        this.moveFirst();
+    }
+
+    @HostListener('document:keydown', ['$event'])
+    private keydownHandler(event: KeyboardEvent): void {
+
+        // Only handle events when focus in within the host element
+        if (!this._elementRef.nativeElement.contains(this._document.activeElement)) {
+            return;
+        }
+
+        let handled = false;
+
+        switch (event.key) {
+
+            case 'ArrowUp':
+                this.movePrevious(event);
+                handled = true;
+                break;
+
+            case 'ArrowDown':
+                this.moveNext(event);
+                handled = true;
+                break;
+
+            case 'ArrowLeft':
+                if (this.menuOrigin === 'left') {
+                    this.navigatedOut.emit(event);
+                    handled = true;
+                }
+                break;
+
+            case 'ArrowRight':
+                if (this.menuOrigin === 'right') {
+                    this.navigatedOut.emit(event);
+                    handled = true;
+                }
+                break;
+
+            case 'Home':
+                this.moveFirst();
+                handled = true;
+                break;
+
+            case 'End':
+                this.moveLast();
+                handled = true;
+                break;
+
+            case 'Escape':
+                this.navigatedOut.emit(event);
+                handled = true;
+                break;
+        }
+
+        if (handled) {
+            event.preventDefault();
+            event.stopPropagation();
+        }
+    }
+
+    private moveNext(event: KeyboardEvent): void {
+
+        // Do nothing if there's no active menu item registered
+        if (this.activeIndex < 0) {
+            return;
+        }
+
+        const nextIndex = this.activeIndex + 1;
+        if (nextIndex < this._itemsOrdered.length) {
+
+            // Activate the next menu item
+            // (uxMenuNavigationItem subscribes to this and applies focus if it matches)
+            this._service.active$.next(this._itemsOrdered[nextIndex]);
+
+        } else {
+
+            // Check if focus went out of bounds in the direction of the origin toggle button
+            if (this.menuOrigin === 'bottom') {
+                this.navigatedOut.emit(event);
+            }
+        }
+    }
+
+    private movePrevious(event: KeyboardEvent): void {
+
+        // Do nothing if there's no active menu item registered
+        if (this.activeIndex < 0) {
+            return;
+        }
+
+        const nextIndex = this.activeIndex - 1;
+        if (nextIndex >= 0) {
+
+            // Activate the previous menu item
+            // (uxMenuNavigationItem subscribes to this and applies focus if it matches)
+            this._service.active$.next(this._itemsOrdered[nextIndex]);
+
+        } else {
+
+            // Check if focus went out of bounds in the direction of the origin toggle button
+            if (this.menuOrigin === 'top') {
+                this.navigatedOut.emit(event);
+            }
+        }
+    }
+
+    private moveFirst(): void {
+        if (this._itemsOrdered.length > 0) {
+            this._service.active$.next(this._itemsOrdered[0]);
+        }
+    }
+
+    private moveLast(): void {
+        if (this._itemsOrdered.length > 0) {
+            this._service.active$.next(this._itemsOrdered[this._itemsOrdered.length - 1]);
+        }
+    }
+}

--- a/src/directives/menu-navigation/menu-navigation.directive.ts
+++ b/src/directives/menu-navigation/menu-navigation.directive.ts
@@ -83,16 +83,19 @@ export class MenuNavigationDirective implements OnInit, AfterContentInit, OnDest
         switch (event.key) {
 
             case 'ArrowUp':
+            case 'Up':
                 this.movePrevious(event);
                 handled = true;
                 break;
 
             case 'ArrowDown':
+            case 'Down':
                 this.moveNext(event);
                 handled = true;
                 break;
 
             case 'ArrowLeft':
+            case 'Left':
                 if (this.toggleButtonPosition === 'left') {
                     this.moveToToggleButton(event);
                     handled = true;
@@ -100,6 +103,7 @@ export class MenuNavigationDirective implements OnInit, AfterContentInit, OnDest
                 break;
 
             case 'ArrowRight':
+            case 'Right':
                 if (this.toggleButtonPosition === 'right') {
                     this.moveToToggleButton(event);
                     handled = true;

--- a/src/directives/menu-navigation/menu-navigation.directive.ts
+++ b/src/directives/menu-navigation/menu-navigation.directive.ts
@@ -1,9 +1,9 @@
-import { Directive, ContentChildren, QueryList, AfterContentInit, HostListener, ElementRef, Inject, Output, EventEmitter, Input, OnDestroy, Renderer2, OnInit } from '@angular/core';
+import { AfterContentInit, ContentChildren, Directive, ElementRef, EventEmitter, HostListener, Inject, Input, OnDestroy, OnInit, Output, QueryList, Renderer2 } from '@angular/core';
 import { DOCUMENT } from '@angular/platform-browser';
 import { Subscription } from 'rxjs/Subscription';
 import { MenuNavigationItemDirective } from './menu-navigation-item.directive';
-import { MenuNavigationService } from './menu-navigation.service';
 import { MenuNavigationToggleDirective } from './menu-navigation-toggle.directive';
+import { MenuNavigationService } from './menu-navigation.service';
 
 @Directive({
     selector: '[uxMenuNavigation]',

--- a/src/directives/menu-navigation/menu-navigation.module.ts
+++ b/src/directives/menu-navigation/menu-navigation.module.ts
@@ -1,0 +1,16 @@
+import { NgModule } from '@angular/core';
+
+import { MenuNavigationDirective } from './menu-navigation.directive';
+import { MenuNavigationItemDirective } from './menu-navigation-item.directive';
+
+const EXPORTS = [
+    MenuNavigationDirective,
+    MenuNavigationItemDirective
+];
+
+@NgModule({
+    imports: [],
+    exports: EXPORTS,
+    declarations: EXPORTS,
+})
+export class MenuNavigationModule { }

--- a/src/directives/menu-navigation/menu-navigation.module.ts
+++ b/src/directives/menu-navigation/menu-navigation.module.ts
@@ -2,10 +2,12 @@ import { NgModule } from '@angular/core';
 
 import { MenuNavigationDirective } from './menu-navigation.directive';
 import { MenuNavigationItemDirective } from './menu-navigation-item.directive';
+import { MenuNavigationToggleDirective } from './menu-navigation-toggle.directive';
 
 const EXPORTS = [
     MenuNavigationDirective,
-    MenuNavigationItemDirective
+    MenuNavigationItemDirective,
+    MenuNavigationToggleDirective
 ];
 
 @NgModule({

--- a/src/directives/menu-navigation/menu-navigation.service.ts
+++ b/src/directives/menu-navigation/menu-navigation.service.ts
@@ -1,0 +1,9 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs/BehaviorSubject';
+import { MenuNavigationItemDirective } from './menu-navigation-item.directive';
+
+@Injectable()
+export class MenuNavigationService {
+
+    active$ = new BehaviorSubject<MenuNavigationItemDirective>(null);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,6 +47,7 @@ export * from './directives/help-center/index';
 export * from './directives/hover-action/index';
 export * from './directives/infinite-scroll/index';
 export * from './directives/layout-switcher/index';
+export * from './directives/menu-navigation/index';
 export * from './directives/resize/index';
 export * from './directives/scroll-into-view-if/index';
 export * from './directives/selection/index';

--- a/src/styles/breadcrumbs.less
+++ b/src/styles/breadcrumbs.less
@@ -12,6 +12,10 @@
         a,
         span {
             color: @breadcrumb-color;
+
+            &:focus {
+                .aspects-outline;
+            }
         }
     }
 }


### PR DESCRIPTION
* Changed navigation and navigation dropdown items to have distinct toggle buttons. These have different layouts depending on whether they have children.
* Added keyboard support for the navigation menu via new directive `uxMenuNavigation`.
* Added roles to the page header sections.
* Added `grunt build:library` for a library-only build.
* Added `uxMenuNavigationToggle` which can be exported and attached to `uxMenuNavigation` to handle keyboard navigation.
* Applied keyboard navigation to the icon menu component.
* Added `label` property to `PageHeaderIconMenu` which attaches an aria-label. Documented this.
* Added standard focus rings to focusable header components.
* Updated code snippets and documentation.

https://jira.autonomy.com/browse/EL-3060