### PR TITLE
Release 1.6.6

### DIFF
--- a/docs/app/pages/changelog/changelog.component.ts
+++ b/docs/app/pages/changelog/changelog.component.ts
@@ -1,6 +1,7 @@
 import { Component } from '@angular/core';
 import { DomSanitizer } from '@angular/platform-browser';
 import { IChangeLog } from '../../interfaces/IChangeLog';
+import { AppConfiguration } from '../../services/app-configuration/app-configuration.service';
 
 @Component({
     selector: 'uxd-changelog-page',
@@ -11,9 +12,14 @@ export class ChangeLogPageComponent {
 
     logs: IChangeLog[];
 
-    constructor(domSanitizer: DomSanitizer) {
+    constructor(domSanitizer: DomSanitizer, appConfig: AppConfiguration) {
 
         this.logs = [
+            {
+                version: '1.6.6',
+                date: 'October 25th 2018',
+                content: require('./logs/release-v1.6.6.md')
+            },
             {
                 version: '1.6.5',
                 date: 'October 11th 2018',
@@ -211,9 +217,9 @@ export class ChangeLogPageComponent {
             }
         ];
 
-        // santize blog posts
         this.logs.forEach(log => {
-            log.content = domSanitizer.bypassSecurityTrustHtml(log.content) as string;
+            const markdown = log.content.replace(/{{baseUrl}}/g, appConfig.baseUrl);
+            log.content = domSanitizer.bypassSecurityTrustHtml(markdown) as string;
         });
 
     }

--- a/docs/app/pages/changelog/logs/release-v1.6.6.md
+++ b/docs/app/pages/changelog/logs/release-v1.6.6.md
@@ -1,0 +1,27 @@
+UX Aspects 1.6.6 is available! Check out the documentation at [uxaspects.github.io/UXAspects](https://uxaspects.github.io/UXAspects).
+
+#### New Features
+* Accessibility (WCAG 2.0 AA level):
+    * [Column Resizing]({{baseUrl}}/#/components/tables#column-resizing)
+    * [Floating Action Button]({{baseUrl}}/#/components/buttons#floating-action-button)
+    * [Hierarchy Bar]({{baseUrl}}/#/components/hierarchy-bar#hierarchy-bar)
+    * [Marquee Wizard]({{baseUrl}}/#/components/wizard#marquee-wizard)
+    * [Pagination]({{baseUrl}}/#/components/buttons#pagination)
+    * [Wizard]({{baseUrl}}/#/components/wizard#wizard)
+* [Icons]({{baseUrl}}/#/css/icons#ux-icons) - added `hpe-zoom-out`.
+
+#### Documentation
+* Updated code examples for accessibility (WCAG 2.0 AA level):
+    * [Component List]({{baseUrl}}/#/components/component-list#component-list)
+    * [File Upload]({{baseUrl}}/#/components/file-upload#file-upload)
+
+#### Bug Fixes and Improvements
+* (EL-3241) [Select]({{baseUrl}}/#/components/select#select) - new `autocomplete` property allows configuration of the `autocomplete` attribute on the component's text input.
+* (EL-3254) [Filters]({{baseUrl}}/#/components/tables#filters) - added new two-way binding property `filters`, allowing the selected filters to be updated externally.
+* (EL-3255) [Hover Actions (AngularJS)]({{baseUrl}}/#/components/tables#hover-actions-ng1) - buttons can be disabled using the new `disabled` property.
+* (EL-3268) [Date &amp; Time Picker]({{baseUrl}}/#/components/date-time-picker#date-time-picker) - support for customization of month names via the `months` and `monthsShort` properties.
+
+#### Angular 7
+[Angular 7](https://blog.angular.io/version-7-of-angular-cli-prompts-virtual-scroll-drag-and-drop-and-more-c594e22e7b8c) has been released, and UX Aspects will support this in an upcoming release. Check the [Angular update tool](https://update.angular.io/) if you are planning to upgrade.
+
+Any questions or feedback? Get in touch on Twitter [@UXAspects](https://twitter.com/UXAspects), open an issue on [GitHub](https://github.com/UXAspects/UXAspects/issues), or check our [blog](https://uxaspects.github.io/UXAspects/#/blog) for more information!

--- a/docs/app/services/app-configuration/app-configuration.service.ts
+++ b/docs/app/services/app-configuration/app-configuration.service.ts
@@ -12,10 +12,17 @@ export class AppConfiguration {
         return this._config['version'];
     }
 
+    get baseUrl(): string {
+        if (!this._config['baseUrl']) {
+            this._config['baseUrl'] = this.getBaseUrl();
+        }
+        return this._config['baseUrl'];
+    }
+
     get assetsUrl(): string {
         if (!this._config['assetsUrl']) {
             // If not configured, derive from the application's base URL.
-            this._config['assetsUrl'] = Location.joinWithSlash(this.getBaseUrl(), 'assets');
+            this._config['assetsUrl'] = Location.joinWithSlash(this.baseUrl, 'assets');
         }
         return this._config['assetsUrl'];
     }
@@ -67,6 +74,6 @@ export class AppConfiguration {
 
     private getBaseUrl(): string {
         const path = this._location.prepareExternalUrl(this._location.path());
-        return window.location.href.substr(0, window.location.href.lastIndexOf(path));
+        return window.location.href.substr(0, window.location.href.lastIndexOf(path)).replace(/\/+$/, '');
     }
 }


### PR DESCRIPTION
Updated the changelog component to replace `{{baseUrl}}` with the application's base URL. This is mostly for the MF site to allow links to work for stack B users as well.

https://autjira.microfocus.com/browse/EL-3276