### PR TITLE
EL-3193 - Single Line Overflow Tooltip Performance

### DIFF
--- a/src/ng1/directives/overflowTooltip/singleLineOverflowTooltip.controller.js
+++ b/src/ng1/directives/overflowTooltip/singleLineOverflowTooltip.controller.js
@@ -1,13 +1,14 @@
 export class SingleLineOverflowController {
 
-    constructor($timeout, $resize, $element, $scope, $document) {
-        this.$resize = $resize;
+    constructor($element, $scope, $document) {
         this.$element = $element;
-        this.$scope = $scope;
         this.$body = $document.find('body');
 
-        // once the directive have finished initialising then initialise
-        $timeout(this.onInit.bind(this));
+        // apply the initial styles to keep it on one line and show ellipsis
+        this.setStyles();
+
+        // once the directive have finished initialising then create the tooltip
+        requestAnimationFrame(this.create.bind(this));
 
         // ensure we teardown correctly
         $element.on('$destroy', this.onDestroy.bind(this));
@@ -15,28 +16,6 @@ export class SingleLineOverflowController {
 
         // when hovered check whether or not we should show the tooltip
         $element.on('mouseenter', this.update.bind(this));
-    }
-
-    /** Once the element is ready set up the tooltip */
-    onInit() {
-
-        // create the tooltip on the element
-        this.create();
-
-        // apply the initial styles to keep it on one line and show ellipsis
-        this.setStyles();
-
-        // perform the initial check to see if there is any overflow
-        this.update();
-
-        // set up out event handlers
-        this.$resize.bind(this.$element.get(0), this.update.bind(this));
-
-        // create a mutation observer to watch all contents
-        this.observer = new MutationObserver(this.update.bind(this));
-
-        // begin watching the element
-        this.observer.observe(this.$element.get(0), { characterData: true, subtree: true });
     }
 
     /** Tear down the component and stop watching events */
@@ -50,19 +29,14 @@ export class SingleLineOverflowController {
         // store the destroyed state
         this.destroyed = true;
 
-        // stop watching the contents of the element
-        this.observer.disconnect();
-
         // remove the tooltip
         this.$element.tooltip('destroy');
-
-        // unbind from the resize events
-        this.$resize.unbind(this.$element.get(0), this.update.bind(this));
     }
 
     /** Create the tooltip */
     create() {
         this.$element.tooltip({ title: this.$element.text(), container: 'body ' });
+        this.$element.tooltip('disable');
     }
 
     /** Apply the styling required to show an ellipsis */
@@ -74,9 +48,7 @@ export class SingleLineOverflowController {
         }
 
         // apply the style to keep it on one line and show ellipsis
-        this.$element.css({
-            overflow: 'hidden', whiteSpace: 'nowrap', textOverflow: 'ellipsis'
-        });
+        this.$element.css({ overflow: 'hidden', whiteSpace: 'nowrap', textOverflow: 'ellipsis' });
     }
 
     update() {
@@ -95,13 +67,14 @@ export class SingleLineOverflowController {
             .appendTo(this.$body);
 
         const width = clone.width();
+        const actualWidth = this.$element.width();
 
         // remove the clone element
         clone.remove();
 
         // determine if there is any overflow
-        return width > this.$element.width();
+        return width > actualWidth;
     }
 }
 
-SingleLineOverflowController.$inject = ['$timeout', '$resize', '$element', '$scope', '$document'];
+SingleLineOverflowController.$inject = ['$element', '$scope', '$document'];

--- a/src/ng1/directives/overflowTooltip/singleLineOverflowTooltip.spec.js
+++ b/src/ng1/directives/overflowTooltip/singleLineOverflowTooltip.spec.js
@@ -1,14 +1,13 @@
 describe('single line overflow tooltip', function () {
-  var $compile, $rootScope, $timeout;
+  var $compile, $rootScope;
 
   beforeEach(module("ux-aspects.overflowTooltip"));
 
   beforeEach(function () {
 
-    inject(function (_$compile_, _$rootScope_, _$timeout_) {
+    inject(function (_$compile_, _$rootScope_) {
       $compile = _$compile_;
       $rootScope = _$rootScope_;
-      $timeout = _$timeout_;
     });
   });
 
@@ -17,18 +16,21 @@ describe('single line overflow tooltip', function () {
     var html = '<p style="width:10px; height:10px; display:inline-block;" single-line-overflow-tooltip>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>';
     var element = $compile(html)($scope);
     $scope.$digest();
-    $timeout.flush();
     return {
       element: element,
       scope: $scope
     };
   }
 
-  it('should remove tooltip on destroy', function () {
+  it('should remove tooltip on destroy', function (done) {
     var directive = create();
-    expect(directive.element.data()["bs.tooltip"]).toBeTruthy();
-    directive.scope.$destroy();
-    expect(directive.element.data()["bs.tooltip"]).not.toBeTruthy();
+
+    setTimeout(() => {
+      expect(directive.element.data()["bs.tooltip"]).toBeTruthy();
+      directive.scope.$destroy();
+      expect(directive.element.data()["bs.tooltip"]).not.toBeTruthy();
+      done();
+    }, 1);
   });
 
 });


### PR DESCRIPTION
Jane raised a ticket on single line overflow performance (https://jira.autonomy.com/browse/EL-3193). Roland happy to include in current sprint.

- Removed use of $timeout as this was running a $rootScope.$digest after each tooltip was applied.
- We were initially determining if all tooltips needed to be shown when the directive initialised and we also were re-checking any time the content changed or the element resized which was unnecessary. Instead we now only check when the tooltip would normally be shown, so when the mouse enters the element we do the check.