### PR TITLE
Added time picker documentation

### DIFF
--- a/docs/app/data/components-page.json
+++ b/docs/app/data/components-page.json
@@ -282,12 +282,29 @@
                 {
                     "title": "Date Range Picker",
                     "component": "ComponentsDateRangePickerNg1Component",
-                    "version": "AngularJS"
+                    "version": "AngularJS",
+                    "deprecated": true
                 },
                 {
                     "title": "Time Picker",
                     "component": "ComponentsTimePickerNg1Component",
-                    "version": "AngularJS"
+                    "version": "AngularJS",
+                    "deprecated": true
+                },
+                {
+                    "title": "Time Picker",
+                    "component": "ComponentsTimePickerComponent",
+                    "version": "Angular",
+                    "usage": [
+                        {
+                            "title": "Selector",
+                            "content": "ux-time-picker"
+                        },
+                        {
+                            "title": "Module",
+                            "content": "TimePickerModule"
+                        }
+                    ]
                 }
             ]
         },

--- a/docs/app/pages/components/components-sections/date-time-picker/date-time-picker.module.ts
+++ b/docs/app/pages/components/components-sections/date-time-picker/date-time-picker.module.ts
@@ -4,7 +4,7 @@ import { FormsModule } from '@angular/forms';
 import { RouterModule } from '@angular/router';
 import { AccordionModule } from 'ngx-bootstrap/accordion';
 import { TabsModule } from 'ngx-bootstrap/tabs';
-import { CheckboxModule, DateTimePickerModule, PopoverModule } from '../../../../../../src/index';
+import { CheckboxModule, DateTimePickerModule, NumberPickerModule, PopoverModule, TimePickerModule } from '../../../../../../src/index';
 import { DocumentationComponentsModule } from '../../../../components/components.module';
 import { DocumentationCategoryComponent } from '../../../../components/documentation-category/documentation-category.component';
 import { DocumentationPage, ResolverService } from '../../../../services/resolver/resolver.service';
@@ -14,15 +14,15 @@ import { ComponentsDateRangePickerNg1Component } from './date-range-picker-ng1/d
 import { ComponentsDateTimePickerComponent } from './date-time-picker/date-time-picker.component';
 import { ComponentsIntegratedDatePickerNg1Component } from './integrated-date-picker-ng1/integrated-date-picker-ng1.component';
 import { ComponentsTimePickerNg1Component } from './time-picker-ng1/time-picker-ng1.component';
