### PR TITLE
Release 1.6.5

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "ux-aspects",
-  "version": "1.6.4",
+  "version": "1.6.5",
   "description": "Responsive UI Framework for Big Data Applications - CSS & Angular modules.",
   "keywords": [
     "js",

--- a/docs/app/data/config.dev.json
+++ b/docs/app/data/config.dev.json
@@ -1,6 +1,5 @@
 {
     "version": "{{VERSION}}",
-    "assetsUrl": "http://localhost:8080/assets",
     "codePen": "https://codepen.io/pen/define",
     "plunker": "https://plnkr.co/edit/?p=preview"
 }

--- a/docs/app/data/config.json
+++ b/docs/app/data/config.json
@@ -1,6 +1,5 @@
 {
     "version": "{{VERSION}}",
-    "assetsUrl": "https://uxaspects.github.io/UXAspects/assets",
     "codePen": "https://codepen.io/pen/define",
     "plunker": "https://plnkr.co/edit/?p=preview"
 }

--- a/docs/app/pages/changelog/changelog.component.ts
+++ b/docs/app/pages/changelog/changelog.component.ts
@@ -15,6 +15,11 @@ export class ChangeLogPageComponent {
 
         this.logs = [
             {
+                version: '1.6.5',
+                date: 'October 11th 2018',
+                content: require('./logs/release-v1.6.5.md')
+            },
+            {
                 version: '1.6.4',
                 date: 'September 28th 2018',
                 content: require('./logs/release-v1.6.4.md')

--- a/docs/app/pages/changelog/logs/release-v1.6.5.md
+++ b/docs/app/pages/changelog/logs/release-v1.6.5.md
@@ -1,0 +1,14 @@
+UX Aspects 1.6.5 is available! Check out the documentation at [uxaspects.github.io/UXAspects](https://uxaspects.github.io/UXAspects).
+
+#### Documentation Updates
+* [Focus](https://uxaspects.github.io/UXAspects/#/components/utilities#focus) - documentation for `uxFocusWithin` and `uxBlurWithin`.
+* [Tabbable List](https://uxaspects.github.io/UXAspects/#/components/utilities#tabbable-list)
+
+#### Bug Fixes and Improvements
+* (EL-3234) [Tree View (AngularJS)](https://uxaspects.github.io/UXAspects/#/components/tree-view#tree-view-ng1) - items can be disabled via the `disabled` property.
+* (EL-3242) [Column Resizing](https://uxaspects.github.io/UXAspects/#/components/tables#column-resizing) - added support for `uxFixedHeaderTable` via the new directive `uxResizableTableCell`; updated the documentation with a fixed header table example.
+* (EL-3246) [Filters](https://uxaspects.github.io/UXAspects/#/components/tables#filters) - "Clear All" button now appears at an appropriate size.
+* (EL-3250) Fixed another compile issue which affected Angular 5 installations.
+* (EL-3258) [Icons](https://uxaspects.github.io/UXAspects/#/css/icons#ux-icons) - added a circular help icon as `hpe-help-circle`.
+
+Any questions or feedback? Get in touch on Twitter [@UXAspects](https://twitter.com/UXAspects), open an issue on [GitHub](https://github.com/UXAspects/UXAspects/issues), or check our [blog](https://uxaspects.github.io/UXAspects/#/blog) for more information!

--- a/docs/app/services/app-configuration/app-configuration.service.ts
+++ b/docs/app/services/app-configuration/app-configuration.service.ts
@@ -1,3 +1,4 @@
+import { Location } from '@angular/common';
 import { Injectable } from '@angular/core';
 import { environment } from '../../../environments/environment';
 const jsonTemplate = require('json-templater/object');
@@ -5,46 +6,67 @@ const jsonTemplate = require('json-templater/object');
 @Injectable()
 export class AppConfiguration {
 
-    private _data = {};
-
-    private _templateVars = {
-        'VERSION': environment.version
-    };
-
     public documentationPages = ['components-page', 'css-page', 'charts-page'];
 
-    constructor() {
+    get version(): string {
+        return this._config['version'];
+    }
 
+    get assetsUrl(): string {
+        if (!this._config['assetsUrl']) {
+            // If not configured, derive from the application's base URL.
+            this._config['assetsUrl'] = Location.joinWithSlash(this.getBaseUrl(), 'assets');
+        }
+        return this._config['assetsUrl'];
+    }
+
+    get codePen(): string {
+        return this._config['codePen'];
+    }
+
+    get plunker(): string {
+        return this._config['plunker'];
+    }
+
+    private _data = {};
+    private _config: {[key: string]: any};
+
+    private _templateVars = {
+        VERSION: environment.version
+    };
+
+    constructor(private _location: Location) {
         this.setConfigurationTemplateData('config', require('../../data/config.json'));
         this.setConfigurationTemplateData('config.dev', require('../../data/config.dev.json'));
         this.setConfigurationTemplateData('footer-navigation', require('../../data/footer-navigation.json'));
         this.setConfigurationTemplateData('landing-page', require('../../data/landing-page.json'));
-        this.setConfigurationData('team-page',  require('../../data/team-page.json'));
-        this.setConfigurationData('top-navigation',  require('../../data/top-navigation.json'));
-        this.setConfigurationData('components-page',  require('../../data/components-page.json'));
-        this.setConfigurationData('css-page',  require('../../data/css-page.json'));
-        this.setConfigurationData('charts-page',  require('../../data/charts-page.json'));
+        this.setConfigurationData('team-page', require('../../data/team-page.json'));
+        this.setConfigurationData('top-navigation', require('../../data/top-navigation.json'));
+        this.setConfigurationData('components-page', require('../../data/components-page.json'));
+        this.setConfigurationData('css-page', require('../../data/css-page.json'));
+        this.setConfigurationData('charts-page', require('../../data/charts-page.json'));
+
+        this._config = environment.production ? this._data['config'] : this._data['config.dev'];
     }
 
     get(key: string): any {
-        return key.split('.').reduce((prev, curr) => {
-            return prev ? prev[curr] : undefined;
-        }, this.getConfig());
+        return this._config[key];
     }
 
-    getConfigurationData(key: string) {
+    getConfigurationData(key: string): any {
         return this._data[key];
     }
 
-    setConfigurationData(key: string, data: any) {
+    setConfigurationData(key: string, data: any): void {
         this._data[key] = data;
     }
 
-    setConfigurationTemplateData(key: string, data: any) {
+    setConfigurationTemplateData(key: string, data: any): void {
         this._data[key] = jsonTemplate(data, this._templateVars);
     }
 
-    private getConfig() {
-        return environment.production ? this._data['config'] : this._data['config.dev'];
+    private getBaseUrl(): string {
+        const path = this._location.prepareExternalUrl(this._location.path());
+        return window.location.href.substr(0, window.location.href.indexOf(path));
     }
 }

--- a/docs/app/services/codepen/codepen.service.ts
+++ b/docs/app/services/codepen/codepen.service.ts
@@ -3,27 +3,43 @@ import { Inject, Injectable } from '@angular/core';
 import { ICodePen } from '../../interfaces/ICodePen';
 import { AppConfiguration } from '../app-configuration/app-configuration.service';
 
-
 @Injectable()
 export class CodePenService {
 
     colorSet: ColorSetName = 'keppel';
-    private codepenAssetsBaseUrl = this.appConfig.get('assetsUrl');
-    private codePenUrl = this.appConfig.get('codePen');
-    
-    constructor(@Inject(DOCUMENT) private document: Document, private appConfig: AppConfiguration) {}
+
+    /** CSS dependencies */
+    codepenStylesheets = [
+        'https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css',
+        this._appConfig.assetsUrl + '/css/ux-aspects.css'
+    ];
+
+    /** JS dependencies */
+    codepenScripts = [
+        'https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js',
+        'https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.11.2/jquery-ui.min.js',
+        'https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js',
+        'https://cdnjs.cloudflare.com/ajax/libs/chance/0.8.0/chance.min.js',
+        'https://cdnjs.cloudflare.com/ajax/libs/angular.js/1.3.6/angular.js',
+        'https://cdnjs.cloudflare.com/ajax/libs/angular-ui-bootstrap/0.13.0/ui-bootstrap-tpls.js',
+        'https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.18.1/moment.min.js',
+        'https://cdnjs.cloudflare.com/ajax/libs/moment-timezone/0.5.13/moment-timezone-with-data.min.js',
+        this._appConfig.assetsUrl + '/ng1/ux-aspects-ng1.js'
+    ];
+
+    constructor(@Inject(DOCUMENT) private _document: Document, private _appConfig: AppConfiguration) {}
 
     launch(title: string, codepen: ICodePen) {
-        
+
         const form = this.initForm(title, codepen);
 
-        this.document.body.appendChild(form);
+        this._document.body.appendChild(form);
 
         form.submit();
 
-        this.document.body.removeChild(form);
+        this._document.body.removeChild(form);
     }
-    
+
     private initForm(title: string, codepen: ICodePen): HTMLFormElement {
 
         // Set up the contents of each of the three editors
@@ -45,16 +61,18 @@ export class CodePenService {
             js_pre_processor: 'none',
             head: `<meta name="viewport" content="width=device-width, initial-scale=1">`,
             css_external: this.codepenStylesheets.join(';'),
-            js_external: this.CODEPEN_SCRIPTS.join(';')
+            js_external: this.codepenScripts.join(';')
         };
 
-        const optionsString = JSON.stringify(options).replace(/"/g, '&​quot;').replace(/'/g, '&apos;');
+        const optionsString = JSON.stringify(options)
+            .replace(/"/g, '&​quot;')
+            .replace(/'/g, '&apos;');
 
         // create form object
         const form = document.createElement('form');
 
         // set form attributes
-        form.action = this.codePenUrl;
+        form.action = this._appConfig.codePen;
         form.method = 'POST';
         form.target = '_blank';
 
@@ -74,7 +92,9 @@ export class CodePenService {
 
     private getBoilerPlate() {
         return {
-            prefix: `angular.module('app', ['ux-aspects']).run(['$colorService', function($colorService) {$colorService.setColorSet('${this.colorSet}'); }]);`,
+            prefix: `angular.module('app', ['ux-aspects']).run(['$colorService', function($colorService) {
+                $colorService.setColorSet('${this.colorSet}');
+            }]);`,
             suffix: `angular.bootstrap(document, ['app']);`
         };
     }
@@ -88,9 +108,8 @@ export class CodePenService {
         // Wrap the main HTML fragment in a div with specified attributes
         let result = this.wrapHtml(codepen.html, null, htmlAttributes);
         if (codepen.htmlTemplates) {
-
             // Append each template provided inside <script> or <template> tags
-            codepen.htmlTemplates.forEach((htmlTemplate) => {
+            codepen.htmlTemplates.forEach(htmlTemplate => {
                 result += '\n\n' + this.wrapHtml(htmlTemplate.content, htmlTemplate.id, htmlTemplate.attributes);
             });
         }
@@ -136,7 +155,7 @@ export class CodePenService {
 
         if (codepen.css) {
             // Simply append the CSS fragments to each other
-            codepen.css.forEach((cssString) => {
+            codepen.css.forEach(cssString => {
                 result += cssString + '\n\n';
             });
         }
@@ -150,7 +169,7 @@ export class CodePenService {
 
         // Append the code fragments with trailing semicolon in case it was missed
         if (codepen.js) {
-            codepen.js.forEach((codeString) => {
+            codepen.js.forEach(codeString => {
                 result += codeString + ';\n\n';
             });
         }
@@ -160,25 +179,6 @@ export class CodePenService {
 
         return result;
     }
-
-    // Stylesheets for CodePen to reference
-    codepenStylesheets = [
-        'https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css',
-        this.codepenAssetsBaseUrl + '/css/ux-aspects.css'
-    ];
-
-    // Script files for CodePen to reference
-    private CODEPEN_SCRIPTS = [
-        'https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js',
-        'https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.11.2/jquery-ui.min.js',
-        'https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js',
-        'https://cdnjs.cloudflare.com/ajax/libs/chance/0.8.0/chance.min.js',
-        'https://cdnjs.cloudflare.com/ajax/libs/angular.js/1.3.6/angular.js',
-        'https://cdnjs.cloudflare.com/ajax/libs/angular-ui-bootstrap/0.13.0/ui-bootstrap-tpls.js',
-        'https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.18.1/moment.min.js',
-        'https://cdnjs.cloudflare.com/ajax/libs/moment-timezone/0.5.13/moment-timezone-with-data.min.js',
-        this.codepenAssetsBaseUrl + '/ng1/ux-aspects-ng1.js'
-    ];
 }
 
 export type ColorSetName = 'keppel' | 'microFocus';

--- a/docs/app/services/plunker/plunker.service.ts
+++ b/docs/app/services/plunker/plunker.service.ts
@@ -3,7 +3,6 @@ import { Inject, Injectable } from '@angular/core';
 import { IPlunk } from '../../interfaces/IPlunk';
 import { AppConfiguration } from '../app-configuration/app-configuration.service';
 
-
 const ASSETS_URL_PLACEHOLDER_REGEX = /\$\{assetsUrl\}/g;
 const MODULES_PLACEHOLDER = /\$\{modules\}/g;
 const DECLARATIONS_PLACEHOLDER = /\$\{declarations\}/g;
@@ -16,9 +15,6 @@ export class PlunkerService {
     indexTemplate: string;
     mainTs: string;
     libraries: Library[] = [];
-
-    private _assetsUrl = this._appConfig.get('assetsUrl');
-    private _plunkerPostUrl = this._appConfig.get('plunker');
 
     constructor(@Inject(DOCUMENT) private _document: Document, private _appConfig: AppConfiguration) { }
 
@@ -86,7 +82,7 @@ export class PlunkerService {
 
         if (!this.indexTemplate) {
             this.indexTemplate = require('./templates/index_html.txt')
-                .replace(ASSETS_URL_PLACEHOLDER_REGEX, this._assetsUrl);
+                .replace(ASSETS_URL_PLACEHOLDER_REGEX, this._appConfig.assetsUrl);
         }
 
         if (!this.mainTs) {
@@ -119,7 +115,7 @@ export class PlunkerService {
 
         const form = this._document.createElement('form');
 
-        form.action = this._plunkerPostUrl;
+        form.action = this._appConfig.plunker;
         form.method = 'POST';
         form.target = '_blank';
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ux-aspects/ux-aspects-docs",
-  "version": "1.6.4",
+  "version": "1.6.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ux-aspects/ux-aspects-docs",
-  "version": "1.6.4",
+  "version": "1.6.5",
   "description": "Open source user interface framework for building modern, responsive, mobile big data applications",
   "main": "docs/app/app.module.ts",
   "contributors": [

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ux-aspects/ux-aspects",
-  "version": "1.6.4",
+  "version": "1.6.5",
   "description": "Open source user interface framework for building modern, responsive, mobile big data applications",
   "main": "dist/bundles/ux-aspects.umd.js",
   "files": [


### PR DESCRIPTION
To accommodate the Stack B hosting of the site, as well as future CI builds, I have removed the explicit `assetsUrl` config setting and instead derived the URL from the active location.

This also means that plunker can load in Firefox in development mode by accessing the documentation at http://127.0.0.1:8080.

https://autjira.microfocus.com/browse/EL-3251