### PR TITLE
EL-3219 - Masthead icon and title

### DIFF
--- a/docs/app/pages/components/components-sections/page-header/page-header/page-header.component.html
+++ b/docs/app/pages/components/components-sections/page-header/page-header/page-header.component.html
@@ -1,4 +1,9 @@
-<ux-page-header header="My Page" [crumbs]="crumbs" [items]="items" [condensed]="condensed" [iconMenus]="iconMenus"></ux-page-header>
+<ux-page-header header="My Page"
+    [crumbs]="crumbs"
+    [items]="items"
+    [condensed]="condensed"
+    [iconMenus]="iconMenus">
+</ux-page-header>
 
 <br>
 

--- a/docs/app/pages/components/components-sections/page-header/page-header/page-header.component.ts
+++ b/docs/app/pages/components/components-sections/page-header/page-header/page-header.component.ts
@@ -1,10 +1,10 @@
 import { Component } from '@angular/core';
-import { DocumentationSectionComponent } from '../../../../../decorators/documentation-section-component';
 import { Breadcrumb } from '../../../../../../../src/components/breadcrumbs/index';
-import { PageHeaderNavigationItem, PageHeaderIconMenu } from '../../../../../../../src/index';
-import { IPlunkProvider } from '../../../../../interfaces/IPlunkProvider';
-import { IPlunk } from '../../../../../interfaces/IPlunk';
+import { PageHeaderIconMenu, PageHeaderNavigationItem } from '../../../../../../../src/index';
 import { BaseDocumentationSection } from '../../../../../components/base-documentation-section/base-documentation-section';
