### PR TITLE
Webpack Memory Issue

### DIFF
--- a/configs/webpack.docs.prod.config.js
+++ b/configs/webpack.docs.prod.config.js
@@ -214,7 +214,8 @@ module.exports = {
                     ecma: 5,
                     warnings: false,
                     ie8: false,
-                    compress: true
+                    compress: true,
+                    mangle: false
                 }
             }),
             new OptimizeCSSAssetsPlugin({})

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "serve:e2e": "lite-server -c=e2e/bs-config.e2e.json",
     "e2e": "concurrently \"npm run serve:e2e\" \"grunt protractor:e2e\" --kill-others --success first",
     "build:library": "ng-packagr -p ./src/ng-package.json",
-    "build:documentation:prod": "webpack --progress --colors --config ./configs/webpack.docs.prod.config.js",
+    "build:documentation:prod": "node --max-old-space-size=4096 ./node_modules/webpack/bin/webpack.js --colors --config ./configs/webpack.docs.prod.config.js",
     "package:library": "grunt build:library && cd dist && npm pack",
     "lint": "grunt lint",
     "e2e:develop": "concurrently \"webpack --watch --progress --colors --config configs/webpack.e2e.config.js\" \"tsc -w --project .\\e2e\\tsconfig.json\" \"npm run serve:e2e\""


### PR DESCRIPTION
Attempting to fix the webpack out of memory error.

- Turning of Uglify mangling as this can be quite an intensive task
- Increasing Webpack's memory cap. I noticed when I was getting this error the build took forever, probably due to all the garbage collection. Bumping this up should make the build go a lot quicker than what you were seeing, usually the docs site production build takes ~4 mins on my machine when the memory error did not occur.