### PR TITLE
EL-3221 - Item Display Panel

### DIFF
--- a/docs/app/pages/components/components-sections/panels/item-display-panel-ng1/item-display-panel-ng1.component.html
+++ b/docs/app/pages/components/components-sections/panels/item-display-panel-ng1/item-display-panel-ng1.component.html
@@ -12,6 +12,12 @@
 
 <p>The following defining the modal are set in the <code>panel</code> property of each <code>item</code>.</p>
 
+<p>
+    If you have a modal that appears over the top of a display panel ensure you
+    add <code>ng-mouseup="$event.stopPropagation()"</code> to the modal element and any buttons within the modal
+    to prevent the display panel from closing when mouse events occur.
+</p>
+
 <uxd-api-properties>
     <tr uxd-api-property name="title" type="string">
         Defines the Header title of the item display panel.

--- a/docs/app/pages/components/components-sections/panels/item-display-panel-ng1/item-display-panel-ng1.component.html
+++ b/docs/app/pages/components/components-sections/panels/item-display-panel-ng1/item-display-panel-ng1.component.html
@@ -15,7 +15,8 @@
 <p>
     If you have a modal that appears over the top of a display panel ensure you
     add <code>ng-mouseup="$event.stopPropagation()"</code> to the modal element and any buttons within the modal
-    to prevent the display panel from closing when mouse events occur.
+    to prevent the display panel from closing when mouse events occur. Alternatively, setting the <code>outsideClick</code>
+    property to <code>false</code> in the display panel options can also be used.
 </p>
 
 <uxd-api-properties>
@@ -42,6 +43,9 @@
     </tr>
     <tr uxd-api-property name="animate" type="boolean" defaultValue="false">
         A boolean value to set the panel to animate in and out of the screen.
+    </tr>
+    <tr uxd-api-property name="outsideClick" type="boolean" defaultValue="true">
+        A boolean value to indicate whether or not clicking outside of the panel should close it.
     </tr>
 </uxd-api-properties>
 

