### PR TITLE
Adding missing export

### DIFF
--- a/src/components/date-time-picker/index.ts
+++ b/src/components/date-time-picker/index.ts
@@ -1,4 +1,5 @@
-export * from './date-time-picker.module';
 export * from './date-time-picker.component';
-export * from './date-time-picker.service';
 export * from './date-time-picker.config';
+export * from './date-time-picker.module';
+export * from './date-time-picker.service';
+export * from './date-time-picker.utils';


### PR DESCRIPTION
The interface got moved due to it causing a circular dependency, however where it was moved to wasn't getting exported by the index.ts