+import { DocumentationSectionComponent } from '../../../../../decorators/documentation-section-component';
+import { IPlunk } from '../../../../../interfaces/IPlunk';
+import { IPlunkProvider } from '../../../../../interfaces/IPlunkProvider';
 
 @Component({
     selector: 'uxd-components-page-header',
@@ -16,19 +16,25 @@ export class ComponentsPageHeaderComponent extends BaseDocumentationSection impl
     plunk: IPlunk = {
         files: {
             'app.component.html': this.snippets.raw.appHtml,
-            'app.component.ts': this.snippets.raw.appTs,
+            'app.component.ts': this.snippets.raw.appTs
         },
-        modules: [{
-            imports: ['PageHeaderModule'],
-            library: '@ux-aspects/ux-aspects'
-        },
-        {
-            library: 'ngx-bootstrap/dropdown',
-            imports: ['BsDropdownModule'],
-            providers: ['BsDropdownModule.forRoot()']
-        }]
+        modules: [
+            {
+                imports: ['PageHeaderModule'],
+                library: '@ux-aspects/ux-aspects'
+            },
+            {
+                imports: ['RouterModule'],
+                library: '@angular/router',
+                providers: ['RouterModule.forRoot([])']
+            },
+            {
+                imports: ['BsDropdownModule'],
+                library: 'ngx-bootstrap/dropdown',
+                providers: ['BsDropdownModule.forRoot()']
+            }
+        ]
     };
-
 
     condensed: boolean = false;
 
@@ -125,5 +131,4 @@ export class ComponentsPageHeaderComponent extends BaseDocumentationSection impl
     constructor() {
         super(require.context('./snippets/', false, /\.(html|css|js|ts)$/));
     }
-
 }

--- a/src/components/page-header/page-header.component.html
+++ b/src/components/page-header/page-header.component.html
@@ -1,43 +1,49 @@
 <div class="ux-page-header" [class.page-header-condensed]="condensed" role="banner">
 
-    <!-- Display Upper Section when not condensed -->
-    <div class="page-header-actions" *ngIf="!condensed">
+    <div *ngIf="!condensed" class="page-header-content">
 
-        <div class="page-header-logo-container" role="presentation" [hidden]="!logo">
-            <img [attr.src]="logo" class="page-header-logo">
+        <!-- Logo/product acronym -->
+        <div class="page-header-logo-container" role="presentation" [style.backgroundColor]="logoBackground" [style.color]="logoForeground">
+            <img *ngIf="logo" [attr.src]="logo" [attr.alt]="header" class="page-header-logo">
+            <h1 *ngIf="header && !logo" class="page-header-acronym">{{header}}</h1>
         </div>
 
-        <div class="page-header-navigation" [ngClass]="alignment" role="navigation" aria-label="Primary Navigation">
-
-            <!-- The Top Navigation Options -->
-            <ux-page-header-horizontal-navigation></ux-page-header-horizontal-navigation>
+        <!-- Sub-title -->
+        <div *ngIf="title || titleTemplate" class="page-header-subtitle-container">
+            <span *ngIf="title" class="page-header-subtitle">{{title}}</span>
+            <ng-container [ngTemplateOutlet]="titleTemplate"></ng-container>
         </div>
-
-        <div class="page-header-icon-menus" role="toolbar">
-            <ng-container *ngFor="let menu of customMenus" [ngTemplateOutlet]="menu"></ng-container>
-
-            <ux-page-header-icon-menu *ngFor="let menu of iconMenus" [menu]="menu"></ux-page-header-icon-menu>
-        </div>
-    </div>
-
-    <!-- Display Lower Section When Not Condensed -->
-    <div class="page-header-details" *ngIf="!condensed">
 
         <div class="page-header-state-container" role="navigation">
 
+            <!-- Back button -->
             <button *ngIf="backVisible === true" class="page-header-back-button" (click)="goBack()" aria-label="Go Back">
                 <span class="hpe-icon hpe-previous text-primary"></span>
             </button>
 
+            <!-- Breadcrumbs and header -->
             <div class="page-header-title-container">
 
-                <ux-breadcrumbs [crumbs]="crumbs"></ux-breadcrumbs>
+                <ux-breadcrumbs *ngIf="crumbs && crumbs.length > 0"
+                    [class.ux-breadcrumbs-small]="crumbsStyle === 'small'"
+                    [crumbs]="crumbs"></ux-breadcrumbs>
 
-                <h1 class="page-header-title" [style.backgroundColor]="familyBackground" [style.color]="familyForeground">{{ header }}</h1>
+                <h1 class="page-header-title">{{header}}</h1>
+
             </div>
 
         </div>
 
+        <!-- Primary navigation -->
+        <div class="page-header-navigation" [ngClass]="alignment" role="navigation" aria-label="Primary Navigation">
+            <ux-page-header-horizontal-navigation></ux-page-header-horizontal-navigation>
+        </div>
+
+        <!-- Icon menus -->
+        <div class="page-header-icon-menus" role="toolbar">
+            <ng-container *ngFor="let menu of customMenus" [ngTemplateOutlet]="menu"></ng-container>
+            <ux-page-header-icon-menu *ngFor="let menu of iconMenus" [menu]="menu"></ux-page-header-icon-menu>
+        </div>
     </div>
 
     <!-- Display This Section Optimized for Condensed Mode -->
@@ -64,8 +70,10 @@
 
 <div *ngIf="secondaryNavigation && ((selectedRoot$ | async) !== (selected$ | async))"
     class="page-header-secondary" [ngClass]="secondaryNavigationAlignment" role="navigation">
+
     <ul *ngIf="(selectedRoot$ | async)?.children; let children"
         class="nav nav-tabs" role="tablist" aria-label="Secondary Navigation">
+
         <li *ngFor="let child of children"
             [class.active]="child.selected"
             role="none"
@@ -78,5 +86,7 @@
                 (keydown.enter)="select(child)">{{ child.title }}</a>
 
         </li>
+
     </ul>
+
 </div>

--- a/src/components/page-header/page-header.component.html
+++ b/src/components/page-header/page-header.component.html
@@ -4,7 +4,7 @@
 
         <!-- Logo/product acronym -->
         <div class="page-header-logo-container" role="presentation" [style.backgroundColor]="logoBackground" [style.color]="logoForeground">
-            <img *ngIf="logo" [attr.src]="logo" [attr.alt]="header" class="page-header-logo">
+            <img *ngIf="logo" [attr.src]="logo" [alt]="header" class="page-header-logo">
             <h1 *ngIf="header && !logo" class="page-header-acronym">{{header}}</h1>
         </div>
 

--- a/src/components/page-header/page-header.component.less
+++ b/src/components/page-header/page-header.component.less
@@ -3,8 +3,6 @@ ux-page-header {
     width: 100%;
 
     .ux-page-header {
-        display: flex;
-        flex-direction: column;
         height: 130px;
         width: 100%;
         padding-left: 23px;
@@ -12,104 +10,108 @@ ux-page-header {
         background-color: @page-header-bg;
         color: @white;
 
-        .page-header-actions {
+        .page-header-content {
+            position: relative;
+            height: 100%;
+        }
+
+        .page-header-logo-container {
+            position: absolute;
+            top: 0;
+            left: 0;
+            height: 40px;
+            overflow: hidden;
+
+            .page-header-logo {
+                max-height: 100%;
+            }
+
+            .page-header-acronym {
+                display: none; // MF only
+            }
+        }
+
+        .page-header-subtitle-container {
+            display: none; // MF only
+        }
+
+        .page-header-state-container {
+            position: absolute;
+            bottom: 0;
+            left: 0;
             display: flex;
-            flex: 1;
+            align-items: center;
+            height: 70px;
 
-            .page-header-logo-container {
+            .page-header-back-button {
                 display: flex;
-                flex: none;
+                height: 28px;
+                width: 28px;
+                margin-top: 16px;
+                margin-right: 2px;
+                border: none;
+                justify-content: center;
                 align-items: center;
-                margin-top: 10px;
-                margin-right: 10px;
-                height: 40px;
-                overflow: hidden;
+                background-color: transparent;
+                cursor: pointer;
+                transition: background-color 0.3s ease-in-out;
 
-                .page-header-logo {
-                    max-height: 100%;
+                &:hover,
+                &:focus {
+                    background-color: @page-header-back-button-hover-bg;
                 }
 
-                &[hidden] {
-                    display: none;
+                &:focus {
+                    .aspects-outline;
+                }
+
+                & > * {
+                    color: @page-header-back-button-color;
+
+                    &:hover {
+                        color: @page-header-back-button-hover-color;
+                    }
                 }
             }
 
-            .page-header-navigation {
+            ux-breadcrumbs {
+                height: 22px;
+            }
+
+            .page-header-title-container {
                 display: flex;
-                justify-content: center;
-                flex: 1;
+                flex-direction: column;
+                margin-right: 10px;
 
-                &.left {
-                    justify-content: flex-start;
-                }
-
-                &.right {
-                    justify-content: flex-end;
+                .page-header-title {
+                    margin-top: 0;
+                    margin-bottom: 8px;
+                    line-height: 35px;
                 }
             }
         }
 
-        .page-header-details {
+        .page-header-navigation {
             display: flex;
-            flex: none;
-            height: 70px;
+            justify-content: center;
+            flex: 1;
+            margin: 0 120px;
 
-            .page-header-state-container {
-                display: inline-flex;
-                align-items: center;
+            &.left {
+                justify-content: flex-start;
+            }
 
-                .page-header-back-button {
-                    display: flex;
-                    height: 28px;
-                    width: 28px;
-                    margin-top: 16px;
-                    margin-right: 2px;
-                    border: none;
-                    justify-content: center;
-                    align-items: center;
-                    background-color: transparent;
-                    cursor: pointer;
-                    transition: background-color 0.3s ease-in-out;
-
-                    &:hover,
-                    &:focus {
-                        background-color: @page-header-back-button-hover-bg;
-                    }
-
-                    &:focus {
-                        .aspects-outline;
-                    }
-
-                    & > * {
-                        color: @page-header-back-button-color;
-
-                        &:hover {
-                            color: @page-header-back-button-hover-color;
-                        }
-                    }
-                }
-
-                .page-header-title-container {
-                    display: inline-flex;
-                    flex-direction: column;
-                    margin-right: 10px;
-
-                    ux-breadcrumbs {
-                        height: 22px;
-                    }
-
-                    .page-header-title {
-                        margin-top: 0;
-                        margin-bottom: 8px;
-                        line-height: 35px;
-                    }
-                }
+            &.right {
+                justify-content: flex-end;
             }
         }
 
         .page-header-icon-menus {
+            position: absolute;
+            top: 0;
+            right: 0;
             display: flex;
-            flex: none;
+            height: 60px;
         }
 
         // Styling For Condensed Header
@@ -117,6 +119,7 @@ ux-page-header {
             height: 57px;
 
             .page-header-condensed-content {
+                position: relative;
                 display: flex;
 
                 .page-header-breadcrumbs {
@@ -137,6 +140,10 @@ ux-page-header {
                     display: flex;
                     flex: 1;
                     justify-content: center;
+                }
+
+                .page-header-icon-menus {
+                    position: static;
                 }
             }
         }

--- a/src/components/page-header/page-header.component.ts
+++ b/src/components/page-header/page-header.component.ts
@@ -1,4 +1,4 @@
-import { Component, ContentChildren, EventEmitter, Input, Output, QueryList, TemplateRef } from '@angular/core';
+import { Component, ContentChild, ContentChildren, EventEmitter, Input, Output, QueryList, TemplateRef } from '@angular/core';
 import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 import { ColorService } from '../../services/color/index';
 import { Breadcrumb } from '../breadcrumbs/index';
@@ -17,13 +17,15 @@ export class PageHeaderComponent {
 
     @Input() logo: string;
     @Input() header: string;
+    @Input() title: string;
     @Input() alignment: 'left' | 'right' | 'center' = 'center';
     @Input() condensed: boolean = false;
     @Input() iconMenus: PageHeaderIconMenu[];
     @Input() backVisible: boolean = true;
-    @Input() secondaryNavigationAlignment: string = 'center';
+    @Input() secondaryNavigationAlignment: 'left' | 'right' | 'center' = 'center';
 
-    @Input() set secondaryNavigationAutoselect(value: boolean) {
+    @Input()
+    set secondaryNavigationAutoselect(value: boolean) {
         this._pageHeaderService.secondaryNavigationAutoselect = value;
     }
 
@@ -31,11 +33,13 @@ export class PageHeaderComponent {
         return this._pageHeaderService.secondaryNavigationAutoselect;
     }
 
-    @Input() set items(items: PageHeaderNavigationItem[]) {
+    @Input()
+    set items(items: PageHeaderNavigationItem[]) {
         this._pageHeaderService.setItems(items);
     }
 
-    @Input() set secondaryNavigation(enabled: boolean) {
+    @Input()
+    set secondaryNavigation(enabled: boolean) {
         this._pageHeaderService.setSecondaryNavigation(enabled);
     }
 
@@ -43,7 +47,8 @@ export class PageHeaderComponent {
         return this._pageHeaderService.secondary$.getValue();
     }
 
-    @Input() set crumbs(crumbs: Breadcrumb[]) {
+    @Input()
+    set crumbs(crumbs: Breadcrumb[]) {
         this._crumbs = crumbs;
     }
 
@@ -51,25 +56,39 @@ export class PageHeaderComponent {
         return this.condensed ? [...this._crumbs, { title: this.header }] : this._crumbs;
     }
 
+    @Input() crumbsStyle: 'standard' | 'small' = 'standard';
+
     @Input()
-    set familyBackground(color: string) {
-        this._familyBackground = this._colorService.resolve(color);
+    set logoBackground(color: string) {
+        this._logoBackground = this._colorService.resolve(color);
     }
 
-    get familyBackground(): string {
-        return this._familyBackground;
+    get logoBackground(): string {
+        return this._logoBackground;
+    }
+
+    @Input()
+    set logoForeground(color: string) {
+        this._logoForeground = this._colorService.resolve(color);
+    }
+
+    get logoForeground(): string {
+        return this._logoForeground;
+    }
+
+    @Input()
+    set familyBackground(color: string) {
+        this.logoBackground = color;
     }
 
     @Input()
     set familyForeground(color: string) {
-        this._familyForeground = this._colorService.resolve(color);
-    }
-
-    get familyForeground(): string {
-        return this._familyForeground;
+        this.logoForeground = color;
     }
 
     @Output() backClick = new EventEmitter();
+
+    @ContentChild('title') titleTemplate: TemplateRef<any>;
 
     @ContentChildren(PageHeaderCustomMenuDirective, { read: TemplateRef }) customMenus: QueryList<TemplateRef<any>>;
 
@@ -77,8 +96,8 @@ export class PageHeaderComponent {
     selectedRoot$: BehaviorSubject<PageHeaderNavigationItem> = this._pageHeaderService.selectedRoot$;
 
     private _crumbs: Breadcrumb[] = [];
-    private _familyBackground: string;
-    private _familyForeground: string;
+    private _logoBackground: string;
+    private _logoForeground: string;
 
     constructor(private _colorService: ColorService, private _pageHeaderService: PageHeaderService) { }
 


### PR DESCRIPTION
* Removed the upper and lower containers of the non-condensed page header. This makes it easier to style the MF layout.
* Added an alternate `header` element in the logo container. which is not shown by default. This is to be used in the MF layout.
* Added `title` property and a title template option.
* Added `crumbsStyle` to allow the old breadcrumb style.
* Renamed `family*` properties to `logo*` with aliases for backward compatibility.

https://jira.autonomy.com/browse/EL-3219