### PR TITLE
EL-3268 - Adding Date Picker Localization Support

### DIFF
--- a/docs/app/pages/components/components-sections/date-time-picker/date-time-picker/date-time-picker.component.html
+++ b/docs/app/pages/components/components-sections/date-time-picker/date-time-picker/date-time-picker.component.html
@@ -115,6 +115,48 @@
     </tr>
 </uxd-api-properties>
 
+<p>
+    To provide default settings for all date pickers within you application, import <code>DateTimePickerModule.forRoot()</code> in your <code>app.module.ts</code>.
+    You can then inject the <code>DateTimePickerConfig</code> and configure the default presentation and localization settings for every date picker
+    within your application.
+</p>
+
+<uxd-api-properties tableTitle="DateTimePickerConfig">
+    <tr uxd-api-property name="showDate" type="boolean">
+        Defines whether or not the date picker should be visible.
+    </tr>
+    <tr uxd-api-property name="showTime" type="boolean">
+        Defines whether or not the time picker should be visible.
+    </tr>
+    <tr uxd-api-property name="showTimezone" type="boolean">
+        Defines whether or not the time picker should allow the user to choose a timezone.
+    </tr>
+    <tr uxd-api-property name="showSeconds" type="boolean">
+        Defines whether or not the time picker should allow the user to specify seconds.
+    </tr>
+    <tr uxd-api-property name="showMeridian" type="boolean">
+        Defines whether or not the time picker should show an AM/PM button, or time should be represented in 24hr format instead.
+    </tr>
+    <tr uxd-api-property name="showSpinners" type="boolean">
+        Defines whether or not the time picker should allow the user to select the time using spinners.
+    </tr>
+    <tr uxd-api-property name="weekdays" type="string[]">
+        If defined will override the weekday names displayed.
+    </tr>
+    <tr uxd-api-property name="nowBtnText" type="string">
+        Defines the text to be displayed in the button used to set the selected time to the current time.
+    </tr>
+    <tr uxd-api-property name="timezones" type="DateTimePickerTimezone[]">
+        Defines the timezones that can be selected.
+    </tr>
+    <tr uxd-api-property name="months" type="string[]">
+        Defines the names of the months. This can be used for localization purposes.
+    </tr>
+    <tr uxd-api-property name="monthsShort" type="string[]">
+        Defines the short names of each month. This can be used for localization purposes.
+    </tr>
+</uxd-api-properties>
+
 <p>The following code can be used to create the example above:</p>
 
 <ux-tabset [minimal]="false">

--- a/docs/app/pages/components/components-sections/date-time-picker/date-time-picker/date-time-picker.component.html
+++ b/docs/app/pages/components/components-sections/date-time-picker/date-time-picker/date-time-picker.component.html
@@ -101,6 +101,12 @@
     <tr uxd-api-property name="weekdays" type="string[]">
         If defined will override the weekday names displayed.
     </tr>
+    <tr uxd-api-property name="months" type="string[]">
+        Defines the names of the months.
+    </tr>
+    <tr uxd-api-property name="monthsShort" type="string[]">
+        Defines the short names of each month.
+    </tr>
     <tr uxd-api-property name="nowBtnText" type="string">
         Defines the text to be displayed in the button used to set the selected time to the current time.
     </tr>
@@ -150,10 +156,10 @@
         Defines the timezones that can be selected.
     </tr>
     <tr uxd-api-property name="months" type="string[]">
-        Defines the names of the months. This can be used for localization purposes.
+        Defines the names of the months.
     </tr>
     <tr uxd-api-property name="monthsShort" type="string[]">
-        Defines the short names of each month. This can be used for localization purposes.
+        Defines the short names of each month.
     </tr>
 </uxd-api-properties>
 

