### PR TITLE
EL-3069 - WCAG Tables

### DIFF
--- a/docs/app/data/components-page.json
+++ b/docs/app/data/components-page.json
@@ -1449,6 +1449,25 @@
             "link": "tables",
             "sections": [
                 {
+                    "title": "Column Resizing",
+                    "component": "ComponentsColumnResizingComponent",
+                    "version": "Angular",
+                    "usage": [
+                        {
+                            "title": "Selector",
+                            "content": "[uxResizableTable]"
+                        },
+                        {
+                            "title": "Selector",
+                            "content": "[uxResizableTableColumn]"
+                        },
+                        {
+                            "title": "Module",
+                            "content": "TableModule"
+                        }
+                    ]
+                },
+                {
                     "title": "Column Sorting",
                     "component": "ComponentsColumnSortingComponent",
                     "version": "Angular",
@@ -1470,23 +1489,14 @@
                 {
                     "title": "Detail Row Responsive Table",
                     "component": "ComponentsDetailRowResponsiveNg1Component",
-                    "version": "AngularJS"
+                    "version": "AngularJS",
+                    "deprecated": true
                 },
                 {
                     "title": "Detail Row Header",
                     "component": "ComponentsDetailRowHeaderNg1Component",
-                    "version": "AngularJS"
-                },
-                {
-                    "title": "Custom Filters Component",
-                    "component": "ComponentsCustomFiltersComponent",
-                    "version": "Angular",
-                    "usage": [
-                        {
-                            "title": "Module",
-                            "content": "FilterModule"
-                        }
-                    ]
+                    "version": "AngularJS",
+                    "deprecated": true
                 },
                 {
                     "title": "Filters",
@@ -1497,6 +1507,17 @@
                             "title": "Selector",
                             "content": "ux-filter-container"
                         },
+                        {
+                            "title": "Module",
+                            "content": "FilterModule"
+                        }
+                    ]
+                },
+                {
+                    "title": "Custom Filters",
+                    "component": "ComponentsCustomFiltersComponent",
+                    "version": "Angular",
+                    "usage": [
                         {
                             "title": "Module",
                             "content": "FilterModule"
@@ -1539,12 +1560,30 @@
                 {
                     "title": "Indices",
                     "component": "ComponentsIndicesNg1Component",
-                    "version": "AngularJS"
+                    "version": "AngularJS",
+                    "deprecated": true
                 },
                 {
                     "title": "Grouping",
                     "component": "ComponentsGroupingNg1Component",
-                    "version": "AngularJS"
+                    "version": "AngularJS",
+                    "deprecated": true
+                },
+                {
+                    "title": "Hover Actions",
+                    "component": "ComponentsHoverActionsComponent",
+                    "version": "Angular",
+                    "usage": [
+                        {
+                            "title": "Selectors",
+                            "content":
+                                "[uxHoverActionContainer], [uxHoverAction]"
+                        },
+                        {
+                            "title": "Module",
+                            "content": "HoverActionModule"
+                        }
+                    ]
                 },
                 {
                     "title": "Layout Switching",
@@ -1581,22 +1620,6 @@
                     "deprecated": true
                 },
                 {
-                    "title": "Hover Actions",
-                    "component": "ComponentsHoverActionsComponent",
-                    "version": "Angular",
-                    "usage": [
-                        {
-                            "title": "Selectors",
-                            "content":
-                                "[uxHoverActionContainer], [uxHoverAction]"
-                        },
-                        {
-                            "title": "Module",
-                            "content": "HoverActionModule"
-                        }
-                    ]
-                },
-                {
                     "title": "Preview Pane",
                     "component": "ComponentsPreviewPaneNg1Component",
                     "version": "AngularJS",
@@ -1605,7 +1628,8 @@
                 {
                     "title": "Preview Pane Window",
                     "component": "ComponentsPreviewPaneWindowNg1Component",
-                    "version": "AngularJS"
+                    "version": "AngularJS",
+                    "deprecated": true
                 },
                 {
                     "title": "Reorderable Table",
@@ -1739,31 +1763,14 @@
                 {
                     "title": "Column Visibility",
                     "component": "ComponentsColumnVisibilityNg1Component",
-                    "version": "AngularJS"
+                    "version": "AngularJS",
+                    "deprecated": true
                 },
                 {
                     "title": "Custom Responsive Table",
                     "component": "ComponentsCustomResponsiveTableNg1Component",
-                    "version": "AngularJS"
-                },
-                {
-                    "title": "Column Resizing",
-                    "component": "ComponentsColumnResizingComponent",
-                    "version": "Angular",
-                    "usage": [
-                        {
-                            "title": "Selector",
-                            "content": "[uxResizableTable]"
-                        },
-                        {
-                            "title": "Selector",
-                            "content": "[uxResizableTableColumn]"
-                        },
-                        {
-                            "title": "Module",
-                            "content": "TableModule"
-                        }
-                    ]
+                    "version": "AngularJS",
+                    "deprecated": true
                 }
             ]
         },

--- a/docs/app/pages/components/components-sections/tables/column-sorting/column-sorting.component.html
+++ b/docs/app/pages/components/components-sections/tables/column-sorting/column-sorting.component.html
@@ -65,7 +65,7 @@
                 <ux-spark [trackColor]="sparkTrackColor" [barColor]="sparkBarColor" [value]="item.completed" [barHeight]="3" [inlineLabel]="item.completed"></ux-spark>
             </td>
             <td class="text-center">
-                <div class="hpe-icon" [class.text-accent]="item.active" [class.hpe-checkmark]="item.active"></div>
+                <div class="hpe-icon" [attr.aria-label]="item.active ? 'Approved' : 'Not approved'" [class.text-accent]="item.active" [class.hpe-checkmark]="item.active"></div>
             </td>
         </tr>
     </tbody>

--- a/docs/app/pages/components/components-sections/tables/column-sorting/snippets/app.html
+++ b/docs/app/pages/components/components-sections/tables/column-sorting/snippets/app.html
@@ -75,6 +75,7 @@
             </td>
             <td class="text-center">
                 <div class="hpe-icon"
+                    [attr.aria-label]="item.active ? 'Approved' : 'Not approved'"
                     [class.text-accent]="item.active"
                     [class.hpe-checkmark]="item.active">
                 </div>

--- a/docs/app/pages/components/components-sections/tables/custom-filters-component/custom-filters.component.ts
+++ b/docs/app/pages/components/components-sections/tables/custom-filters-component/custom-filters.component.ts
@@ -1,9 +1,9 @@
 import { Component } from '@angular/core';
-import { DocumentationSectionComponent } from '../../../../../decorators/documentation-section-component';
 import { Filter } from '../../../../../../../src/index';
+import { BaseDocumentationSection } from '../../../../../components/base-documentation-section/base-documentation-section';
+import { DocumentationSectionComponent } from '../../../../../decorators/documentation-section-component';
 import { IPlunk } from '../../../../../interfaces/IPlunk';
 import { IPlunkProvider } from '../../../../../interfaces/IPlunkProvider';
-import { BaseDocumentationSection } from '../../../../../components/base-documentation-section/base-documentation-section';
 
 @Component({
     selector: 'uxd-components-custom-filters',
@@ -36,7 +36,7 @@ export class ComponentsCustomFiltersComponent extends BaseDocumentationSection i
             'sample-filter.component.ts': this.snippets.raw.sampleTs
         },
         modules: [{
-            imports: ['FilterModule', 'RadioButtonModule'],
+            imports: ['FilterModule', 'RadioButtonModule', 'MenuNavigationModule'],
             library: '@ux-aspects/ux-aspects'
         }, {
             imports: ['SampleFilterCustomComponent'],

--- a/docs/app/pages/components/components-sections/tables/custom-filters-component/sample/sample-filter.component.html
+++ b/docs/app/pages/components/components-sections/tables/custom-filters-component/sample/sample-filter.component.html
@@ -1,12 +1,44 @@
-<div class="btn-group ux-filter-custom" dropdown>
-    <button dropdownToggle type="button" class="filter-dropdown btn dropdown-toggle"
-    [class.active]="selected !== initial">{{ selected?.title }}
+<div class="btn-group ux-custom-filter"
+    dropdown
+    #dropdown="bs-dropdown"
+    [autoClose]="true">
+
+    <button type="button"
+        tabindex="0"
+        dropdownToggle
+        uxMenuNavigationToggle
+        #toggle="uxMenuNavigationToggle"
+        [(menuOpen)]="dropdown.isOpen"
+        aria-haspopup="true"
+        [attr.aria-expanded]="dropdown.isOpen"
+        class="filter-dropdown btn dropdown-toggle"
+        [class.active]="selected !== initial">
+        {{ selected?.title }}
         <span class="hpe-icon hpe-down"></span>
     </button>
-    <ul *dropdownMenu class="dropdown-menu" role="menu">
-        <li class="dropdown-list-item" *ngFor="let filter of filters" role="menuitem">
-            <ux-radio-button (click)="selectFilter(filter)" name="filterGroup" [(value)]="selected"
-            [option]="filter">{{ filter.name }}</ux-radio-button>
+
+    <ul *dropdownMenu
+        uxMenuNavigation
+        [toggleButton]="toggle"
+        class="dropdown-menu"
+        role="menu">
+
+        <li class="dropdown-list-item"
+            *ngFor="let filter of filters"
+            role="none">
+
+            <a class="dropdown-item"
+                role="listitem"
+                tabindex="-1"
+                uxMenuNavigationItem
+                [attr.aria-selected]="filter === selected"
+                (click)="selectFilter(filter, $event); toggle.focus()"
+                (keydown.enter)="selectFilter(filter, $event); toggle.focus()"
+                (keydown.escape)="toggle.focus()">
+
+                <i class="hpe-icon" [class.hpe-checkmark]="filter === selected"></i>
+                <span class="filter-dropdown-title">{{ filter.name }}</span>
+            </a>
         </li>
     </ul>
 </div>

--- a/docs/app/pages/components/components-sections/tables/custom-filters-component/sample/sample-filter.component.html
+++ b/docs/app/pages/components/components-sections/tables/custom-filters-component/sample/sample-filter.component.html
@@ -28,7 +28,7 @@
             role="none">
 
             <a class="dropdown-item"
-                role="listitem"
+                role="menuitem"
                 tabindex="-1"
                 uxMenuNavigationItem
                 [attr.aria-selected]="filter === selected"

--- a/docs/app/pages/components/components-sections/tables/custom-filters-component/sample/sample-filter.component.less
+++ b/docs/app/pages/components/components-sections/tables/custom-filters-component/sample/sample-filter.component.less
@@ -1,15 +1,25 @@
-.ux-filter-custom {
-    .filter-dropdown {
-        &.active {
-            font-weight: 600;
-        }
+.ux-custom-filter {
+    &.active {
+        font-weight: 600;
+    }
 
-        .hpe-down {
-            font-size: 0.625rem;
-        }
+    .hpe-down {
+        font-size: 0.625rem;
     }
 
     .dropdown-menu {
-        padding: 10px;
+        .dropdown-list-item {
+            .dropdown-item {
+                padding-left: 10px;
+
+                .hpe-icon {
+                    width: 16px;
+                }
+
+                .filter-dropdown-title {
+                    padding-left: 10px;
+                }
+            }
+        }
     }
 }

--- a/docs/app/pages/components/components-sections/tables/custom-filters-component/snippets/sample.css
+++ b/docs/app/pages/components/components-sections/tables/custom-filters-component/snippets/sample.css
@@ -1,11 +1,19 @@
-.ux-filter-custom .filter-dropdown.active {
+.ux-custom-filter.active {
     font-weight: 600;
 }
 
-.ux-filter-custom .filter-dropdown .hpe-down {
+.ux-custom-filter .hpe-down {
     font-size: 0.625rem;
 }
 
-.ux-filter-custom .dropdown-menu {
-    padding: 10px;
+.ux-custom-filter .dropdown-menu .dropdown-list-item .dropdown-item {
+    padding-left: 10px;
+}
+
+.ux-custom-filter .dropdown-menu .dropdown-list-item .dropdown-item .hpe-icon {
+    width: 16px;
+}
+
+.ux-custom-filter .dropdown-menu .dropdown-list-item .dropdown-item .filter-dropdown-title {
+    padding-left: 10px;
 }

--- a/docs/app/pages/components/components-sections/tables/custom-filters-component/snippets/sample.html
+++ b/docs/app/pages/components/components-sections/tables/custom-filters-component/snippets/sample.html
@@ -1,17 +1,44 @@
-<div class="btn-group ux-filter-custom" dropdown>
-    <button dropdownToggle type="button" class="filter-dropdown btn dropdown-toggle"
-    [class.active]="selected !== initial">{{ selected?.title }}
+<div class="btn-group ux-custom-filter"
+    dropdown
+    #dropdown="bs-dropdown"
+    [autoClose]="true">
+
+    <button type="button"
+        tabindex="0"
+        dropdownToggle
+        uxMenuNavigationToggle
+        #toggle="uxMenuNavigationToggle"
+        [(menuOpen)]="dropdown.isOpen"
+        aria-haspopup="true"
+        [attr.aria-expanded]="dropdown.isOpen"
+        class="filter-dropdown btn dropdown-toggle"
+        [class.active]="selected !== initial">
+        {{ selected?.title }}
         <span class="hpe-icon hpe-down"></span>
     </button>
-    <ul *dropdownMenu class="dropdown-menu" role="menu">
-        <li class="dropdown-list-item" *ngFor="let filter of filters" role="menuitem">
-            <ux-radio-button
-                (click)="selectFilter(filter)"
-                name="filterGroup"
-                [(value)]="selected"
-                [option]="filter">
-                {{ filter.name }}
-            </ux-radio-button>
+
+    <ul *dropdownMenu
+        uxMenuNavigation
+        [toggleButton]="toggle"
+        class="dropdown-menu"
+        role="menu">
+
+        <li class="dropdown-list-item"
+            *ngFor="let filter of filters"
+            role="none">
+
+            <a class="dropdown-item"
+                role="listitem"
+                tabindex="-1"
+                uxMenuNavigationItem
+                [attr.aria-selected]="filter === selected"
+                (click)="selectFilter(filter, $event); toggle.focus()"
+                (keydown.enter)="selectFilter(filter, $event); toggle.focus()"
+                (keydown.escape)="toggle.focus()">
+
+                <i class="hpe-icon" [class.hpe-checkmark]="filter === selected"></i>
+                <span class="filter-dropdown-title">{{ filter.name }}</span>
+            </a>
         </li>
     </ul>
 </div>

--- a/docs/app/pages/components/components-sections/tables/custom-filters-component/snippets/sample.html
+++ b/docs/app/pages/components/components-sections/tables/custom-filters-component/snippets/sample.html
@@ -28,7 +28,7 @@
             role="none">
 
             <a class="dropdown-item"
-                role="listitem"
+                role="menuitem"
                 tabindex="-1"
                 uxMenuNavigationItem
                 [attr.aria-selected]="filter === selected"

--- a/docs/app/pages/components/components-sections/tables/filters/filters.component.html
+++ b/docs/app/pages/components/components-sections/tables/filters/filters.component.html
@@ -31,6 +31,7 @@
             </td>
             <td class="text-center vertical-center-icon">
                 <div class="hpe-icon"
+                    [attr.aria-label]="document.active ? 'Approved' : 'Not approved'"
                     [class.text-accent]="document.active"
                     [class.hpe-checkmark]="document.active">
                 </div>

--- a/docs/app/pages/components/components-sections/tables/filters/snippets/app.html
+++ b/docs/app/pages/components/components-sections/tables/filters/snippets/app.html
@@ -34,6 +34,7 @@
             </td>
             <td class="text-center vertical-center-icon">
                 <div class="hpe-icon"
+                    [attr.aria-label]="document.active ? 'Approved' : 'Not approved'"
                     [class.text-accent]="document.active"
                     [class.hpe-checkmark]="document.active">
                 </div>

--- a/docs/app/pages/components/components-sections/tables/fixed-header-table/fixed-header-table.component.html
+++ b/docs/app/pages/components/components-sections/tables/fixed-header-table/fixed-header-table.component.html
@@ -15,7 +15,7 @@
             <td>{{ person.name }}</td>
             <td>{{ person.address }}</td>
             <td>{{ person.phone }}</td>
-            <td>
+            <td [attr.aria-label]="person.active ? 'Active' : 'Inactive'">
                 <i class="hpe-icon hpe-checkmark" *ngIf="person.active"></i>
             </td>
         </tr>

--- a/docs/app/pages/components/components-sections/tables/fixed-header-table/fixed-header-table.component.html
+++ b/docs/app/pages/components/components-sections/tables/fixed-header-table/fixed-header-table.component.html
@@ -10,7 +10,7 @@
     </thead>
 
     <tbody>
-        <tr *ngFor="let person of people">
+        <tr *ngFor="let person of people; let index = index" [attr.aria-setsize]="total" [attr.aria-posinset]="index">
             <td class="table-col-id">{{ person.id }}</td>
             <td>{{ person.name }}</td>
             <td>{{ person.address }}</td>

--- a/docs/app/pages/components/components-sections/tables/fixed-header-table/fixed-header-table.component.ts
+++ b/docs/app/pages/components/components-sections/tables/fixed-header-table/fixed-header-table.component.ts
@@ -1,8 +1,8 @@
 import { Component } from '@angular/core';
-import { DocumentationSectionComponent } from '../../../../../decorators/documentation-section-component';
 import { BaseDocumentationSection } from '../../../../../components/base-documentation-section/base-documentation-section';
-import { IPlunkProvider } from '../../../../../interfaces/IPlunkProvider';
+import { DocumentationSectionComponent } from '../../../../../decorators/documentation-section-component';
 import { IPlunk } from '../../../../../interfaces/IPlunk';
+import { IPlunkProvider } from '../../../../../interfaces/IPlunkProvider';
 
 @Component({
     selector: 'uxd-components-fixed-header-table',
@@ -14,6 +14,7 @@ export class ComponentsFixedHeaderTableComponent extends BaseDocumentationSectio
 
     people: Person[] = [];
     loading: boolean = false;
+    total: number = 250;
 
     private _page: number = 0;
 

--- a/docs/app/pages/components/components-sections/tables/fixed-header-table/snippets/app.html
+++ b/docs/app/pages/components/components-sections/tables/fixed-header-table/snippets/app.html
@@ -10,7 +10,10 @@
     </thead>
 
     <tbody>
-        <tr *ngFor="let person of people">
+        <tr *ngFor="let person of people; let index = index"
+            [attr.aria-setsize]="total"
+            [attr.aria-posinset]="index">
+
             <td class="table-col-id">{{ person.id }}</td>
             <td>{{ person.name }}</td>
             <td>{{ person.address }}</td>

--- a/docs/app/pages/components/components-sections/tables/fixed-header-table/snippets/app.html
+++ b/docs/app/pages/components/components-sections/tables/fixed-header-table/snippets/app.html
@@ -18,7 +18,7 @@
             <td>{{ person.name }}</td>
             <td>{{ person.address }}</td>
             <td>{{ person.phone }}</td>
-            <td>
+            <td [attr.aria-label]="person.active ? 'Active' : 'Inactive'">
                 <i class="hpe-icon hpe-checkmark" *ngIf="person.active"></i>
             </td>
         </tr>

--- a/docs/app/pages/components/components-sections/tables/fixed-header-table/snippets/app.ts
+++ b/docs/app/pages/components/components-sections/tables/fixed-header-table/snippets/app.ts
@@ -9,6 +9,7 @@ export class AppComponent {
 
     people: Person[] = [];
     loading: boolean = false;
+    total: number = 250;
 
     private _page: number = 0;
 

--- a/docs/app/pages/components/components-sections/tables/hover-actions/hover-actions.component.html
+++ b/docs/app/pages/components/components-sections/tables/hover-actions/hover-actions.component.html
@@ -18,13 +18,13 @@
                 <ux-spark theme="chart2" [value]="document.complete" [inlineLabel]="document.complete" barHeight="3"></ux-spark>
             </td>
             <td>
-                <button class="hover-action-btn" aria-label="View" uxTooltip="View" uxHoverAction>
+                <button type="button" class="hover-action-btn" aria-label="View" uxTooltip="View" uxHoverAction>
                     <i class="hpe-icon hpe-view hover-action-icon"></i>
                 </button>
-                <button class="hover-action-btn" aria-label="Share" uxTooltip="Share" uxHoverAction>
+                <button type="button" class="hover-action-btn" aria-label="Share" uxTooltip="Share" uxHoverAction>
                     <i class="hpe-icon hpe-share hover-action-icon"></i>
                 </button>
-                <button class="hover-action-btn" aria-label="Delete" uxTooltip="Delete" uxHoverAction>
+                <button type="button" class="hover-action-btn" aria-label="Delete" uxTooltip="Delete" uxHoverAction>
                     <i class="hpe-icon hpe-trash hover-action-icon"></i>
                 </button>
             </td>

--- a/docs/app/pages/components/components-sections/tables/hover-actions/hover-actions.component.html
+++ b/docs/app/pages/components/components-sections/tables/hover-actions/hover-actions.component.html
@@ -18,9 +18,9 @@
                 <ux-spark theme="chart2" [value]="document.complete" [inlineLabel]="document.complete" barHeight="3"></ux-spark>
             </td>
             <td>
-                <i class="hpe-icon hpe-view hover-action-icon" uxTooltip="View" uxHoverAction></i>
-                <i class="hpe-icon hpe-share hover-action-icon" uxTooltip="Share" uxHoverAction></i>
-                <i class="hpe-icon hpe-trash hover-action-icon" uxTooltip="Delete" uxHoverAction></i>
+                <i class="hpe-icon hpe-view hover-action-icon" aria-label="View" uxTooltip="View" uxHoverAction></i>
+                <i class="hpe-icon hpe-share hover-action-icon" aria-label="Share" uxTooltip="Share" uxHoverAction></i>
+                <i class="hpe-icon hpe-trash hover-action-icon" aria-label="Delete" uxTooltip="Delete" uxHoverAction></i>
             </td>
         </tr>
     </tbody>

--- a/docs/app/pages/components/components-sections/tables/hover-actions/hover-actions.component.html
+++ b/docs/app/pages/components/components-sections/tables/hover-actions/hover-actions.component.html
@@ -18,9 +18,15 @@
                 <ux-spark theme="chart2" [value]="document.complete" [inlineLabel]="document.complete" barHeight="3"></ux-spark>
             </td>
             <td>
-                <i class="hpe-icon hpe-view hover-action-icon" aria-label="View" uxTooltip="View" uxHoverAction></i>
-                <i class="hpe-icon hpe-share hover-action-icon" aria-label="Share" uxTooltip="Share" uxHoverAction></i>
-                <i class="hpe-icon hpe-trash hover-action-icon" aria-label="Delete" uxTooltip="Delete" uxHoverAction></i>
+                <button class="hover-action-btn" aria-label="View" uxTooltip="View" uxHoverAction>
+                    <i class="hpe-icon hpe-view hover-action-icon"></i>
+                </button>
+                <button class="hover-action-btn" aria-label="Share" uxTooltip="Share" uxHoverAction>
+                    <i class="hpe-icon hpe-share hover-action-icon"></i>
+                </button>
+                <button class="hover-action-btn" aria-label="Delete" uxTooltip="Delete" uxHoverAction>
+                    <i class="hpe-icon hpe-trash hover-action-icon"></i>
+                </button>
             </td>
         </tr>
     </tbody>

--- a/docs/app/pages/components/components-sections/tables/hover-actions/hover-actions.component.less
+++ b/docs/app/pages/components/components-sections/tables/hover-actions/hover-actions.component.less
@@ -6,19 +6,6 @@
         background-color: #f5f5f5;
     }
 
-    .hover-action-btn {
-        border: none;
-        background-color: transparent;
-        padding: 0;
-
-        &:focus {
-            outline: 2px dotted;
-            outline: auto -webkit-focus-ring-color;
-            outline-color: #00a7a2;
-            outline-offset: 0;
-        }
-    }
-
     .hover-action-icon {
         display: inline-block;
         padding: 3px 6px;

--- a/docs/app/pages/components/components-sections/tables/hover-actions/hover-actions.component.less
+++ b/docs/app/pages/components/components-sections/tables/hover-actions/hover-actions.component.less
@@ -6,6 +6,19 @@
         background-color: #f5f5f5;
     }
 
+    .hover-action-btn {
+        border: none;
+        background-color: transparent;
+        padding: 0;
+
+        &:focus {
+            outline: 2px dotted;
+            outline: auto -webkit-focus-ring-color;
+            outline-color: #00a7a2;
+            outline-offset: 0;
+        }
+    }
+
     .hover-action-icon {
         display: inline-block;
         padding: 3px 6px;

--- a/docs/app/pages/components/components-sections/tables/hover-actions/snippets/app.css
+++ b/docs/app/pages/components/components-sections/tables/hover-actions/snippets/app.css
@@ -13,13 +13,6 @@
     padding: 0;
 }
 
-.hover-action-container .hover-action-btn:focus {
-    outline: 2px dotted;
-    outline: auto -webkit-focus-ring-color;
-    outline-color: #00a7a2;
-    outline-offset: 0;
-}
-
 .hover-action-container .hover-action-icon {
     display: inline-block;
     padding: 3px 6px;

--- a/docs/app/pages/components/components-sections/tables/hover-actions/snippets/app.css
+++ b/docs/app/pages/components/components-sections/tables/hover-actions/snippets/app.css
@@ -7,6 +7,19 @@
     background-color: #f5f5f5;
 }
 
+.hover-action-container .hover-action-btn {
+    border: none;
+    background-color: transparent;
+    padding: 0;
+}
+
+.hover-action-container .hover-action-btn:focus {
+    outline: 2px dotted;
+    outline: auto -webkit-focus-ring-color;
+    outline-color: #00a7a2;
+    outline-offset: 0;
+}
+
 .hover-action-container .hover-action-icon {
     display: inline-block;
     padding: 3px 6px;

--- a/docs/app/pages/components/components-sections/tables/hover-actions/snippets/app.html
+++ b/docs/app/pages/components/components-sections/tables/hover-actions/snippets/app.html
@@ -19,21 +19,15 @@
                     barHeight="3"></ux-spark>
             </td>
             <td>
-                <i class="hpe-icon hpe-view hover-action-icon"
-                    aria-label="View"
-                    uxTooltip="View"
-                    uxHoverAction>
-                </i>
-                <i class="hpe-icon hpe-share hover-action-icon"
-                    aria-label="Share"
-                    uxTooltip="Share"
-                    uxHoverAction>
-                </i>
-                <i class="hpe-icon hpe-trash hover-action-icon"
-                    aria-label="Delete"
-                    uxTooltip="Delete"
-                    uxHoverAction>
-                </i>
+                <button class="hover-action-btn" aria-label="View" uxTooltip="View" uxHoverAction>
+                    <i class="hpe-icon hpe-view hover-action-icon"></i>
+                </button>
+                <button class="hover-action-btn" aria-label="Share" uxTooltip="Share" uxHoverAction>
+                    <i class="hpe-icon hpe-share hover-action-icon"></i>
+                </button>
+                <button class="hover-action-btn" aria-label="Delete" uxTooltip="Delete" uxHoverAction>
+                    <i class="hpe-icon hpe-trash hover-action-icon"></i>
+                </button>
             </td>
         </tr>
     </tbody>

--- a/docs/app/pages/components/components-sections/tables/hover-actions/snippets/app.html
+++ b/docs/app/pages/components/components-sections/tables/hover-actions/snippets/app.html
@@ -19,13 +19,25 @@
                     barHeight="3"></ux-spark>
             </td>
             <td>
-                <button class="hover-action-btn" aria-label="View" uxTooltip="View" uxHoverAction>
+                <button type="button"
+                    class="hover-action-btn"
+                    aria-label="View"
+                    uxTooltip="View"
+                    uxHoverAction>
                     <i class="hpe-icon hpe-view hover-action-icon"></i>
                 </button>
-                <button class="hover-action-btn" aria-label="Share" uxTooltip="Share" uxHoverAction>
+                <button type="button"
+                    class="hover-action-btn"
+                    aria-label="Share"
+                    uxTooltip="Share"
+                    uxHoverAction>
                     <i class="hpe-icon hpe-share hover-action-icon"></i>
                 </button>
-                <button class="hover-action-btn" aria-label="Delete" uxTooltip="Delete" uxHoverAction>
+                <button type="button"
+                    class="hover-action-btn"
+                    aria-label="Delete"
+                    uxTooltip="Delete"
+                    uxHoverAction>
                     <i class="hpe-icon hpe-trash hover-action-icon"></i>
                 </button>
             </td>

--- a/docs/app/pages/components/components-sections/tables/hover-actions/snippets/app.html
+++ b/docs/app/pages/components/components-sections/tables/hover-actions/snippets/app.html
@@ -19,9 +19,21 @@
                     barHeight="3"></ux-spark>
             </td>
             <td>
-                <i class="hpe-icon hpe-view hover-action-icon" uxTooltip="View" uxHoverAction></i>
-                <i class="hpe-icon hpe-share hover-action-icon" uxTooltip="Share" uxHoverAction></i>
-                <i class="hpe-icon hpe-trash hover-action-icon" uxTooltip="Delete" uxHoverAction></i>
+                <i class="hpe-icon hpe-view hover-action-icon"
+                    aria-label="View"
+                    uxTooltip="View"
+                    uxHoverAction>
+                </i>
+                <i class="hpe-icon hpe-share hover-action-icon"
+                    aria-label="Share"
+                    uxTooltip="Share"
+                    uxHoverAction>
+                </i>
+                <i class="hpe-icon hpe-trash hover-action-icon"
+                    aria-label="Delete"
+                    uxTooltip="Delete"
+                    uxHoverAction>
+                </i>
             </td>
         </tr>
     </tbody>

--- a/docs/app/pages/components/components-sections/tables/reorderable-table/reorderable-table.component.html
+++ b/docs/app/pages/components/components-sections/tables/reorderable-table/reorderable-table.component.html
@@ -14,6 +14,7 @@
             *ngFor="let item of data; let idx = index"
             [uxReorderableModel]="item"
             tabindex="0"
+            attr.aria-label="{{ item.document }} by {{ item.author }}. Use arrow keys to reorder items."
             (keydown.arrowdown)="movedown(item, idx, $event)"
             (keydown.arrowup)="moveup(item, idx, $event)">
 

--- a/docs/app/pages/components/components-sections/tables/reorderable-table/reorderable-table.component.html
+++ b/docs/app/pages/components/components-sections/tables/reorderable-table/reorderable-table.component.html
@@ -28,7 +28,7 @@
                 <ux-spark theme="chart2" [value]="item.completed" barHeight="3" [inlineLabel]="item.completed + '%'"></ux-spark>
             </td>
             <td class="text-center">
-                <div class="hpe-icon" [class.hpe-checkmark]="item.active"></div>
+                <div [attr.aria-label]="item.active ? 'Approved' : 'Not approved'" class="hpe-icon" [class.hpe-checkmark]="item.active"></div>
             </td>
         </tr>
     </tbody>

--- a/docs/app/pages/components/components-sections/tables/reorderable-table/reorderable-table.component.less
+++ b/docs/app/pages/components/components-sections/tables/reorderable-table/reorderable-table.component.less
@@ -2,6 +2,13 @@
     background-color: #fff;
 }
 
+.reorderable-row:focus {
+    outline: 2px dotted;
+    outline: auto -webkit-focus-ring-color;
+    outline-color: #00a7a2;
+    outline-offset: 0;
+}
+
 .table tr:hover .drag-handle-column {
     color: #dcdedf;
 }

--- a/docs/app/pages/components/components-sections/tables/reorderable-table/reorderable-table.component.less
+++ b/docs/app/pages/components/components-sections/tables/reorderable-table/reorderable-table.component.less
@@ -2,13 +2,6 @@
     background-color: #fff;
 }
 
-.reorderable-row:focus {
-    outline: 2px dotted;
-    outline: auto -webkit-focus-ring-color;
-    outline-color: #00a7a2;
-    outline-offset: 0;
-}
-
 .table tr:hover .drag-handle-column {
     color: #dcdedf;
 }

--- a/docs/app/pages/components/components-sections/tables/reorderable-table/snippets/app.css
+++ b/docs/app/pages/components/components-sections/tables/reorderable-table/snippets/app.css
@@ -2,6 +2,13 @@
     background-color: #fff;
 }
 
+.reorderable-row:focus {
+    outline: 2px dotted;
+    outline: auto -webkit-focus-ring-color;
+    outline-color: #00a7a2;
+    outline-offset: 0;
+}
+
 .table tr:hover .drag-handle-column {
     color: #dcdedf;
 }

--- a/docs/app/pages/components/components-sections/tables/reorderable-table/snippets/app.css
+++ b/docs/app/pages/components/components-sections/tables/reorderable-table/snippets/app.css
@@ -2,13 +2,6 @@
     background-color: #fff;
 }
 
-.reorderable-row:focus {
-    outline: 2px dotted;
-    outline: auto -webkit-focus-ring-color;
-    outline-color: #00a7a2;
-    outline-offset: 0;
-}
-
 .table tr:hover .drag-handle-column {
     color: #dcdedf;
 }

--- a/docs/app/pages/components/components-sections/tables/reorderable-table/snippets/app.html
+++ b/docs/app/pages/components/components-sections/tables/reorderable-table/snippets/app.html
@@ -11,8 +11,11 @@
     </thead>
     <tbody uxReorderable [(reorderableModel)]="data">
         <tr class="reorderable-row"
-            *ngFor="let item of data; let idx = index" [uxReorderableModel]="item"
-            tabindex="0" (keydown.arrowdown)="movedown(item, idx, $event)"
+            *ngFor="let item of data; let idx = index"
+            [uxReorderableModel]="item"
+            tabindex="0"
+            attr.aria-label="{{ item.document }} by {{ item.author }}. Use arrow keys to reorder items."
+            (keydown.arrowdown)="movedown(item, idx, $event)"
             (keydown.arrowup)="moveup(item, idx, $event)">
 
             <td class="drag-handle-column">

--- a/docs/app/pages/components/components-sections/tables/reorderable-table/snippets/app.html
+++ b/docs/app/pages/components/components-sections/tables/reorderable-table/snippets/app.html
@@ -29,7 +29,10 @@
                     [inlineLabel]="item.completed + '%'"></ux-spark>
             </td>
             <td class="text-center">
-                <div class="hpe-icon" [class.hpe-checkmark]="item.active"></div>
+                <div class="hpe-icon"
+                    [attr.aria-label]="item.active ? 'Approved' : 'Not approved'"
+                    [class.hpe-checkmark]="item.active">
+                </div>
             </td>
         </tr>
     </tbody>

--- a/docs/app/pages/components/components-sections/tables/selection/selection.component.html
+++ b/docs/app/pages/components/components-sections/tables/selection/selection.component.html
@@ -15,7 +15,7 @@
             [(selected)]="item.selected">
 
             <td>
-                <ux-checkbox class="m-b-nil" [clickable]="false" [value]="item.selected"></ux-checkbox>
+                <ux-checkbox aria-hidden="true" class="m-b-nil" [clickable]="false" [value]="item.selected"></ux-checkbox>
             </td>
             <td>{{ item.name }}</td>
             <td>{{ item.author }}</td>

--- a/docs/app/pages/components/components-sections/tables/selection/selection.component.html
+++ b/docs/app/pages/components/components-sections/tables/selection/selection.component.html
@@ -7,15 +7,16 @@
             <th>Created Date</th>
         </tr>
     </thead>
-    <tbody #select="ux-selection" [(uxSelection)]="selection" [mode]="mode" [disabled]="false">
+    <tbody #select="ux-selection" [(uxSelection)]="selection" [mode]="mode">
 
         <tr *ngFor="let item of data"
             class="clickable"
             [uxSelectionItem]="item"
+            [attr.aria-selected]="item.selected"
             [(selected)]="item.selected">
 
             <td>
-                <ux-checkbox aria-hidden="true" class="m-b-nil" [clickable]="false" [value]="item.selected"></ux-checkbox>
+                <ux-checkbox tabindex="-1" aria-hidden="true" class="m-b-nil" [(value)]="item.selected"></ux-checkbox>
             </td>
             <td>{{ item.name }}</td>
             <td>{{ item.author }}</td>

--- a/docs/app/pages/components/components-sections/tables/selection/selection.component.html
+++ b/docs/app/pages/components/components-sections/tables/selection/selection.component.html
@@ -1,4 +1,4 @@
-<table class="table table-hover">
+<table class="table table-hover" aria-multiselectable="true">
     <thead>
         <tr>
             <th></th>

--- a/docs/app/pages/components/components-sections/tables/selection/snippets/app.html
+++ b/docs/app/pages/components/components-sections/tables/selection/snippets/app.html
@@ -15,7 +15,7 @@
             [(selected)]="item.selected">
 
             <td>
-                <ux-checkbox class="m-b-nil" [clickable]="false" [value]="item.selected"></ux-checkbox>
+                <ux-checkbox aria-hidden="true" class="m-b-nil" [clickable]="false" [value]="item.selected"></ux-checkbox>
             </td>
             <td>{{ item.name }}</td>
             <td>{{ item.author }}</td>

--- a/docs/app/pages/components/components-sections/tables/selection/snippets/app.html
+++ b/docs/app/pages/components/components-sections/tables/selection/snippets/app.html
@@ -7,15 +7,20 @@
             <th>Created Date</th>
         </tr>
     </thead>
-    <tbody #select="ux-selection" [(uxSelection)]="selection" [mode]="mode" [disabled]="false">
+    <tbody #select="ux-selection" [(uxSelection)]="selection" [mode]="mode">
 
         <tr *ngFor="let item of data"
             class="clickable"
             [uxSelectionItem]="item"
+            [attr.aria-selected]="item.selected"
             [(selected)]="item.selected">
 
             <td>
-                <ux-checkbox aria-hidden="true" class="m-b-nil" [clickable]="false" [value]="item.selected"></ux-checkbox>
+                <ux-checkbox tabindex="-1"
+                    aria-hidden="true"
+                    class="m-b-nil"
+                    [(value)]="item.selected">
+                </ux-checkbox>
             </td>
             <td>{{ item.name }}</td>
             <td>{{ item.author }}</td>
@@ -32,12 +37,13 @@
 <div class="row uxd-customize-example">
     <div class="col-md-12">
         <ux-accordion>
-            <ux-accordion-panel heading="Customize Example...">
+            <ux-accordion-panel class="accordion-chevron" heading="Customize Example...">
                 <div class="row uxd-customize-row">
                     <div class="col-md-12">
                         <label>mode</label>
                         <ux-radio-button [(ngModel)]="mode" option="simple">simple</ux-radio-button>
                         <ux-radio-button [(ngModel)]="mode" option="row">row</ux-radio-button>
+                        <ux-radio-button [(ngModel)]="mode" option="row-alt">row-alt</ux-radio-button>
                     </div>
                 </div>
             </ux-accordion-panel>

--- a/docs/app/pages/components/components-sections/tables/selection/snippets/app.html
+++ b/docs/app/pages/components/components-sections/tables/selection/snippets/app.html
@@ -1,4 +1,4 @@
-<table class="table table-hover">
+<table class="table table-hover" aria-multiselectable="true">
     <thead>
         <tr>
             <th></th>

--- a/docs/app/pages/components/components-sections/tables/sorting/snippets/app.html
+++ b/docs/app/pages/components/components-sections/tables/sorting/snippets/app.html
@@ -19,8 +19,9 @@
 
         <!-- Dropdown List -->
         <ul *dropdownMenu class="dropdown-menu" role="menu">
-            <li role="menuitem" *ngFor="let option of options">
+            <li *ngFor="let option of options">
                 <a (click)="sort(option)"
+                    role="menuitem"
                     (keydown.enter)="sort(option); toggle.focus()"
                     tabindex="-1"
                     uxMenuNavigationItem>
@@ -35,8 +36,8 @@
 
         <!-- Sort Direction Toggle -->
         <button class="sort-icon hpe-icon text-muted"
-            aria-label="Toggle sort direction"
-            [attr.aria-sort]="descending ? 'descending' : 'ascending'"
+            attr.aria-label="{{ descending ? 'Descending' : 'Ascending' }} sort applied, activate
+            to apply a {{ !descending ? 'descending' : 'ascending' }} sort"
             [class.hpe-descend]="descending"
             [class.hpe-ascend]="!descending"
             (click)="descending = !descending">

--- a/docs/app/pages/components/components-sections/tables/sorting/snippets/app.html
+++ b/docs/app/pages/components/components-sections/tables/sorting/snippets/app.html
@@ -1,17 +1,30 @@
 <div class="sorter-container">
     <span class="sorter-title">Sort by</span>
 
-    <div class="btn-group filter sort-direction-toggle" dropdown>
+    <div class="btn-group filter sort-direction-toggle"
+        uxMenuNavigation
+        (navigatedOut)="toggle.focus()"
+        [toggleButton]="toggle"
+        dropdown
+        #dropdown="bs-dropdown">
 
         <!-- Dropdown Button -->
-        <button dropdownToggle class="btn dropdown-toggle filter-dropdown">
+        <button #toggle="uxMenuNavigationToggle"
+            uxMenuNavigationToggle
+            [(menuOpen)]="dropdown.isOpen"
+            dropdownToggle
+            class="btn dropdown-toggle filter-dropdown">
             {{ selected }} <span class="hpe-icon hpe-down"></span>
         </button>
 
         <!-- Dropdown List -->
         <ul *dropdownMenu class="dropdown-menu" role="menu">
             <li role="menuitem" *ngFor="let option of options">
-                <a (click)="sort(option)">
+                <a (click)="sort(option)"
+                    (keydown.enter)="sort(option); toggle.focus()"
+                    tabindex="-1"
+                    uxMenuNavigationItem>
+
                     <i class="hpe-icon hpe-checkmark sorter-icon"
                         [class.invisible]="option !== selected">
                     </i>
@@ -21,10 +34,12 @@
         </ul>
 
         <!-- Sort Direction Toggle -->
-        <span class="sort-icon hpe-icon text-muted"
+        <button class="sort-icon hpe-icon text-muted"
+            aria-label="Toggle sort direction"
+            [attr.aria-sort]="descending ? 'descending' : 'ascending'"
             [class.hpe-descend]="descending"
             [class.hpe-ascend]="!descending"
             (click)="descending = !descending">
-        </span>
+        </button>
     </div>
 </div>

--- a/docs/app/pages/components/components-sections/tables/sorting/sorting.component.html
+++ b/docs/app/pages/components/components-sections/tables/sorting/sorting.component.html
@@ -19,10 +19,11 @@
 
         <!-- Dropdown List -->
         <ul *dropdownMenu class="dropdown-menu" role="menu">
-            <li role="menuitem" *ngFor="let option of options">
+            <li *ngFor="let option of options">
                 <a (click)="sort(option)"
                    (keydown.enter)="sort(option); toggle.focus()"
                    tabindex="-1"
+                   role="menuitem"
                    uxMenuNavigationItem>
 
                     <i class="hpe-icon hpe-checkmark sorter-icon"
@@ -35,8 +36,7 @@
 
         <!-- Sort Direction Toggle -->
         <button class="sort-icon hpe-icon text-muted"
-            aria-label="Toggle sort direction"
-            [attr.aria-sort]="descending ? 'descending' : 'ascending'"
+            attr.aria-label="{{ descending ? 'Descending' : 'Ascending' }} sort applied, activate to apply a {{ !descending ? 'descending' : 'ascending' }} sort"
             [class.hpe-descend]="descending"
             [class.hpe-ascend]="!descending"
             (click)="descending = !descending">

--- a/docs/app/pages/components/components-sections/tables/sorting/sorting.component.html
+++ b/docs/app/pages/components/components-sections/tables/sorting/sorting.component.html
@@ -1,17 +1,30 @@
 <div class="sorter-container">
     <span class="sorter-title">Sort by</span>
 
-    <div class="btn-group filter sort-direction-toggle" dropdown>
+    <div class="btn-group filter sort-direction-toggle"
+        uxMenuNavigation
+        (navigatedOut)="toggle.focus()"
+        [toggleButton]="toggle"
+        dropdown
+        #dropdown="bs-dropdown">
 
         <!-- Dropdown Button -->
-        <button dropdownToggle class="btn dropdown-toggle filter-dropdown">
+        <button #toggle="uxMenuNavigationToggle"
+            uxMenuNavigationToggle
+            [(menuOpen)]="dropdown.isOpen"
+            dropdownToggle
+            class="btn dropdown-toggle filter-dropdown">
             {{ selected }} <span class="hpe-icon hpe-down"></span>
         </button>
 
         <!-- Dropdown List -->
         <ul *dropdownMenu class="dropdown-menu" role="menu">
             <li role="menuitem" *ngFor="let option of options">
-                <a (click)="sort(option)">
+                <a (click)="sort(option)"
+                   (keydown.enter)="sort(option); toggle.focus()"
+                   tabindex="-1"
+                   uxMenuNavigationItem>
+
                     <i class="hpe-icon hpe-checkmark sorter-icon"
                         [class.invisible]="option !== selected">
                     </i>
@@ -21,11 +34,13 @@
         </ul>
 
         <!-- Sort Direction Toggle -->
-        <span class="sort-icon hpe-icon text-muted"
+        <button class="sort-icon hpe-icon text-muted"
+            aria-label="Toggle sort direction"
+            [attr.aria-sort]="descending ? 'descending' : 'ascending'"
             [class.hpe-descend]="descending"
             [class.hpe-ascend]="!descending"
             (click)="descending = !descending">
-        </span>
+        </button>
     </div>
 </div>
 

--- a/docs/app/pages/components/components-sections/tables/sorting/sorting.component.ts
+++ b/docs/app/pages/components/components-sections/tables/sorting/sorting.component.ts
@@ -11,7 +11,7 @@ import { IPlunkProvider } from '../../../../../interfaces/IPlunkProvider';
 })
 @DocumentationSectionComponent('ComponentsSortingComponent')
 export class ComponentsSortingComponent extends BaseDocumentationSection implements IPlunkProvider {
-    
+
     options: string[] = [
         'Date Modified',
         'Name',
@@ -31,6 +31,10 @@ export class ComponentsSortingComponent extends BaseDocumentationSection impleme
                 imports: ['BsDropdownModule'],
                 library: 'ngx-bootstrap',
                 forRoot: true
+            },
+            {
+                imports: ['MenuNavigationModule'],
+                library: '@ux-aspects/ux-aspects'
             }
         ]
     };

--- a/docs/app/pages/components/components-sections/tables/tables.module.ts
+++ b/docs/app/pages/components/components-sections/tables/tables.module.ts
@@ -6,7 +6,7 @@ import { RouterModule } from '@angular/router';
 import { ButtonsModule } from 'ngx-bootstrap/buttons';
 import { BsDropdownModule } from 'ngx-bootstrap/dropdown';
 import { LayoutSwitcherModule } from '../../../../../../src/directives/layout-switcher/index';
-import { AccordionModule, CheckboxModule, ColumnSortingModule, FilterModule, FixedHeaderTableModule, HoverActionModule, RadioButtonModule, ReorderableModule, SelectionModule, SliderModule, SparkModule, TableModule, TabsetModule, TooltipModule } from '../../../../../../src/index';
+import { AccordionModule, CheckboxModule, ColumnSortingModule, FilterModule, FixedHeaderTableModule, HoverActionModule, MenuNavigationModule, RadioButtonModule, ReorderableModule, SelectionModule, SliderModule, SparkModule, TableModule, TabsetModule, TooltipModule } from '../../../../../../src/index';
 import { DocumentationComponentsModule } from '../../../../components/components.module';
 import { DocumentationCategoryComponent } from '../../../../components/documentation-category/documentation-category.component';
 import { DocumentationPage, ResolverService } from '../../../../services/resolver/resolver.service';
@@ -97,29 +97,30 @@ const ROUTES = [
 
 @NgModule({
     imports: [
-        WrappersModule,
-        CommonModule,
-        FormsModule,
-        TabsetModule,
-        CheckboxModule,
-        RadioButtonModule,
-        ColumnSortingModule,
-        SparkModule,
-        FilterModule,
-        SelectionModule,
-        LayoutSwitcherModule,
-        DocumentationComponentsModule,
+        A11yModule,
+        AccordionModule,
         BsDropdownModule,
         ButtonsModule,
-        AccordionModule,
-        SliderModule,
-        ReorderableModule,
-        HoverActionModule,
+        CheckboxModule,
+        ColumnSortingModule,
+        CommonModule,
+        DocumentationComponentsModule,
+        FilterModule,
         FixedHeaderTableModule,
-        TooltipModule,
+        FormsModule,
+        HoverActionModule,
+        LayoutSwitcherModule,
+        MenuNavigationModule,
+        RadioButtonModule,
+        ReorderableModule,
         RouterModule.forChild(ROUTES),
-        A11yModule,
-        TableModule
+        SelectionModule,
+        SliderModule,
+        SparkModule,
+        TableModule,
+        TabsetModule,
+        TooltipModule,
+        WrappersModule,
     ],
     exports: SECTIONS,
     declarations: SECTIONS,

--- a/src/components/checkbox/checkbox.component.less
+++ b/src/components/checkbox/checkbox.component.less
@@ -1,10 +1,18 @@
 ux-checkbox {
+    &:focus {
+        outline: none;
+    }
+
     .ux-checkbox {
         display: inline-flex;
         align-items: baseline;
         margin: 0;
         cursor: pointer;
         margin-bottom: 5px;
+
+        &:focus {
+            outline: none;
+        }
 
         .ux-checkbox-container {
             display: inline-flex;

--- a/src/components/filters/filter-dropdown/filter-dropdown.component.html
+++ b/src/components/filters/filter-dropdown/filter-dropdown.component.html
@@ -30,7 +30,8 @@
                 uxMenuNavigationItem
                 [attr.aria-selected]="filter === selected"
                 (click)="selectFilter(filter, $event); dropdown.hide(); menuNavigationToggle.focus()"
-                (keydown.enter)="selectFilter(filter, $event); dropdown.hide(); menuNavigationToggle.focus()">
+                (keydown.enter)="selectFilter(filter, $event); dropdown.hide(); menuNavigationToggle.focus()"
+                (keydown.escape)="menuNavigationToggle.focus()">
 
                 <i class="hpe-icon" [class.hpe-checkmark]="filter === selected"></i>
                 <span class="filter-dropdown-title">{{ filter.name }}</span>

--- a/src/components/filters/filter-dynamic/filter-dynamic.component.html
+++ b/src/components/filters/filter-dynamic/filter-dynamic.component.html
@@ -34,7 +34,8 @@
                 uxMenuNavigationItem
                 [attr.aria-selected]="initial === selected"
                 (click)="removeFilter(); $event.stopPropagation(); $event.preventDefault(); dynamicDropdown.hide(); menuNavigationToggle.focus()"
-                (keydown.enter)="removeFilter(); $event.stopPropagation(); $event.preventDefault(); dynamicDropdown.hide(); menuNavigationToggle.focus()">
+                (keydown.enter)="removeFilter(); $event.stopPropagation(); $event.preventDefault(); dynamicDropdown.hide(); menuNavigationToggle.focus()"
+                (keydown.escape)="menuNavigationToggle.focus()">
 
                 <i class="hpe-icon" [class.hpe-checkmark]="initial === selected"></i>
                 <span class="filter-dropdown-title">{{ initial.name }}</span>

--- a/src/components/table/table-column-resize/resizable-table-column.component.html
+++ b/src/components/table/table-column-resize/resizable-table-column.component.html
@@ -2,9 +2,16 @@
 
 <div #handle
      uxDrag
+     cdkMonitorElementFocus
+     tabindex="0"
+     aria-label="Column resize handle. Use arrow keys to change the column width."
      class="ux-resizable-table-column-handle"
      *ngIf="!disabled"
      (onDragStart)="onDragStart($event)"
      (onDrag)="onDragMove($event, handle)"
-     (onDragEnd)="onDragEnd()">
+     (onDragEnd)="onDragEnd()"
+     (keydown.ArrowLeft)="onMoveLeft()"
+     (keydown.ArrowRight)="onMoveRight()">
+
+     <div class="ux-resizable-table-column-handle-icon"></div>
 </div>

--- a/src/components/table/table-column-resize/resizable-table-column.component.less
+++ b/src/components/table/table-column-resize/resizable-table-column.component.less
@@ -15,12 +15,25 @@
 .ux-resizable-table-column-handle {
     content: '';
     position: absolute;
-    display: block;
+    display: flex;
+    justify-content: center;
+    align-items: center;
     top: 0;
     right: 0;
     width: 16px;
     height: 100%;
     cursor: ew-resize;
+
+    &.cdk-keyboard-focused {
+        .aspects-outline();
+    }
+
+    .ux-resizable-table-column-handle-icon {
+        width: 5px;
+        height: 24px;
+        background-repeat: no-repeat;
+        background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAeCAYAAADkftS9AAAAIklEQVQoU2M4c+bMfxAGAgYYmwGrIIiDjrELjpo5aiZeMwF+yNnOs5KSvgAAAABJRU5ErkJggg==);
+    }
 
     &:hover,
     &.ux-drag-dragging {

--- a/src/components/table/table-column-resize/resizable-table-column.component.ts
+++ b/src/components/table/table-column-resize/resizable-table-column.component.ts
@@ -86,6 +86,14 @@ export class ResizableTableColumnComponent {
     this._table.setResizing(false);
   }
 
+  onMoveLeft(): void {
+    this._table.resizeColumn(this.getCellIndex(), -10);
+  }
+
+  onMoveRight(): void {
+    this._table.resizeColumn(this.getCellIndex(), 10);
+  }
+
   /** Get the column index this cell is part of */
   private getCellIndex(): number {
     return (this._elementRef.nativeElement as HTMLTableCellElement).cellIndex;

--- a/src/components/table/table.module.ts
+++ b/src/components/table/table.module.ts
@@ -1,3 +1,4 @@
+import { A11yModule } from '@angular/cdk/a11y';
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { DragModule } from '../../directives/drag/index';
@@ -10,7 +11,8 @@ import { ResizableTableDirective } from './table-column-resize/resizable-table.d
     imports: [
         CommonModule,
         DragModule,
-        ResizeModule
+        ResizeModule,
+        A11yModule
     ],
     declarations: [
         ResizableTableDirective,

--- a/src/directives/menu-navigation/menu-navigation-item.directive.ts
+++ b/src/directives/menu-navigation/menu-navigation-item.directive.ts
@@ -1,4 +1,5 @@
 import { Directive, ElementRef, EventEmitter, OnDestroy, Output } from '@angular/core';
+import { filter } from 'rxjs/operators';
 import { Subscription } from 'rxjs/Subscription';
 import { MenuNavigationService } from './menu-navigation.service';
 
@@ -7,16 +8,13 @@ import { MenuNavigationService } from './menu-navigation.service';
 })
 export class MenuNavigationItemDirective implements OnDestroy {
 
-    @Output() activated = new EventEmitter();
+    @Output() activated = new EventEmitter<void>();
 
     private _subscription: Subscription;
 
     constructor(service: MenuNavigationService, private _elementRef: ElementRef) {
-        this._subscription = service.active$.subscribe((next) => {
-            if (next === this) {
-                this.setActive();
-            }
-        });
+        this._subscription = service.active$.pipe(filter(item => item === this))
+            .subscribe(() => this.setActive());
     }
 
     ngOnDestroy(): void {

--- a/src/directives/menu-navigation/menu-navigation-toggle.directive.ts
+++ b/src/directives/menu-navigation/menu-navigation-toggle.directive.ts
@@ -1,3 +1,4 @@
+import { DOWN_ARROW, ENTER, LEFT_ARROW, RIGHT_ARROW, SPACE, UP_ARROW } from '@angular/cdk/keycodes';
 import { Directive, ElementRef, EventEmitter, HostListener, Input, Output } from '@angular/core';
 
 @Directive({
@@ -35,41 +36,35 @@ export class MenuNavigationToggleDirective {
     @HostListener('keydown', ['$event'])
     keydownHandler(event: KeyboardEvent): void {
 
-        if (this.isKeyMatch(event.key)) {
+        if (this.isKeyMatch(event.which)) {
 
             // Open the menu
             this.menuOpen = true;
 
             // Allow the menu to init, then send the event to give it focus
-            setTimeout(() => {
-                this.keyEnter.emit();
-            });
+            setTimeout(() => this.keyEnter.emit());
 
             event.preventDefault();
             event.stopPropagation();
         }
     }
 
-    private isKeyMatch(key: string): boolean {
+    private isKeyMatch(key: number): boolean {
         switch (key) {
-            case 'Enter':
-            case ' ':
+            case ENTER:
+            case SPACE:
                 return true;
 
-            case 'ArrowUp':
-            case 'Up':
+            case UP_ARROW:
                 return this.menuPosition === 'top';
 
-            case 'ArrowDown':
-            case 'Down':
+            case DOWN_ARROW:
                 return this.menuPosition === 'bottom';
 
-            case 'ArrowLeft':
-            case 'Left':
+            case LEFT_ARROW:
                 return this.menuPosition === 'left';
 
-            case 'ArrowRight':
-            case 'Right':
+            case RIGHT_ARROW:
                 return this.menuPosition === 'right';
         }
 

--- a/src/directives/menu-navigation/menu-navigation-toggle.directive.ts
+++ b/src/directives/menu-navigation/menu-navigation-toggle.directive.ts
@@ -23,6 +23,7 @@ export class MenuNavigationToggleDirective {
     @Output()
     menuOpenChange = new EventEmitter<boolean>();
 
+    @Output()
     keyEnter = new EventEmitter<void>();
 
     private _menuOpen: boolean;

--- a/src/directives/selection/selection-item.directive.ts
+++ b/src/directives/selection/selection-item.directive.ts
@@ -11,7 +11,9 @@ export class SelectionItemDirective implements OnInit, OnDestroy {
 
     @Input() uxSelectionItem: any;
 
-    @Input() @HostBinding('class.ux-selection-selected')
+    @Input()
+    @HostBinding('class.ux-selection-selected')
+    @HostBinding('attr.aria-selected')
     set selected(selected: boolean) {
         selected ? this.select() : this.deselect();
     }

--- a/src/styles/navigation.less
+++ b/src/styles/navigation.less
@@ -1000,6 +1000,10 @@ h4 {
             background-color: @dropdown-hover-bg;
             color: @dropdown-hover-color;
         }
+
+        &:focus {
+            .aspects-outline();
+        }
     }
 
     li.dropdown-indent > a {

--- a/src/styles/tables.less
+++ b/src/styles/tables.less
@@ -999,20 +999,24 @@ table {
     }
 
     .sort-icon {
+        display: inline-flex;
+        justify-content: center;
+        align-items: center;
         height: 34px;
         margin-right: 1px;
         float: right;
         padding: 6px;
-        padding-top: 10px;
         cursor: pointer;
+        border: none;
+        background-color: transparent;
 
         &:hover,
         &:focus {
-            background: @table-sort-hover-bg;
+            background-color: @table-sort-hover-bg;
         }
 
         &:focus {
-            outline: 1px solid @table-sort-focus-outline;
+            .aspects-outline();
         }
     }
 }

--- a/src/styles/tables.less
+++ b/src/styles/tables.less
@@ -190,6 +190,16 @@ table {
             outline: 0;
         }
     }
+
+    .hover-action-btn {
+        border: none;
+        background-color: transparent;
+        padding: 0;
+
+        &:focus {
+            .aspects-outline();
+        }
+    }
 }
 
 .table > tbody > tr {
@@ -1164,5 +1174,14 @@ th {
         overflow-y: scroll;
         min-height: 1px;
         margin-top: -1px;
+    }
+}
+
+/*
+ * Reorderable Table
+ */
+.reorderable-row {
+    &:focus {
+        .aspects-outline();
     }
 }


### PR DESCRIPTION
Ticket Comments Below:

Deprecated remaining AngularJS table sections as they are examples only or things we are not looking to migrate.

Column Sorting - **Previously Done**

Custom Filters - Example Updated - Now uses a list and menu navigation directives

Filters - **Done**

Fixed Header Table:
- Possibly aria-setsize and aria-posinset. **Done**
- Maybe aria-live for start and end of async loading? Compare with infinite scroll/paging select component. **The other components didn't do this, however I can add it in if you think it should be there**

Hover Actions:
- Update example with aria-labels on the action buttons. **Done**

Selection:
- Update the directive to add aria-selected as appropriate. **Done**
- Checkbox should become aria-hidden. **Done**

Toolbar Sorting:
- Add keyboard control and focus management to the dropdown. Compare with masthead dropdowns or use uxTabbableList. **Done**
- Sort direction button requires an aria-label. **Done**

Column Resizing:
- Allow focus on the resize thumb. Keyboard control similar to the splitter. **Done**
- Make the size thumb visible so that the user knows that it is focusable. **Done**
- Aria label/description to indicate functionality. **Done**