### PR TITLE
EL-3237 - Static Tooltip Width

### DIFF
--- a/src/components/popover/popover.component.less
+++ b/src/components/popover/popover.component.less
@@ -1,7 +1,6 @@
 ux-popover {
     .popover {
         position: static;
-        max-width: none;
 
         &.top {
             transform: translateY(-11px);


### PR DESCRIPTION
Reverted change that previously removed the max-width. This change was made as part of the colour picker ticket, however the colour picker ended up using the dropdown instead of the popover anyway so this change has no effect on the colour picker.