--- a/docs/app/pages/components/components-sections/date-time-picker/date-time-picker/date-time-picker.component.ts
+++ b/docs/app/pages/components/components-sections/date-time-picker/date-time-picker/date-time-picker.component.ts
@@ -2,11 +2,11 @@ import { AfterViewInit, Component, ElementRef, OnDestroy, ViewChild, ViewEncapsu
 import { fromEvent } from 'rxjs/observable/fromEvent';
 import { debounceTime } from 'rxjs/operators';
 import { Subscription } from 'rxjs/Subscription';
-import { DateTimePickerTimezone } from '../../../../../../../src/index';
 import { BaseDocumentationSection } from '../../../../../components/base-documentation-section/base-documentation-section';
 import { DocumentationSectionComponent } from '../../../../../decorators/documentation-section-component';
 import { IPlunk } from '../../../../../interfaces/IPlunk';
 import { IPlunkProvider } from '../../../../../interfaces/IPlunkProvider';
+import { DateTimePickerTimezone } from '../../../../../../../src/components/date-time-picker/date-time-picker.utils';
 
 @Component({
     selector: 'uxd-components-date-time-picker',
@@ -41,7 +41,7 @@ export class ComponentsDateTimePickerComponent extends BaseDocumentationSection 
             }
         ]
     };
-    
+
     constructor() {
         super(require.context('./snippets/', false, /\.(html|css|js|ts)$/));
     }

--- a/src/components/date-time-picker/date-time-picker.component.ts
+++ b/src/components/date-time-picker/date-time-picker.component.ts
@@ -42,6 +42,14 @@ export class DateTimePickerComponent implements OnDestroy {
     this.datepicker.weekdays$.next(value);
   }
 
+  @Input() set months(months: string[]) {
+    this.datepicker.months = months;
+  }
+
+  @Input() set monthsShort(months: string[]) {
+    this.datepicker.monthsShort = months;
+  }
+
   @Input() set nowBtnText(value: string) {
     this.datepicker.nowBtnText$.next(value);
   }

--- a/src/components/date-time-picker/date-time-picker.component.ts
+++ b/src/components/date-time-picker/date-time-picker.component.ts
@@ -1,8 +1,8 @@
 import { Component, EventEmitter, Input, OnDestroy, Output, ChangeDetectionStrategy } from '@angular/core';
 import { Subscription } from 'rxjs/Subscription';
 import { distinctUntilChanged } from 'rxjs/operators';
