### PR TITLE
Click on primary button should toggle open state

### DIFF
--- a/src/components/floating-action-buttons/floating-action-button.component.html
+++ b/src/components/floating-action-buttons/floating-action-button.component.html
@@ -1,7 +1,7 @@
 <button class="btn floating-action-button" 
         [class.button-primary]="primary" 
         [class.button-secondary]="!primary" 
-        (click)="primary ? fab.open() : fab.close()">
+        (click)="primary ? fab.toggle() : fab.close()">
 
     <span class="hpe-icon floating-action-button-icon" *ngIf="icon" [ngClass]="icon"></span>
     <ng-content *ngIf="!icon"></ng-content>


### PR DESCRIPTION
Clicking on the primary button a second time should close the floating action button list. Currently clicking repeatedly does nothing. You must click off the button in order to close the menu.