### PR TITLE
Ensure the selectChildren option applies to rows that are not visible

### DIFF
--- a/src/ng1/directives/multipleSelect/multipleSelect.provider.js
+++ b/src/ng1/directives/multipleSelect/multipleSelect.provider.js
@@ -178,6 +178,13 @@ MultipleSelect.prototype.isSelected = function(item) {
     return false;
 };
 
+MultipleSelect.prototype.setSelected = function(item, isSelected) {
+    var currentState = this.isSelected(item);
+    if (isSelected !== undefined && isSelected !== currentState) {
+        this.itemClicked(item);
+    }
+}
+
 /*
   Method for selecting a range of necessarily contiguous items simultaneously
 */

--- a/src/ng1/directives/treegrid/treegrid.controller.js
+++ b/src/ng1/directives/treegrid/treegrid.controller.js
@@ -2,7 +2,7 @@ TreegridCtrl.$inject = ["$scope", "$q", "multipleSelectProvider", "$timeout"];
 
 export default function TreegridCtrl($scope, $q, multipleSelectProvider, $timeout) {
   var vm = this;
-  
+
   var treegridId = multipleSelectProvider.getNextComponentId();
 
   var defaultOptions = {
@@ -109,7 +109,7 @@ export default function TreegridCtrl($scope, $q, multipleSelectProvider, $timeou
   };
 
   vm.checkboxClick = function (event) {
-    event.stopPropagation(); 
+    event.stopPropagation();
   };
 
   // Expand the specified row if possible. Returns true if the row is expandable.
@@ -163,7 +163,7 @@ export default function TreegridCtrl($scope, $q, multipleSelectProvider, $timeou
 
   function updateView() {
     vm.loading = true;
-    getTreeData(getChildren(), 0)
+    getTreeData(getChildren(), null, 0)
       .then(function (rows) {
         // Populate top level rows
         vm.treeData = rows;
@@ -190,7 +190,7 @@ export default function TreegridCtrl($scope, $q, multipleSelectProvider, $timeou
   }
 
   // Get row data suitable for angular binding from an array of source data
-  function getTreeData(dataPromise, level) {
+  function getTreeData(dataPromise, parent, level) {
     // dataPromise might also be just regular data
     return $q.when(dataPromise).then(function (data) {
       var rows = [];
@@ -219,6 +219,11 @@ export default function TreegridCtrl($scope, $q, multipleSelectProvider, $timeou
         };
         row.api = rowApi(row);
         rows.push(row);
+
+        // Propagate selection to lazy loaded data
+        if (vm.allOptions.select.selectChildren && parent && parent.selected && !vm.multipleSelectInstance.isSelected(row.dataItem)) {
+          vm.multipleSelectInstance.itemClicked(row.dataItem);
+        }
       }
       if (angular.isFunction(vm.allOptions.sort)) {
         rows = rows.sort(vm.allOptions.sort);
@@ -297,7 +302,7 @@ export default function TreegridCtrl($scope, $q, multipleSelectProvider, $timeou
   // Add children of a row to the view model
   function expand(row) {
     row.expanding = true;
-    return getTreeData(getChildren(row.dataItem), row.level + 1)
+    return getTreeData(getChildren(row.dataItem), row, row.level + 1)
       .then(function (newRows) {
         row.children = newRows;
         row.expanded = true;

--- a/src/ng1/directives/treegrid/treegrid.html
+++ b/src/ng1/directives/treegrid/treegrid.html
@@ -1,42 +1,41 @@
 <div class="table-container">
     <table class="table table-hover treegrid" keyboard-navigable-table>
         <thead>
-        <tr class="table-header-dark">
-            <th ng-repeat="column in vm.columns" ng-class="column.headerClass" ng-style="{'width': column.width}">
-            <span ng-if="$first && vm.allOptions.select.check" class="treegrid-header-checkbox">
-                <checkbox class="treegrid-multiple-select-checkbox" ng-model="selected" ng-click="vm.toggleAllRows($event); $event.preventDefault();"></checkbox>
-            </span>
-            <span ng-class="[$first ? 'treegrid-expand-header' : '', vm.allOptions.select.check ? 'has-checkbox' : '']" ng-bind="column.name"></span>
-            </th>
-        </tr>
+            <tr class="table-header-dark">
+                <th ng-repeat="column in vm.columns" ng-class="column.headerClass" ng-style="{'width': column.width}">
+                    <span ng-if="$first && vm.allOptions.select.check" class="treegrid-header-checkbox">
+                        <checkbox class="treegrid-multiple-select-checkbox" ng-model="selected" ng-click="vm.toggleAllRows($event); $event.preventDefault();"></checkbox>
+                    </span>
+                    <span ng-class="[$first ? 'treegrid-expand-header' : '', vm.allOptions.select.check ? 'has-checkbox' : '']" ng-bind="column.name"></span>
+                </th>
+            </tr>
         </thead>
         <tbody ng-if="!vm.loading">
-        <tr ng-repeat="row in vm.getGridRows()" class="clickable hover-actions" 
-        ng-class="[row.rowClass, row.selected ? vm.allOptions.select.rowClass : '', row.level > 0 ? 'sub-row' : '']"
-            treegrid-multiple-select-item="row" treegrid-multiple-select-options="vm.allOptions.select" treegrid-row-key-handler
-            treegrid-expand="vm.expand(row)" treegrid-contract="vm.contract(row)" ng-focus="vm.rowFocus(row, $event)" tabindex="-1">
-            <td ng-repeat="col in vm.columns" ng-class="col.cellClass">
-            <span ng-if="$first" class="treegrid-indent" ng-class="row.levelClass"></span>
-            <span ng-if="$first" class="treegrid-expand">
-                <span ng-if="row.canExpand && !row.expanding" class="treegrid-expand-toggle" ng-click="vm.expanderClick(row, $event)" ng-mousedown="$event.preventDefault()">
-                <i ng-if="row.expander.type === 'class'" ng-class="vm.iconClass(row.expanded ? row.expander.expanded : row.expander.contracted)"></i>
-                <img ng-if="row.expander.type === 'url'" ng-src="{{row.expanded ? row.expander.expanded : row.expander.contracted}}" alt="expander" />
-                </span>
-            <span ng-if="row.expanding" class="treegrid-expand-toggle" tooltip="Loading">
-                <i ng-if="row.expander.type === 'class'" ng-class="vm.iconClass(row.expander.expanding)"></i>
-                <img ng-if="row.expander.type === 'url'" ng-src="{{row.expander.expanding}}" alt="expander" />
-                </span>
-            </span>
-            <span ng-if="$first && vm.allOptions.select.check" class="treegrid-checkbox">
-                <checkbox class="treegrid-multiple-select-checkbox" ng-model="row.selected" ng-click="vm.checkboxClick($event);"></checkbox>
-            </span>
-            <span ng-if="$first" class="treegrid-icon">
-                <i ng-if="row.icon.type === 'class'" class="hpe-icon" ng-class="row.icon.get(row.dataItem, row.expanded)"></i>
-                <img ng-if="row.icon.type === 'url'" ng-src="{{row.icon.get(row.dataItem, row.expanded)}}" alt="icon" />
-            </span>
-            <treegrid-cell row="row" column="col"></treegrid-cell>
-            </td>
-        </tr>
+            <tr ng-repeat="row in vm.getGridRows()" class="clickable hover-actions" ng-class="[row.rowClass, row.selected ? vm.allOptions.select.rowClass : '', row.level > 0 ? 'sub-row' : '']"
+                treegrid-multiple-select-item="row" treegrid-multiple-select-options="vm.allOptions" treegrid-row-key-handler
+                treegrid-expand="vm.expand(row)" treegrid-contract="vm.contract(row)" ng-focus="vm.rowFocus(row, $event)" tabindex="-1">
+                <td ng-repeat="col in vm.columns" ng-class="col.cellClass">
+                    <span ng-if="$first" class="treegrid-indent" ng-class="row.levelClass"></span>
+                    <span ng-if="$first" class="treegrid-expand">
+                        <span ng-if="row.canExpand && !row.expanding" class="treegrid-expand-toggle" ng-click="vm.expanderClick(row, $event)" ng-mousedown="$event.preventDefault()">
+                            <i ng-if="row.expander.type === 'class'" ng-class="vm.iconClass(row.expanded ? row.expander.expanded : row.expander.contracted)"></i>
+                            <img ng-if="row.expander.type === 'url'" ng-src="{{row.expanded ? row.expander.expanded : row.expander.contracted}}" alt="expander" />
+                        </span>
+                        <span ng-if="row.expanding" class="treegrid-expand-toggle" tooltip="Loading">
+                            <i ng-if="row.expander.type === 'class'" ng-class="vm.iconClass(row.expander.expanding)"></i>
+                            <img ng-if="row.expander.type === 'url'" ng-src="{{row.expander.expanding}}" alt="expander" />
+                        </span>
+                    </span>
+                    <span ng-if="$first && vm.allOptions.select.check" class="treegrid-checkbox">
+                        <checkbox class="treegrid-multiple-select-checkbox" ng-model="row.selected" ng-click="vm.checkboxClick($event);"></checkbox>
+                    </span>
+                    <span ng-if="$first" class="treegrid-icon">
+                        <i ng-if="row.icon.type === 'class'" class="hpe-icon" ng-class="row.icon.get(row.dataItem, row.expanded)"></i>
+                        <img ng-if="row.icon.type === 'url'" ng-src="{{row.icon.get(row.dataItem, row.expanded)}}" alt="icon" />
+                    </span>
+                    <treegrid-cell row="row" column="col"></treegrid-cell>
+                </td>
+            </tr>
         </tbody>
     </table>
     <div ng-if="vm.loading" class="treegrid-loading">

--- a/src/ng1/directives/treegrid/treegrid.html
+++ b/src/ng1/directives/treegrid/treegrid.html
@@ -27,7 +27,7 @@
                         </span>
                     </span>
                     <span ng-if="$first && vm.allOptions.select.check" class="treegrid-checkbox">
-                        <checkbox class="treegrid-multiple-select-checkbox" ng-model="row.selected" ng-click="vm.checkboxClick($event);"></checkbox>
+                        <checkbox class="treegrid-multiple-select-checkbox" ng-model="row.selected" ng-click="vm.checkboxClick($event, row);" clickable="false"></checkbox>
                     </span>
                     <span ng-if="$first" class="treegrid-icon">
                         <i ng-if="row.icon.type === 'class'" class="hpe-icon" ng-class="row.icon.get(row.dataItem, row.expanded)"></i>

--- a/src/ng1/directives/treegrid/treegridMultipleSelectItem.directive.js
+++ b/src/ng1/directives/treegrid/treegridMultipleSelectItem.directive.js
@@ -13,6 +13,7 @@ export default function treegridMultipleSelectItem(multipleSelectProvider) {
 
                 var treeGridRow = scope.$eval(attrs.treegridMultipleSelectItem);
                 var options = scope.$eval(attrs.treegridMultipleSelectOptions) || {};
+                var selectOptions = options.select || {};
 
                 if (treeGridRow) {
 
@@ -28,7 +29,7 @@ export default function treegridMultipleSelectItem(multipleSelectProvider) {
 
                     //set up click
                     element.on("click.multiSelect", function (e) {
-                        if (!options.row) return;
+                        if (!selectOptions.row) return;
 
                         if (e.shiftKey) {
                             extendOrStartSelection();
@@ -47,7 +48,7 @@ export default function treegridMultipleSelectItem(multipleSelectProvider) {
 
                     // for keyboard controls
                     element.on("keydown.multiSelect", function (e) {
-                        if (!options.row) return;
+                        if (!selectOptions.row) return;
 
                         if (e.keyCode === 32) {
                             addToOrStartSelection();
@@ -59,7 +60,7 @@ export default function treegridMultipleSelectItem(multipleSelectProvider) {
 
                     // Custom event triggered by keyboardNavigableTable to handle shift key extension
                     element.on("receivedSelection.keyboardNavigableTable", function (e) {
-                        if (!options.row) return;
+                        if (!selectOptions.row) return;
 
                         if (!e.ctrlKey) {
                             if (e.shiftKey) {
@@ -196,9 +197,36 @@ export default function treegridMultipleSelectItem(multipleSelectProvider) {
 
             function setSelected(row, isSelected) {
                 row.selected = isSelected;
-                if (options.selectChildren && row.children) {
-                    for (var childRow of row.children) {
-                        setSelected(childRow, isSelected);
+                if (selectOptions.selectChildren) {
+
+                    // Set selection for visible/loaded children
+                    if (row.children && row.children.length > 0) {
+                        for (var childRow of row.children) {
+                            setSelected(childRow, isSelected);
+                        }
+                    } else {
+                        // Set selection for dataItems which have not been loaded into rows yet
+                        setSelectedDataItemChildren(row.dataItem, isSelected);
+                    }
+                }
+            }
+
+            function setSelectedDataItem(dataItem, isSelected) {
+
+                // Ensure that the selection state in multipleSelectProvider matches isSelected
+                var currentState = multipleSelectInstance.isSelected(dataItem);
+                if (currentState !== isSelected) {
+                    multipleSelectInstance.itemClicked(dataItem);
+                }
+
+                setSelectedDataItemChildren(dataItem, isSelected);
+            }
+
+            function setSelectedDataItemChildren(dataItem, isSelected) {
+                var children = dataItem[options.childrenProperty];
+                if (Array.isArray(children)) {
+                    for (var child of children) {
+                        setSelectedDataItem(child, isSelected);
                     }
                 }
             }

--- a/src/ng1/directives/treegrid/treegridMultipleSelectItem.directive.js
+++ b/src/ng1/directives/treegrid/treegridMultipleSelectItem.directive.js
@@ -88,14 +88,6 @@ export default function treegridMultipleSelectItem(multipleSelectProvider) {
                         setSelected(treeGridRow, nv);
                     });
 
-                    // Handler for checkbox click, which uses ng-model="row.selected"
-                    scope.$watch(attrs.treegridMultipleSelectItem + ".selected", function (nv) {
-                        var currentState = multipleSelectInstance.isSelected(treeGridRow.dataItem);
-                        if (nv !== undefined && nv !== currentState) {
-                            currentState = multipleSelectInstance.itemClicked(treeGridRow.dataItem);
-                        }
-                    }, true);
-
                     scope.$on("destroy", function () {
                         element.off("click.multiSelect");
                         element.off("keydown.multiSelect");
@@ -196,37 +188,22 @@ export default function treegridMultipleSelectItem(multipleSelectProvider) {
             }
 
             function setSelected(row, isSelected) {
+
+                // Set status for checkbox and the API
                 row.selected = isSelected;
+
+                // If selectChildren is set, set the selection state for the children
                 if (selectOptions.selectChildren) {
-
-                    // Set selection for visible/loaded children
-                    if (row.children && row.children.length > 0) {
-                        for (var childRow of row.children) {
-                            setSelected(childRow, isSelected);
-                        }
-                    } else {
-                        // Set selection for dataItems which have not been loaded into rows yet
-                        setSelectedDataItemChildren(row.dataItem, isSelected);
-                    }
+                    setSelectedChildren(row.dataItem, isSelected);
                 }
             }
 
-            function setSelectedDataItem(dataItem, isSelected) {
-
-                // Ensure that the selection state in multipleSelectProvider matches isSelected
-                var currentState = multipleSelectInstance.isSelected(dataItem);
-                if (currentState !== isSelected) {
-                    multipleSelectInstance.itemClicked(dataItem);
-                }
-
-                setSelectedDataItemChildren(dataItem, isSelected);
-            }
-
-            function setSelectedDataItemChildren(dataItem, isSelected) {
+            function setSelectedChildren(dataItem, isSelected) {
                 var children = dataItem[options.childrenProperty];
                 if (Array.isArray(children)) {
                     for (var child of children) {
-                        setSelectedDataItem(child, isSelected);
+                        multipleSelectInstance.setSelected(child, isSelected);
+                        setSelectedChildren(child, isSelected);
                     }
                 }
             }


### PR DESCRIPTION
* For pre-determined data, traverse the source data tree and update the items in the multipleSelectProvider directly.
* For lazy loaded data, update the items in the multipleSelectProvider as soon as they are loaded (after expanding parent).

https://jira.autonomy.com/browse/EL-3181