### PR TITLE
Add openChange event to floating action button

### DIFF
--- a/docs/app/pages/components/components-sections/buttons/floating-action-button/floating-action-button.component.html
+++ b/docs/app/pages/components/components-sections/buttons/floating-action-button/floating-action-button.component.html
@@ -49,6 +49,12 @@
     </tr>
 </uxd-api-properties>
 
+<uxd-api-properties tableTitle="Outputs">
+    <tr uxd-api-property name="openChange" type="boolean">
+        Emits an event when the list of additional buttons is opened or closed.
+    </tr>
+</uxd-api-properties>
+
 <p>The following input can be used to customize the appearance of the <code>ux-floating-action-button</code> component:</p>
 
 <uxd-api-properties tableTitle="Inputs">

--- a/src/components/floating-action-buttons/floating-action-buttons.component.ts
+++ b/src/components/floating-action-buttons/floating-action-buttons.component.ts
@@ -2,6 +2,7 @@ import { animate, query, stagger, style, transition, trigger } from '@angular/an
 import { AfterViewInit, ChangeDetectionStrategy, Component, ContentChildren, ElementRef, HostListener, Input, OnDestroy, QueryList } from '@angular/core';
 import { TooltipDirective } from 'ngx-bootstrap/tooltip';
 import { filter } from 'rxjs/operators';
+import { Observable } from 'rxjs/Observable';
 import { Subscription } from 'rxjs/Subscription';
 import { FloatingActionButtonsService } from './floating-action-buttons.service';
 
@@ -27,6 +28,10 @@ export class FloatingActionButtonsComponent implements AfterViewInit, OnDestroy 
 
     @Input() direction: FloatingActionButtonDirection = 'top';
     @ContentChildren(TooltipDirective) tooltips: QueryList<TooltipDirective>;
+
+    get open$(): Observable<boolean> {
+        return this.fab.open$;
+    }
 
     private _subscription: Subscription;
 

--- a/src/components/floating-action-buttons/floating-action-buttons.component.ts
+++ b/src/components/floating-action-buttons/floating-action-buttons.component.ts
@@ -1,8 +1,7 @@
 import { animate, query, stagger, style, transition, trigger } from '@angular/animations';
-import { AfterViewInit, ChangeDetectionStrategy, Component, ContentChildren, ElementRef, HostListener, Input, OnDestroy, QueryList } from '@angular/core';
+import { AfterViewInit, ChangeDetectionStrategy, Component, ContentChildren, ElementRef, HostListener, Input, OnDestroy, QueryList, Output, EventEmitter } from '@angular/core';
 import { TooltipDirective } from 'ngx-bootstrap/tooltip';
 import { filter } from 'rxjs/operators';
-import { Observable } from 'rxjs/Observable';
 import { Subscription } from 'rxjs/Subscription';
 import { FloatingActionButtonsService } from './floating-action-buttons.service';
 
@@ -28,18 +27,17 @@ export class FloatingActionButtonsComponent implements AfterViewInit, OnDestroy 
 
     @Input() direction: FloatingActionButtonDirection = 'top';
     @ContentChildren(TooltipDirective) tooltips: QueryList<TooltipDirective>;
+    @Output() openChange = new EventEmitter<boolean>();
 
-    get open$(): Observable<boolean> {
-        return this.fab.open$;
+    private _subscription: Subscription = new Subscription();
+
+    constructor(public fab: FloatingActionButtonsService, private _elementRef: ElementRef) {
+        this._subscription.add(this.fab.open$.subscribe(value => this.openChange.emit(value)));
     }
 
-    private _subscription: Subscription;
-
-    constructor(public fab: FloatingActionButtonsService, private _elementRef: ElementRef) { }
-
     ngAfterViewInit(): void {
-        this._subscription = this.fab.open$.pipe(filter(open => open === false))
-            .subscribe(() => this.tooltips.forEach(tooltip => tooltip.hide()));
+        this._subscription.add(this.fab.open$.pipe(filter(open => open === false))
+            .subscribe(() => this.tooltips.forEach(tooltip => tooltip.hide())));
     }
 
     ngOnDestroy(): void {


### PR DESCRIPTION
I have a component that consumes the FloatingActionButtonsComponent and needs to track the open state. There was no way that I could find to do this with the current API. So, I added a get property to return the open$ observable from the FloatingActionButtonsService.