### PR TITLE
Fixed a dependency which was causing build problems

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "chart.js": "~2.6.0",
     "core-js": "^2.5.7",
     "dragula": "^3.7.2",
-    "highlight.js": "^9.12.0",
+    "highlight.js": "9.12.0",
     "jquery": "^3.2.1",
     "jquery-ui": "^1.12.1",
     "json-templater": "1.1.0",


### PR DESCRIPTION
The updated version of highlight.js was causing a build error, so I have removed the range operator.