-
-
+import { ComponentsTimePickerComponent } from './time-picker/time-picker.component';
 
 const SECTIONS = [
     ComponentsDatePickerNg1Component,
-    ComponentsIntegratedDatePickerNg1Component,
     ComponentsDateRangePickerNg1Component,
+    ComponentsDateTimePickerComponent,
+    ComponentsIntegratedDatePickerNg1Component,
+    ComponentsTimePickerComponent,
     ComponentsTimePickerNg1Component,
-    ComponentsDateTimePickerComponent
 ];
 
 const ROUTES = [
@@ -37,16 +37,18 @@ const ROUTES = [
 
 @NgModule({
     imports: [
-        CommonModule,
         AccordionModule.forRoot(),
-        PopoverModule,
-        WrappersModule,
-        TabsModule.forRoot(),
-        DateTimePickerModule,
-        FormsModule,
         CheckboxModule,
+        CommonModule,
+        DateTimePickerModule,
         DocumentationComponentsModule,
-        RouterModule.forChild(ROUTES)
+        FormsModule,
+        NumberPickerModule,
+        PopoverModule,
+        RouterModule.forChild(ROUTES),
+        TabsModule.forRoot(),
+        TimePickerModule,
+        WrappersModule,
     ],
     exports: SECTIONS,
     declarations: SECTIONS,

--- a/docs/app/pages/components/components-sections/date-time-picker/time-picker/snippets/app.html
+++ b/docs/app/pages/components/components-sections/date-time-picker/time-picker/snippets/app.html
@@ -1,0 +1,11 @@
+<ux-time-picker [(value)]="value"
+    [showMeridian]="showMeridian"
+    [showHours]="showHours"
+    [showMinutes]="showMinutes"
+    [showSeconds]="showSeconds"
+    [showSpinners]="showSpinners"
+    [hourStep]="hourStep"
+    [minuteStep]="minuteStep"
+    [secondStep]="secondStep"
+    [disabled]="disabled">
+</ux-time-picker>

--- a/docs/app/pages/components/components-sections/date-time-picker/time-picker/snippets/app.ts
+++ b/docs/app/pages/components/components-sections/date-time-picker/time-picker/snippets/app.ts
@@ -1,0 +1,18 @@
+import { Component } from '@angular/core';
+
+@Component({
+    selector: 'app',
+    templateUrl: 'app.component.html'
+})
+export class AppComponent {
+    value = new Date();
+    showMeridian = true;
+    showHours = true;
+    showMinutes = true;
+    showSeconds = false;
+    showSpinners = true;
+    hourStep = 1;
+    minuteStep = 1;
+    secondStep = 1;
+    disabled = false;
+}

--- a/docs/app/pages/components/components-sections/date-time-picker/time-picker/time-picker.component.html
+++ b/docs/app/pages/components/components-sections/date-time-picker/time-picker/time-picker.component.html
@@ -36,19 +36,19 @@
                 <label for="hourStep">hourStep</label>
             </div>
             <div class="col-md-2 col-sm-3">
-                <ux-number-picker id="hourStep" [(value)]="hourStep" [min]="1"></ux-number-picker>
+                <ux-number-picker id="hourStep" class="number-picker-compact" [(value)]="hourStep" [min]="1"></ux-number-picker>
             </div>
             <div class="col-md-2 col-sm-3">
                 <label for="minuteStep">minuteStep</label>
             </div>
             <div class="col-md-2 col-sm-3">
-                <ux-number-picker id="minuteStep" [(value)]="minuteStep" [min]="1"></ux-number-picker>
+                <ux-number-picker id="minuteStep" class="number-picker-compact" [(value)]="minuteStep" [min]="1"></ux-number-picker>
             </div>
             <div class="col-md-2 col-sm-3">
                 <label for="secondStep">secondStep</label>
             </div>
             <div class="col-md-2 col-sm-3">
-                <ux-number-picker id="secondStep" [(value)]="secondStep" [min]="1"></ux-number-picker>
+                <ux-number-picker id="secondStep" class="number-picker-compact" [(value)]="secondStep" [min]="1"></ux-number-picker>
             </div>
         </div>
         <div class="row uxd-customize-row">

--- a/docs/app/pages/components/components-sections/date-time-picker/time-picker/time-picker.component.html
+++ b/docs/app/pages/components/components-sections/date-time-picker/time-picker/time-picker.component.html
@@ -1,0 +1,136 @@
+<ux-time-picker [(value)]="value"
+    [showMeridian]="showMeridian"
+    [showHours]="showHours"
+    [showMinutes]="showMinutes"
+    [showSeconds]="showSeconds"
+    [showSpinners]="showSpinners"
+    [hourStep]="hourStep"
+    [minuteStep]="minuteStep"
+    [secondStep]="secondStep"
+    [disabled]="disabled">
+</ux-time-picker>
+
+<accordion class="uxd-customize-example">
+    <accordion-group class="accordion-chevron" heading="Customize Example...">
+        <div class="row uxd-customize-row">
+            <div class="col-md-4 col-sm-6">
+                <ux-checkbox id="showHours" [(value)]="showHours">showHours</ux-checkbox>
+            </div>
+            <div class="col-md-4 col-sm-6">
+                <ux-checkbox id="showMinutes" [(value)]="showMinutes">showMinutes</ux-checkbox>
+            </div>
+            <div class="col-md-4 col-sm-6">
+                <ux-checkbox id="showSeconds" [(value)]="showSeconds">showSeconds</ux-checkbox>
+            </div>
+        </div>
+        <div class="row uxd-customize-row">
+            <div class="col-md-4 col-sm-6">
+                <ux-checkbox [(value)]="showMeridian">showMeridian</ux-checkbox>
+            </div>
+            <div class="col-md-4 col-sm-6">
+                <ux-checkbox [(value)]="showSpinners">showSpinners</ux-checkbox>
+            </div>
+        </div>
+        <div class="row uxd-customize-row">
+            <div class="col-md-2 col-sm-3">
+                <label for="hourStep">hourStep</label>
+            </div>
+            <div class="col-md-2 col-sm-3">
+                <ux-number-picker id="hourStep" [(value)]="hourStep" [min]="1"></ux-number-picker>
+            </div>
+            <div class="col-md-2 col-sm-3">
+                <label for="minuteStep">minuteStep</label>
+            </div>
+            <div class="col-md-2 col-sm-3">
+                <ux-number-picker id="minuteStep" [(value)]="minuteStep" [min]="1"></ux-number-picker>
+            </div>
+            <div class="col-md-2 col-sm-3">
+                <label for="secondStep">secondStep</label>
+            </div>
+            <div class="col-md-2 col-sm-3">
+                <ux-number-picker id="secondStep" [(value)]="secondStep" [min]="1"></ux-number-picker>
+            </div>
+        </div>
+        <div class="row uxd-customize-row">
+            <div class="col-md-4 col-sm-6">
+                <ux-checkbox [(value)]="disabled">disabled</ux-checkbox>
+            </div>
+        </div>
+    </accordion-group>
+</accordion>
+
+<hr>
+
+<p>
+    The <code>ux-time-picker</code> component can be used to select the time component of a <code>Date</code> object.
+</p>
+
+<p>
+    The following options can be used to configure the appearance and behavior of the component.
+</p>
+
+<uxd-api-properties tableTitle="Inputs">
+    <tr uxd-api-property name="value" type="Date">
+        The value to display.
+    </tr>
+    <tr uxd-api-property name="showHours" type="boolean" defaultValue="true">
+        Whether to show the hour selector.
+    </tr>
+    <tr uxd-api-property name="showMinutes" type="boolean" defaultValue="true">
+        Whether to show the minute selector.
+    </tr>
+    <tr uxd-api-property name="showSeconds" type="boolean" defaultValue="false">
+        Whether to show the second selector.
+    </tr>
+    <tr uxd-api-property name="showMeridian" type="boolean" defaultValue="true">
+        Whether to show the meridian (AM/PM) selector. If this is false, the 24-hour clock will be used.
+    </tr>
+    <tr uxd-api-property name="showSpinners" type="boolean" defaultValue="true">
+        Whether to show increment and decrement buttons in the time picker.
+    </tr>
+    <tr uxd-api-property name="hourStep" type="number" defaultValue="1">
+        The number of hours to increment or decrement by when using the spinner buttons, arrow keys, or mouse scroll wheel.
+    </tr>
+    <tr uxd-api-property name="minuteStep" type="number" defaultValue="1">
+        The number of minutes to increment or decrement by when using the spinner buttons, arrow keys, or mouse scroll wheel.
+    </tr>
+    <tr uxd-api-property name="secondStep" type="number" defaultValue="1">
+        The number of seconds to increment or decrement by when using the spinner buttons, arrow keys, or mouse scroll wheel.
+    </tr>
+    <tr uxd-api-property name="min" type="Date">
+        The minimum value that the component will allow.
+    </tr>
+    <tr uxd-api-property name="max" type="Date">
+        The maximum value that the component will allow.
+    </tr>
+    <tr uxd-api-property name="meridians" type="string[]" defaultValue="['AM', 'PM']">
+        An array containing the labels to show in the meridian selector.
+    </tr>
+    <tr uxd-api-property name="arrowkeys" type="boolean" defaultValue="true">
+        Whether the arrow keys can be used to increment or decrement the selected time component.
+    </tr>
+    <tr uxd-api-property name="mousewheel" type="boolean" defaultValue="true">
+        Whether the mouse scroll wheel can be used to increment or decrement the selected time component.
+    </tr>
+    <tr uxd-api-property name="disabled" type="boolean" defaultValue="false">
+        Whether the control is disabled.
+    </tr>
+</uxd-api-properties>
+
+<uxd-api-properties tableTitle="Outputs">
+    <tr uxd-api-property name="valueChange" type="Date">
+        Emitted when the <code>value</code> changes.
+    </tr>
+    <tr uxd-api-property name="isValid" type="boolean">
+        Emitted when the validity of the control changes.
+    </tr>
+</uxd-api-properties>
+
+<tabset>
+    <tab heading="HTML">
+        <uxd-snippet [content]="snippets.compiled.appHtml"></uxd-snippet>
+    </tab>
+    <tab heading="TypeScript">
+        <uxd-snippet [content]="snippets.compiled.appTs"></uxd-snippet>
+    </tab>
+</tabset>

--- a/docs/app/pages/components/components-sections/date-time-picker/time-picker/time-picker.component.ts
+++ b/docs/app/pages/components/components-sections/date-time-picker/time-picker/time-picker.component.ts
@@ -1,0 +1,41 @@
+import { Component } from '@angular/core';
+import { BaseDocumentationSection } from '../../../../../components/base-documentation-section/base-documentation-section';
+import { DocumentationSectionComponent } from '../../../../../decorators/documentation-section-component';
+import { IPlunk } from '../../../../../interfaces/IPlunk';
+import { IPlunkProvider } from '../../../../../interfaces/IPlunkProvider';
+
+@Component({
+    selector: 'uxd-time-picker',
+    templateUrl: './time-picker.component.html'
+})
+@DocumentationSectionComponent('ComponentsTimePickerComponent')
+export class ComponentsTimePickerComponent extends BaseDocumentationSection implements IPlunkProvider {
+
+    plunk: IPlunk = {
+        files: {
+            'app.component.html': this.snippets.raw.appHtml,
+            'app.component.ts': this.snippets.raw.appTs,
+        },
+        modules: [
+            {
+                imports: ['TimePickerModule'],
+                library: '@ux-aspects/ux-aspects'
+            },
+        ]
+    };
+
+    value = new Date();
+    showMeridian = true;
+    showHours = true;
+    showMinutes = true;
+    showSeconds = false;
+    showSpinners = true;
+    hourStep = 1;
+    minuteStep = 1;
+    secondStep = 1;
+    disabled = false;
+
+    constructor() {
+        super(require.context('./snippets/', false, /\.(html|css|js|ts)$/));
+    }
+}

--- a/src/components/time-picker/time-format.pipe.ts
+++ b/src/components/time-picker/time-format.pipe.ts
@@ -1,12 +1,10 @@
 import { Pipe, PipeTransform } from '@angular/core';
 
 @Pipe({
-  name: 'timeFormat'
+    name: 'timeFormat'
 })
 export class TimeFormatPipe implements PipeTransform {
-
-  transform(value: number): string | number {
-    return value < 10 ? '0' + value : value;
-  }
-
+    transform(value: number, pad: boolean): string | number {
+        return value < 10 && pad ? '0' + value : value;
+    }
 }

--- a/src/components/time-picker/time-picker.component.html
+++ b/src/components/time-picker/time-picker.component.html
@@ -3,12 +3,12 @@
     <div class="time-picker-column" [class.has-error]="!(valid$ | async)" *ngIf="showHours">
 
         <ux-spin-button
-            type="number"
+            type="text"
             class="time-spinner"
             placeholder="HH"
             [min]="0"
             [max]="showMeridian ? 12 : 23"
-            [value]="hour$ | async | timeFormat"
+            [value]="hour$ | async | timeFormat:!showMeridian"
             (valueChange)="hourChange($event)"
             [spinners]="showSpinners"
             [disabled]="disabled"
@@ -27,12 +27,12 @@
     <div class="time-picker-column" [class.has-error]="!(valid$ | async)" *ngIf="showMinutes">
 
         <ux-spin-button
-            type="number"
+            type="text"
             class="time-spinner"
             placeholder="MM"
             [min]="0"
             [max]="59"
-            [value]="minute$ | async | timeFormat"
+            [value]="minute$ | async | timeFormat:true"
             (valueChange)="minuteChange($event)"
             [spinners]="showSpinners"
             [disabled]="disabled"
@@ -51,13 +51,12 @@
     <div class="time-picker-column" [class.has-error]="!(valid$ | async)" *ngIf="showSeconds">
 
         <ux-spin-button
-            type="number"
+            type="text"
             class="time-spinner"
-            type="number"
             placeholder="SS"
             [min]="0"
             [max]="59"
-            [value]="second$ | async | timeFormat"
+            [value]="second$ | async | timeFormat:true"
             (valueChange)="secondChange($event)"
             [spinners]="showSpinners"
             [disabled]="disabled"

--- a/src/components/time-picker/time-picker.component.less
+++ b/src/components/time-picker/time-picker.component.less
@@ -1,5 +1,5 @@
 ux-time-picker {
-    display: flex;
+    display: inline-flex;
     flex-direction: row;
     justify-content: space-between;
 

--- a/src/components/time-picker/time-picker.component.ts
+++ b/src/components/time-picker/time-picker.component.ts
@@ -1,9 +1,9 @@
-import { ChangeDetectionStrategy, Component, EventEmitter, Input, OnDestroy, Output, ViewEncapsulation, forwardRef } from '@angular/core';
+import { ChangeDetectionStrategy, Component, EventEmitter, forwardRef, Input, OnDestroy, Output, ViewEncapsulation } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 import { Observable } from 'rxjs/Observable';
-import { Subscription } from 'rxjs/Subscription';
 import { distinctUntilChanged, map } from 'rxjs/operators';
+import { Subscription } from 'rxjs/Subscription';
 
 export const TIME_PICKER_VALUE_ACCESSOR: any = {
     provide: NG_VALUE_ACCESSOR,

--- a/src/styles/documentation.less
+++ b/src/styles/documentation.less
@@ -71,10 +71,9 @@
             display: flex;
             align-items: center;
             min-height: 36px;
-            margin: 0 -0.5em;
 
-            & > * {
-                padding: 0 0.5em;
+            & > * + * {
+                margin-left: 1rem;
             }
 
             & > input {


### PR DESCRIPTION
* Added documentation and deprecated the ng1 section.
* Fixed an issue where time values were not padded in Firefox, this is an issue with type="number" in FF so I changed the type to text.
* Also changed the padding for hours, this is conventionally not padded in 12-hour mode.
* Fixed an alignment issue with the customize section styling.

https://jira.autonomy.com/browse/EL-3046