### PR TITLE
EL-3190 - fixing error when providing an initial value to multiple se…

### DIFF
--- a/src/components/select/select.component.ts
+++ b/src/components/select/select.component.ts
@@ -1,10 +1,10 @@
-import { Component, ElementRef, EventEmitter, HostBinding, Inject, Input, OnChanges, OnDestroy, OnInit, Output, SimpleChanges, StaticProvider, TemplateRef, ViewChild, forwardRef } from '@angular/core';
+import { Component, ElementRef, EventEmitter, forwardRef, HostBinding, Inject, Input, OnChanges, OnDestroy, OnInit, Output, SimpleChanges, StaticProvider, TemplateRef, ViewChild } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { DOCUMENT } from '@angular/platform-browser';
 import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 import { Observable } from 'rxjs/Observable';
-import { debounceTime, filter, map } from 'rxjs/operators';
-import { Subscription } from 'rxjs/Subscription';
+import { debounceTime, delay, distinctUntilChanged, filter, map, takeUntil } from 'rxjs/operators';
+import { Subject } from 'rxjs/Subject';
 import { InfiniteScrollLoadFunction } from '../../directives/infinite-scroll/index';
 import { TypeaheadComponent, TypeaheadKeyService, TypeaheadOptionEvent } from '../typeahead/index';
 
@@ -26,36 +26,28 @@ export class SelectComponent implements OnInit, OnChanges, OnDestroy, ControlVal
     @Input() @HostBinding('attr.id') id: string = `ux-select-${++uniqueId}`;
 
     @Input()
-    get value() {
-        return this._value;
-    }
     set value(value: any) {
-        this._value = value;
-        this.valueChange.emit(value);
-        this.propagateChange(value);
-
-        // if we are not allow multiple selection update the input value (supporting ngModel)
-        if (!this.multiple && value !== null) {
-            this.input = this.getDisplay(value);
-        }
+        this._value$.next(value);
+    }
+    get value() {
+        return this._value$.value;
     }
 
     @Input()
+    set input(value: string) {
+        this._input$.next(value);
+    }
     get input() {
         return this._input$.value;
     }
-    set input(value: string) {
-        this._input$.next(value);
-        this.inputChange.emit(value);
-    }
 
     @Input()
-    get dropdownOpen() {
-        return this._dropdownOpen;
-    }
     set dropdownOpen(value: boolean) {
         this._dropdownOpen = value;
         this.dropdownOpenChange.emit(value);
+    }
+    get dropdownOpen() {
+        return this._dropdownOpen;
     }
 
     @Input() options: any[] | InfiniteScrollLoadFunction;
@@ -85,10 +77,10 @@ export class SelectComponent implements OnInit, OnChanges, OnDestroy, ControlVal
     filter$: Observable<string>;
     propagateChange = (_: any) => { };
 
-    private _value: any;
+    private _value$ = new BehaviorSubject<any>(null);
     private _input$ = new BehaviorSubject<string>('');
     private _dropdownOpen: boolean = false;
