### PR TITLE
EL-3142 - Calendar Overflow

### DIFF
--- a/src/directives/observers/overflow/overflow-observer.directive.ts
+++ b/src/directives/observers/overflow/overflow-observer.directive.ts
@@ -40,7 +40,7 @@ export class OverflowDirective implements OnInit, AfterViewInit, OnDestroy {
 
   /** Perform an intial check for overflow */
   ngAfterViewInit(): void {
-    this.checkForOverflow();
+    setTimeout(() => this.checkForOverflow());
   }
 
   /** Unsubscribe from the trigger */

--- a/src/directives/observers/overflow/overflow-observer.directive.ts
+++ b/src/directives/observers/overflow/overflow-observer.directive.ts
@@ -40,7 +40,7 @@ export class OverflowDirective implements OnInit, AfterViewInit, OnDestroy {
 
   /** Perform an intial check for overflow */
   ngAfterViewInit(): void {
-    setTimeout(() => this.checkForOverflow());
+    requestAnimationFrame(() => this.checkForOverflow());
   }
 
   /** Unsubscribe from the trigger */


### PR DESCRIPTION
It appears the previous fix worked in development mode but not in production mode as change detection is run twice in dev mode producing different behaviours.

I have made an additional change to delay the check for overflow until the component is now fully rendered.

To test you can ensure `enableProdMode()` is called in `main.ts`.

This should hopefully now resolve the issue.