### PR TITLE
Fixing issue with Marquee Wizard icon and its size

### DIFF
--- a/src/ng1/directives/marqueeWizard/marqueeWizard.html
+++ b/src/ng1/directives/marqueeWizard/marqueeWizard.html
@@ -4,8 +4,8 @@
 
 <div class="side-panel">
   <div class="marquee-logo">
-    <div ng-if="!mc.icon" class="marquee-wizard-user"></div>
-    <img ng-if="mc.icon" ng-src="{{mc.icon}}" alt="Marquee wizard icon"/>
+    <div ng-if="!mc.wizardIcon" class="marquee-wizard-user marquee-wizard-icon"></div>
+    <img ng-if="mc.wizardIcon" ng-src="{{mc.wizardIcon}}" alt="Marquee wizard icon" class="marquee-wizard-icon"/>
   </div>
 
   <div class="marquee-wizard-info-panel" ng-if="mc.sideInfo">

--- a/src/styles/wizard.less
+++ b/src/styles/wizard.less
@@ -251,6 +251,9 @@ Wizard
 
 .marquee-wizard-user {
     background: url(../img/IconUser.png) no-repeat;
+}
+
+.marquee-wizard-icon {
     height: 48px;
 }
 


### PR DESCRIPTION
I've found another issue with the Marquee Wizard which should be easy to fix for 1.6.1: the `wizard-icon` property is not working because the markup is checking for a property named `icon` instead (see [here](https://github.com/UXAspects/UXAspects/blob/develop/src/ng1/directives/marqueeWizard/marqueeWizard.html#L7-L8). I changed the code to check for `wizardIcon` and I was able to see the proper icon. However, once that happened, I noticed the custom icon size is not the same as the default icon (48px). This is because the `marquee-wizard-user` class is not applied in both cases. To address that, I created a class named `marquee-wizard-icon` and applied to both the default and custom marquee wizard icons.