### PR TITLE
EL-3153 - Adding Conduit Tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ e2e/xml/
 .ng_build/
 .ng_pkg_build/
 target/
+.vscode/launch.json

--- a/docs/app/data/components-page.json
+++ b/docs/app/data/components-page.json
@@ -200,24 +200,12 @@
                 {
                     "title": "Conduits",
                     "component": "ComponentsConduitComponent",
-                    "version": "Angular",
-                    "usage": [
-                        {
-                            "title": "Module",
-                            "content": "ConduitModule"
-                        }
-                    ]
+                    "version": "Angular"
                 },
                 {
                     "title": "Multiple Zones",
                     "component": "ComponentsMultipleZonesComponent",
-                    "version": "Angular",
-                    "usage": [
-                        {
-                            "title": "Module",
-                            "content": "ConduitModule"
-                        }
-                    ]
+                    "version": "Angular"
                 }
             ]
         },

--- a/docs/app/pages/components/components-sections/conduits/conduit/conduit.component.ts
+++ b/docs/app/pages/components/components-sections/conduits/conduit/conduit.component.ts
@@ -20,7 +20,7 @@ export class ComponentsConduitComponent extends BaseDocumentationSection impleme
         },
         modules: [
             {
-                imports: ['ConduitModule', 'CheckboxModule'],
+                imports: ['CheckboxModule'],
                 library: '@ux-aspects/ux-aspects'
             },
             {

--- a/docs/app/pages/components/components-sections/conduits/conduits.module.ts
+++ b/docs/app/pages/components/components-sections/conduits/conduits.module.ts
@@ -2,7 +2,7 @@ import { CommonModule } from '@angular/common';
 import { ComponentFactoryResolver, NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { RouterModule } from '@angular/router';
-import { CheckboxModule, ConduitModule, PopoverModule, TabsetModule } from '../../../../../../src';
+import { CheckboxModule, PopoverModule, TabsetModule } from '../../../../../../src';
 import { DocumentationComponentsModule } from '../../../../components/components.module';
 import { DocumentationCategoryComponent } from '../../../../components/documentation-category/documentation-category.component';
 import { DocumentationPage, ResolverService } from '../../../../services/resolver/resolver.service';
@@ -41,7 +41,6 @@ const ROUTES = [
 @NgModule({
     imports: [
         CommonModule,
-        ConduitModule,
         CheckboxModule,
         PopoverModule,
         DocumentationComponentsModule,

--- a/docs/app/pages/components/components-sections/conduits/multiple-zones/example/example.component.ts
+++ b/docs/app/pages/components/components-sections/conduits/multiple-zones/example/example.component.ts
@@ -1,11 +1,12 @@
 import { Component, forwardRef } from '@angular/core';
 import { BehaviorSubject } from 'rxjs/BehaviorSubject';
-import { Conduit, ConduitZoneComponent } from '../../../../../../../../src';
+import { Conduit, ConduitZone, ConduitZoneComponent } from '../../../../../../../../src';
 
 @Component({
     selector: 'uxd-conduit-zone-example',
     templateUrl: './example.component.html',
-    styleUrls: ['./example.component.less']
+    styleUrls: ['./example.component.less'],
+    providers: [ConduitZone]
 })
 export class ConduitZoneExampleComponent extends ConduitZoneComponent {
     zoneId: string = 'root-zone';

--- a/docs/app/pages/components/components-sections/conduits/multiple-zones/multiple-zones.component.ts
+++ b/docs/app/pages/components/components-sections/conduits/multiple-zones/multiple-zones.component.ts
@@ -29,7 +29,7 @@ export class ComponentsMultipleZonesComponent extends BaseDocumentationSection i
         },
         modules: [
             {
-                imports: ['ConduitModule', 'CheckboxModule', 'PopoverModule'],
+                imports: ['CheckboxModule', 'PopoverModule'],
                 library: '@ux-aspects/ux-aspects'
             },
             {

--- a/docs/app/pages/components/components-sections/conduits/multiple-zones/snippets/app.component.ts
+++ b/docs/app/pages/components/components-sections/conduits/multiple-zones/snippets/app.component.ts
@@ -1,11 +1,12 @@
 import { Component } from '@angular/core';
-import { Conduit, ConduitZoneComponent } from '@ux-aspects/ux-aspects';
+import { Conduit, ConduitZone, ConduitZoneComponent } from '@ux-aspects/ux-aspects';
 import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 
 @Component({
     selector: 'app',
     templateUrl: './app.component.html',
-    styleUrls: ['./app.component.css']
+    styleUrls: ['./app.component.css'],
+    providers: [ConduitZone]
 })
 export class AppComponent extends ConduitZoneComponent {
     zoneId: string = 'root-zone';

--- a/e2e/pages/app/app.module.ts
+++ b/e2e/pages/app/app.module.ts
@@ -2,7 +2,7 @@ import { Injector, NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterModule, Routes } from '@angular/router';
-import { UpgradeModule, downgradeComponent } from '@angular/upgrade/static';
+import { downgradeComponent, UpgradeModule } from '@angular/upgrade/static';
 import * as angular from 'angular';
 import { AppComponent } from './app.component';
 import { FloatingActionButtonsNg1TestPageComponent } from './floating-action-buttons-ng1/floating-action-buttons-ng1.testpage.component';
@@ -56,6 +56,10 @@ const ROUTES: Routes = [
         path: 'colored-buttons',
         loadChildren:
             './colored-buttons/colored-buttons.module#ColoredButtonsTestPageModule'
+    },
+    {
+        path: 'conduits',
+        loadChildren: './conduits/conduits.module#ConduitsTestPageModule'
     },
     {
         path: 'dashboard',

--- a/e2e/pages/app/conduits/conduit.component.html
+++ b/e2e/pages/app/conduits/conduit.component.html
@@ -1,0 +1,15 @@
+<div class="container-fluid">
+    <div class="row p-lg">
+        <div class="col-md-4">
+            <app-zone-one></app-zone-one>
+        </div>
+        <div class="col-md-4">
+            <app-zone-two></app-zone-two>
+        </div>
+        <div class="col-md-4">
+            <app-zone-three *ngIf="visible"></app-zone-three>
+        </div>
+    </div>
+</div>
+
+<button id="toggle-visibility" class="btn button-primary" (click)="visible = !visible">Toggle Zone 3</button>

--- a/e2e/pages/app/conduits/conduit.component.ts
+++ b/e2e/pages/app/conduits/conduit.component.ts
@@ -1,0 +1,9 @@
+import { Component } from '@angular/core';
+
+@Component({
+    selector: 'app-conduit',
+    templateUrl: './conduit.component.html'
+})
+export class ConduitTestPageComponent {
+    visible: boolean = true;
+}

--- a/e2e/pages/app/conduits/conduits.module.ts
+++ b/e2e/pages/app/conduits/conduits.module.ts
@@ -1,0 +1,30 @@
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { RouterModule } from '@angular/router';
+import { CheckboxModule } from '../../../../dist';
+import { ConduitTestPageComponent } from './conduit.component';
+import { ZoneOneComponent } from './zones/zone-one/zone-one.component';
+import { ZoneThreeComponent } from './zones/zone-three/zone-three.component';
+import { ZoneTwoComponent } from './zones/zone-two/zone-two.component';
+
+@NgModule({
+    imports: [
+        CommonModule,
+        CheckboxModule,
+        FormsModule,
+        RouterModule.forChild([
+            {
+                path: '',
+                component: ConduitTestPageComponent
+            }
+        ])
+    ],
+    declarations: [
+        ConduitTestPageComponent,
+        ZoneOneComponent,
+        ZoneTwoComponent,
+        ZoneThreeComponent
+    ]
+})
+export class ConduitsTestPageModule { }

--- a/e2e/pages/app/conduits/zones/zone-one/zone-one.component.html
+++ b/e2e/pages/app/conduits/zones/zone-one/zone-one.component.html
@@ -1,0 +1,14 @@
+<input type="text"
+    id="zone-one-input"
+    class="form-control"
+    placeholder="Search..."
+    [ngModel]="search | async"
+    (ngModelChange)="search.next($event)">
+
+<br>
+
+<ux-checkbox id="zone-1-produces-output" [(ngModel)]="producesOutput" (ngModelChange)="updateConduit()">Produces Output</ux-checkbox>
+<br>
+<ux-checkbox id="zone-1-accepts-input-2" [(ngModel)]="acceptsInput2" (ngModelChange)="updateConduit()">Accepts Input from Zone 2</ux-checkbox>
+<br>
+<ux-checkbox id="zone-1-accepts-input-3" [(ngModel)]="acceptsInput3" (ngModelChange)="updateConduit()">Accepts Input from Zone 3</ux-checkbox>

--- a/e2e/pages/app/conduits/zones/zone-one/zone-one.component.ts
+++ b/e2e/pages/app/conduits/zones/zone-one/zone-one.component.ts
@@ -1,0 +1,32 @@
+import { Component } from '@angular/core';
+import { BehaviorSubject } from 'rxjs/BehaviorSubject';
+import { Conduit, ConduitZone, ConduitZoneComponent } from '../../../../../../dist';
+
+@Component({
+    selector: 'app-zone-one',
+    templateUrl: './zone-one.component.html',
+    providers: [ConduitZone]
+})
+export class ZoneOneComponent extends ConduitZoneComponent {
+    zoneId: string = 'zone-one';
+    producesOutput: boolean = true;
+    acceptsInput2: boolean = true;
+    acceptsInput3: boolean = true;
+
+    @Conduit({ id: 'search' })
+    search = new BehaviorSubject<string>('');
+
+    updateConduit(): void {
+        const acceptsInput = [];
+
+        if (this.acceptsInput2) {
+            acceptsInput.push('zone-two');
+        }
+
+        if (this.acceptsInput3) {
+            acceptsInput.push('zone-three');
+        }
+
+        this.setConduitProperties(this.search, { producesOutput: this.producesOutput, acceptsInput });
+    }
+}

--- a/e2e/pages/app/conduits/zones/zone-three/zone-three.component.html
+++ b/e2e/pages/app/conduits/zones/zone-three/zone-three.component.html
@@ -1,0 +1,14 @@
+<input type="text"
+    id="zone-three-input"
+    class="form-control"
+    placeholder="Search..."
+    [ngModel]="search | async"
+    (ngModelChange)="search.next($event)">
+
+<br>
+
+<ux-checkbox id="zone-3-produces-output" [(ngModel)]="producesOutput" (ngModelChange)="updateConduit()">Produces Output</ux-checkbox>
+<br>
+<ux-checkbox id="zone-3-accepts-input-1" [(ngModel)]="acceptsInput1" (ngModelChange)="updateConduit()">Accepts Input from Zone 1</ux-checkbox>
+<br>
+<ux-checkbox id="zone-3-accepts-input-2" [(ngModel)]="acceptsInput2" (ngModelChange)="updateConduit()">Accepts Input from Zone 2</ux-checkbox>

--- a/e2e/pages/app/conduits/zones/zone-three/zone-three.component.ts
+++ b/e2e/pages/app/conduits/zones/zone-three/zone-three.component.ts
@@ -1,0 +1,32 @@
+import { Component } from '@angular/core';
+import { BehaviorSubject } from 'rxjs/BehaviorSubject';
+import { Conduit, ConduitZone, ConduitZoneComponent } from '../../../../../../dist';
+
+@Component({
+    selector: 'app-zone-three',
+    templateUrl: './zone-three.component.html',
+    providers: [ConduitZone]
+})
+export class ZoneThreeComponent extends ConduitZoneComponent {
+    zoneId: string = 'zone-three';
+    producesOutput: boolean = true;
+    acceptsInput1: boolean = true;
+    acceptsInput2: boolean = true;
+
+    @Conduit({ id: 'search' })
+    search = new BehaviorSubject<string>('');
+
+    updateConduit(): void {
+        const acceptsInput = [];
+
+        if (this.acceptsInput1) {
+            acceptsInput.push('zone-one');
+        }
+
+        if (this.acceptsInput2) {
+            acceptsInput.push('zone-two');
+        }
+
+        this.setConduitProperties(this.search, { producesOutput: this.producesOutput, acceptsInput });
+    }
+}

--- a/e2e/pages/app/conduits/zones/zone-two/zone-two.component.html
+++ b/e2e/pages/app/conduits/zones/zone-two/zone-two.component.html
@@ -1,0 +1,14 @@
+<input type="text"
+    id="zone-two-input"
+    class="form-control"
+    placeholder="Search..."
+    [ngModel]="search | async"
+    (ngModelChange)="search.next($event)">
+
+<br>
+
+<ux-checkbox id="zone-2-produces-output" [(ngModel)]="producesOutput" (ngModelChange)="updateConduit()">Produces Output</ux-checkbox>
+<br>
+<ux-checkbox id="zone-2-accepts-input-1" [(ngModel)]="acceptsInput1" (ngModelChange)="updateConduit()">Accepts Input from Zone 1</ux-checkbox>
+<br>
+<ux-checkbox id="zone-2-accepts-input-3" [(ngModel)]="acceptsInput3" (ngModelChange)="updateConduit()">Accepts Input from Zone 3</ux-checkbox>

--- a/e2e/pages/app/conduits/zones/zone-two/zone-two.component.ts
+++ b/e2e/pages/app/conduits/zones/zone-two/zone-two.component.ts
@@ -1,0 +1,32 @@
+import { Component } from '@angular/core';
+import { BehaviorSubject } from 'rxjs/BehaviorSubject';
+import { Conduit, ConduitZone, ConduitZoneComponent } from '../../../../../../dist';
+
+@Component({
+    selector: 'app-zone-two',
+    templateUrl: './zone-two.component.html',
+    providers: [ConduitZone]
+})
+export class ZoneTwoComponent extends ConduitZoneComponent {
+    zoneId: string = 'zone-two';
+    producesOutput: boolean = true;
+    acceptsInput1: boolean = true;
+    acceptsInput3: boolean = true;
+
+    @Conduit({ id: 'search' })
+    search = new BehaviorSubject<string>('');
+
+    updateConduit(): void {
+        const acceptsInput = [];
+
+        if (this.acceptsInput1) {
+            acceptsInput.push('zone-one');
+        }
+
+        if (this.acceptsInput3) {
+            acceptsInput.push('zone-three');
+        }
+
+        this.setConduitProperties(this.search, { producesOutput: this.producesOutput, acceptsInput });
+    }
+}

--- a/e2e/tests/components/conduits/conduits.e2e-spec.ts
+++ b/e2e/tests/components/conduits/conduits.e2e-spec.ts
@@ -1,0 +1,144 @@
+import { ConduitsPage, Zone } from './conduits.po.spec';
+
+describe('Conduit Tests', () => {
+
+    let page: ConduitsPage;
+
+    beforeEach(() => {
+        page = new ConduitsPage();
+        page.getPage();
+    });
+
+    it('should have correct initial states', async () => {
+        expect(await page.getConduitValue(Zone.One)).toBe('');
+        expect(await page.getConduitValue(Zone.Two)).toBe('');
+        expect(await page.getConduitValue(Zone.Three)).toBe('');
+    });
+
+    it('when zone 1 changes, zone 2 and 3 should update', async () => {
+        await page.setConduitValue(Zone.One, 'UX Aspects');
+
+        expect(await page.getConduitValue(Zone.One)).toBe('UX Aspects');
+        expect(await page.getConduitValue(Zone.Two)).toBe('UX Aspects');
+        expect(await page.getConduitValue(Zone.Three)).toBe('UX Aspects');
+    });
+
+    it('when zone 2 changes, zone 1 and 3 should update', async () => {
+        await page.setConduitValue(Zone.Two, 'UX Aspects');
+
+        expect(await page.getConduitValue(Zone.One)).toBe('UX Aspects');
+        expect(await page.getConduitValue(Zone.Two)).toBe('UX Aspects');
+        expect(await page.getConduitValue(Zone.Three)).toBe('UX Aspects');
+    });
+
+    it('when zone 3 changes, zone 1 and 2 should update', async () => {
+        await page.setConduitValue(Zone.Three, 'UX Aspects');
+
+        expect(await page.getConduitValue(Zone.One)).toBe('UX Aspects');
+        expect(await page.getConduitValue(Zone.Two)).toBe('UX Aspects');
+        expect(await page.getConduitValue(Zone.Three)).toBe('UX Aspects');
+    });
+
+    it('should not update other zones when producesOutput is set to false', async () => {
+        await page.setConduitValue(Zone.One, 'UX Aspects');
+
+        expect(await page.getConduitValue(Zone.One)).toBe('UX Aspects');
+        expect(await page.getConduitValue(Zone.Two)).toBe('UX Aspects');
+        expect(await page.getConduitValue(Zone.Three)).toBe('UX Aspects');
+
+        await page.toggleProducesOutput(Zone.One);
+
+        await page.setConduitValue(Zone.One, 'Conduit Changing');
+
+        expect(await page.getConduitValue(Zone.One)).toBe('Conduit Changing');
+        expect(await page.getConduitValue(Zone.Two)).toBe('UX Aspects');
+        expect(await page.getConduitValue(Zone.Three)).toBe('UX Aspects');
+    });
+
+    it('should still receive input from other zones when producesOutput is set to false', async () => {
+        await page.setConduitValue(Zone.One, 'UX Aspects');
+
+        expect(await page.getConduitValue(Zone.One)).toBe('UX Aspects');
+        expect(await page.getConduitValue(Zone.Two)).toBe('UX Aspects');
+        expect(await page.getConduitValue(Zone.Three)).toBe('UX Aspects');
+
+        await page.toggleProducesOutput(Zone.One);
+
+        await page.setConduitValue(Zone.One, 'Conduit Changing');
+
+        expect(await page.getConduitValue(Zone.One)).toBe('Conduit Changing');
+        expect(await page.getConduitValue(Zone.Two)).toBe('UX Aspects');
+        expect(await page.getConduitValue(Zone.Three)).toBe('UX Aspects');
+
+        await page.setConduitValue(Zone.Two, 'Another Change');
+
+        expect(await page.getConduitValue(Zone.One)).toBe('Another Change');
+        expect(await page.getConduitValue(Zone.Two)).toBe('Another Change');
+        expect(await page.getConduitValue(Zone.Three)).toBe('Another Change');
+    });
+
+    it('should be able to prevent any input', async () => {
+        // disable all inputs
+        await page.toggleAcceptsInput(Zone.One, Zone.Two);
+        await page.toggleAcceptsInput(Zone.One, Zone.Three);
+
+        await page.setConduitValue(Zone.Two, 'Should not change zone one');
+
+        expect(await page.getConduitValue(Zone.One)).toBe('');
+        expect(await page.getConduitValue(Zone.Two)).toBe('Should not change zone one');
+        expect(await page.getConduitValue(Zone.Three)).toBe('Should not change zone one');
+
+        await page.setConduitValue(Zone.Two, 'Also should not change zone one');
+
+        expect(await page.getConduitValue(Zone.One)).toBe('');
+        expect(await page.getConduitValue(Zone.Two)).toBe('Also should not change zone one');
+        expect(await page.getConduitValue(Zone.Three)).toBe('Also should not change zone one');
+    });
+
+    it('should allow input from only one zone', async () => {
+        await page.toggleAcceptsInput(Zone.One, Zone.Two);
+        await page.toggleAcceptsInput(Zone.Three, Zone.Two);
+
+        // setting zone 2 should have no effect on either zone 1 or 3
+        await page.setConduitValue(Zone.Two, 'Zone two changing');
+
+        expect(await page.getConduitValue(Zone.One)).toBe('');
+        expect(await page.getConduitValue(Zone.Two)).toBe('Zone two changing');
+        expect(await page.getConduitValue(Zone.Three)).toBe('');
+
+        // should update all zones when zone 3 changes
+        await page.setConduitValue(Zone.Three, 'Zone three changing');
+
+        expect(await page.getConduitValue(Zone.One)).toBe('Zone three changing');
+        expect(await page.getConduitValue(Zone.Two)).toBe('Zone three changing');
+        expect(await page.getConduitValue(Zone.Three)).toBe('Zone three changing');
+    });
+
+    it('should allow indirect zone changes', async () => {
+
+        // turn off inputs from zone 2
+        await page.toggleAcceptsInput(Zone.One, Zone.Two);
+
+        // setting zone 2 should update zone 3, but zone 1 accepts input from zone 3 so should still get updated
+        await page.setConduitValue(Zone.Two, 'Zone two changing');
+
+        expect(await page.getConduitValue(Zone.One)).toBe('Zone two changing');
+        expect(await page.getConduitValue(Zone.Two)).toBe('Zone two changing');
+        expect(await page.getConduitValue(Zone.Three)).toBe('Zone two changing');
+    });
+
+    it('should get an initial value when zone is dynamically added', async () => {
+
+        // remove the zone completely
+        await page.toggleZoneThreeVisibility();
+
+        await page.setConduitValue(Zone.One, 'Zone one producing some output');
+
+        await page.toggleZoneThreeVisibility();
+
+        expect(await page.getConduitValue(Zone.One)).toBe('Zone one producing some output');
+        expect(await page.getConduitValue(Zone.Two)).toBe('Zone one producing some output');
+        expect(await page.getConduitValue(Zone.Three)).toBe('Zone one producing some output');
+    });
+
+});

--- a/e2e/tests/components/conduits/conduits.po.spec.ts
+++ b/e2e/tests/components/conduits/conduits.po.spec.ts
@@ -1,0 +1,111 @@
+import { browser, by, element } from 'protractor';
+
+export class ConduitsPage {
+
+    zone1Input = element(by.id('zone-one-input'));
+    zone2Input = element(by.id('zone-two-input'));
+    zone3Input = element(by.id('zone-three-input'));
+
+    zone1ProducesOutput = element(by.id('zone-1-produces-output'));
+    zone2ProducesOutput = element(by.id('zone-2-produces-output'));
+    zone3ProducesOutput = element(by.id('zone-3-produces-output'));
+
+    zone1AcceptsInput2 = element(by.id('zone-1-accepts-input-2'));
+    zone1AcceptsInput3 = element(by.id('zone-1-accepts-input-3'));
+
+    zone2AcceptsInput1 = element(by.id('zone-2-accepts-input-1'));
+    zone2AcceptsInput3 = element(by.id('zone-2-accepts-input-3'));
+
+    zone3AcceptsInput1 = element(by.id('zone-3-accepts-input-1'));
+    zone3AcceptsInput2 = element(by.id('zone-3-accepts-input-2'));
+
+    toggleBtn = element(by.id('toggle-visibility'));
+
+    getPage(): void {
+        browser.get('#/conduits');
+    }
+
+    async getConduitValue(zone: Zone): Promise<string> {
+        switch (zone) {
+            case Zone.One:
+                return await this.zone1Input.getAttribute('value');
+
+            case Zone.Two:
+                return await this.zone2Input.getAttribute('value');
+
+            case Zone.Three:
+                return await this.zone3Input.getAttribute('value');
+        }
+    }
+
+    async setConduitValue(zone: Zone, value: string): Promise<void> {
+        switch (zone) {
+            case Zone.One:
+                await this.zone1Input.clear();
+                return await this.zone1Input.sendKeys(value);
+
+            case Zone.Two:
+                await this.zone2Input.clear();
+                return await this.zone2Input.sendKeys(value);
+
+            case Zone.Three:
+                await this.zone3Input.clear();
+                return await this.zone3Input.sendKeys(value);
+        }
+    }
+
+    async toggleProducesOutput(zone: Zone): Promise<void> {
+        switch (zone) {
+            case Zone.One:
+                return await this.zone1ProducesOutput.click();
+
+            case Zone.Two:
+                return await this.zone2ProducesOutput.click();
+
+            case Zone.Three:
+                return await this.zone3ProducesOutput.click();
+        }
+    }
+
+    async toggleAcceptsInput(zone: Zone, target: Zone): Promise<void> {
+        switch (zone) {
+            case Zone.One:
+                if (target === Zone.Two) {
+                    return await this.zone1AcceptsInput2.click();
+                }
+
+                if (target === Zone.Three) {
+                    return await this.zone1AcceptsInput3.click();
+                }
+
+            case Zone.Two:
+                if (target === Zone.One) {
+                    return await this.zone2AcceptsInput1.click();
+                }
+
+                if (target === Zone.Three) {
+                    return await this.zone1AcceptsInput3.click();
+                }
+
+            case Zone.Three:
+                if (target === Zone.One) {
+                    return await this.zone3AcceptsInput1.click();
+                }
+
+                if (target === Zone.Two) {
+                    return await this.zone3AcceptsInput2.click();
+                }
+        }
+    }
+
+    async toggleZoneThreeVisibility(): Promise<void> {
+        return await this.toggleBtn.click();
+    }
+}
+
+export enum Zone {
+    One,
+    Two,
+    Three
+}
+

--- a/src/components/conduit/conduit-subject.ts
+++ b/src/components/conduit/conduit-subject.ts
@@ -14,15 +14,15 @@ export class ConduitSubject {
         // store the target subject object
         this._subject = conduit.subject;
 
+        // check if there are any conduits that have supplied an initial value
+        this.getInitialValue();
+
         // subscribe to changes to the source subject
         this._subject.pipe(distinctUntilChanged(conduit.changeDetection), takeUntil(this._onDestroy))
             .subscribe(this.onOutput.bind(this));
 
         // subscribe to the zone events and root zone events
-        _zone.rootZone.events.pipe(filter(event => event.conduit.id === conduit.id), takeUntil(this._onDestroy)).subscribe(this.onInput.bind(this));
-
-        // check if there are any conduits that have supplied an initial value
-        this.getInitialValue();
+        _zone.getEvents().pipe(filter(event => event.conduit.id === conduit.id), takeUntil(this._onDestroy)).subscribe(this.onInput.bind(this));
     }
 
     /** Check all allow inputs to see if there is a value we should initially set the conduit to */

--- a/src/components/conduit/conduit.module.ts
+++ b/src/components/conduit/conduit.module.ts
@@ -1,7 +1,0 @@
-import { NgModule } from '@angular/core';
-import { ConduitZone } from './conduit-zone.service';
-
-@NgModule({
-    providers: [ConduitZone]
-})
-export class ConduitModule { }

--- a/src/components/conduit/index.ts
+++ b/src/components/conduit/index.ts
@@ -3,7 +3,7 @@ export * from './conduit-zone.component';
 export * from './conduit-zone.service';
 export * from './conduit.component';
 export * from './conduit.decorator';
-export * from './conduit.module';
 export * from './interfaces/conduit-event';
 export * from './interfaces/conduit-metadata';
 export * from './interfaces/conduit-properties';
+


### PR DESCRIPTION
Adding conduit tests and fixing some bugs revealed when creating tests:

- Issue with dynamically adding conduit, it would not get an initial value. To fix this I removed the need for a root zone, which got a bit complex injecting and passing data up and down the zone hierarchy, instead we now just have two static fields shared across all zones. Also needed to move the position of the getInitialValue() call to get called earlier.

- With the changes mentioned above, I also removed the ConduitModule as it is now no longer needed - it originally just registered a root zone. Updated docs and examples to remove ConduitModule.

- Also issue when destroying a zone - it was destroying all conduits except the ones in the zone, when it should have been doing the opposite.