### PR TITLE
Added 'row-alt' mode for ux-selection and allow custom strategies to …

### DIFF
--- a/docs/app/pages/components/components-sections/tables/selection/selection.component.html
+++ b/docs/app/pages/components/components-sections/tables/selection/selection.component.html
@@ -38,6 +38,7 @@
                         <label>mode</label>
                         <ux-radio-button [(ngModel)]="mode" option="simple">simple</ux-radio-button>
                         <ux-radio-button [(ngModel)]="mode" option="row">row</ux-radio-button>
+                        <ux-radio-button [(ngModel)]="mode" option="row-alt">row-alt</ux-radio-button>
                     </div>
                 </div>
             </accordion-panel>
@@ -70,7 +71,7 @@
         Defines the items that should be selected.
     </tr>
 
-    <tr uxd-api-property name="mode" type="'simple' | 'row'" defaultValue="'simple'">
+    <tr uxd-api-property name="mode" type="'simple' | 'row' | 'row-alt' | SelectionStrategy" defaultValue="'simple'">
         Defines the selection behavior. The following modes can be used:
 
         <ul>
@@ -85,7 +86,19 @@
                 Keyboard navigation is also provided using the arrow keys and spacebar to toggle selection and <code>ctrl</code> and <code>shift</code> support
                 is also available for multiple selection.
             </li>
+
+            <li>
+                <code>row-alt</code> - This is similar to <code>row</code> mode, except that the cursor keys move the
+                selection as well as the focus. Holding <code>ctrl</code> with the cursor keys allows the focus to be
+                moved without affecting the selection.
+            </li>
         </ul>
+
+        <p>
+            Alternatively, custom selection behavior can be defined by defining a class which extends
+            <code>SelectionStrategy</code>, and providing an instance of the custom class to this property.
+            See below for details of the <code>SelectionStrategy</code> class.
+        </p>
     </tr>
 
     <tr uxd-api-property name="disabled" type="boolean">
@@ -143,6 +156,38 @@
     </tr>
     <tr uxd-api-property name="deselect">
         This function can be called to deselect this item.
+    </tr>
+</uxd-api-properties>
+
+<p>
+    The <code>SelectionStrategy</code> class, which can be subclassed to provide custom selection behavior, has the
+    following interface:
+</p>
+
+<uxd-api-properties tableTitle="SelectionStrategy">
+    <tr uxd-api-property name="mousedown" args="event: MouseEvent, data: any">
+        Called when the mousedown event occurs on the item representing <code>data</code>. Override this function to provide custom behavior.
+    </tr>
+    <tr uxd-api-property name="click" args="event: MouseEvent, data: any">
+        Called when the click event occurs on the item representing <code>data</code>. Override this function to provide custom behavior.
+    </tr>
+    <tr uxd-api-property name="keydown" args="event: KeyboardEvent, data: any">
+        Called when the keydown event occurs on the item representing <code>data</code>. Override this function to provide custom behavior.
+    </tr>
+    <tr uxd-api-property name="select" args="...data: any[]">
+        Select the item(s).
+    </tr>
+    <tr uxd-api-property name="toggle" args="...data: any[]">
+        Toggle the selected state of the item(s).
+    </tr>
+    <tr uxd-api-property name="deselect" args="...data: any[]">
+        Deselect the item(s).
+    </tr>
+    <tr uxd-api-property name="selectAll">
+        Select all items.
+    </tr>
+    <tr uxd-api-property name="deselectAll">
+        Deselect all items.
     </tr>
 </uxd-api-properties>
 

--- a/e2e/pages/app/selection/selection.testpage.component.html
+++ b/e2e/pages/app/selection/selection.testpage.component.html
@@ -30,6 +30,7 @@
 
 <ux-radio-button class="simple-mode" [(ngModel)]="mode" option="simple">simple</ux-radio-button>
 <ux-radio-button class="row-mode" [(ngModel)]="mode" option="row">row</ux-radio-button>
+<ux-radio-button class="row-alt-mode" [(ngModel)]="mode" option="row-alt">row-alt</ux-radio-button>
 
 <hr>
 

