### PR TITLE
EL-3057 - Media Player QA Fixes

### DIFF
--- a/src/components/media-player/extensions/controls/controls.component.html
+++ b/src/components/media-player/extensions/controls/controls.component.html
@@ -15,7 +15,8 @@
                 [uxTooltip]="muteTooltip"
                 [showTriggers]="['mouseenter']"
                 [hideTriggers]="['mouseleave']"
-                (click)="toggleMute()">
+                (click)="toggleMute()"
+                (mouseup)="volumeIcon.blur()">
 
             <span class="hpe-icon"
                   [class.hpe-volume-mute]="volume === 0"
@@ -30,8 +31,10 @@
     </div>
 </div>
 
-<button class="control-button"
+<button #startButton
+    class="control-button"
     (click)="goToStart()"
+    (mouseup)="startButton.blur()"
     aria-label="Go to start"
     i18n-aria-label>
 
@@ -41,10 +44,12 @@
     </svg>
 </button>
 
-<button class="control-button"
+<button #playButton
+    class="control-button"
     attr.aria-label="{{ (mediaPlayerService.playing | async) ? 'Pause' : 'Play' }}"
     i18n-aria-label
-    (click)="mediaPlayerService.togglePlay()">
+    (click)="mediaPlayerService.togglePlay()"
+    (mouseup)="playButton.blur()">
 
     <svg *ngIf="!(mediaPlayerService.playing | async)" viewBox="0 0 45 64" width="20" height="29" focusable="false">
         <polygon points="0.4,0 0.4,64 44.6,32" />
@@ -55,8 +60,10 @@
     </svg>
 </button>
 
-<button class="control-button"
+<button #endButton
+    class="control-button"
     (click)="goToEnd()"
+    (mouseup)="endButton.blur()"
     aria-label="Go to end"
     i18n-aria-label>
 
@@ -71,8 +78,11 @@
     <ng-content></ng-content>
 
     <div class="action-button-container" *ngIf="mediaPlayerService.textTracks.length > 0 && mediaPlayerService.type === 'video'">
-        <button class="action-button"
-            (click)="subtitlesOpen = !subtitlesOpen"
+        <button #subtitlesButton
+            class="action-button"
+            (keydown)="returnFocus = true"
+            (click)="subtitlesOpen = !subtitlesOpen; subtitlesButton.blur()"
+            (mouseup)="returnFocus = false"
             i18n-aria-label
             attr.aria-label="Select subtitles, {{ getSubtitleTrack() }} currently selected."
             [attr.aria-expanded]="subtitlesOpen"
@@ -91,7 +101,7 @@
             <div class="arrow"></div>
             <h3 class="popover-title" i18n>Subtitles</h3>
             <div class="popover-content">
-                <ul class="subtitles-list" uxTabbableList [focusOnShow]="true" [returnFocus]="true">
+                <ul class="subtitles-list" uxTabbableList [focusOnShow]="returnFocus" [returnFocus]="returnFocus">
                     <li uxTabbableListItem
                         tabindex="0"
                         class="subtitles-list-item"
@@ -119,11 +129,13 @@
     </div>
 
     <div class="action-button-container">
-        <button *ngIf="mediaPlayerService.type !== 'audio'"
+        <button #fullscreenButton
+            *ngIf="mediaPlayerService.type !== 'audio'"
             class="action-button"
             attr.aria-label="{{ mediaPlayerService.fullscreen ? 'Exit full screen' : 'Full screen' }}"
             i18n-aria-label
-            (click)="mediaPlayerService.toggleFullscreen()">
+            (click)="mediaPlayerService.toggleFullscreen()"
+            (mouseup)="fullscreenButton.blur()">
 
             <span class="hpe-icon"
                   [class.hpe-expand]="!mediaPlayerService.fullscreen"

