### PR TITLE
Fixed a focus issue with IE11

### DIFF
--- a/src/components/select/select.component.html
+++ b/src/components/select/select.component.html
@@ -54,7 +54,7 @@
         [loadingTemplate]="loadingTemplate"
         [optionTemplate]="optionTemplate"
         [noOptionsTemplate]="noOptionsTemplate"
-        (optionSelected)="singleOptionSelected($event)" >
+        (optionSelected)="singleOptionSelected($event)">
     </ux-typeahead>
 
 </div>

--- a/src/components/select/select.component.ts
+++ b/src/components/select/select.component.ts
@@ -70,8 +70,8 @@ export class SelectComponent implements OnInit, OnChanges, OnDestroy, ControlVal
     @Input() optionTemplate: TemplateRef<any>;
 
     @Output() valueChange = new EventEmitter<any>();
-    @Output() inputChange = new EventEmitter<string>();    
-    @Output() dropdownOpenChange = new EventEmitter<boolean>();    
+    @Output() inputChange = new EventEmitter<string>();
+    @Output() dropdownOpenChange = new EventEmitter<boolean>();
 
     @ViewChild('singleInput') singleInput: ElementRef;
     @ViewChild('multipleTypeahead') multipleTypeahead: TypeaheadComponent;
@@ -144,6 +144,14 @@ export class SelectComponent implements OnInit, OnChanges, OnDestroy, ControlVal
     }
 
     inputBlurHandler(event: Event) {
+
+        // If a click on the typeahead is in progress, just refocus the input.
+        // This works around an issue in IE where clicking a scrollbar drops focus.
+        if (this.singleTypeahead && this.singleTypeahead.clicking) {
+            this.singleInput.nativeElement.focus();
+            return;
+        }
+
         // Close dropdown and reset text input if focus is lost
         setTimeout(() => {
             if (!this._element.nativeElement.contains(this._document.activeElement)) {

--- a/src/components/typeahead/typeahead.component.ts
+++ b/src/components/typeahead/typeahead.component.ts
@@ -1,21 +1,7 @@
+import { AfterViewInit, ChangeDetectorRef, Component, ElementRef, EventEmitter, Input, OnChanges, Output, SimpleChanges, TemplateRef, ViewChild, HostListener } from '@angular/core';
+import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 import { InfiniteScrollLoadFunction } from '../../directives/infinite-scroll/index';
 import { TypeaheadOptionEvent } from './typeahead-event';
-import {
-    Component,
-    ElementRef,
-    EventEmitter,
-    Input,
-    OnChanges,
-    OnInit,
-    Output,
-    SimpleChanges,
-    TemplateRef,
-    ViewChild,
-    AfterViewInit,
-    ChangeDetectorRef
-} from '@angular/core';
-import { BehaviorSubject } from 'rxjs/BehaviorSubject';
-import { Observable } from 'rxjs/Observable';
 
 @Component({
     selector: 'ux-typeahead',
@@ -77,6 +63,7 @@ export class TypeaheadComponent implements AfterViewInit, OnChanges {
     loadOptionsCallback: InfiniteScrollLoadFunction;
     visibleOptions: any[] = [];
     loading = false;
+    clicking = false;
 
     optionApi: TypeaheadOptionApi = {
         getKey: this.getKey.bind(this),
@@ -125,6 +112,16 @@ export class TypeaheadComponent implements AfterViewInit, OnChanges {
         this.updateOptions();
     }
 
+    @HostListener('mousedown')
+    private mousedownHandler() {
+        this.clicking = true;
+    }
+
+    @HostListener('mouseup')
+    private mouseupHandler() {
+        this.clicking = false;
+    }
+
     optionMousedownHandler(event: MouseEvent) {
         // Workaround to prevent focus changing when an option is clicked
         event.preventDefault();
@@ -162,7 +159,7 @@ export class TypeaheadComponent implements AfterViewInit, OnChanges {
 
     /**
      * Returns the display value of the given option with HTML markup added to highlight the part which matches the current filter value.
-     * @param option 
+     * @param option
      */
     getDisplayHtml(option: any) {
         let displayText;
@@ -184,7 +181,7 @@ export class TypeaheadComponent implements AfterViewInit, OnChanges {
     }
 
     /**
-     * Returns true if the infinite scroll component should load 
+     * Returns true if the infinite scroll component should load
      */
     isInfiniteScroll() {
         return typeof this.options === 'function';


### PR DESCRIPTION
* Added a `clicking` property to ux-typeahead to indicate when the mouse is down over the element.
* Added a check for the typeahead clicking property in the blur handlers for ux-select and ux-tag-input.
* Also added subscription cleanup to ux-tag-input.

Sorry, I don't know why the diffs aren't working correctly.

https://jira.autonomy.com/browse/EL-3156