-import { DatePickerMode, DateTimePickerService, DateTimePickerTimezone } from './date-time-picker.service';
-import { dateComparator, timezoneComparator } from './date-time-picker.utils';
+import { DatePickerMode, DateTimePickerService } from './date-time-picker.service';
+import { dateComparator, timezoneComparator, DateTimePickerTimezone } from './date-time-picker.utils';
 
 @Component({
   selector: 'ux-date-time-picker',

--- a/src/components/date-time-picker/date-time-picker.component.ts
+++ b/src/components/date-time-picker/date-time-picker.component.ts
@@ -1,8 +1,8 @@
-import { Component, EventEmitter, Input, OnDestroy, Output, ChangeDetectionStrategy } from '@angular/core';
-import { Subscription } from 'rxjs/Subscription';
-import { distinctUntilChanged } from 'rxjs/operators';
+import { ChangeDetectionStrategy, Component, EventEmitter, Input, OnDestroy, Output } from '@angular/core';
+import { distinctUntilChanged, takeUntil } from 'rxjs/operators';
+import { Subject } from 'rxjs/Subject';
 import { DatePickerMode, DateTimePickerService } from './date-time-picker.service';
-import { dateComparator, timezoneComparator, DateTimePickerTimezone } from './date-time-picker.utils';
+import { dateComparator, DateTimePickerTimezone, timezoneComparator } from './date-time-picker.utils';
 
 @Component({
   selector: 'ux-date-time-picker',
@@ -11,8 +11,6 @@ import { dateComparator, timezoneComparator, DateTimePickerTimezone } from './da
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class DateTimePickerComponent implements OnDestroy {
-
-  private _timezone: DateTimePickerTimezone;
 
   @Input() set showDate(value: boolean) {
     this.datepicker.showDate$.next(value);
@@ -58,7 +56,6 @@ export class DateTimePickerComponent implements OnDestroy {
     this.datepicker.timezones$.next(value);
   }
 
-
   @Output() dateChange: EventEmitter<Date> = new EventEmitter<Date>();
   @Output() timezoneChange: EventEmitter<DateTimePickerTimezone> = new EventEmitter<DateTimePickerTimezone>();
 
@@ -77,18 +74,19 @@ export class DateTimePickerComponent implements OnDestroy {
   // expose enum to view
   DatePickerMode = DatePickerMode;
 
-  private _subscription = new Subscription();
+  private _onDestroy = new Subject<void>();
 
   constructor(public datepicker: DateTimePickerService) {
-    const valueChange = datepicker.selected$.pipe(distinctUntilChanged(dateComparator))
+    datepicker.selected$.pipe(takeUntil(this._onDestroy), distinctUntilChanged(dateComparator))
       .subscribe(date => this.dateChange.emit(date));
 
-    const timezoneChange = datepicker.timezone$.pipe(distinctUntilChanged(timezoneComparator))
+    datepicker.timezone$.pipe(takeUntil(this._onDestroy), distinctUntilChanged(timezoneComparator))
       .subscribe((timezone: DateTimePickerTimezone) => this.timezoneChange.emit(timezone));
   }
 
   ngOnDestroy(): void {
-    this._subscription.unsubscribe();
+    this._onDestroy.next();
+    this._onDestroy.complete();
   }
 
   /**

--- a/src/components/date-time-picker/date-time-picker.config.ts
+++ b/src/components/date-time-picker/date-time-picker.config.ts
@@ -5,8 +5,7 @@
  */
 
 import { Injectable } from '@angular/core';
-import { weekdaysShort } from './date-time-picker.utils';
-import { DateTimePickerTimezone } from './date-time-picker.service';
+import { weekdaysShort, timezones, months, DateTimePickerTimezone, monthsShort } from './date-time-picker.utils';
 
 @Injectable()
 export class DateTimePickerConfig {
@@ -19,31 +18,7 @@ export class DateTimePickerConfig {
     showSpinners: boolean = true;
     weekdays: string[] = weekdaysShort;
     nowBtnText: string = 'Today';
-
-    timezones: DateTimePickerTimezone[] = [
-        { name: 'GMT-11', offset: 660 },
-        { name: 'GMT-10', offset: 600 },
-        { name: 'GMT-9', offset: 540 },
-        { name: 'GMT-8', offset: 480 },
-        { name: 'GMT-7', offset: 420 },
-        { name: 'GMT-6', offset: 360 },
-        { name: 'GMT-5', offset: 300 },
-        { name: 'GMT-4', offset: 240 },
-        { name: 'GMT-3', offset: 180 },
-        { name: 'GMT-2', offset: 120 },
-        { name: 'GMT-1', offset: 60 },
-        { name: 'GMT', offset: 0 },
-        { name: 'GMT+1', offset: -60 },
-        { name: 'GMT+2', offset: -120 },
-        { name: 'GMT+3', offset: -180 },
-        { name: 'GMT+4', offset: -240 },
-        { name: 'GMT+5', offset: -300 },
-        { name: 'GMT+6', offset: -360 },
-        { name: 'GMT+7', offset: -420 },
-        { name: 'GMT+8', offset: -480 },
-        { name: 'GMT+9', offset: -540 },
-        { name: 'GMT+10', offset: -600 },
-        { name: 'GMT+11', offset: -660 },
-        { name: 'GMT+12', offset: -720 }
-    ];
+    timezones: DateTimePickerTimezone[] = timezones;
+    months: string[] = months;
+    monthsShort: string[] = monthsShort;
 }

--- a/src/components/date-time-picker/date-time-picker.module.ts
+++ b/src/components/date-time-picker/date-time-picker.module.ts
@@ -11,6 +11,7 @@ import { MonthViewComponent } from './month-view/month-view.component';
 import { TimeViewComponent } from './time-view/time-view.component';
 import { YearViewComponent } from './year-view/year-view.component';
 import { FocusIfModule } from '../../directives/focus-if/index';
+import { ModuleWithProviders } from '@angular/core';
 
 @NgModule({
     imports: [
@@ -21,9 +22,15 @@ import { FocusIfModule } from '../../directives/focus-if/index';
         FocusIfModule
     ],
     exports: [DateTimePickerComponent],
-    declarations: [DateTimePickerComponent, HeaderComponent, DayViewComponent, MonthViewComponent, YearViewComponent, TimeViewComponent],
-    providers: [
-        DateTimePickerConfig
-    ]
+    declarations: [DateTimePickerComponent, HeaderComponent, DayViewComponent, MonthViewComponent, YearViewComponent, TimeViewComponent]
 })
-export class DateTimePickerModule { }
+export class DateTimePickerModule {
+    static forRoot(): ModuleWithProviders {
+        return {
+            ngModule: DateTimePickerModule,
+            providers: [
+                DateTimePickerConfig
+            ]
+        };
+    }
+}

--- a/src/components/date-time-picker/date-time-picker.service.ts
+++ b/src/components/date-time-picker/date-time-picker.service.ts
@@ -1,10 +1,10 @@
-import { Injectable } from '@angular/core';
+import { Injectable, Optional } from '@angular/core';
 import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 import { Subject } from 'rxjs/Subject';
 import { Subscription } from 'rxjs/Subscription';
 import { distinctUntilChanged } from 'rxjs/operators';
 import { DateTimePickerConfig } from './date-time-picker.config';
-import { dateComparator } from './date-time-picker.utils';
+import { dateComparator, weekdaysShort, timezones, DateTimePickerTimezone } from './date-time-picker.utils';
 
 @Injectable()
 export class DateTimePickerService {
@@ -18,15 +18,15 @@ export class DateTimePickerService {
     month$: BehaviorSubject<number> = new BehaviorSubject<number>(new Date().getMonth());
     year$: BehaviorSubject<number> = new BehaviorSubject<number>(new Date().getFullYear());
 
-    showDate$ = new BehaviorSubject<boolean>(this._config.showDate);
-    showTime$ = new BehaviorSubject<boolean>(this._config.showTime);
-    showTimezone$ = new BehaviorSubject<boolean>(this._config.showTimezone);
-    showSeconds$ = new BehaviorSubject<boolean>(this._config.showSeconds);
-    showMeridian$ = new BehaviorSubject<boolean>(this._config.showMeridian);
-    showSpinners$ = new BehaviorSubject<boolean>(this._config.showSpinners);
-    weekdays$ = new BehaviorSubject<string[]>(this._config.weekdays);
-    nowBtnText$ = new BehaviorSubject<string>(this._config.nowBtnText);
-    timezones$ = new BehaviorSubject<DateTimePickerTimezone[]>(this._config.timezones);
+    showDate$ = new BehaviorSubject<boolean>(this._config ? this._config.showDate : true);
+    showTime$ = new BehaviorSubject<boolean>(this._config ? this._config.showTime : true);
+    showTimezone$ = new BehaviorSubject<boolean>(this._config ? this._config.showTimezone : true);
+    showSeconds$ = new BehaviorSubject<boolean>(this._config ? this._config.showSeconds : false);
+    showMeridian$ = new BehaviorSubject<boolean>(this._config ? this._config.showMeridian : true);
+    showSpinners$ = new BehaviorSubject<boolean>(this._config ? this._config.showSpinners : true);
+    weekdays$ = new BehaviorSubject<string[]>(this._config ? this._config.weekdays : weekdaysShort);
+    nowBtnText$ = new BehaviorSubject<string>(this._config ? this._config.nowBtnText : 'Today');
+    timezones$ = new BehaviorSubject<DateTimePickerTimezone[]>(this._config ? this._config.timezones : timezones);
 
     header$ = new BehaviorSubject<string>(null);
     headerEvent$ = new Subject<DatePickerHeaderEvent>();
@@ -34,7 +34,7 @@ export class DateTimePickerService {
 
     private _subscription: Subscription;
 
-    constructor(private _config: DateTimePickerConfig) {
+    constructor(@Optional() private _config: DateTimePickerConfig) {
 
         // when the active date changes set the currently selected date
         this._subscription = this.selected$.pipe(distinctUntilChanged(dateComparator)).subscribe(date => {
@@ -126,7 +126,8 @@ export class DateTimePickerService {
 
     getCurrentTimezone(): DateTimePickerTimezone {
         const offset = new Date().getTimezoneOffset();
-        return this._config.timezones.find(timezone => timezone.offset === offset);
+        const zones = this._config ? this._config.timezones : timezones;
+        return zones.find(timezone => timezone.offset === offset);
     }
 
     setTimezone(timezone: DateTimePickerTimezone): void {
@@ -149,9 +150,4 @@ export enum ModeDirection {
 export enum DatePickerHeaderEvent {
     Previous,
     Next
-}
-
-export interface DateTimePickerTimezone {
-    name: string;
-    offset: number;
 }

--- a/src/components/date-time-picker/date-time-picker.service.ts
+++ b/src/components/date-time-picker/date-time-picker.service.ts
@@ -4,7 +4,7 @@ import { Subject } from 'rxjs/Subject';
 import { Subscription } from 'rxjs/Subscription';
 import { distinctUntilChanged } from 'rxjs/operators';
 import { DateTimePickerConfig } from './date-time-picker.config';
-import { dateComparator, weekdaysShort, timezones, DateTimePickerTimezone } from './date-time-picker.utils';
+import { dateComparator, weekdaysShort, timezones, DateTimePickerTimezone, months, monthsShort } from './date-time-picker.utils';
 
 @Injectable()
 export class DateTimePickerService {
@@ -31,6 +31,9 @@ export class DateTimePickerService {
     header$ = new BehaviorSubject<string>(null);
     headerEvent$ = new Subject<DatePickerHeaderEvent>();
     modeDirection: ModeDirection = ModeDirection.None;
+
+    months: string[] = this._config ? this._config.months : months;
+    monthsShort: string[] = this._config ? this._config.monthsShort : monthsShort;
 
     private _subscription: Subscription;
 

--- a/src/components/date-time-picker/date-time-picker.utils.ts
+++ b/src/components/date-time-picker/date-time-picker.utils.ts
@@ -1,6 +1,3 @@
-import { DateTimePickerTimezone } from './date-time-picker.service';
-
-
 /**
  * Convert a single dimension array to a double dimension array
  * @param items the single dimension array to convert
@@ -93,3 +90,36 @@ export const monthsShort = months.map(month => month.substring(0, 3));
  */
 export const weekdays = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'];
 export const weekdaysShort = weekdays.map(weekday => weekday.substring(0, 3));
+
+/** Export the default set of time zone */
+export const timezones: DateTimePickerTimezone[] = [
+    { name: 'GMT-11', offset: 660 },
+    { name: 'GMT-10', offset: 600 },
+    { name: 'GMT-9', offset: 540 },
+    { name: 'GMT-8', offset: 480 },
+    { name: 'GMT-7', offset: 420 },
+    { name: 'GMT-6', offset: 360 },
+    { name: 'GMT-5', offset: 300 },
+    { name: 'GMT-4', offset: 240 },
+    { name: 'GMT-3', offset: 180 },
+    { name: 'GMT-2', offset: 120 },
+    { name: 'GMT-1', offset: 60 },
+    { name: 'GMT', offset: 0 },
+    { name: 'GMT+1', offset: -60 },
+    { name: 'GMT+2', offset: -120 },
+    { name: 'GMT+3', offset: -180 },
+    { name: 'GMT+4', offset: -240 },
+    { name: 'GMT+5', offset: -300 },
+    { name: 'GMT+6', offset: -360 },
+    { name: 'GMT+7', offset: -420 },
+    { name: 'GMT+8', offset: -480 },
+    { name: 'GMT+9', offset: -540 },
+    { name: 'GMT+10', offset: -600 },
+    { name: 'GMT+11', offset: -660 },
+    { name: 'GMT+12', offset: -720 }
+];
+
+export interface DateTimePickerTimezone {
+    name: string;
+    offset: number;
+}

--- a/src/components/date-time-picker/date-time-picker.utils.ts
+++ b/src/components/date-time-picker/date-time-picker.utils.ts
@@ -88,7 +88,7 @@ export const monthsShort = months.map(month => month.substring(0, 3));
 /**
  * Export an array of all the available days of the week
  */
-export const weekdays = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'];
+export const weekdays = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
 export const weekdaysShort = weekdays.map(weekday => weekday.substring(0, 3));
 
 /** Export the default set of time zone */

--- a/src/components/date-time-picker/day-view/day-view.component.ts
+++ b/src/components/date-time-picker/day-view/day-view.component.ts
@@ -52,7 +52,7 @@ export class DayViewComponent implements OnDestroy {
     return index;
   }
 
-  trackDayByFn(index: number, item: DayViewItem): string {
+  trackDayByFn(_index: number, item: DayViewItem): string {
     return `${ item.day } ${ item.month } ${ item.year }`;
   }
 

--- a/src/components/date-time-picker/day-view/day-view.service.ts
+++ b/src/components/date-time-picker/day-view/day-view.service.ts
@@ -4,6 +4,8 @@ import { Subscription } from 'rxjs/Subscription';
 import { combineLatest } from 'rxjs/observable/combineLatest';
 import { DateTimePickerService, ModeDirection } from '../date-time-picker.service';
 import { compareDays, dateRange, gridify, months } from '../date-time-picker.utils';
+import { DateTimePickerConfig } from '../date-time-picker.config';
+import { Optional } from '@angular/core';
 
 @Injectable()
 export class DayViewService implements OnDestroy {
@@ -13,7 +15,7 @@ export class DayViewService implements OnDestroy {
 
     private _subscription: Subscription;
 
-    constructor(private _datepicker: DateTimePickerService) {
+    constructor(private _datepicker: DateTimePickerService, @Optional() private _config: DateTimePickerConfig | undefined) {
         this._subscription = combineLatest(_datepicker.month$, _datepicker.year$)
             .subscribe(([month, year]) => this.createDayGrid(month, year));
     }
@@ -32,8 +34,11 @@ export class DayViewService implements OnDestroy {
 
     private createDayGrid(month: number, year: number): void {
 
+        // get the list of months
+        const monthList = this._config ? this._config.months : months;
+
         // update the header
-        this._datepicker.setHeader(months[month] + ' ' + year);
+        this._datepicker.setHeader(monthList[month] + ' ' + year);
 
         // find the lower and upper boundaries
         const start = new Date(year, month, 1);
@@ -73,7 +78,7 @@ export class DayViewService implements OnDestroy {
 
                 // find the first day of the month
                 const first = dates.find(date => date.day === 1);
-    
+
                 // focus the date
                 this.setFocus(first.day, first.month, first.year);
             }

--- a/src/components/date-time-picker/day-view/day-view.service.ts
+++ b/src/components/date-time-picker/day-view/day-view.service.ts
@@ -3,9 +3,7 @@ import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 import { Subscription } from 'rxjs/Subscription';
 import { combineLatest } from 'rxjs/observable/combineLatest';
 import { DateTimePickerService, ModeDirection } from '../date-time-picker.service';
-import { compareDays, dateRange, gridify, months } from '../date-time-picker.utils';
-import { DateTimePickerConfig } from '../date-time-picker.config';
-import { Optional } from '@angular/core';
+import { compareDays, dateRange, gridify } from '../date-time-picker.utils';
 
 @Injectable()
 export class DayViewService implements OnDestroy {
@@ -15,7 +13,7 @@ export class DayViewService implements OnDestroy {
 
     private _subscription: Subscription;
 
-    constructor(private _datepicker: DateTimePickerService, @Optional() private _config: DateTimePickerConfig | undefined) {
+    constructor(private _datepicker: DateTimePickerService) {
         this._subscription = combineLatest(_datepicker.month$, _datepicker.year$)
             .subscribe(([month, year]) => this.createDayGrid(month, year));
     }
@@ -34,11 +32,8 @@ export class DayViewService implements OnDestroy {
 
     private createDayGrid(month: number, year: number): void {
 
-        // get the list of months
-        const monthList = this._config ? this._config.months : months;
-
         // update the header
-        this._datepicker.setHeader(monthList[month] + ' ' + year);
+        this._datepicker.setHeader(this._datepicker.months[month] + ' ' + year);
 
         // find the lower and upper boundaries
         const start = new Date(year, month, 1);

--- a/src/components/date-time-picker/month-view/month-view.service.ts
+++ b/src/components/date-time-picker/month-view/month-view.service.ts
@@ -2,7 +2,9 @@ import { Injectable, OnDestroy } from '@angular/core';
 import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 import { Subscription } from 'rxjs/Subscription';
 import { DateTimePickerService, ModeDirection } from '../date-time-picker.service';
-import { gridify, monthsShort, range } from '../date-time-picker.utils';
+import { gridify, range, monthsShort } from '../date-time-picker.utils';
+import { DateTimePickerConfig } from '../date-time-picker.config';
+import { Optional } from '@angular/core';
 
 @Injectable()
 export class MonthViewService implements OnDestroy {
@@ -12,7 +14,7 @@ export class MonthViewService implements OnDestroy {
 
     private _subscription: Subscription;
 
-    constructor(private _datepicker: DateTimePickerService) {
+    constructor(private _datepicker: DateTimePickerService, @Optional() private _config: DateTimePickerConfig | undefined) {
         this._subscription = _datepicker.year$.subscribe(year => this.createMonthGrid(year));
     }
 
@@ -43,7 +45,7 @@ export class MonthViewService implements OnDestroy {
         // create a 4x3 grid of month numbers
         const months: MonthViewItem[] = range(0, 11).map(month => {
             return {
-                name: monthsShort[month],
+                name: this._config ? this._config.monthsShort[month] : monthsShort[month],
                 month: month,
                 year: year,
                 isCurrentMonth: year === currentYear && month === currentMonth,
@@ -59,7 +61,7 @@ export class MonthViewService implements OnDestroy {
 
         // if there is no focused month select the first one
         if (this._datepicker.modeDirection === ModeDirection.Descend && this.focused$.value === null) {
-            
+
             // check if the selected month is in view
             const selectedMonth = months.find(month => month.isActiveMonth);
 

--- a/src/components/date-time-picker/month-view/month-view.service.ts
+++ b/src/components/date-time-picker/month-view/month-view.service.ts
@@ -2,9 +2,7 @@ import { Injectable, OnDestroy } from '@angular/core';
 import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 import { Subscription } from 'rxjs/Subscription';
 import { DateTimePickerService, ModeDirection } from '../date-time-picker.service';
-import { gridify, range, monthsShort } from '../date-time-picker.utils';
-import { DateTimePickerConfig } from '../date-time-picker.config';
-import { Optional } from '@angular/core';
+import { gridify, range } from '../date-time-picker.utils';
 
 @Injectable()
 export class MonthViewService implements OnDestroy {
@@ -14,7 +12,7 @@ export class MonthViewService implements OnDestroy {
 
     private _subscription: Subscription;
 
-    constructor(private _datepicker: DateTimePickerService, @Optional() private _config: DateTimePickerConfig | undefined) {
+    constructor(private _datepicker: DateTimePickerService) {
         this._subscription = _datepicker.year$.subscribe(year => this.createMonthGrid(year));
     }
 
@@ -45,7 +43,7 @@ export class MonthViewService implements OnDestroy {
         // create a 4x3 grid of month numbers
         const months: MonthViewItem[] = range(0, 11).map(month => {
             return {
-                name: this._config ? this._config.monthsShort[month] : monthsShort[month],
+                name: this._datepicker.monthsShort[month],
                 month: month,
                 year: year,
                 isCurrentMonth: year === currentYear && month === currentMonth,


### PR DESCRIPTION
- Added month and monthShort properties to our date picker config service
- Added a forRoot function on our module to ensure this service is only imported in the app module, otherwise this will not work in lazy loaded modules.
- Updated components to always use the value from the config service when it is available - otherwise fallback on default values
- Documented the configuration service
- Added month properties to the component to change it only for a specific instance of the component rather than setting it as the global default

Additional Issue Reported. The day headers were showing Friday when the day was actually a Thursday. It turns out we had an array of day names. The array started at Monday, when Sunday would be day 0 so I have reordered the array to display correctly. We may want to allow customisation of the start day, however there is quite a bit of calculation involved to do this and larger work than the scope of this ticket.