--- a/src/components/media-player/extensions/controls/controls.component.less
+++ b/src/components/media-player/extensions/controls/controls.component.less
@@ -162,7 +162,7 @@ ux-media-player-controls {
     }
 
     .media-player-subtitles-popover {
-        left: unset;
+        left: auto;
         right: -35px;
 
         .popover-title {
@@ -172,13 +172,13 @@ ux-media-player-controls {
         }
 
         &.top > .arrow {
-            left: unset;
+            left: auto;
             right: 37px;
         }
 
         .popover-content {
             padding: 7px;
-            max-width: unset;
+            max-width: none;
 
             .subtitles-list {
                 margin: 0;
@@ -202,18 +202,10 @@ ux-media-player-controls {
 
                     &:hover {
                         background-color: @grey7;
-
-                        .hpe-icon {
-                            opacity: 0.5;
-                        }
                     }
 
                     &:focus {
                         .aspects-outline();
-
-                        .hpe-icon {
-                            opacity: 0.5;
-                        }
                     }
 
                     &.active {

--- a/src/components/media-player/extensions/controls/controls.component.ts
+++ b/src/components/media-player/extensions/controls/controls.component.ts
@@ -18,6 +18,7 @@ export class MediaPlayerControlsExtensionComponent extends MediaPlayerBaseExtens
 
     volumeActive: boolean = false;
     volumeFocus: boolean = false;
+    returnFocus: boolean = true;
     subtitlesId: string = `ux-media-player-subtitle-popover-${uniqueId++}`;
     subtitlesOpen: boolean = false;
     mouseEnterVolume = new Subject<void>();

--- a/src/components/media-player/extensions/controls/controls.component.ts
+++ b/src/components/media-player/extensions/controls/controls.component.ts
@@ -104,8 +104,15 @@ export class MediaPlayerControlsExtensionComponent extends MediaPlayerBaseExtens
         // hide all tracks
         this.mediaPlayerService.hideSubtitleTracks();
 
+        // set the position of the subtitle track
+        for (let idx = 0; idx < track.cues.length; idx++) {
+            const cue: any = track.cues[idx];
+            cue.line = -3;
+        }
+
         // activate the selected one
         track.mode = 'showing';
+
     }
 
     getSubtitleTrack(): string {

--- a/src/components/media-player/media-player.component.html
+++ b/src/components/media-player/media-player.component.html
@@ -94,10 +94,8 @@
     </div>
 
     <div class="control-bar"
-        (focusWithin)="focus.next()"
-        (blurWithin)="blur.next()"
-        (keydown.ArrowLeft)="focus.next()"
-        (keydown.ArrowRight)="focus.next()">
+        (focusWithin)="focused = true"
+        (blurWithin)="focused = false">
 
         <ux-media-player-timeline></ux-media-player-timeline>
         <ux-media-player-controls>

--- a/src/components/media-player/media-player.component.ts
+++ b/src/components/media-player/media-player.component.ts
@@ -1,7 +1,6 @@
 import { AfterViewInit, Component, ElementRef, Input, OnDestroy, ViewChild } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
 import { fromEvent } from 'rxjs/observable/fromEvent';
-import { merge } from 'rxjs/observable/merge';
 import { debounceTime, takeUntil, tap } from 'rxjs/operators';
 import { Subject } from 'rxjs/Subject';
 import { AudioMetadata, AudioService } from '../../services/audio/index';
@@ -16,7 +15,7 @@ import { MediaPlayerService } from './media-player.service';
         '[class.standard]': '!mediaPlayerService.fullscreen',
         '[class.fullscreen]': 'mediaPlayerService.fullscreen',
         '[class.quiet]': 'quietMode && type === "video" || mediaPlayerService.fullscreen',
-        '[class.hover]': 'hovering',
+        '[class.hover]': 'hovering || focused',
         '[class.video]': 'type === "video"',
         '[class.audio]': 'type === "audio"',
         '(mouseenter)': 'hovering = true',
@@ -31,9 +30,8 @@ export class MediaPlayerComponent implements AfterViewInit, OnDestroy {
     @ViewChild('player') private _playerRef: ElementRef;
 
     hovering: boolean = false;
+    focused: boolean = false;
     audioMetadata: Observable<AudioMetadata>;
-    focus = new Subject<void>();
-    blur = new Subject<void>();
 
     @Input() crossorigin: 'use-credentials' | 'anonymous' = 'use-credentials';
 
@@ -68,16 +66,12 @@ export class MediaPlayerComponent implements AfterViewInit, OnDestroy {
 
     constructor(public mediaPlayerService: MediaPlayerService, private _audioService: AudioService, private _elementRef: ElementRef) {
 
-        const mousemove = fromEvent(this._elementRef.nativeElement, 'mousemove');
-
         // show controls when hovering and in quiet mode
-        merge(mousemove, this.focus).pipe(
+        fromEvent(this._elementRef.nativeElement, 'mousemove').pipe(
             tap(() => this.hovering = true),
             debounceTime(2000),
             takeUntil(this._onDestroy)
         ).subscribe(() => this.hovering = false);
-
-        this.blur.pipe(takeUntil(this._onDestroy)).subscribe(() => this.hovering = false);
     }
 
     ngAfterViewInit(): void {

--- a/src/components/media-player/media-player.service.ts
+++ b/src/components/media-player/media-player.service.ts
@@ -209,12 +209,12 @@ export class MediaPlayerService {
         this._mediaPlayer.src = value;
     }
 
-    get textTracks(): TextTrackList | Array<TextTrack> {
-        return this._mediaPlayer ? this._mediaPlayer.textTracks : [];
+    get textTracks(): Array<TextTrack> {
+        return this._mediaPlayer ? Array.from(this._mediaPlayer.textTracks) : [];
     }
 
-    get videoTracks(): VideoTrackList | Array<VideoTrack> {
-        return this._mediaPlayer ? this._mediaPlayer.videoTracks : [];
+    get videoTracks(): Array<VideoTrack> {
+        return this._mediaPlayer ? Array.from(this._mediaPlayer.videoTracks) : [];
     }
 
     get volume(): number {


### PR DESCRIPTION
- Making controls remain visible until focus leaves the controls
- Removing faded tick on focus to meet wcag contrast requirements
- Positioning subtitles higher to avoid being behind the controls