--- a/src/ng1/directives/displayPanels/displayPanel.service.js
+++ b/src/ng1/directives/displayPanels/displayPanel.service.js
@@ -1,99 +1,164 @@
-$displayPanel.$inject = ["$compile", "$timeout", "$document"];
+export class DisplayPanelService {
 
-export default function $displayPanel($compile, $timeout, $document) {
-  var $displayPanel = {};
-  var isOpen = false;
-  var isHidden = false;
-  var current;
-  var element;
-  var scope;
-  var content;
+/**
+ * @param {ng.ICompileService} $compile
+ * @param {ng.ITimeoutService} $timeout
+ * @param {ng.IDocumentService} $document
+ */
+  constructor($compile, $timeout, $document) {
 
-  $displayPanel.open = function(elem, itemDisplayPanelOptions, shadow, previous, next){
-    if(!isOpen){
-      //create item display panel if one dosnt exist
-      var displayPanel = '<div display-panel class="displayPanel"></div>';
-      scope = itemDisplayPanelOptions.scope.$new();
-      scope.modalOpt = itemDisplayPanelOptions;
-      scope.shadow = shadow;
-      scope.previousBtnStatus = previous;
-      scope.nextBtnStatus = next;
-      element = $compile(displayPanel)(scope);
-      $document.find("body").append(element);
-      isOpen = true;
-    } else if (isHidden){
-      //add scope
-      scope = itemDisplayPanelOptions.scope.$new();
-      scope.modalOpt = itemDisplayPanelOptions;
-      scope.shadow = shadow;
-      scope.previousBtnStatus = previous;
-      scope.nextBtnStatus = next;
-      element = $compile(element)(scope);
+    this.$compile = $compile;
+    this.$timeout = $timeout;
+    this.$document = $document;
 
-      //show display panel again if its hidden (only applies to animate)
-      scope.modalOpt = itemDisplayPanelOptions;
-      content.style.transform = "translate(110%)";
-      content.classList.add("display-panel-animate");
-      $timeout(function() {
-        content.style.transform = "translate(0)";
-      }); 
-      isHidden = false;
+    /** @type {boolean} */
+    this.isOpen = false;
+
+    /** @type {boolean} */
+    this.isHidden = false;
+
+    /** @type {JQuery} */
+    this.current = null;
+
+    /** @type {JQuery} */
+    this.element = null;
+
+    /** @type {ng.IScope} */
+    this.scope = null;
+
+    /** @type {*} */
+    this.content = null;
+  }
+
+  /**
+   * Open a Display Panel
+   * @param {JQuery} element
+   * @param {DisplayPanelOptions} options
+   * @param {boolean} shadow
+   * @param {boolean} previous
+   * @param {boolean} next
+   */
+  open(element, options, shadow, isFirst, isLast) {
+
+    if (!this.isOpen) {
+      // create item display panel if one dosnt exist
+      this.scope = options.scope.$new();
+      this.scope.modalOpt = options;
+      this.scope.shadow = shadow;
+      this.scope.previousBtnStatus = isFirst;
+      this.scope.nextBtnStatus = isLast;
+      this.element = this.$compile('<div display-panel class="displayPanel"></div>')(this.scope);
+      this.$document.find('body').append(this.element);
+      this.isOpen = true;
+    } else if (this.isHidden) {
+      // add scope
+      this.scope = options.scope.$new();
+      this.scope.modalOpt = options;
+      this.scope.shadow = shadow;
+      this.scope.previousBtnStatus = isFirst;
+      this.scope.nextBtnStatus = isLast;
+      this.element = this.$compile(this.element)(this.scope);
+
+      // show display panel again if its hidden (only applies to animate)
+      this.scope.modalOpt = options;
+      this.content.style.transform = 'translate(110%)';
+      this.content.classList.add('display-panel-animate');
+      this.$timeout(() => this.content.style.transform = 'translate(0)');
+      this.isHidden = false;
     }
-    else if (elem !== current) {
-      //update if display panel exists
-      scope.modalOpt = itemDisplayPanelOptions;
-      scope.previousBtnStatus = previous;
-      scope.nextBtnStatus = next;
+    else if (element !== this.current) {
+      // update if display panel exists
+      this.scope.modalOpt = options;
+      this.scope.previousBtnStatus = isFirst;
+      this.scope.nextBtnStatus = isLast;
     }
-    current = elem;
-  };
+    this.current = element;
+  }
 
-  $displayPanel.close = function(itemDisplayPanelOptions){
-    if(itemDisplayPanelOptions.animate){
-        //only hide if animate is true to avoid iddues with transitions then destroy scope
-        content = element[0].querySelector(".display-panel");
-        content.style.transform = "translate(110%)";
-        isHidden = true;
-        scope.$destroy();
-      } else {
-        //remove item display panel
-        element.remove();
-        isOpen = false;
-        scope.$destroy();
-      }
-  };
+  /**
+   * Close a display panel
+   * @param {DisplayPanelOptions} options
+   */
+  close(options) {
+    if (options.animate) {
+      //only hide if animate is true to avoid iddues with transitions then destroy scope
+      this.content = this.element[0].querySelector('.display-panel');
+      this.content.style.transform = 'translate(110%)';
+      this.isHidden = true;
+      this.scope.$destroy();
+    } else {
+      //remove item display panel
+      this.element.remove();
+      this.isOpen = false;
+      this.scope.$destroy();
+    }
+  }
 
-  $displayPanel.panelOpen = function(){
-    return isOpen;
-  };
+  /**
+   * Determine if a display panel is open
+   * @returns {boolean}
+   */
+  panelOpen() {
+    return this.isOpen;
+  }
 
-  $displayPanel.panelHidden = function(){
-    return isHidden;
-  };
+  /**
+   * Determine if a display panel is hidden
+   * @returns {boolean}
+   */
+  panelHidden() {
+    return this.isHidden;
+  }
 
-  $displayPanel.getCurrentPanel = function() {
-    return current;
-  };
+  /**
+   * Get the current panel element
+   * @returns {JQuery}
+   */
+  getCurrentPanel() {
+    return this.current;
+  }
 
-  $displayPanel.movePrev = function(selector) {
-    if (current && current.length) {
-      var prev = current.prevAll(selector).first();
+  /**
+   * Move to the previous display panel item
+   * @param {string} selector
+   */
+  movePrev(selector) {
+    if (this.current && this.current.length) {
+      var prev = this.current.prevAll(selector).first();
       if (prev.length > 0) {
         prev.focus();
-        current = prev;
+        this.current = prev;
       }
     }
-  };
+  }
 
-  $displayPanel.moveNext = function(selector) {
-    if (current && current.length) {
-      var next = current.nextAll(selector).first();
+  /**
+   * Move to the next display panel item
+   * @param {string} selector
+   */
+  moveNext(selector) {
+    if (this.current && this.current.length) {
+      var next = this.current.nextAll(selector).first();
       if (next.length > 0) {
         next.focus();
-        current = next;
+        this.current = next;
       }
     }
-  };
-
-  return $displayPanel;
+  }
 }
+
+DisplayPanelService.$inject = ['$compile', '$timeout', '$document'];
+
+/**
+ * @typedef DisplayPanelOptions
+ * @type {Object}
+ * @property {string} title - Defines the Header title of the item display panel.
+ * @property {string} main - Provides a path to a template representing item display panel content.
+ * @property {string} footer - Provides a path to a template representing item display panel footer content.
+ * @property {string} modalColumns - Classes defining the number of columns as per the grid system for a responsive item display panel or a class with a preset width.
+ * @property {number} top - Defines the initial top position of the modal with respect to standard header, condensed header or toolbar.
+ * @property {string} reference - Element id or class, item display panel is displayed in reference to this element after scroll.
+ * @property {ng.IScope} scope - A scope instance to be used for the modal's main content.
+ * @property {boolean} animate - A boolean value to set the panel to animate in and out of the screen.
+ * @property {boolean} outsideClick - A boolean value to indicate whether or not clicking outside of the panel should close it.
+ */

--- a/src/ng1/directives/displayPanels/displayPanelItem/displayPanelItem.directive.js
+++ b/src/ng1/directives/displayPanels/displayPanelItem/displayPanelItem.directive.js
@@ -1,6 +1,6 @@
-displayPanelItem.$inject = ["$displayPanel", "keyboardService", "$timeout"];
+DisplayPanelItemDirective.$inject = ['$displayPanel', 'keyboardService', '$timeout'];
 
-export default function displayPanelItem($displayPanel, keyboardService, $timeout) {
+export function DisplayPanelItemDirective($displayPanel, keyboardService, $timeout) {
   return {
     restrict: 'A',
     scope: true,
@@ -8,47 +8,39 @@ export default function displayPanelItem($displayPanel, keyboardService, $timeou
       scope.displayPanelItem = scope.$eval(attrs.displayPanelItem);
       scope.shadow = scope.$eval(attrs.shadow);
 
-      var showDisplayPanel = function(){
-        var previous = (element.is(':first-child')) ? true : false;
-        var next = (element.is(':last-child')) ? true : false;
+      const showDisplayPanel = function () {
+        const isFirst = (element.is(':first-child')) ? true : false;
+        const isLast = (element.is(':last-child')) ? true : false;
 
-        $displayPanel.open(element, scope.displayPanelItem, scope.shadow, previous, next);          
+        $displayPanel.open(element, scope.displayPanelItem, scope.shadow, isFirst, isLast);
       };
 
-      var hideDisplayPanel = function(){
-        $displayPanel.close(scope.displayPanelItem);          
-      };
+      const hideDisplayPanel = () => $displayPanel.close(scope.displayPanelItem);
 
       //update the panel if it visible
-      var updatePanel = function() {
+      const updatePanel = function () {
         if ($displayPanel.panelOpen() && !$displayPanel.panelHidden()) {
-          $timeout( function() {
-            showDisplayPanel();
-          });
+          $timeout(() => showDisplayPanel());
         }
       };
 
+      // this will be the item we are focusing on
+      let goToItem = element;
+
       //listen for click
-      element[0].addEventListener("click", function() {
-        $timeout(function() {
-          showDisplayPanel();  
-        });          
-      });
+      element[0].addEventListener('click', () => $timeout(() => showDisplayPanel()));
 
       //listen for focus
-      element[0].addEventListener("focus", updatePanel);
+      element[0].addEventListener('focus', updatePanel);
 
       // down key press - go to next item
-      keyboardService.keydown(element, 40, function(evt) {
+      keyboardService.keydown(element, 40, function (evt) {
         evt.preventDefault();
         goToNext();
       });
 
-      // this will be the item we are focusing on
-      var goToItem = element;
-      
       // up keypress - go to previous item
-      keyboardService.keydown(element, 38, function(evt) {
+      keyboardService.keydown(element, 38, function (evt) {
         evt.preventDefault();
         goToPrevious();
       });
@@ -60,7 +52,7 @@ export default function displayPanelItem($displayPanel, keyboardService, $timeou
       }
 
       // down key press - go to next item
-      keyboardService.keydown(element, 40, function(evt) {
+      keyboardService.keydown(element, 40, function (evt) {
         evt.preventDefault();
         goToNext();
       });
@@ -73,22 +65,22 @@ export default function displayPanelItem($displayPanel, keyboardService, $timeou
 
       // when clicking Previous button go to previous item
       scope.$on('$displayPanelPrevious', function () {
-        if($displayPanel.getCurrentPanel() === element){
+        if ($displayPanel.getCurrentPanel() === element) {
           goToPrevious();
         }
       });
 
       // when clicking Next button go to next item
       scope.$on('$displayPanelNext', function () {
-        if($displayPanel.getCurrentPanel() === element){
+        if ($displayPanel.getCurrentPanel() === element) {
           goToNext();
         }
       });
 
       // pg up key press - go to 10th previous item or 1st item if not possible
-      keyboardService.keydown(element, 33, function(evt) {
+      keyboardService.keydown(element, 33, function (evt) {
         evt.preventDefault();
-        var itemToJumpTo = element.prevAll('[display-panel-item]');
+        const itemToJumpTo = element.prevAll('[display-panel-item]');
         if (itemToJumpTo.length) {
           goToItem = element.prevAll('[display-panel-item]:eq(10)').length ? element.prevAll('[display-panel-item]:eq(10)') : itemToJumpTo[itemToJumpTo.length - 1];
           goToItem.focus();
@@ -96,9 +88,9 @@ export default function displayPanelItem($displayPanel, keyboardService, $timeou
       });
 
       // pg down key press - go to 10th next item or last item if not possible
-      keyboardService.keydown(element, 34, function(evt) {
+      keyboardService.keydown(element, 34, function (evt) {
         evt.preventDefault();
-        var itemToJumpTo = element.nextAll('[display-panel-item]');
+        const itemToJumpTo = element.nextAll('[display-panel-item]');
         if (itemToJumpTo.length) {
           goToItem = element.nextAll('[display-panel-item]:eq(10)').length ? element.nextAll('[display-panel-item]:eq(10)') : itemToJumpTo[itemToJumpTo.length - 1];
           goToItem.focus();
@@ -106,40 +98,34 @@ export default function displayPanelItem($displayPanel, keyboardService, $timeou
       });
 
       // home key press - go to the first item
-      keyboardService.keydown(element, 36, function(evt) {
+      keyboardService.keydown(element, 36, function (evt) {
         evt.preventDefault();
         goToItem = element.prevAll('[display-panel-item]:last');
         goToItem.focus();
       });
 
       // end key press - go to the last item
-      keyboardService.keydown(element, 35, function(evt) {
+      keyboardService.keydown(element, 35, function (evt) {
         evt.preventDefault();
         goToItem = element.nextAll('[display-panel-item]:last');
         goToItem.focus();
       });
 
       // esc key press - if display panel is open, close it. Otherwise blur focus on item
-      keyboardService.keydown(element, 27, function(evt) {
+      keyboardService.keydown(element, 27, function (evt) {
         evt.preventDefault();
         if ($displayPanel.panelOpen() && !$displayPanel.panelHidden()) {
           hideDisplayPanel();
         } else {
           element.blur();
-        }  
+        }
       });
 
-      // enter key press - show the display panel 
-      keyboardService.keydown(element, 13, function() {
-        $timeout( function() {
-          showDisplayPanel();
-        });
-      });
+      // enter key press - show the display panel
+      keyboardService.keydown(element, 13, () => $timeout(() => showDisplayPanel()));
 
-      // spacebar press - show the display panel 
-      keyboardService.keydown(element, 32, function(evt) {
-        evt.preventDefault();
-      });
+      // spacebar press - show the display panel
+      keyboardService.keydown(element, 32, evt => evt.preventDefault());
 
     }
   };

--- a/src/ng1/directives/displayPanels/displayPanels.module.js
+++ b/src/ng1/directives/displayPanels/displayPanels.module.js
@@ -1,9 +1,9 @@
-import DisplayPanelService from './displayPanel.service.js';
-import DisplayPanelDirective from './displayPanel/displayPanel.directive.js';
-import DisplayPanelItemDirective from './displayPanelItem/displayPanelItem.directive.js';
-import '../../services/keyboardService/keyboardService.module.js';
-  
+import '../../services/keyboardService/keyboardService.module';
+import { DisplayPanelService } from './displayPanel.service';
+import { DisplayPanelDirective } from './displayPanel/displayPanel.directive';
+import { DisplayPanelItemDirective } from './displayPanelItem/displayPanelItem.directive';
+
 angular.module("ux-aspects.displayPanels", ['ux-aspects.keyboardService'])
-	.factory('$displayPanel', DisplayPanelService)
+	.service('$displayPanel', DisplayPanelService)
 	.directive('displayPanel', DisplayPanelDirective)
 	.directive('displayPanelItem', DisplayPanelItemDirective);


### PR DESCRIPTION
The display panel listens for a document mouse up event to check if an outside click has occurred. To prevent clicks within a modal from closing a display panel you can use `ng-mouseup="$event.stopPropagation()"`. I have documented this.