### PR TITLE
Fixing column resizing

### DIFF
--- a/src/components/table/table-column-resize/resizable-table-column.component.html
+++ b/src/components/table/table-column-resize/resizable-table-column.component.html
@@ -4,7 +4,7 @@
      uxDrag
      class="ux-resizable-table-column-handle"
      *ngIf="!disabled"
-     (dragstart)="dragstart()"
-     (drag)="drag($event, handle)"
-     (dragend)="dragend()">
+     (onDragStart)="dragstart()"
+     (onDrag)="drag($event, handle)"
+     (onDragEnd)="dragend()">
 </div>


### PR DESCRIPTION
I recently renamed the events that uxDrag emits as they used to be `(dragstart)`, `(drag)` and `(dragend)` which are also native browser events which clashed, causing errors. I updated all usages, but as this wasn't merged at the time this got missed. The outputs should now be updated to use the correct names.