### PR TITLE
EL-3226 - Splitter Panel Bug Fix

### DIFF
--- a/src/ng1/directives/splitter/splitter.directive.js
+++ b/src/ng1/directives/splitter/splitter.directive.js
@@ -207,7 +207,6 @@ export default function splitter($compile, $timeout) {
               Create a toggle for the side panel
             */
             function createToggleButton(mainPanel, sidePanel) {
-
                 var toggleDirection;
 
                 options = getOptions();
@@ -409,7 +408,9 @@ export default function splitter($compile, $timeout) {
                     //side panel to the right of main panel
                     gutterIndex = sidePanelIndex - 1;
                 }
-                return element.find(".gutter").eq(gutterIndex);
+
+                // find gutters that are immediate children (in case there are nested splitters)
+                return element.find("> .gutter").eq(gutterIndex);
             }
 
             function getWidths(mainPanel, sidePanel) {


### PR DESCRIPTION
When inserting the toggle button a search was performed for `.gutter`, however when there is a nested splitter in the first splitter panel, it was detecting the gutter in the nested splitter rather than the parent splitter.

Altered the query to only perform the search on immediate children