### PR TITLE
EL-3051 - Flippable Cards WCAG

### DIFF
--- a/docs/app/pages/components/components-sections/flippable-cards/flippable-cards.module.ts
+++ b/docs/app/pages/components/components-sections/flippable-cards/flippable-cards.module.ts
@@ -1,15 +1,16 @@
-import { NgModule, ComponentFactoryResolver } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ComponentFactoryResolver, NgModule } from '@angular/core';
 import { RouterModule } from '@angular/router';
-import { DocumentationComponentsModule } from '../../../../components/components.module';
-import { ResolverService, DocumentationPage } from '../../../../services/resolver/resolver.service';
-import { DocumentationCategoryComponent } from '../../../../components/documentation-category/documentation-category.component';
-
-import { ComponentsFlippableCardsNg1Component } from './flippable-cards-ng1/flippable-cards-ng1.component';
-import { WrappersModule } from '../../../../wrappers/wrappers.module';
 import { TabsModule } from 'ngx-bootstrap/tabs';
-import { ComponentsFlippableCardsComponent } from './flippable-cards/flippable-cards.component';
-import { FlippableCardModule, ColorServiceModule, SparkModule } from '../../../../../../src/index';
 import { HybridModule } from '../../../../../../src/hybrid/hybrid.module';
+import { ColorServiceModule, FlippableCardModule, SparkModule } from '../../../../../../src/index';
+import { DocumentationComponentsModule } from '../../../../components/components.module';
+import { DocumentationCategoryComponent } from '../../../../components/documentation-category/documentation-category.component';
+import { DocumentationPage, ResolverService } from '../../../../services/resolver/resolver.service';
+import { WrappersModule } from '../../../../wrappers/wrappers.module';
+import { ComponentsFlippableCardsNg1Component } from './flippable-cards-ng1/flippable-cards-ng1.component';
+import { ComponentsFlippableCardsComponent } from './flippable-cards/flippable-cards.component';
+
 
 const SECTIONS = [
     ComponentsFlippableCardsNg1Component,
@@ -28,6 +29,7 @@ const ROUTES = [
 
 @NgModule({
     imports: [
+        CommonModule,
         WrappersModule,
         HybridModule,
         TabsModule,

--- a/docs/app/pages/components/components-sections/flippable-cards/flippable-cards.module.ts
+++ b/docs/app/pages/components/components-sections/flippable-cards/flippable-cards.module.ts
@@ -1,3 +1,4 @@
+import { A11yModule } from '@angular/cdk/a11y';
 import { CommonModule } from '@angular/common';
 import { ComponentFactoryResolver, NgModule } from '@angular/core';
 import { RouterModule } from '@angular/router';
@@ -29,6 +30,7 @@ const ROUTES = [
 
 @NgModule({
     imports: [
+        A11yModule,
         CommonModule,
         WrappersModule,
         HybridModule,

--- a/docs/app/pages/components/components-sections/flippable-cards/flippable-cards/flippable-cards.component.html
+++ b/docs/app/pages/components/components-sections/flippable-cards/flippable-cards/flippable-cards.component.html
@@ -10,7 +10,9 @@
         [height]="180">
 
         <ux-flippable-card-front>
-            <img src="../../../../../assets/img/IconCaseColorized36x36.png" alt="Flippable card icon" class="flip-card-logo">
+            <img src="../../../../../assets/img/IconCaseColorized36x36.png"
+                 alt="Flippable card icon"
+                 class="flip-card-logo">
 
             <button
                 #frontFlipBtn
@@ -40,7 +42,11 @@
                     </p>
                 </div>
 
-                <nested-donut class="flip-card-chart" [dataset]="card.chart" [options]="options"></nested-donut>
+                <nested-donut
+                    class="flip-card-chart"
+                    [dataset]="card.chart"
+                    [options]="options">
+                </nested-donut>
             </div>
 
         </ux-flippable-card-front>

--- a/docs/app/pages/components/components-sections/flippable-cards/flippable-cards/flippable-cards.component.html
+++ b/docs/app/pages/components/components-sections/flippable-cards/flippable-cards/flippable-cards.component.html
@@ -1,7 +1,7 @@
 <div class="flex-container">
     <ux-flippable-card
         *ngFor="let card of cards"
-        [ariaLabel]="card.label"
+        [attr.aria-label]="card.label"
         class="m-sm"
         [class.flip-card-flipped]="card.flipped"
         [(flipped)]="card.flipped"

--- a/docs/app/pages/components/components-sections/flippable-cards/flippable-cards/flippable-cards.component.html
+++ b/docs/app/pages/components/components-sections/flippable-cards/flippable-cards/flippable-cards.component.html
@@ -5,6 +5,7 @@
         class="m-sm"
         [class.flip-card-flipped]="card.flipped"
         [(flipped)]="card.flipped"
+        (flippedChange)="onCardFlip(card.flipped)"
         [trigger]="card.trigger"
         [direction]="card.direction"
         [width]="260"

--- a/docs/app/pages/components/components-sections/flippable-cards/flippable-cards/flippable-cards.component.html
+++ b/docs/app/pages/components/components-sections/flippable-cards/flippable-cards/flippable-cards.component.html
@@ -1,6 +1,7 @@
 <div class="flex-container">
     <ux-flippable-card
         *ngFor="let card of cards"
+        [ariaLabel]="card.label"
         class="m-sm"
         [class.flip-card-flipped]="card.flipped"
         [(flipped)]="card.flipped"
@@ -11,12 +12,14 @@
 
         <ux-flippable-card-front>
             <img src="../../../../../assets/img/IconCaseColorized36x36.png"
-                 alt="Flippable card icon"
-                 class="flip-card-logo">
+                aria-hidden="true"
+                alt="Flippable card icon"
+                class="flip-card-logo">
 
             <button
                 #frontFlipBtn
                 aria-label="Activate to show back of card"
+                [attr.aria-hidden]="card.trigger !== 'manual'"
                 [hidden]="card.trigger !== 'manual'"
                 [tabindex]="!card.flipped ? 0 : -1"
                 class="hpe-icon hpe-link-down flip-card-btn"
@@ -57,6 +60,7 @@
                 <button
                     #backFlipBtn
                     aria-label="Activate to show front of card"
+                    [attr.aria-hidden]="card.trigger !== 'manual'"
                     [hidden]="card.trigger !== 'manual'"
                     [tabindex]="card.flipped ? 0 : -1"
                     class="hpe-icon hpe-link-up flip-card-btn text-white"

--- a/docs/app/pages/components/components-sections/flippable-cards/flippable-cards/flippable-cards.component.html
+++ b/docs/app/pages/components/components-sections/flippable-cards/flippable-cards/flippable-cards.component.html
@@ -1,170 +1,102 @@
 <div class="flex-container">
+    <ux-flippable-card
+        *ngFor="let card of cards"
+        class="m-sm"
+        [class.flip-card-flipped]="card.flipped"
+        [(flipped)]="card.flipped"
+        [trigger]="card.trigger"
+        [direction]="card.direction"
+        [width]="260"
+        [height]="180">
 
-  <ux-flippable-card #flippableCard class="m-sm" trigger="manual" direction="vertical" [width]="260" [height]="180">
+        <ux-flippable-card-front>
+            <img src="../../../../../assets/img/IconCaseColorized36x36.png" alt="Flippable card icon" class="flip-card-logo">
 
-    <ux-flippable-card-front>
-      <i class="hpe-icon hpe-link-down pull-right clickable-icon" aria-hidden="true" (click)="flippableCard.toggleFlipped()"></i>
-      <img class="card-logo" [src]="icon">
-      <div class="flip-card-content">
-        <p class="front-title">NYC vs Volkswagen</p>
-        <div class="m-t-sm">
-          <p class="card-text documents">23,456<span class="text-muted"> documents</span></p>
-          <p class="card-text reviewed">19,976<span class="text-muted"> reviewed</span></p>
-          <p class="card-text produced">11,123<span class="text-muted"> produced</span></p>
-        </div>
-        <nested-donut class="flip-card-nested-donut" [dataset]="donut1" [options]="options"></nested-donut>
-      </div>
-    </ux-flippable-card-front>
+            <button
+                #frontFlipBtn
+                aria-label="Activate to show back of card"
+                [hidden]="card.trigger !== 'manual'"
+                [tabindex]="!card.flipped ? 0 : -1"
+                class="hpe-icon hpe-link-down flip-card-btn"
+                (click)="card.flipped = true; backFlipBtn.focus()">
+            </button>
 
-    <ux-flippable-card-back>
-      <i class="hpe-icon hpe-link-up pull-right clickable-icon icon-back" aria-hidden="true" (click)="flippableCard.toggleFlipped()"></i>
-      <div class="flip-card-content card-back">
-        <p>NYC vs Volkswagen</p>
-        <div class="row">
-          <div class="col-xs-5">
-            <p>23,456 <span class="muted"> documents</span></p>
-          </div>
-          <div class="col-xs-7">
-            <p>
-              <span class="muted right-align">total </span>
-              <span class="left-align">1.2 GB</span>
-            </p>
-          </div>
-        </div>
-        <hr/>
-        <div class="row">
-          <div class="col-xs-5">
-            <p>
-              <span class="reviewed">19,976</span>
-              <span class="muted"> reviewed</span>
-            </p>
-          </div>
-          <div class="col-xs-7">
-            <p class="m-b-xxs">
-              <span class="muted right-align">responsive</span>
-              <ux-spark value="65" barHeight="5" class="spark-left-align"></ux-spark>
-            </p>
-            <p class="m-b-xxs">
-              <span class="muted right-align">privilege</span>
-              <ux-spark value="65" barHeight="5" class="spark-left-align second"></ux-spark>
-            </p>
-          </div>
+            <h3 class="flip-card-title">{{ card.title }}</h3>
 
-        </div>
-      </div>
-    </ux-flippable-card-back>
+            <div class="flip-card-content-front">
 
-  </ux-flippable-card>
+                <div class="flip-card-stats">
+                    <p class="flip-card-stat">
+                        <span>{{ card.stats.documents | number }}</span>
+                        <span class="text-muted"> documents</span>
+                    </p>
+                    <p class="flip-card-stat">
+                        <span class="text-vibrant1">{{ card.stats.reviewed | number }}</span>
+                        <span class="text-muted"> reviewed</span>
+                    </p>
+                    <p class="flip-card-stat">
+                        <span class="text-vibrant2">{{ card.stats.produced | number }}</span>
+                        <span class="text-muted"> produced</span>
+                    </p>
+                </div>
 
+                <nested-donut class="flip-card-chart" [dataset]="card.chart" [options]="options"></nested-donut>
+            </div>
 
-  <ux-flippable-card class="m-sm" trigger="hover" direction="horizontal" [width]="260" [height]="180">
+        </ux-flippable-card-front>
 
-    <ux-flippable-card-front>
-      <img class="card-logo" [src]="icon">
-      <div class="flip-card-content">
-        <p class="front-title">The Dorling Case</p>
-        <div class="m-t-sm">
-          <p class="card-text documents">15,678<span class="text-muted"> documents</span></p>
-          <p class="card-text reviewed">10,123<span class="text-muted"> reviewed</span></p>
-          <p class="card-text produced">3,123<span class="text-muted"> produced</span></p>
-        </div>
-        <nested-donut class="flip-card-nested-donut" [dataset]="donut2" [options]="options"></nested-donut>
-      </div>
-    </ux-flippable-card-front>
+        <ux-flippable-card-back>
+            <div class="flip-card-content-back">
 
-    <ux-flippable-card-back>
-      <div class="flip-card-content card-back">
-        <p>The Dorling Case</p>
-        <div class="row">
-          <div class="col-xs-5">
-            <p>
-              <span>15,678</span>
-              <span class="muted"> documents</span>
-            </p>
-          </div>
-          <div class="col-xs-7">
-            <p>
-              <span class="muted right-align">total </span>
-              <span class="left-align">0.8 GB</span>
-            </p>
-          </div>
-        </div>
-        <hr/>
-        <div class="row">
-          <div class="col-xs-5">
-            <p>
-              <span class="reviewed">10,123</span>
-              <span class="muted"> reviewed</span>
-            </p>
-          </div>
-          <div class="col-xs-7">
-            <p class="m-b-xxs">
-              <span class="muted right-align">responsive</span>
-              <ux-spark value="65" barHeight="5" class="spark-left-align"></ux-spark>
-            </p>
-            <p class="m-b-xxs">
-              <span class="muted right-align">privilege</span>
-              <ux-spark value="65" barHeight="5" class="spark-left-align second"></ux-spark>
-            </p>
-          </div>
+                <button
+                    #backFlipBtn
+                    aria-label="Activate to show front of card"
+                    [hidden]="card.trigger !== 'manual'"
+                    [tabindex]="card.flipped ? 0 : -1"
+                    class="hpe-icon hpe-link-up flip-card-btn text-white"
+                    (click)="card.flipped = false; frontFlipBtn.focus()">
+                </button>
 
-        </div>
-      </div>
-    </ux-flippable-card-back>
-  </ux-flippable-card>
+                <h4 class="flip-card-heading">{{ card.title }}</h4>
 
+                <div class="flip-card-row">
+                    <div class="flip-card-col">
+                        <p>
+                            <span class="text-white">{{ card.stats.documents | number }}</span>
+                            <span class="text-muted"> documents</span>
+                        </p>
+                    </div>
+                    <div class="flip-card-col">
+                        <p>
+                            <span class="text-muted">total</span>
+                            <span class="text-white">{{ card.stats.size }} GB</span>
+                        </p>
+                    </div>
+                </div>
 
-  <ux-flippable-card class="m-sm" trigger="click" direction="horizontal" [width]="260" [height]="180">
-    <ux-flippable-card-front>
-      <img class="card-logo" [src]="icon">
-      <div class="flip-card-content">
-        <p class="front-title">The Salisbury Case</p>
-        <div class="m-t-sm">
-          <p class="card-text documents">256,987<span class="text-muted"> documents</span></p>
-          <p class="card-text reviewed">143,567<span class="text-muted"> reviewed</span></p>
-          <p class="card-text produced">45,678<span class="text-muted"> produced</span></p>
-        </div>
-        <nested-donut class="flip-card-nested-donut" [dataset]="donut3" [options]="options"></nested-donut>
-      </div>
-    </ux-flippable-card-front>
+                <hr>
 
-    <ux-flippable-card-back>
-      <div class="flip-card-content card-back">
-        <p>The Salisbury Case</p>
-        <div class="row">
-          <div class="col-xs-5">
-            <p>256,987<span class="muted"> documents</span></p>
-          </div>
-          <div class="col-xs-7">
-            <p>
-              <span class="muted right-align">total </span>
-              <span class="left-align">10.7 GB</span>
-            </p>
-          </div>
-        </div>
-        <hr/>
-        <div class="row">
-          <div class="col-xs-5">
-            <p>
-              <span class="reviewed">143,567</span>
-              <span class="muted"> reviewed</span>
-            </p>
-          </div>
-          <div class="col-xs-7">
-            <p class="m-b-xxs">
-              <span class="muted right-align">responsive</span>
-              <ux-spark value="65" barHeight="5" class="spark-left-align"></ux-spark>
-            </p>
-            <p class="m-b-xxs">
-              <span class="muted right-align">privilege</span>
-              <ux-spark value="65" barHeight="5" class="spark-left-align second"></ux-spark>
-            </p>
-          </div>
-
-        </div>
-      </div>
-    </ux-flippable-card-back>
-  </ux-flippable-card>
+                <div class="flip-card-row">
+                    <div class="flip-card-col">
+                        <p>
+                            <span class="text-vibrant1">{{ card.stats.reviewed | number }}</span>
+                            <span class="text-muted">reviewed</span>
+                        </p>
+                    </div>
+                    <div class="flip-card-col">
+                        <p class="flip-inline-chart">
+                            <span class="text-muted text-right">responsive</span>
+                            <ux-spark [value]="65" [barHeight]="5"></ux-spark>
+                        </p>
+                        <p class="flip-inline-chart">
+                            <span class="text-muted text-right">privilege</span>
+                            <ux-spark [value]="40" [barHeight]="5"></ux-spark>
+                        </p>
+                    </div>
+                </div>
+            </div>
+        </ux-flippable-card-back>
+    </ux-flippable-card>
 </div>
 
 <hr>
@@ -172,45 +104,50 @@
 <p>Flippable Cards are a neat and tidy way to show more information about something, without taking up screen space.</p>
 
 <p>To define the content that should be displayed on the front and back sides of the card you should add html to
-  <code>ux-flippable-card-front</code> and <code>ux-flippable-card-back</code> components that are placed inside the <code>ux-flippable-card</code>  tags.</p>
+    <code>ux-flippable-card-front</code> and
+    <code>ux-flippable-card-back</code> components that are placed inside the
+    <code>ux-flippable-card</code> tags.</p>
 
 <p>You can customize the appearance and behavior of Flippable Cards by using the following attributes:</p>
 
 <uxd-api-properties tableTitle="Inputs">
     <tr uxd-api-property name="flipped" type="boolean">
-      Determines whether or not the card is flipped.
+        Determines whether or not the card is flipped.
     </tr>
     <tr uxd-api-property name="direction" type="string" defaultValue="horizontal">
-      Determines whether the card should flip horizontally or vertically. 
+        Determines whether the card should flip horizontally or vertically.
     </tr>
     <tr uxd-api-property name="trigger" type="string" defaultValue="hover">
-      Determines when the card should flip. Possible options are <code>click</code>, <code>hover</code> and <code>manual</code>.
-        The <code>manual</code> option should be used if you want complete control over when the card should flip.
+        Determines when the card should flip. Possible options are
+        <code>click</code>,
+        <code>hover</code> and
+        <code>manual</code>. The
+        <code>manual</code> option should be used if you want complete control over when the card should flip.
     </tr>
     <tr uxd-api-property name="width" type="number" defaultValue="280">
-      Sets the width (in pixels) of the card.
+        Sets the width (in pixels) of the card.
     </tr>
     <tr uxd-api-property name="height" type="number" defaultValue="200">
-      Sets the height (in pixels) of the card.
+        Sets the height (in pixels) of the card.
     </tr>
 </uxd-api-properties>
 
 <uxd-api-properties tableTitle="Outputs">
     <tr uxd-api-property name="flippedChange" type="boolean">
-      If two way binding is used this value will be updated when the state of the card changes.
+        If two way binding is used this value will be updated when the state of the card changes.
     </tr>
 </uxd-api-properties>
 
 <p>The following code was used in the example above:</p>
 
 <tabset>
-  <tab heading="HTML">
-    <uxd-snippet language="html" [content]="snippets.compiled.appHtml"></uxd-snippet>
-  </tab>
-  <tab heading="TypeScript">
-    <uxd-snippet language="javascript" [content]="snippets.compiled.appTs"></uxd-snippet>
-  </tab>
-  <tab heading="CSS">
-    <uxd-snippet language="css" [content]="snippets.compiled.appCss"></uxd-snippet>
-  </tab>
+    <tab heading="HTML">
+        <uxd-snippet language="html" [content]="snippets.compiled.appHtml"></uxd-snippet>
+    </tab>
+    <tab heading="TypeScript">
+        <uxd-snippet language="javascript" [content]="snippets.compiled.appTs"></uxd-snippet>
+    </tab>
+    <tab heading="CSS">
+        <uxd-snippet language="css" [content]="snippets.compiled.appCss"></uxd-snippet>
+    </tab>
 </tabset>

--- a/docs/app/pages/components/components-sections/flippable-cards/flippable-cards/flippable-cards.component.less
+++ b/docs/app/pages/components/components-sections/flippable-cards/flippable-cards/flippable-cards.component.less
@@ -1,0 +1,113 @@
+.flex-container {
+    display: flex;
+}
+
+.flip-card-btn {
+    position: absolute;
+    top: 0;
+    right: 0;
+    padding: 10px;
+    cursor: pointer;
+    color: #999;
+    border: none;
+    background: transparent;
+}
+
+.flip-card-logo {
+    margin: 0 20px;
+    transform: translateY(-5px);
+    transition: transform 250ms linear;
+}
+
+.flip-card-title {
+    font-size: 21px;
+    font-weight: 600;
+    color: #333;
+    margin: 10px 20px;
+}
+
+.flip-card-content-front {
+    display: flex;
+    justify-content: space-between;
+    padding: 5px 10px 12px 20px;
+}
+
+.flip-card-content-back {
+    padding: 18px 10px 10px;
+    background-color: #7b63a3;
+    height: 100%;
+    font-size: 18px;
+    font-weight: 600;
+
+    .text-muted {
+        font-size: 12px;
+        color: #ccc;
+    }
+
+    hr {
+        margin-top: 7px;
+        margin-bottom: 7px;
+        border-top: 1px solid #ccc;
+        opacity: 0.25;
+    }
+}
+
+.flip-card-stats {
+    flex: 1;
+    color: #666;
+
+    .text-muted {
+        font-size: 14px;
+        color: #999;
+    }
+}
+
+.flip-card-stat {
+    font-size: 18px;
+    font-weight: 600;
+    margin-bottom: 3px;
+}
+
+.flip-card-chart {
+    flex: none;
+    width: 70px;
+    height: 70px;
+    align-self: center;
+}
+
+.flip-card-heading {
+    color: #fff;
+    font-size: 16px;
+    font-weight: 600;
+    margin-top: 0;
+}
+
+.flip-card-row {
+    display: flex;
+    justify-content: space-between;
+}
+
+.flip-card-col {
+    &:last-of-type {
+        text-align: right;
+    }
+}
+
+.flip-inline-chart {
+    margin-bottom: 2px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    width: 118px;
+    height: 22px;
+
+    ux-spark {
+        width: 53px;
+    }
+}
+
+.flip-card-flipped {
+    .flip-card-logo {
+        transform: translateY(0);
+    }
+}

--- a/docs/app/pages/components/components-sections/flippable-cards/flippable-cards/flippable-cards.component.less
+++ b/docs/app/pages/components/components-sections/flippable-cards/flippable-cards/flippable-cards.component.less
@@ -11,6 +11,13 @@
     color: #999;
     border: none;
     background: transparent;
+
+    &:focus {
+        outline: 2px dotted;
+        outline: auto -webkit-focus-ring-color;
+        outline-color: #00a7a2;
+        outline-offset: 0;
+    }
 }
 
 .flip-card-logo {

--- a/docs/app/pages/components/components-sections/flippable-cards/flippable-cards/flippable-cards.component.ts
+++ b/docs/app/pages/components/components-sections/flippable-cards/flippable-cards/flippable-cards.component.ts
@@ -1,58 +1,15 @@
 import { Component } from '@angular/core';
-import { DocumentationSectionComponent } from '../../../../../decorators/documentation-section-component';
-import { BaseDocumentationSection } from '../../../../../components/base-documentation-section/base-documentation-section';
 import { ColorService } from '../../../../../../../src/index';
+import { BaseDocumentationSection } from '../../../../../components/base-documentation-section/base-documentation-section';
+import { DocumentationSectionComponent } from '../../../../../decorators/documentation-section-component';
 
 @Component({
     selector: 'uxd-components-flippable-cards',
-    templateUrl: './flippable-cards.component.html'
+    templateUrl: './flippable-cards.component.html',
+    styleUrls: ['./flippable-cards.component.less']
 })
 @DocumentationSectionComponent('ComponentsFlippableCardsComponent')
 export class ComponentsFlippableCardsComponent extends BaseDocumentationSection {
-
-    icon: string = require('../../../../../assets/img/IconCaseColorized36x36.png');
-
-    donut1 = [{
-        label: 'documents',
-        color: this.colorService.getColor('grey6').toHex(),
-        value: 23456
-    }, {
-        label: 'reviewed',
-        color: this.colorService.getColor('vibrant1').toHex(),
-        value: 19876
-    }, {
-        label: 'produced',
-        color: this.colorService.getColor('vibrant2').toHex(),
-        value: 11123
-    }];
-
-    donut2 = [{
-        label: 'documents',
-        color: this.colorService.getColor('grey6').toHex(),
-        value: 15678
-    }, {
-        label: 'reviewed',
-        color: this.colorService.getColor('vibrant1').toHex(),
-        value: 10123
-    }, {
-        label: 'produced',
-        color: this.colorService.getColor('vibrant2').toHex(),
-        value: 3123
-    }];
-
-    donut3 = [{
-        label: 'documents',
-        color: this.colorService.getColor('grey6').toHex(),
-        value: 256987
-    }, {
-        label: 'reviewed',
-        color: this.colorService.getColor('vibrant1').toHex(),
-        value: 143567
-    }, {
-        label: 'produced',
-        color: this.colorService.getColor('vibrant2').toHex(),
-        value: 45678
-    }];
 
     options = {
         size: 70,
@@ -67,8 +24,88 @@ export class ComponentsFlippableCardsComponent extends BaseDocumentationSection 
         }
     };
 
+    cards: Card[] = [
+        {
+            title: 'NYC vs Volkswagen',
+            flipped: false,
+            trigger: 'manual',
+            direction: 'vertical',
+            stats: {
+                documents: 23456,
+                reviewed: 19876,
+                produced: 11123,
+                size: 1.2
+            },
+            chart: this.getChartData(23456, 19876, 11123)
+        },
+        {
+            title: 'The Dorling Case',
+            flipped: false,
+            trigger: 'hover',
+            direction: 'horizontal',
+            stats: {
+                documents: 15678,
+                reviewed: 10123,
+                produced: 3123,
+                size: 0.8
+            },
+            chart: this.getChartData(15678, 10123, 3123)
+        },
+        {
+            title: 'The Salisbury Case',
+            flipped: false,
+            trigger: 'click',
+            direction: 'horizontal',
+            stats: {
+                documents: 256987,
+                reviewed: 143567,
+                produced: 45678,
+                size: 10.7
+            },
+            chart: this.getChartData(256987, 143567, 45678)
+        }
+    ];
+
     constructor(public colorService: ColorService) {
         super(require.context('./snippets/', false, /\.(html|css|js|ts)$/));
     }
 
+    getChartData(documents: number, reviewed: number, produced: number): ChartData[] {
+        return [
+            {
+                label: 'documents',
+                color: this.colorService.getColor('grey6').toHex(),
+                value: documents
+            }, {
+                label: 'reviewed',
+                color: this.colorService.getColor('vibrant1').toHex(),
+                value: reviewed
+            }, {
+                label: 'produced',
+                color: this.colorService.getColor('vibrant2').toHex(),
+                value: produced
+            }
+        ];
+    }
+
+}
+
+export interface Card {
+    title: string;
+    flipped: boolean;
+    trigger: string;
+    direction: string;
+    stats: {
+        documents: number;
+        reviewed: number;
+        produced: number;
+        size: number;
+    };
+    chart: ChartData[];
+}
+
+export interface ChartData {
+    label: string;
+    color: string;
+    value: number;
 }

--- a/docs/app/pages/components/components-sections/flippable-cards/flippable-cards/flippable-cards.component.ts
+++ b/docs/app/pages/components/components-sections/flippable-cards/flippable-cards/flippable-cards.component.ts
@@ -1,4 +1,5 @@
-import { Component } from '@angular/core';
+import { LiveAnnouncer } from '@angular/cdk/a11y';
+import { Component, OnDestroy } from '@angular/core';
 import { ColorService } from '../../../../../../../src/index';
 import { BaseDocumentationSection } from '../../../../../components/base-documentation-section/base-documentation-section';
 import { DocumentationSectionComponent } from '../../../../../decorators/documentation-section-component';
@@ -9,7 +10,7 @@ import { DocumentationSectionComponent } from '../../../../../decorators/documen
     styleUrls: ['./flippable-cards.component.less']
 })
 @DocumentationSectionComponent('ComponentsFlippableCardsComponent')
-export class ComponentsFlippableCardsComponent extends BaseDocumentationSection {
+export class ComponentsFlippableCardsComponent extends BaseDocumentationSection implements OnDestroy {
 
     options = {
         size: 70,
@@ -69,8 +70,12 @@ export class ComponentsFlippableCardsComponent extends BaseDocumentationSection 
         }
     ];
 
-    constructor(public colorService: ColorService) {
+    constructor(public colorService: ColorService, private _announcer: LiveAnnouncer) {
         super(require.context('./snippets/', false, /\.(html|css|js|ts)$/));
+    }
+
+    ngOnDestroy(): void {
+        this._announcer.ngOnDestroy();
     }
 
     getChartData(documents: number, reviewed: number, produced: number): ChartData[] {
@@ -89,6 +94,10 @@ export class ComponentsFlippableCardsComponent extends BaseDocumentationSection 
                 value: produced
             }
         ];
+    }
+
+    onCardFlip(flipped: boolean): void {
+        this._announcer.announce(flipped ? 'Card is flipped.' : 'Card is not flipped.', 'assertive');
     }
 
 }

--- a/docs/app/pages/components/components-sections/flippable-cards/flippable-cards/flippable-cards.component.ts
+++ b/docs/app/pages/components/components-sections/flippable-cards/flippable-cards/flippable-cards.component.ts
@@ -27,6 +27,7 @@ export class ComponentsFlippableCardsComponent extends BaseDocumentationSection 
     cards: Card[] = [
         {
             title: 'NYC vs Volkswagen',
+            label: 'Flippable Card: Activate toggle button to flip card',
             flipped: false,
             trigger: 'manual',
             direction: 'vertical',
@@ -40,6 +41,7 @@ export class ComponentsFlippableCardsComponent extends BaseDocumentationSection 
         },
         {
             title: 'The Dorling Case',
+            label: 'Flippable Card: Activate to flip card',
             flipped: false,
             trigger: 'hover',
             direction: 'horizontal',
@@ -53,6 +55,7 @@ export class ComponentsFlippableCardsComponent extends BaseDocumentationSection 
         },
         {
             title: 'The Salisbury Case',
+            label: 'Flippable Card: Activate to flip card',
             flipped: false,
             trigger: 'click',
             direction: 'horizontal',
@@ -92,6 +95,7 @@ export class ComponentsFlippableCardsComponent extends BaseDocumentationSection 
 
 export interface Card {
     title: string;
+    label: string;
     flipped: boolean;
     trigger: string;
     direction: string;

--- a/docs/app/pages/components/components-sections/flippable-cards/flippable-cards/snippets/app.css
+++ b/docs/app/pages/components/components-sections/flippable-cards/flippable-cards/snippets/app.css
@@ -13,6 +13,13 @@
     background: transparent;
 }
 
+.flip-card-btn:focus {
+    outline: 2px dotted;
+    outline: auto -webkit-focus-ring-color;
+    outline-color: #00a7a2;
+    outline-offset: 0;
+}
+
 .flip-card-logo {
     margin: 0 20px;
     transform: translateY(-5px);

--- a/docs/app/pages/components/components-sections/flippable-cards/flippable-cards/snippets/app.css
+++ b/docs/app/pages/components/components-sections/flippable-cards/flippable-cards/snippets/app.css
@@ -1,184 +1,109 @@
-/*
-    Flippable Cards
-*/
-.flip-card-content {
-    padding-top: 35px;
-    padding-left: 20px;
-    padding-right: 10px;
-    padding-bottom: 15px;
+.flex-container {
+    display: flex;
 }
 
-.flip-card-content.cursor-pointer {
+.flip-card-btn {
+    position: absolute;
+    top: 0;
+    right: 0;
+    padding: 10px;
     cursor: pointer;
+    color: #999;
+    border: none;
+    background: transparent;
 }
 
-.flip-card-content .front-title {
+.flip-card-logo {
+    margin: 0 20px;
+    transform: translateY(-5px);
+    transition: transform 250ms linear;
+}
+
+.flip-card-title {
     font-size: 21px;
     font-weight: 600;
     color: #333;
-    margin-top: 9px;
-    margin-bottom: 0;
+    margin: 10px 20px;
 }
 
-.flip-card-content.card-back {
-    padding: 15px 10px 10px 10px;
-    background-color: #7B63A3;
+.flip-card-content-front {
+    display: flex;
+    justify-content: space-between;
+    padding: 5px 10px 12px 20px;
+}
+
+.flip-card-content-back {
+    padding: 18px 10px 10px;
+    background-color: #7b63a3;
     height: 100%;
-}
-
-.flip-card-content.card-back p {
-    color: #fff;
-    font-size: 16px;
+    font-size: 18px;
     font-weight: 600;
-    white-space: nowrap;
 }
 
-.flip-card-content.card-back span.muted {
+.flip-card-content-back .text-muted {
     font-size: 12px;
     color: #ccc;
 }
 
-.flip-card-content.card-back span.right-align {
-    display: inline-block;
-    width: 65px;
-    text-align: right;
-}
-
-.flip-card-content.card-back span.left-align {
-    display: inline-block;
-    width: 70px;
-    text-align: left;
-    margin-left: 5px;
-}
-
-.spark-left-align {
-    display: inline-block;
-    width: 53px;
-    text-align: left;
-    margin-left: 5px;
-}
-
-.spark-left-align.second {
-    width: 35px;
-}
-
-.flip-card-content.card-back span.reviewed {
-    color: #2ad2c9;
-}
-
-.flip-card-content.card-back span.produced {
-    color: #ff8d6d;
-}
-
-.card-back hr {
+.flip-card-content-back hr {
     margin-top: 7px;
     margin-bottom: 7px;
     border-top: 1px solid #ccc;
     opacity: 0.25;
 }
 
-.card-logo {
-    margin-left: 20px;
-    margin-top: -5px;
-    position: absolute;
+.flip-card-stats {
+    flex: 1;
+    color: #666;
 }
 
-.flip-card-nested-donut {
-    position: absolute;
-    right: 10px;
-    bottom: 16px;
-    width: 70px;
-    height: 70px;
+.flip-card-stats .text-muted {
+    font-size: 14px;
+    color: #999;
 }
 
-.card-text {
+.flip-card-stat {
     font-size: 18px;
     font-weight: 600;
     margin-bottom: 3px;
 }
 
-.card-text.documents {
-    color: #666;
+.flip-card-chart {
+    flex: none;
+    width: 70px;
+    height: 70px;
+    align-self: center;
 }
 
-.card-text.reviewed {
-    color: #24b2a4;
-}
-
-.card-text.produced {
-    color: #ea7e65;
-    display: inline-block;
-    margin-bottom: 0px;
-}
-
-.card-text .text-muted {
-    font-size: 14px;
-    color: #999;
-}
-
-.clickable-icon {
-    margin: 10px;
-    cursor: pointer;
-    color: #999
-}
-
-.clickable-icon.icon-back {
-    color: white;
-}
-
-.flex-container {
-    display: flex;
-    flex-direction: row;
-    flex-wrap: wrap;
-    justify-content: flex-start;
-    align-content: flex-start;
-    align-items: flex-start;
-}
-
-.nested-donut-example {
-    width: 100%;
-    margin-top: 15px;
-}
-
-.nested-donut-example:before {
-    content: ' ';
-    display: inline-block;
-    vertical-align: middle;
-    height: 100%;
-}
-
-.nested-donut-example .nested-donut-text {
-    margin-right: 50px;
-    display: inline-block;
-    vertical-align: middle;
-}
-
-.nested-donut-example .nested-donut-container {
-    vertical-align: middle;
-}
-
-.nested-donut-text p {
-    font-size: 18px;
+.flip-card-heading {
+    color: #fff;
+    font-size: 16px;
     font-weight: 600;
+    margin-top: 0;
 }
 
-.nested-donut-text p.documents {
-    color: #666;
+.flip-card-row {
+    display: flex;
+    justify-content: space-between;
 }
 
-.nested-donut-text p.reviewed {
-    color: #24b2a4;
+.flip-card-col:last-of-type {
+    text-align: right;
 }
 
-.nested-donut-text p.produced {
-    color: #ea7e65;
+.flip-inline-chart {
+    margin-bottom: 2px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    width: 118px;
+    height: 22px;
 }
 
-.nested-donut-text p span+span {
-    font-size: 14px;
-    color: #999;
+.flip-inline-chart ux-spark {
+    width: 53px;
 }
 
-.bold-icon {
-    font-weight: bold;
+.flip-card-flipped .flip-card-logo {
+    transform: translateY(0);
 }

--- a/docs/app/pages/components/components-sections/flippable-cards/flippable-cards/snippets/app.html
+++ b/docs/app/pages/components/components-sections/flippable-cards/flippable-cards/snippets/app.html
@@ -1,174 +1,106 @@
 <div class="flex-container">
+    <ux-flippable-card
+        *ngFor="let card of cards"
+        class="m-sm"
+        [class.flip-card-flipped]="card.flipped"
+        [(flipped)]="card.flipped"
+        [trigger]="card.trigger"
+        [direction]="card.direction"
+        [width]="260"
+        [height]="180">
 
-  <ux-flippable-card #flippableCard="ux-flippable-card" class="m-sm" 
-    trigger="manual" direction="vertical" [width]="260" [height]="180">
+        <ux-flippable-card-front>
+            <img src="../../../../../assets/img/IconCaseColorized36x36.png"
+                 alt="Flippable card icon"
+                 class="flip-card-logo">
 
-    <ux-flippable-card-front>
-      <i class="hpe-icon hpe-link-down pull-right clickable-icon" aria-hidden="true" 
-        (click)="flippableCard.toggleFlipped()"></i>
-      <img class="card-logo" src="../../../../../assets/img/IconCaseColorized36x36.png">
-      <div class="flip-card-content">
-        <p class="front-title">NYC vs Volkswagen</p>
-        <div class="m-t-sm">
-          <p class="card-text documents">23,456<span class="text-muted"> documents</span></p>
-          <p class="card-text reviewed">19,976<span class="text-muted"> reviewed</span></p>
-          <p class="card-text produced">11,123<span class="text-muted"> produced</span></p>
-        </div>
-        <nested-donut class="flip-card-nested-donut" 
-            [dataset]="donut1" [options]="options"></nested-donut>
-      </div>
-    </ux-flippable-card-front>
+            <button
+                #frontFlipBtn
+                aria-label="Activate to show back of card"
+                [hidden]="card.trigger !== 'manual'"
+                [tabindex]="!card.flipped ? 0 : -1"
+                class="hpe-icon hpe-link-down flip-card-btn"
+                (click)="card.flipped = true; backFlipBtn.focus()">
+            </button>
 
-    <ux-flippable-card-back>
-      <i class="hpe-icon hpe-link-up pull-right clickable-icon icon-back" 
-         aria-hidden="true" (click)="flippableCard.toggleFlipped()"></i>
-      <div class="flip-card-content card-back">
-        <p>NYC vs Volkswagen</p>
-        <div class="row">
-          <div class="col-xs-5">
-            <p>23,456 <span class="muted"> documents</span></p>
-          </div>
-          <div class="col-xs-7">
-            <p>
-              <span class="muted right-align">total </span>
-              <span class="left-align">1.2 GB</span>
-            </p>
-          </div>
-        </div>
-        <hr/>
-        <div class="row">
-          <div class="col-xs-5">
-            <p>
-              <span class="reviewed">19,976</span>
-              <span class="muted"> reviewed</span>
-            </p>
-          </div>
-          <div class="col-xs-7">
-            <p class="m-b-xxs">
-              <span class="muted right-align">responsive</span>
-              <ux-spark value="65" barHeight="5" class="spark-left-align"></ux-spark>
-            </p>
-            <p class="m-b-xxs">
-              <span class="muted right-align">privilege</span>
-              <ux-spark value="65" barHeight="5" class="spark-left-align second"></ux-spark>
-            </p>
-          </div>
+            <h3 class="flip-card-title">{{ card.title }}</h3>
 
-        </div>
-      </div>
-    </ux-flippable-card-back>
+            <div class="flip-card-content-front">
 
-  </ux-flippable-card>
+                <div class="flip-card-stats">
+                    <p class="flip-card-stat">
+                        <span>{{ card.stats.documents | number }}</span>
+                        <span class="text-muted"> documents</span>
+                    </p>
+                    <p class="flip-card-stat">
+                        <span class="text-vibrant1">{{ card.stats.reviewed | number }}</span>
+                        <span class="text-muted"> reviewed</span>
+                    </p>
+                    <p class="flip-card-stat">
+                        <span class="text-vibrant2">{{ card.stats.produced | number }}</span>
+                        <span class="text-muted"> produced</span>
+                    </p>
+                </div>
 
+                <nested-donut
+                    class="flip-card-chart"
+                    [dataset]="card.chart"
+                    [options]="options">
+                </nested-donut>
+            </div>
 
-  <ux-flippable-card class="m-sm" trigger="hover" direction="horizontal" [height]="180" [width]="260">
+        </ux-flippable-card-front>
 
-    <ux-flippable-card-front>
-      <img class="card-logo" src="../../../../../assets/img/IconCaseColorized36x36.png">
-      <div class="flip-card-content">
-        <p class="front-title">The Dorling Case</p>
-        <div class="m-t-sm">
-          <p class="card-text documents">15,678<span class="text-muted"> documents</span></p>
-          <p class="card-text reviewed">10,123<span class="text-muted"> reviewed</span></p>
-          <p class="card-text produced">3,123<span class="text-muted"> produced</span></p>
-        </div>
-        <nested-donut class="flip-card-nested-donut" 
-            [dataset]="donut2" [options]="options"></nested-donut>
-      </div>
-    </ux-flippable-card-front>
+        <ux-flippable-card-back>
+            <div class="flip-card-content-back">
 
-    <ux-flippable-card-back>
-      <div class="flip-card-content card-back">
-        <p>The Dorling Case</p>
-        <div class="row">
-          <div class="col-xs-5">
-            <p>
-              <span>15,678</span>
-              <span class="muted"> documents</span>
-            </p>
-          </div>
-          <div class="col-xs-7">
-            <p>
-              <span class="muted right-align">total </span>
-              <span class="left-align">0.8 GB</span>
-            </p>
-          </div>
-        </div>
-        <hr/>
-        <div class="row">
-          <div class="col-xs-5">
-            <p>
-              <span class="reviewed">10,123</span>
-              <span class="muted"> reviewed</span>
-            </p>
-          </div>
-          <div class="col-xs-7">
-            <p class="m-b-xxs">
-              <span class="muted right-align">responsive</span>
-              <ux-spark value="65" barHeight="5" class="spark-left-align"></ux-spark>
-            </p>
-            <p class="m-b-xxs">
-              <span class="muted right-align">privilege</span>
-              <ux-spark value="65" barHeight="5" class="spark-left-align second"></ux-spark>
-            </p>
-          </div>
+                <button
+                    #backFlipBtn
+                    aria-label="Activate to show front of card"
+                    [hidden]="card.trigger !== 'manual'"
+                    [tabindex]="card.flipped ? 0 : -1"
+                    class="hpe-icon hpe-link-up flip-card-btn text-white"
+                    (click)="card.flipped = false; frontFlipBtn.focus()">
+                </button>
 
-        </div>
-      </div>
-    </ux-flippable-card-back>
-  </ux-flippable-card>
+                <h4 class="flip-card-heading">{{ card.title }}</h4>
 
+                <div class="flip-card-row">
+                    <div class="flip-card-col">
+                        <p>
+                            <span class="text-white">{{ card.stats.documents | number }}</span>
+                            <span class="text-muted"> documents</span>
+                        </p>
+                    </div>
+                    <div class="flip-card-col">
+                        <p>
+                            <span class="text-muted">total</span>
+                            <span class="text-white">{{ card.stats.size }} GB</span>
+                        </p>
+                    </div>
+                </div>
 
-  <ux-flippable-card class="m-sm" trigger="click" direction="horizontal" [height]="180" [width]="260">
-    <ux-flippable-card-front>
-      <img class="card-logo" src="../../../../../assets/img/IconCaseColorized36x36.png">
-      <div class="flip-card-content">
-        <p class="front-title">The Salisbury Case</p>
-        <div class="m-t-sm">
-          <p class="card-text documents">256,987<span class="text-muted"> documents</span></p>
-          <p class="card-text reviewed">143,567<span class="text-muted"> reviewed</span></p>
-          <p class="card-text produced">45,678<span class="text-muted"> produced</span></p>
-        </div>
-        <nested-donut class="flip-card-nested-donut" 
-            [dataset]="donut3" [options]="options"></nested-donut>
-      </div>
-    </ux-flippable-card-front>
+                <hr>
 
-    <ux-flippable-card-back>
-      <div class="flip-card-content card-back">
-        <p>The Salisbury Case</p>
-        <div class="row">
-          <div class="col-xs-5">
-            <p>256,987<span class="muted"> documents</span></p>
-          </div>
-          <div class="col-xs-7">
-            <p>
-              <span class="muted right-align">total </span>
-              <span class="left-align">10.7 GB</span>
-            </p>
-          </div>
-        </div>
-        <hr/>
-        <div class="row">
-          <div class="col-xs-5">
-            <p>
-              <span class="reviewed">143,567</span>
-              <span class="muted"> reviewed</span>
-            </p>
-          </div>
-          <div class="col-xs-7">
-            <p class="m-b-xxs">
-              <span class="muted right-align">responsive</span>
-              <ux-spark value="65" barHeight="5" class="spark-left-align"></ux-spark>
-            </p>
-            <p class="m-b-xxs">
-              <span class="muted right-align">privilege</span>
-              <ux-spark value="65" barHeight="5" class="spark-left-align second"></ux-spark>
-            </p>
-          </div>
-
-        </div>
-      </div>
-    </ux-flippable-card-back>
-  </ux-flippable-card>
+                <div class="flip-card-row">
+                    <div class="flip-card-col">
+                        <p>
+                            <span class="text-vibrant1">{{ card.stats.reviewed | number }}</span>
+                            <span class="text-muted">reviewed</span>
+                        </p>
+                    </div>
+                    <div class="flip-card-col">
+                        <p class="flip-inline-chart">
+                            <span class="text-muted text-right">responsive</span>
+                            <ux-spark [value]="65" [barHeight]="5"></ux-spark>
+                        </p>
+                        <p class="flip-inline-chart">
+                            <span class="text-muted text-right">privilege</span>
+                            <ux-spark [value]="40" [barHeight]="5"></ux-spark>
+                        </p>
+                    </div>
+                </div>
+            </div>
+        </ux-flippable-card-back>
+    </ux-flippable-card>
 </div>

--- a/docs/app/pages/components/components-sections/flippable-cards/flippable-cards/snippets/app.html
+++ b/docs/app/pages/components/components-sections/flippable-cards/flippable-cards/snippets/app.html
@@ -1,6 +1,7 @@
 <div class="flex-container">
     <ux-flippable-card
         *ngFor="let card of cards"
+        aria-label="Flippable Card"
         class="m-sm"
         [class.flip-card-flipped]="card.flipped"
         [(flipped)]="card.flipped"

--- a/docs/app/pages/components/components-sections/flippable-cards/flippable-cards/snippets/app.html
+++ b/docs/app/pages/components/components-sections/flippable-cards/flippable-cards/snippets/app.html
@@ -5,6 +5,7 @@
         class="m-sm"
         [class.flip-card-flipped]="card.flipped"
         [(flipped)]="card.flipped"
+        (flippedChange)="onCardFlip(card.flipped)"
         [trigger]="card.trigger"
         [direction]="card.direction"
         [width]="260"

--- a/docs/app/pages/components/components-sections/flippable-cards/flippable-cards/snippets/app.html
+++ b/docs/app/pages/components/components-sections/flippable-cards/flippable-cards/snippets/app.html
@@ -1,7 +1,7 @@
 <div class="flex-container">
     <ux-flippable-card
         *ngFor="let card of cards"
-        aria-label="Flippable Card"
+        [attr.aria-label]="card.label"
         class="m-sm"
         [class.flip-card-flipped]="card.flipped"
         [(flipped)]="card.flipped"
@@ -12,12 +12,14 @@
 
         <ux-flippable-card-front>
             <img src="../../../../../assets/img/IconCaseColorized36x36.png"
-                 alt="Flippable card icon"
-                 class="flip-card-logo">
+                aria-hidden="true"
+                alt="Flippable card icon"
+                class="flip-card-logo">
 
             <button
                 #frontFlipBtn
                 aria-label="Activate to show back of card"
+                [attr.aria-hidden]="card.trigger !== 'manual'"
                 [hidden]="card.trigger !== 'manual'"
                 [tabindex]="!card.flipped ? 0 : -1"
                 class="hpe-icon hpe-link-down flip-card-btn"
@@ -58,6 +60,7 @@
                 <button
                     #backFlipBtn
                     aria-label="Activate to show front of card"
+                    [attr.aria-hidden]="card.trigger !== 'manual'"
                     [hidden]="card.trigger !== 'manual'"
                     [tabindex]="card.flipped ? 0 : -1"
                     class="hpe-icon hpe-link-up flip-card-btn text-white"

--- a/docs/app/pages/components/components-sections/flippable-cards/flippable-cards/snippets/app.ts
+++ b/docs/app/pages/components/components-sections/flippable-cards/flippable-cards/snippets/app.ts
@@ -1,4 +1,5 @@
-import { Component } from '@angular/core';
+import { LiveAnnouncer } from '@angular/cdk/a11y';
+import { Component, OnDestroy } from '@angular/core';
 import { ColorService } from '@ux-aspects/ux-aspects';
 
 @Component({
@@ -6,7 +7,7 @@ import { ColorService } from '@ux-aspects/ux-aspects';
     templateUrl: './app.component.html',
     styleUrls: ['./app.component.css']
 })
-export class AppComponent {
+export class AppComponent implements OnDestroy {
 
     options = {
         size: 70,
@@ -66,8 +67,10 @@ export class AppComponent {
         }
     ];
 
-    constructor(public colorService: ColorService) {
-        super(require.context('./snippets/', false, /\.(html|css|js|ts)$/));
+    constructor(public colorService: ColorService, private _announcer: LiveAnnouncer) {}
+
+    ngOnDestroy(): void {
+        this._announcer.ngOnDestroy();
     }
 
     getChartData(documents: number, reviewed: number, produced: number): ChartData[] {
@@ -86,6 +89,10 @@ export class AppComponent {
                 value: produced
             }
         ];
+    }
+
+    onCardFlip(flipped: boolean): void {
+        this._announcer.announce(flipped ? 'Card is flipped.' : 'Card is not flipped.', 'assertive');
     }
 
 }

--- a/docs/app/pages/components/components-sections/flippable-cards/flippable-cards/snippets/app.ts
+++ b/docs/app/pages/components/components-sections/flippable-cards/flippable-cards/snippets/app.ts
@@ -8,48 +8,6 @@ import { ColorService } from '@ux-aspects/ux-aspects';
 })
 export class AppComponent {
 
-    donut1 = [{
-        label: 'documents',
-        color: this.colorService.getColor('grey6').toHex(),
-        value: 23456
-    }, {
-        label: 'reviewed',
-        color: this.colorService.getColor('vibrant1').toHex(),
-        value: 19876
-    }, {
-        label: 'produced',
-        color: this.colorService.getColor('vibrant2').toHex(),
-        value: 11123
-    }];
-
-    donut2 = [{
-        label: 'documents',
-        color: this.colorService.getColor('grey6').toHex(),
-        value: 15678
-    }, {
-        label: 'reviewed',
-        color: this.colorService.getColor('vibrant1').toHex(),
-        value: 10123
-    }, {
-        label: 'produced',
-        color: this.colorService.getColor('vibrant2').toHex(),
-        value: 3123
-    }];
-
-    donut3 = [{
-        label: 'documents',
-        color: this.colorService.getColor('grey6').toHex(),
-        value: 256987
-    }, {
-        label: 'reviewed',
-        color: this.colorService.getColor('vibrant1').toHex(),
-        value: 143567
-    }, {
-        label: 'produced',
-        color: this.colorService.getColor('vibrant2').toHex(),
-        value: 45678
-    }];
-
     options = {
         size: 70,
         donutWidth: 3,
@@ -63,6 +21,86 @@ export class AppComponent {
         }
     };
 
-    constructor(public colorService: ColorService) { }
+    cards: Card[] = [
+        {
+            title: 'NYC vs Volkswagen',
+            flipped: false,
+            trigger: 'manual',
+            direction: 'vertical',
+            stats: {
+                documents: 23456,
+                reviewed: 19876,
+                produced: 11123,
+                size: 1.2
+            },
+            chart: this.getChartData(23456, 19876, 11123)
+        },
+        {
+            title: 'The Dorling Case',
+            flipped: false,
+            trigger: 'hover',
+            direction: 'horizontal',
+            stats: {
+                documents: 15678,
+                reviewed: 10123,
+                produced: 3123,
+                size: 0.8
+            },
+            chart: this.getChartData(15678, 10123, 3123)
+        },
+        {
+            title: 'The Salisbury Case',
+            flipped: false,
+            trigger: 'click',
+            direction: 'horizontal',
+            stats: {
+                documents: 256987,
+                reviewed: 143567,
+                produced: 45678,
+                size: 10.7
+            },
+            chart: this.getChartData(256987, 143567, 45678)
+        }
+    ];
 
+    constructor(public colorService: ColorService) {}
+
+    getChartData(documents: number, reviewed: number, produced: number): ChartData[] {
+        return [
+            {
+                label: 'documents',
+                color: this.colorService.getColor('grey6').toHex(),
+                value: documents
+            }, {
+                label: 'reviewed',
+                color: this.colorService.getColor('vibrant1').toHex(),
+                value: reviewed
+            }, {
+                label: 'produced',
+                color: this.colorService.getColor('vibrant2').toHex(),
+                value: produced
+            }
+        ];
+    }
+
+}
+
+export interface Card {
+    title: string;
+    flipped: boolean;
+    trigger: string;
+    direction: string;
+    stats: {
+        documents: number;
+        reviewed: number;
+        produced: number;
+        size: number;
+    };
+    chart: ChartData[];
+}
+
+export interface ChartData {
+    label: string;
+    color: string;
+    value: number;
 }

--- a/docs/app/pages/components/components-sections/flippable-cards/flippable-cards/snippets/app.ts
+++ b/docs/app/pages/components/components-sections/flippable-cards/flippable-cards/snippets/app.ts
@@ -24,6 +24,7 @@ export class AppComponent {
     cards: Card[] = [
         {
             title: 'NYC vs Volkswagen',
+            label: 'Flippable Card: Activate toggle button to flip card',
             flipped: false,
             trigger: 'manual',
             direction: 'vertical',
@@ -37,6 +38,7 @@ export class AppComponent {
         },
         {
             title: 'The Dorling Case',
+            label: 'Flippable Card: Activate to flip card',
             flipped: false,
             trigger: 'hover',
             direction: 'horizontal',
@@ -50,6 +52,7 @@ export class AppComponent {
         },
         {
             title: 'The Salisbury Case',
+            label: 'Flippable Card: Activate to flip card',
             flipped: false,
             trigger: 'click',
             direction: 'horizontal',
@@ -63,7 +66,9 @@ export class AppComponent {
         }
     ];
 
-    constructor(public colorService: ColorService) {}
+    constructor(public colorService: ColorService) {
+        super(require.context('./snippets/', false, /\.(html|css|js|ts)$/));
+    }
 
     getChartData(documents: number, reviewed: number, produced: number): ChartData[] {
         return [
@@ -87,6 +92,7 @@ export class AppComponent {
 
 export interface Card {
     title: string;
+    label: string;
     flipped: boolean;
     trigger: string;
     direction: string;

--- a/src/components/flippable-card/flippable-card.component.html
+++ b/src/components/flippable-card/flippable-card.component.html
@@ -1,11 +1,7 @@
 <div class="ux-flipper"
-     tabindex="0"
-     [attr.aria-label]="ariaLabel"
      [class.ux-flip-card]="flipped"
      [style.width.px]="width"
-     [style.height.px]="height"
-     (keydown.enter)="onKeyDown($event)"
-     (keydown.space)="onKeyDown($event)">
+     [style.height.px]="height">
 
     <div class="ux-flippable-card-front"
          [style.width.px]="width"

--- a/src/components/flippable-card/flippable-card.component.html
+++ b/src/components/flippable-card/flippable-card.component.html
@@ -1,10 +1,24 @@
-<div class="ux-flipper" [class.ux-flip-card]="flipped" [style.width.px]="width" [style.height.px]="height">
+<div class="ux-flipper"
+     tabindex="0"
+     [class.ux-flip-card]="flipped"
+     [style.width.px]="width"
+     [style.height.px]="height"
+     (keydown.enter)="onKeyDown($event)"
+     (keydown.space)="onKeyDown($event)">
 
-    <div class="ux-flippable-card-front" [style.width.px]="width" [style.height.px]="height">
+    <div class="ux-flippable-card-front"
+         [style.width.px]="width"
+         [style.height.px]="height"
+         [attr.aria-hidden]="flipped">
+
         <ng-content select="ux-flippable-card-front"></ng-content>
     </div>
 
-    <div class="ux-flippable-card-back" [style.width.px]="width" [style.height.px]="height">
+    <div class="ux-flippable-card-back"
+         [style.width.px]="width"
+         [style.height.px]="height"
+         [attr.aria-hidden]="!flipped">
+
         <ng-content select="ux-flippable-card-back"></ng-content>
     </div>
 </div>

--- a/src/components/flippable-card/flippable-card.component.html
+++ b/src/components/flippable-card/flippable-card.component.html
@@ -1,5 +1,6 @@
 <div class="ux-flipper"
      tabindex="0"
+     [attr.aria-label]="ariaLabel"
      [class.ux-flip-card]="flipped"
      [style.width.px]="width"
      [style.height.px]="height"

--- a/src/components/flippable-card/flippable-card.component.less
+++ b/src/components/flippable-card/flippable-card.component.less
@@ -3,6 +3,10 @@ ux-flippable-card {
     transform-style: preserve-3d;
     display: inline-block;
 
+    &:focus {
+        .aspects-outline();
+    }
+
     .ux-flipper.ux-flip-card {
         transform: none;
     }

--- a/src/components/flippable-card/flippable-card.component.ts
+++ b/src/components/flippable-card/flippable-card.component.ts
@@ -16,6 +16,7 @@ export class FlippableCardComponent {
     @Input() width: number = 280;
     @Input() height: number = 200;
     @Input() flipped: boolean = false;
+    @Input() ariaLabel: string;
     @Output() flippedChange: EventEmitter<boolean> = new EventEmitter<boolean>();
 
     setFlipped(state: boolean): void {

--- a/src/components/flippable-card/flippable-card.component.ts
+++ b/src/components/flippable-card/flippable-card.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, Directive, HostListener, Output, EventEmitter } from '@angular/core';
+import { Component, Directive, EventEmitter, HostListener, Input, Output } from '@angular/core';
 
 @Component({
     selector: 'ux-flippable-card',
@@ -18,16 +18,17 @@ export class FlippableCardComponent {
     @Input() flipped: boolean = false;
     @Output() flippedChange: EventEmitter<boolean> = new EventEmitter<boolean>();
 
-    setFlipped(state: boolean) {
+    setFlipped(state: boolean): void {
         this.flipped = state;
         this.flippedChange.emit(this.flipped);
     }
 
-    toggleFlipped() {
+    toggleFlipped(): void {
         this.setFlipped(!this.flipped);
     }
 
-    @HostListener('click') clickTrigger() {
+    @HostListener('click')
+    clickTrigger(): void {
 
         // add or remove the class depending on whether or not the card has been flipped
         if (this.trigger === 'click') {
@@ -35,20 +36,28 @@ export class FlippableCardComponent {
         }
     }
 
-    @HostListener('mouseenter') hoverEnter() {
+    @HostListener('mouseenter')
+    hoverEnter(): void {
         // if the trigger is hover then begin to flip
         if (this.trigger === 'hover') {
             this.setFlipped(true);
         }
     }
 
-    @HostListener('mouseleave') hoverExit() {
+    @HostListener('mouseleave')
+    hoverExit(): void {
         if (this.trigger === 'hover') {
             this.setFlipped(false);
         }
     }
-}
 
+    onKeyDown(event: KeyboardEvent): void {
+        if (this.trigger !== 'manual') {
+            this.toggleFlipped();
+            event.preventDefault();
+        }
+    }
+}
 
 @Directive({
     selector: 'ux-flippable-card-front'

--- a/src/components/flippable-card/flippable-card.component.ts
+++ b/src/components/flippable-card/flippable-card.component.ts
@@ -4,6 +4,7 @@ import { Component, Directive, EventEmitter, HostListener, Input, Output } from 
     selector: 'ux-flippable-card',
     templateUrl: './flippable-card.component.html',
     host: {
+        'tabindex': '0',
         '[class.horizontal]': 'direction === "horizontal"',
         '[class.vertical]': 'direction === "vertical"'
     },
@@ -16,7 +17,6 @@ export class FlippableCardComponent {
     @Input() width: number = 280;
     @Input() height: number = 200;
     @Input() flipped: boolean = false;
-    @Input() ariaLabel: string;
     @Output() flippedChange: EventEmitter<boolean> = new EventEmitter<boolean>();
 
     setFlipped(state: boolean): void {
@@ -52,6 +52,8 @@ export class FlippableCardComponent {
         }
     }
 
+    @HostListener('keydown.enter', ['$event'])
+    @HostListener('keydown.space', ['$event'])
     onKeyDown(event: KeyboardEvent): void {
         if (this.trigger !== 'manual') {
             this.toggleFlipped();

--- a/src/components/flippable-card/flippable-card.component.ts
+++ b/src/components/flippable-card/flippable-card.component.ts
@@ -54,6 +54,7 @@ export class FlippableCardComponent {
 
     @HostListener('keydown.enter', ['$event'])
     @HostListener('keydown.space', ['$event'])
+    @HostListener('keydown.spacebar', ['$event']) // IE uses different naming
     onKeyDown(event: KeyboardEvent): void {
         if (this.trigger !== 'manual') {
             this.toggleFlipped();

--- a/src/ng1/directives/nestedDonut/nestedDonut.directive.js
+++ b/src/ng1/directives/nestedDonut/nestedDonut.directive.js
@@ -143,7 +143,10 @@ export default function nestedDonut(d3) {
             }
 
             function init_chart() {
-                svg = d3.select(container).append("svg").attr("width", chart_options.size).attr("height", chart_options.size)
+                svg = d3.select(container)
+                    .append("svg").attr("width", chart_options.size)
+                    .attr("focusable", false)
+                    .attr("height", chart_options.size)
                     .append("g").attr("transform", "translate(" + chart_options.size / 2 + "," + chart_options.size / 2 + ")");
 
                 // draw initial chart

--- a/src/styles/utilities.less
+++ b/src/styles/utilities.less
@@ -497,6 +497,7 @@
 //===============
 //Angular
 //==============
+[hidden],
 [ng\:cloak],
 [ng-cloak],
 [data-ng-cloak],


### PR DESCRIPTION
JIRA: https://jira.autonomy.com/browse/EL-3051

- Reworked Example Code - the layout spilled outside it container a lot causing focus ring to have weird bits sticking out. Now reworked to be simpler and container within the flippable card (with the exception of the icon at the top). Also improved accessibility.
- Made cards focusable and added support for enter/spacebar
- Updated code snippets
- Nested donut chart - IE by default focuses SVGs on tabbing whereas other browsers do not. Added `focusable="false"` attribute to have consistent tabbing behavior