### PR TITLE
Allow facets to be sorted in the list

### DIFF
--- a/src/components/facets/facet-container.component.html
+++ b/src/components/facets/facet-container.component.html
@@ -23,13 +23,14 @@
     </div>
 
     <!-- Display Tags For Selected Items -->
-    <div class="facets-selected-list">
+    <div class="facets-selected-list" uxReorderable [(reorderableModel)]="facets">
 
         <!-- Show Selected Tags -->
-        <div class="facet-selected-tag" tabindex="0" *ngFor="let facet of facets" (mousedown)="$event.preventDefault()" (click)="deselectFacet(facet)" (keyup.enter)="deselectFacet(facet)">
+        <div class="facet-selected-tag" tabindex="0" *ngFor="let facet of facets" (mousedown)="$event.preventDefault()" (click)="deselectFacet(facet)" (keyup.enter)="deselectFacet(facet)"
+             [uxReorderableModel]="facet">
 
             <!-- Display Label -->
-            <span class="facet-selected-tag-label">{{ facet.title }}</span>
+            <span class="facet-selected-tag-label" uxReorderableHandle>{{ facet.title }}</span>
 
             <!-- Display Remove Icon -->
             <span class="hpe-icon hpe-close"></span>

--- a/src/components/facets/facets.module.ts
+++ b/src/components/facets/facets.module.ts
@@ -9,6 +9,7 @@ import { FacetTypeaheadListComponent, FacetTypeaheadHighlight } from './facet-ty
 import { FormsModule } from '@angular/forms';
 import { CheckboxModule } from '../checkbox/index';
 import { TooltipModule } from '../tooltip/index';
+import { ReorderableModule } from './../../directives/reorderable/reorderable.module';
 
 const DECLARATIONS = [
     FacetContainerComponent,
@@ -25,6 +26,7 @@ const DECLARATIONS = [
         FormsModule,
         CheckboxModule,
         TooltipModule,
+        ReorderableModule,
         TypeaheadModule.forRoot()
     ],
     exports: DECLARATIONS,


### PR DESCRIPTION
Our application required the facet list to be ordered. Added the uxReorderable directive to the list of facets in facet-container allowing them to be re-ordered using drag and drop.