--- a/e2e/tests/components/selection/selection.e2e-spec.ts
+++ b/e2e/tests/components/selection/selection.e2e-spec.ts
@@ -124,7 +124,52 @@ describe('Selection Tests', () => {
 
         // only the second row should be focused
         expect(await page.getSelection()).toBe('[ { "name": "Document 2", "author": "John Smith", "selected": true } ]');
-        
+
+    });
+
+    it('should allow keyboard navigation (row-alt)', async () => {
+
+        // select row mode
+        await page.setRowAltMode();
+
+        // nothing should be selected initially
+        expect(await page.getSelection()).toBe('[]');
+
+        await page.clickSelectRow(page.row0);
+
+        // first row should be selected
+        expect(await page.getSelection()).toBe('[ { "name": "Document 1", "author": "John Smith", "selected": true } ]', '1. initial click');
+
+        // press down
+        await page.arrowDown();
+
+        // second row should be selected
+        expect(await page.getSelection()).toBe('[ { "name": "Document 2", "author": "John Smith", "selected": true } ]', '2. down');
+
+        // press shift+down
+        await page.arrowDown(true);
+
+        // second and third
+        expect(await page.getSelection()).toBe('[ { "name": "Document 2", "author": "John Smith", "selected": true }, { "name": "Document 3", "author": "John Smith", "selected": true } ]', '3. shift+down');
+
+        // press ctrl+down
+        await page.arrowDown(false, true);
+
+        // second and third (still)
+        expect(await page.getSelection()).toBe('[ { "name": "Document 2", "author": "John Smith", "selected": true }, { "name": "Document 3", "author": "John Smith", "selected": true } ]', '4. ctrl+down');
+
+        // press space
+        await page.spacebar();
+
+        // second, third, and fourth
+        expect(await page.getSelection()).toBe('[ { "name": "Document 2", "author": "John Smith", "selected": true }, { "name": "Document 3", "author": "John Smith", "selected": true }, { "name": "Document 4", "author": "John Smith", "selected": true } ]', '5. space');
+
+        // press down
+        await page.arrowDown();
+
+        // fourth
+        expect(await page.getSelection()).toBe('[ { "name": "Document 4", "author": "John Smith", "selected": true } ]', '6. down');
+
     });
 
     it('should select a row on click (row)', async () => {
@@ -188,7 +233,7 @@ describe('Selection Tests', () => {
     });
 
     it('should allow deselect all (row)', async () => {
-        
+
         // select row mode
         await page.setRowMode();
 
@@ -251,7 +296,7 @@ describe('Selection Tests', () => {
 
         // only the second row should be focused
         expect(await page.getSelection()).toBe('[ { "name": "Document 1", "author": "John Smith", "selected": true } ]');
-        
+
     });
 
     it('should allow multiple click selection with ctrl key down (row)', async () => {
@@ -269,11 +314,11 @@ describe('Selection Tests', () => {
         expect(await page.getSelection()).toBe('[ { "name": "Document 1", "author": "John Smith", "selected": true } ]');
 
         // ctrl + click the second row
-        await page.clickSelectRow(page.row1, false, true); 
+        await page.clickSelectRow(page.row1, false, true);
 
         // the selection should be updated
         expect(await page.getSelection()).toBe('[ { "name": "Document 1", "author": "John Smith", "selected": true }, { "name": "Document 2", "author": "John Smith", "selected": true } ]');
-        
+
     });
 
     it('should allow group click selection with shift key down (row)', async () => {
@@ -291,11 +336,11 @@ describe('Selection Tests', () => {
         expect(await page.getSelection()).toBe('[ { "name": "Document 1", "author": "John Smith", "selected": true } ]');
 
         // shift + click the last row
-        await page.clickSelectRow(page.row3, true);     
+        await page.clickSelectRow(page.row3, true);
 
         // the selection should be updated
         expect(await page.getSelection()).toBe('[ { "name": "Document 1", "author": "John Smith", "selected": true }, { "name": "Document 2", "author": "John Smith", "selected": true }, { "name": "Document 3", "author": "John Smith", "selected": true }, { "name": "Document 4", "author": "John Smith", "selected": true } ]');
-        
+
     });
 
 });

--- a/e2e/tests/components/selection/selection.po.spec.ts
+++ b/e2e/tests/components/selection/selection.po.spec.ts
@@ -5,6 +5,7 @@ export class SelectionPage {
     selection = element(by.id('selection'));
     simpleMode = element(by.className('simple-mode'));
     rowMode = element(by.className('row-mode'));
+    rowAltMode = element(by.className('row-alt-mode'));
     row0 = element(by.id('row-0'));
     row1 = element(by.id('row-1'));
     row2 = element(by.id('row-2'));
@@ -28,6 +29,10 @@ export class SelectionPage {
         return await this.rowMode.click();
     }
 
+    async setRowAltMode() {
+        return await this.rowAltMode.click();
+    }
+
     async clickSelectRow(row: ElementFinder, shift: boolean = false, ctrl: boolean = false) {
 
         if (shift) {
@@ -47,12 +52,24 @@ export class SelectionPage {
         return this.deselectAllBtn.click();
     }
 
-    async arrowDown() {
-        await browser.actions().sendKeys(Key.ARROW_DOWN).perform();
+    async arrowDown(shift: boolean = false, ctrl: boolean = false) {
+        let keys = Key.ARROW_DOWN;
+        if (shift) {
+            keys = Key.chord(Key.SHIFT, Key.ARROW_DOWN);
+        } else if (ctrl) {
+            keys = Key.chord(Key.CONTROL, Key.ARROW_DOWN);
+        }
+        await browser.actions().sendKeys(keys).perform();
     }
 
-    async arrowUp() {
-        await browser.actions().sendKeys(Key.ARROW_UP).perform();
+    async arrowUp(shift: boolean = false, ctrl: boolean = false) {
+        let keys = Key.ARROW_UP;
+        if (shift) {
+            keys = Key.chord(Key.SHIFT, Key.ARROW_UP);
+        } else if (ctrl) {
+            keys = Key.chord(Key.CONTROL, Key.ARROW_UP);
+        }
+        await browser.actions().sendKeys(keys).perform();
     }
 
     async spacebar() {

--- a/src/directives/selection/index.ts
+++ b/src/directives/selection/index.ts
@@ -1,3 +1,6 @@
 export * from './selection-item.directive';
 export * from './selection.directive';
 export * from './selection.module';
+export * from './selection.service';
+export * from './strategies/selection.strategy';
+

--- a/src/directives/selection/selection.directive.ts
+++ b/src/directives/selection/selection.directive.ts
@@ -2,6 +2,7 @@ import { AfterContentInit, ChangeDetectorRef, ContentChildren, Directive, EventE
 import { Subscription } from 'rxjs/Subscription';
 import { SelectionItemDirective } from './selection-item.directive';
 import { SelectionMode, SelectionService } from './selection.service';
+import { SelectionStrategy } from './strategies/selection.strategy';
 
 
 @Directive({
@@ -19,7 +20,7 @@ export class SelectionDirective implements AfterContentInit, OnDestroy {
     this._selectionService.setDisabled(disabled);
   }
 
-  @Input() set mode(mode: SelectionMode) {
+  @Input() set mode(mode: SelectionMode | SelectionStrategy) {
     this._selectionService.setMode(mode);
   }
 

--- a/src/directives/selection/strategies/keycode.enum.ts
+++ b/src/directives/selection/strategies/keycode.enum.ts
@@ -1,0 +1,5 @@
+export enum KeyCode {
+    UpArrow = 38,
+    DownArrow = 40,
+    Spacebar = 32
+}

--- a/src/directives/selection/strategies/row-alt-selection.strategy.ts
+++ b/src/directives/selection/strategies/row-alt-selection.strategy.ts
@@ -1,0 +1,40 @@
+import { KeyCode } from './keycode.enum';
+import { RowSelectionStrategy } from './row-selection.strategy';
+
+export class RowAltSelectionStrategy extends RowSelectionStrategy {
+    keydown(event: KeyboardEvent, data: any): void {
+        switch (event.keyCode) {
+            case KeyCode.UpArrow:
+            case KeyCode.DownArrow:
+                event.preventDefault();
+                this.handleCursorKey(event, data);
+                break;
+
+            case KeyCode.Spacebar:
+                event.preventDefault();
+                this.selectionService.strategy.toggle(data);
+                break;
+        }
+    }
+
+    /**
+     * Select the sibling item when arrow keys are pressed
+     */
+    private handleCursorKey(event: KeyboardEvent, data: any): void {
+        // determine which modifier keys are pressed
+        const { ctrlKey, shiftKey } = event;
+
+        // if no modifier keys are pressed then deselect all and clear the selection
+        if (!ctrlKey && !shiftKey) {
+            this.deselectAll();
+            this.clearSelection(false);
+        }
+
+        if (ctrlKey) {
+            this.selectionService.activateSibling(event.keyCode === KeyCode.UpArrow);
+        } else {
+            const sibling = this.selectionService.getSibling(event.keyCode === KeyCode.UpArrow);
+            this.multipleSelect(sibling ? sibling : data);
+        }
+    }
+}

--- a/src/directives/selection/strategies/row-selection.strategy.ts
+++ b/src/directives/selection/strategies/row-selection.strategy.ts
@@ -1,3 +1,4 @@
+import { KeyCode } from './keycode.enum';
 import { SelectionStrategy } from './selection.strategy';
 
 export class RowSelectionStrategy extends SelectionStrategy {
@@ -51,7 +52,7 @@ export class RowSelectionStrategy extends SelectionStrategy {
         event.preventDefault();
         this.navigate(event, data);
         break;
-        
+
       case KeyCode.Spacebar:
         event.preventDefault();
         this.selectionService.strategy.toggle(data, true);
@@ -98,7 +99,7 @@ export class RowSelectionStrategy extends SelectionStrategy {
    * 2. If a start item has been selected - select all in between
    * 3. If a start and end item have been selected clear the range and then select the new range
    */
-  private multipleSelect(data: any): void {
+  protected multipleSelect(data: any): void {
 
     // if no selection currently exists then perform initial selection
     if (!this._selection.start) {
@@ -147,7 +148,7 @@ export class RowSelectionStrategy extends SelectionStrategy {
   /**
    * Clear both start and end selection points
    */
-  private clearSelection(deactivate: boolean = true): void {
+  protected clearSelection(deactivate: boolean = true): void {
 
     // reset the selected item
     this._selection = { start: null, end: null };
@@ -209,10 +210,4 @@ export class RowSelectionStrategy extends SelectionStrategy {
 export interface Selection {
   start: any;
   end: any;
-}
-
-enum KeyCode {
-  UpArrow = 38,
-  DownArrow = 40,
-  Spacebar = 32
 }

--- a/src/directives/selection/strategies/selection.strategy.ts
+++ b/src/directives/selection/strategies/selection.strategy.ts
@@ -2,7 +2,11 @@ import { SelectionService } from '../selection.service';
 
 export class SelectionStrategy {
 
-  constructor(protected selectionService: SelectionService) { }
+  constructor(protected selectionService?: SelectionService) { }
+
+  setSelectionService(selectionService: SelectionService): void {
+    this.selectionService = selectionService;
+  }
 
   mousedown(event: MouseEvent, data: any): void { }
 

--- a/src/directives/selection/strategies/simple-selection.strategy.ts
+++ b/src/directives/selection/strategies/simple-selection.strategy.ts
@@ -1,3 +1,4 @@
+import { KeyCode } from './keycode.enum';
 import { SelectionStrategy } from './selection.strategy';
 
 export class SimpleSelectionStrategy extends SelectionStrategy {
@@ -16,17 +17,17 @@ export class SimpleSelectionStrategy extends SelectionStrategy {
   keydown(event: KeyboardEvent, data: any): void {
 
     switch (event.keyCode) {
-      
+
       case KeyCode.UpArrow:
         event.preventDefault();
         return this.selectionService.activateSibling(true);
-        
+
       case KeyCode.DownArrow:
         event.preventDefault();
         return this.selectionService.activateSibling(false);
-      
+
       case KeyCode.Spacebar:
-        event.preventDefault();      
+        event.preventDefault();
         return this.toggle(data);
     }
   }
@@ -38,10 +39,4 @@ export class SimpleSelectionStrategy extends SelectionStrategy {
     super.toggle(data);
     this.selectionService.activate(data);
   }
-}
-
-enum KeyCode {
-  UpArrow = 38,
-  DownArrow = 40,
-  Spacebar = 32
 }


### PR DESCRIPTION
…be provided

* Added `row-alt` option for `mode` with the requested behavior.
* Extended the type of the `mode` property to allow objects of type SelectionStrategy.
* Added documentation for the new mode and details of the SelectionStrategy type. I excluded `destroy` from this since it is only called automatically on objects created within the component.
* Added protractor tests for the row-alt mode. For some reason that I was not able to track down, this failed if run after the `row` tests. It seems like some state is leaking between tests when run in headless mode.

If you can think of a better name than "row-alt" I will gladly change it!

https://jira.autonomy.com/browse/EL-3159