### PR TITLE
Adding support for a delay in focusIf directive

### DIFF
--- a/src/directives/focus-if/focus-if.directive.ts
+++ b/src/directives/focus-if/focus-if.directive.ts
@@ -1,23 +1,25 @@
-import { Directive, Input, ElementRef } from '@angular/core';
+import { Directive, ElementRef, Input } from '@angular/core';
 
-@Directive({ 
-    selector: '[focusIf]' 
+@Directive({
+    selector: '[focusIf]'
 })
 export class FocusIfDirective {
 
-    @Input() 
+    @Input() focusIfDelay: number = 0;
+
+    @Input()
     set focusIf(focus: boolean) {
 
         // if a timeout is pending then cancel it
-        if (this._timeout !== null) {
+        if (!focus && this._timeout !== null) {
             clearTimeout(this._timeout);
         }
 
-        if (focus) {
-            this._timeout = setTimeout(() => {
+        if (focus && this._timeout === null) {
+            this._timeout = window.setTimeout(() => {
                 this._elementRef.nativeElement.focus();
                 this._timeout = null;
-            });
+            }, this.focusIfDelay);
         }
     }
 


### PR DESCRIPTION
Adding support for delay in focusIf directive. Useful for animated modals so we can delay the focus until the elements are visible