-    private _subscription = new Subscription();
+    private _onDestroy = new Subject<void>();
 
     constructor(
         private _element: ElementRef,
@@ -97,8 +89,19 @@ export class SelectComponent implements OnInit, OnChanges, OnDestroy, ControlVal
 
     ngOnInit() {
 
+        // Emit change events
+        this._value$.pipe(takeUntil(this._onDestroy), distinctUntilChanged()).subscribe(value => {
+            this.valueChange.emit(value);
+            this.propagateChange(value);
+        });
+
+        this._input$.pipe(takeUntil(this._onDestroy), distinctUntilChanged()).subscribe(value => {
+            this.inputChange.emit(value);
+        });
+
         // Changes to the input field
-        const onInput = this._input$.pipe(
+        this._input$.pipe(
+            takeUntil(this._onDestroy),
             filter(value => this.allowNull),
             filter(value => !this.multiple && value !== this.getDisplay(this.value))
         ).subscribe(value => this.value = null);
@@ -110,11 +113,20 @@ export class SelectComponent implements OnInit, OnChanges, OnDestroy, ControlVal
         );
 
         // Open the dropdown when filter is nonempty.
-        const onFilter = this.filter$.pipe(filter(value => value && value.length > 0)).subscribe(() => this.dropdownOpen = true);
+        this.filter$.pipe(
+            takeUntil(this._onDestroy),
+            filter(value => value && value.length > 0)
+        ).subscribe(() => this.dropdownOpen = true);
 
-        // store the subscriptions
-        this._subscription.add(onInput);
-        this._subscription.add(onFilter);
+        // Update the single-select input when the model changes
+        this._value$.pipe(
+            takeUntil(this._onDestroy),
+            distinctUntilChanged(),
+            delay(0),
+            filter(value => value !== null && !this.multiple)
+        ).subscribe(value => {
+            this.input = this.getDisplay(value);
+        });
     }
 
     ngOnChanges(changes: SimpleChanges) {
@@ -124,11 +136,12 @@ export class SelectComponent implements OnInit, OnChanges, OnDestroy, ControlVal
     }
 
     ngOnDestroy(): void {
-        this._subscription.unsubscribe();
+        this._onDestroy.next();
+        this._onDestroy.complete();
     }
 
     writeValue(obj: any): void {
-        if (obj !== undefined && obj !== this._value) {
+        if (obj !== undefined && obj !== this.value) {
             this.value = obj;
         }
     }

--- a/src/components/tag-input/tag-input.component.ts
+++ b/src/components/tag-input/tag-input.component.ts
@@ -1,7 +1,6 @@
 import { AfterContentInit, Component, ContentChildren, ElementRef, EventEmitter, forwardRef, HostBinding, HostListener, Inject, Input, OnChanges, OnDestroy, OnInit, Output, QueryList, SimpleChanges, TemplateRef, ViewChild } from '@angular/core';
 import { ControlValueAccessor, NG_VALIDATORS, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { DOCUMENT } from '@angular/platform-browser';
-import { delay } from 'rxjs/operators/delay';
 import { Subscription } from 'rxjs/Subscription';
 import { TypeaheadComponent, TypeaheadKeyService } from '../typeahead/index';
 import { TypeaheadOptionEvent } from '../typeahead/typeahead-event';
@@ -531,7 +530,7 @@ export class TagInputComponent implements OnInit, AfterContentInit, OnChanges, C
             // Set up event handler for the highlighted element
             // Added a delay to move it out of the current change detection cycle
             this._typeaheadSubscription.add(
-                this.typeahead.highlightedElementChange.pipe(delay(0)).subscribe((element: HTMLElement) => {
+                this.typeahead.highlightedElementChange.subscribe((element: HTMLElement) => {
                     this.highlightedElement = element;
                 })
             );

--- a/src/components/typeahead/typeahead.component.ts
+++ b/src/components/typeahead/typeahead.component.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, EventEmitter, HostBinding, HostListener, Input, OnChanges, OnDestroy, Output, SimpleChanges, TemplateRef } from '@angular/core';
+import { ChangeDetectorRef, Component, ElementRef, EventEmitter, HostBinding, HostListener, Input, OnChanges, OnDestroy, Output, SimpleChanges, TemplateRef } from '@angular/core';
 import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 import { combineLatest } from 'rxjs/observable/combineLatest';
 import { distinctUntilChanged, takeUntil } from 'rxjs/operators';
@@ -79,6 +79,7 @@ export class TypeaheadComponent implements OnChanges, OnDestroy {
 
     constructor(
         public typeaheadElement: ElementRef,
+        private _changeDetector: ChangeDetectorRef,
         private _service: TypeaheadService
     ) {
 
@@ -243,6 +244,7 @@ export class TypeaheadComponent implements OnChanges, OnDestroy {
     highlight(option: TypeaheadVisibleOption) {
         if (!this.isDisabled(option)) {
             this.highlighted$.next(option);
+            this._changeDetector.detectChanges();
         }
     }
 
@@ -264,7 +266,7 @@ export class TypeaheadComponent implements OnChanges, OnDestroy {
         while (inBounds && disabled);
 
         if (!disabled && inBounds) {
-            this.highlighted$.next(visibleOptions[newIndex]);
+            this.highlight(visibleOptions[newIndex]);
         }
 
         return this.highlighted;
@@ -308,6 +310,8 @@ export class TypeaheadComponent implements OnChanges, OnDestroy {
         }
 
         this.initOptions();
+
+        this._changeDetector.detectChanges();
     }
 
     /**


### PR DESCRIPTION
…lect

This was caused because there was a condition in the `value` setter which depends on the value of `multiple` which is not yet set on init.
* Changed `value` to use a BehaviorSubject and added a subscription with delay(0) to allow other property changes to apply before evaluating the condition and updating `input`.
* Several "expression changed after checked" errors were also found. `detectChanges` has been applied in several places in the TypeaheadComponent, although this may require a closer look to see if there is a better design to avoid this problem.

Plunker used to test the different use cases:
https://plnkr.co/edit/9ra3b2aSS7mCG6TpmK66?p=preview

https://jira.autonomy.com/browse/EL-3190