### PR TITLE
Fixed an issue which appeared when navigating to the base URL directly

### DIFF
--- a/docs/app/services/app-configuration/app-configuration.service.ts
+++ b/docs/app/services/app-configuration/app-configuration.service.ts
@@ -67,6 +67,6 @@ export class AppConfiguration {
 
     private getBaseUrl(): string {
         const path = this._location.prepareExternalUrl(this._location.path());
-        return window.location.href.substr(0, window.location.href.indexOf(path));
+        return window.location.href.substr(0, window.location.href.lastIndexOf(path));
     }
 }


### PR DESCRIPTION
The path was empty, causing getBaseUrl() to return an empty string.

https://autjira.microfocus.com/browse/EL-3251