### PR TITLE
EL-3227 - Button Dropdown Spacing

### DIFF
--- a/docs/app/pages/components/components-sections/buttons/dropdowns/dropdowns.component.less
+++ b/docs/app/pages/components/components-sections/buttons/dropdowns/dropdowns.component.less
@@ -12,7 +12,6 @@
 
 .case-items {
     height: 195px;
-    width: 160px;
     overflow: auto;
 }
 

--- a/src/styles/navigation.less
+++ b/src/styles/navigation.less
@@ -1031,6 +1031,7 @@ h4 {
         .dropdown-menu-hint {
             color: @dropdown-menu-hint;
             font-size: 80%;
+            margin-left: 16px;
         }
     }
 


### PR DESCRIPTION
- Ensuring that there is always enough spacing between the dropdown item and the shortcut hint
- Ensuring that the scrollbar does not appear in the middle of the menu