### PR TITLE
EL-3278 - Select List

### DIFF
--- a/src/components/navigation/index.ts
+++ b/src/components/navigation/index.ts
@@ -1,5 +1,7 @@
-export * from './navigation.module';
-export * from './navigation.component';
-export * from './navigation.service';
 export * from './navigation-item.inferface';
 export * from './navigation-item/navigation-item.component';
+export * from './navigation-link/navigation-link.directive';
+export * from './navigation.component';
+export * from './navigation.module';
+export * from './navigation.service';
+

--- a/src/components/select-list/multiple-select-list.strategy.ts
+++ b/src/components/select-list/multiple-select-list.strategy.ts
@@ -1,16 +1,16 @@
 import { DOWN_ARROW, ENTER, SPACE, UP_ARROW } from '@angular/cdk/keycodes';
 import { SelectionStrategy } from '../../directives/selection/strategies/selection.strategy';
 
-export class MultipleSelectListStrategy extends SelectionStrategy {
+export class MultipleSelectListStrategy<T> extends SelectionStrategy<T> {
 
-    private _lastSelection: any;
+    private _lastSelection: T;
 
     /** Prevent the browser from highlighting text on shift click */
     mousedown(event: MouseEvent): void {
         event.preventDefault();
     }
 
-    click(event: MouseEvent, data: any): void {
+    click(event: MouseEvent, data: T): void {
 
         // activate the clicked item
         this.selectionService.activate(data);
@@ -30,7 +30,7 @@ export class MultipleSelectListStrategy extends SelectionStrategy {
         }
     }
 
-    keydown(event: KeyboardEvent, data: any): void {
+    keydown(event: KeyboardEvent, data: T): void {
 
         switch (event.which) {
 
@@ -65,12 +65,13 @@ export class MultipleSelectListStrategy extends SelectionStrategy {
         }
     }
 
-    multipleSelect(data: any): void {
+    multipleSelect(data: T): void {
 
         // if there is no start item selected
         if (!this._lastSelection) {
             this.select(data);
-            return this._lastSelection = data;
+            this._lastSelection = data;
+            return;
         }
 
         // if there already is a start item then find the items in the range
@@ -80,7 +81,7 @@ export class MultipleSelectListStrategy extends SelectionStrategy {
         this._lastSelection = data;
     }
 
-    private getSelectedItems(start: any, end: any): any[] {
+    private getSelectedItems(start: T, end: T): T[] {
 
         // get the latest dataset
         const { dataset } = this.selectionService;

--- a/src/components/select-list/select-list-item/select-list-item.component.ts
+++ b/src/components/select-list/select-list-item/select-list-item.component.ts
@@ -10,9 +10,9 @@ import { SelectionService } from '../../../directives/selection/selection.servic
         role: 'listitem'
     }
 })
-export class SelectListItemComponent implements OnDestroy {
+export class SelectListItemComponent<T> implements OnDestroy {
 
-    @Input() data: any;
+    @Input() data: T;
     @HostBinding('tabindex') tabindex: number = -1;
 
     @HostBinding('class.selected')
@@ -27,7 +27,7 @@ export class SelectListItemComponent implements OnDestroy {
 
     private _onDestroy = new Subject<void>();
 
-    constructor(private _selection: SelectionService, elementRef: ElementRef) {
+    constructor(private _selection: SelectionService<T>, elementRef: ElementRef) {
 
         _selection.active$.pipe(takeUntil(this._onDestroy), filter(data => data === this.data)).subscribe(active => {
             _selection.focus$.next(active);

--- a/src/components/select-list/select-list-item/select-list-item.component.ts
+++ b/src/components/select-list/select-list-item/select-list-item.component.ts
@@ -1,6 +1,7 @@
 import { Component, ElementRef, HostBinding, HostListener, Input, OnDestroy } from '@angular/core';
 import { filter, takeUntil } from 'rxjs/operators';
 import { Subject } from 'rxjs/Subject';
+import { tick } from '../../../common/index';
 import { SelectionService } from '../../../directives/selection/selection.service';
 
 @Component({
@@ -35,7 +36,7 @@ export class SelectListItemComponent<T> implements OnDestroy {
         });
 
         // make this item tabbable or not based on the focused element
-        _selection.focus$.pipe(takeUntil(this._onDestroy))
+        _selection.focus$.pipe(takeUntil(this._onDestroy), tick())
             .subscribe(focused => this.tabindex = focused === this.data ? 0 : -1);
     }
 

--- a/src/components/select-list/select-list.component.ts
+++ b/src/components/select-list/select-list.component.ts
@@ -13,21 +13,35 @@ import { SingleSelectListStrategy } from './single-select-list.strategy';
         role: 'list'
     }
 })
-export class SelectListComponent implements AfterContentInit, OnDestroy {
+export class SelectListComponent<T> implements AfterContentInit, OnDestroy {
 
+    /** Determine if we allow multiple items to be selected */
     @Input() set multiple(multiple: boolean) {
         this._selection.strategy.deselectAll();
         this._selection.setStrategy(multiple ? new MultipleSelectListStrategy() : new SingleSelectListStrategy());
     }
 
-    @Input() selected: any[] = [];
-    @Output() selectedChange = new EventEmitter<any[]>();
+    /** Set the selected items */
+    @Input() set selected(selected: T | T[]) {
 
-    @ContentChildren(SelectListItemComponent) items: QueryList<SelectListItemComponent>;
+        // deselect all currently selected items
+        this._selection.deselectAll();
+
+        // select only the specified items
+        if (Array.isArray(selected)) {
+            this._selection.select(...selected);
+        } else {
+            this._selection.select(selected);
+        }
+    }
+
+    @Output() selectedChange = new EventEmitter<T[]>();
+
+    @ContentChildren(SelectListItemComponent) items: QueryList<SelectListItemComponent<T>>;
 
     private _subscription: Subscription;
 
-    constructor(private _selection: SelectionService) {
+    constructor(private _selection: SelectionService<T>) {
         // set the selection strategy to single by default
         this._selection.setStrategy(new SingleSelectListStrategy());
 

--- a/src/components/select-list/select-list.component.ts
+++ b/src/components/select-list/select-list.component.ts
@@ -1,5 +1,6 @@
 import { AfterContentInit, Component, ContentChildren, EventEmitter, Input, OnDestroy, Output, QueryList } from '@angular/core';
-import { Subscription } from 'rxjs/Subscription';
+import { takeUntil } from 'rxjs/operators';
+import { Subject } from 'rxjs/Subject';
 import { SelectionService } from '../../directives/selection/selection.service';
 import { MultipleSelectListStrategy } from './multiple-select-list.strategy';
 import { SelectListItemComponent } from './select-list-item/select-list-item.component';
@@ -18,7 +19,7 @@ export class SelectListComponent<T> implements AfterContentInit, OnDestroy {
     /** Determine if we allow multiple items to be selected */
     @Input() set multiple(multiple: boolean) {
         this._selection.strategy.deselectAll();
-        this._selection.setStrategy(multiple ? new MultipleSelectListStrategy() : new SingleSelectListStrategy());
+        this._selection.setStrategy(multiple ? new MultipleSelectListStrategy<T>() : new SingleSelectListStrategy<T>());
     }
 
     /** Set the selected items */
@@ -35,18 +36,22 @@ export class SelectListComponent<T> implements AfterContentInit, OnDestroy {
         }
     }
 
+    /** Emit when the selection changes */
     @Output() selectedChange = new EventEmitter<T[]>();
 
-    @ContentChildren(SelectListItemComponent) items: QueryList<SelectListItemComponent<T>>;
+    /** Find all select list items */
+    @ContentChildren(SelectListItemComponent, { descendants: true }) items: QueryList<SelectListItemComponent<T>>;
 
-    private _subscription: Subscription;
+    /** Automatically unsubscribe all observables */
+    private _onDestroy = new Subject<void>();
 
     constructor(private _selection: SelectionService<T>) {
         // set the selection strategy to single by default
-        this._selection.setStrategy(new SingleSelectListStrategy());
+        this._selection.setStrategy(new SingleSelectListStrategy<T>());
 
         // emit the selection changes when they occur
-        this._subscription = this._selection.selection$.subscribe(selection => this.selectedChange.emit(selection));
+        this._selection.selection$.pipe(takeUntil(this._onDestroy))
+            .subscribe(selection => this.selectedChange.emit(selection));
     }
 
     ngAfterContentInit(): void {
@@ -55,10 +60,11 @@ export class SelectListComponent<T> implements AfterContentInit, OnDestroy {
         this._selection.dataset = this.items.map(item => item.data);
 
         // if the item set changes update the list
-        this.items.changes.subscribe(() => this._selection.dataset = this.items.map(item => item.data));
+        this.items.changes.pipe(takeUntil(this._onDestroy)).subscribe(() => this._selection.dataset = this.items.map(item => item.data));
     }
 
     ngOnDestroy(): void {
-        this._subscription.unsubscribe();
+        this._onDestroy.next();
+        this._onDestroy.complete();
     }
 }

--- a/src/components/select-list/select-list.component.ts
+++ b/src/components/select-list/select-list.component.ts
@@ -40,7 +40,7 @@ export class SelectListComponent<T> implements AfterContentInit, OnDestroy {
     @Output() selectedChange = new EventEmitter<T[]>();
 
     /** Find all select list items */
-    @ContentChildren(SelectListItemComponent, { descendants: true }) items: QueryList<SelectListItemComponent<T>>;
+    @ContentChildren(SelectListItemComponent) items: QueryList<SelectListItemComponent<T>>;
 
     /** Automatically unsubscribe all observables */
     private _onDestroy = new Subject<void>();

--- a/src/components/select-list/single-select-list.strategy.ts
+++ b/src/components/select-list/single-select-list.strategy.ts
@@ -1,9 +1,9 @@
 import { DOWN_ARROW, ENTER, SPACE, UP_ARROW } from '@angular/cdk/keycodes';
 import { SelectionStrategy } from '../../directives/selection/strategies/selection.strategy';
 
-export class SingleSelectListStrategy extends SelectionStrategy {
+export class SingleSelectListStrategy<T> extends SelectionStrategy<T> {
 
-    click(_event: MouseEvent, data: any): void {
+    click(_event: MouseEvent, data: T): void {
 
         if (!this.selectionService.isSelected(data)) {
             // deselect all other items
@@ -17,7 +17,7 @@ export class SingleSelectListStrategy extends SelectionStrategy {
         this.toggle(data);
     }
 
-    keydown(event: KeyboardEvent, data: any): void {
+    keydown(event: KeyboardEvent, data: T): void {
 
         switch (event.which) {
 

--- a/src/directives/menu-navigation/index.ts
+++ b/src/directives/menu-navigation/index.ts
@@ -1,3 +1,5 @@
 export * from './menu-navigation-item.directive';
+export * from './menu-navigation-toggle.directive';
 export * from './menu-navigation.directive';
 export * from './menu-navigation.module';
+

--- a/src/directives/selection/selection-item.directive.ts
+++ b/src/directives/selection/selection-item.directive.ts
@@ -7,9 +7,9 @@ import { SelectionService } from './selection.service';
     selector: '[uxSelectionItem]',
     exportAs: 'ux-selection-item'
 })
-export class SelectionItemDirective implements OnInit, OnDestroy {
+export class SelectionItemDirective<T> implements OnInit, OnDestroy {
 
-    @Input() uxSelectionItem: any;
+    @Input() uxSelectionItem: T;
 
     @Input()
     @HostBinding('class.ux-selection-selected')
@@ -37,7 +37,7 @@ export class SelectionItemDirective implements OnInit, OnDestroy {
     private _managedTabIndex: number = -1;
     private _onDestroy = new Subject<void>();
 
-    constructor(private _selectionService: SelectionService, private _elementRef: ElementRef) { }
+    constructor(private _selectionService: SelectionService<T>, private _elementRef: ElementRef) { }
 
     ngOnInit(): void {
 

--- a/src/directives/selection/selection.directive.ts
+++ b/src/directives/selection/selection.directive.ts
@@ -5,15 +5,14 @@ import { SelectionItemDirective } from './selection-item.directive';
 import { SelectionMode, SelectionService } from './selection.service';
 import { SelectionStrategy } from './strategies/selection.strategy';
 
-
 @Directive({
   selector: '[uxSelection]',
   exportAs: 'ux-selection',
   providers: [ SelectionService ]
 })
-export class SelectionDirective implements AfterContentInit, OnDestroy {
+export class SelectionDirective<T> implements AfterContentInit, OnDestroy {
 
-  @Input() set uxSelection(items: any[]) {
+  @Input() set uxSelection(items: T[]) {
     this._selectionService.select(...items);
   }
 
@@ -21,7 +20,7 @@ export class SelectionDirective implements AfterContentInit, OnDestroy {
     this._selectionService.setDisabled(disabled);
   }
 
-  @Input() set mode(mode: SelectionMode | SelectionStrategy) {
+  @Input() set mode(mode: SelectionMode | SelectionStrategy<T>) {
     this._selectionService.setStrategy(mode);
   }
 
@@ -35,13 +34,13 @@ export class SelectionDirective implements AfterContentInit, OnDestroy {
 
   @Input() @HostBinding('attr.tabindex') tabindex: number = null;
 
-  @Output() uxSelectionChange = new EventEmitter<any[]>();
+  @Output() uxSelectionChange = new EventEmitter<T[]>();
 
-  @ContentChildren(SelectionItemDirective) items: QueryList<SelectionItemDirective>;
+  @ContentChildren(SelectionItemDirective) items: QueryList<SelectionItemDirective<T>>;
 
   private _onDestroy = new Subject<void>();
 
-  constructor(private _selectionService: SelectionService, private _cdRef: ChangeDetectorRef) {
+  constructor(private _selectionService: SelectionService<T>, private _cdRef: ChangeDetectorRef) {
     _selectionService.selection$.pipe(takeUntil(this._onDestroy)).subscribe(items => this.uxSelectionChange.emit(items));
   }
 

--- a/src/directives/selection/selection.service.ts
+++ b/src/directives/selection/selection.service.ts
@@ -8,32 +8,32 @@ import { SelectionStrategy } from './strategies/selection.strategy';
 import { SimpleSelectionStrategy } from './strategies/simple-selection.strategy';
 
 @Injectable()
-export class SelectionService implements OnDestroy {
+export class SelectionService<T> implements OnDestroy {
 
-  set dataset(dataset: ReadonlyArray<any>) {
+  set dataset(dataset: ReadonlyArray<T>) {
     this._dataset = dataset;
     if (this._dataset.indexOf(this._active) === -1) {
       this.setFirstItemFocusable();
     }
   }
 
-  get dataset(): ReadonlyArray<any> {
+  get dataset(): ReadonlyArray<T> {
     return this._dataset;
   }
 
-  strategy: SelectionStrategy = new SimpleSelectionStrategy(this);
+  strategy: SelectionStrategy<T> = new SimpleSelectionStrategy<T>(this);
   isEnabled: boolean = true;
   isClickEnabled: boolean = true;
   isKeyboardEnabled: boolean = true;
 
-  focus$ = new BehaviorSubject<any>(null);
-  active$ = new BehaviorSubject<any>(null);
-  selection$ = new BehaviorSubject<any[]>([]);
+  focus$ = new BehaviorSubject<T>(null);
+  active$ = new BehaviorSubject<T>(null);
+  selection$ = new BehaviorSubject<T[]>([]);
 
-  private _active: any;
-  private _dataset: ReadonlyArray<any> = [];
+  private _active: T;
+  private _dataset: ReadonlyArray<T> = [];
   private _selection = new Set();
-  private _strategyToDestroy: SelectionStrategy = this.strategy;
+  private _strategyToDestroy: SelectionStrategy<T> = this.strategy;
 
   ngOnDestroy(): void {
     if (this._strategyToDestroy) {
@@ -45,7 +45,7 @@ export class SelectionService implements OnDestroy {
    * If the item is not currently selected then add it
    * to the list of selected items
    */
-  select(...selections: any[]): void {
+  select(...selections: T[]): void {
 
     // add each selection to the set
     selections.forEach(selection => this._selection.add(selection));
@@ -57,7 +57,7 @@ export class SelectionService implements OnDestroy {
   /**
    * Remove an item from the list of selected items
    */
-  deselect(...selections: any[]): void {
+  deselect(...selections: T[]): void {
     // remove each item from the set
     selections.forEach(selection => this._selection.delete(selection));
 
@@ -79,14 +79,14 @@ export class SelectionService implements OnDestroy {
   /**
    * Toggle the selected state of any specified items
    */
-  toggle(...selections: any[]): void {
+  toggle(...selections: T[]): void {
     selections.forEach(selection => this.isSelected(selection) ? this.deselect(selection) : this.select(selection));
   }
 
   /**
    * Determine whether or not a specific item is currently selected
    */
-  isSelected(data: any): boolean {
+  isSelected(data: T): boolean {
     return this._selection.has(data);
   }
 
@@ -94,7 +94,7 @@ export class SelectionService implements OnDestroy {
    * Return an observable specifically for notifying the subscriber
    * only when the selection state of a specific object has changed
    */
-  getSelectionState(data: any): Observable<boolean> {
+  getSelectionState(data: T): Observable<boolean> {
     return this.selection$.pipe(map(() => this.isSelected(data)), distinctUntilChanged());
   }
 
@@ -104,7 +104,7 @@ export class SelectionService implements OnDestroy {
    * and mouse interactions while keeping each mode separated and
    * easily extensible if we want to add more modes in future!
    */
-  setStrategy(mode: SelectionMode | SelectionStrategy): void {
+  setStrategy(mode: SelectionMode | SelectionStrategy<T>): void {
 
     if (this._strategyToDestroy) {
       // Destroy previous strategy if it was created internally
@@ -127,11 +127,11 @@ export class SelectionService implements OnDestroy {
           break;
 
         case 'row':
-          this.strategy = this._strategyToDestroy = new RowSelectionStrategy(this);
+          this.strategy = this._strategyToDestroy = new RowSelectionStrategy<T>(this);
           break;
 
         case 'row-alt':
-          this.strategy = this._strategyToDestroy = new RowAltSelectionStrategy(this);
+          this.strategy = this._strategyToDestroy = new RowAltSelectionStrategy<T>(this);
           break;
 
         default:
@@ -143,7 +143,7 @@ export class SelectionService implements OnDestroy {
   /**
    * Set the current active item
    */
-  activate(data: any): void {
+  activate(data: T): void {
     this._active = data;
     this.active$.next(this._active);
   }
@@ -160,7 +160,7 @@ export class SelectionService implements OnDestroy {
    * Return the next or previous sibling of the current active item.
    * @param previous If true, the previous sibling will be returned.
    */
-  getSibling(previous: boolean = false): any {
+  getSibling(previous: boolean = false): T {
 
     // check if there is a current active item
     if (!this._active) {
@@ -180,7 +180,7 @@ export class SelectionService implements OnDestroy {
    * rather than the next sibling. This function will also return the
    * data of the newly activated sibling
    */
-  activateSibling(previous: boolean = false): any {
+  activateSibling(previous: boolean = false): T {
 
     const target = this.getSibling(previous);
 

--- a/src/directives/selection/selection.service.ts
+++ b/src/directives/selection/selection.service.ts
@@ -123,7 +123,7 @@ export class SelectionService<T> implements OnDestroy {
       switch (mode.toLowerCase().trim()) {
 
         case 'simple':
-          this.strategy = this._strategyToDestroy = new SimpleSelectionStrategy(this);
+          this.strategy = this._strategyToDestroy = new SimpleSelectionStrategy<T>(this);
           break;
 
         case 'row':

--- a/src/directives/selection/strategies/row-alt-selection.strategy.ts
+++ b/src/directives/selection/strategies/row-alt-selection.strategy.ts
@@ -1,8 +1,8 @@
 import { DOWN_ARROW, SPACE, UP_ARROW } from '@angular/cdk/keycodes';
 import { RowSelectionStrategy } from './row-selection.strategy';
 
-export class RowAltSelectionStrategy extends RowSelectionStrategy {
-    keydown(event: KeyboardEvent, data: any): void {
+export class RowAltSelectionStrategy<T> extends RowSelectionStrategy<T> {
+    keydown(event: KeyboardEvent, data: T): void {
         switch (event.which) {
             case UP_ARROW:
             case DOWN_ARROW:
@@ -20,7 +20,7 @@ export class RowAltSelectionStrategy extends RowSelectionStrategy {
     /**
      * Select the sibling item when arrow keys are pressed
      */
-    private handleCursorKey(event: KeyboardEvent, data: any): void {
+    private handleCursorKey(event: KeyboardEvent, data: T): void {
         // determine which modifier keys are pressed
         const { ctrlKey, shiftKey } = event;
 

--- a/src/directives/selection/strategies/row-selection.strategy.ts
+++ b/src/directives/selection/strategies/row-selection.strategy.ts
@@ -1,10 +1,10 @@
 import { DOWN_ARROW, SPACE, UP_ARROW } from '@angular/cdk/keycodes';
 import { SelectionStrategy } from './selection.strategy';
 
-export class RowSelectionStrategy extends SelectionStrategy {
+export class RowSelectionStrategy<T> extends SelectionStrategy<T> {
 
   // store the most recently selected row
-  private _selection: Selection = { start: null, end: null };
+  private _selection: Selection<T> = { start: null, end: null };
 
   /**
    * By default on shift click the browser will highlight
@@ -17,7 +17,7 @@ export class RowSelectionStrategy extends SelectionStrategy {
   /**
    * When a row is clicked we want to handle selection
    */
-  click(event: MouseEvent, data: any): void {
+  click(event: MouseEvent, data: T): void {
 
     // determine which modifier keys are pressed
     const { ctrlKey, shiftKey } = event;
@@ -43,7 +43,7 @@ export class RowSelectionStrategy extends SelectionStrategy {
    * 3. Shift + Arrow keys to multiple select
    * 4. Ctrl + Arrow keys to allow retained selection and navigation
    */
-  keydown(event: KeyboardEvent, data: any): void {
+  keydown(event: KeyboardEvent, data: T): void {
 
     switch (event.which) {
 
@@ -55,7 +55,10 @@ export class RowSelectionStrategy extends SelectionStrategy {
 
       case SPACE:
         event.preventDefault();
-        this.selectionService.strategy.toggle(data, true);
+        this.selectionService.strategy.toggle(data);
+
+        // also activate the item
+        this.selectionService.activate(data);
         break;
 
     }
@@ -65,23 +68,18 @@ export class RowSelectionStrategy extends SelectionStrategy {
    * Override the standard toggle function to store or clear the
    * most recently selected item
    */
-  toggle(data: any, activate: boolean = false): void {
+  toggle(data: T): void {
     super.toggle(data);
 
     // store or clear the selection
     this.selectionService.isSelected(data) ? this.setSelectionStart(data) : this.clearSelection();
-
-    // if we want to keep the item activated then activate
-    if (activate) {
-      this.selectionService.activate(data);
-    }
   }
 
   /**
    * Clear all other selected items and select only
    * the most recently selected item
    */
-  private singleSelect(data: any): void {
+  private singleSelect(data: T): void {
 
     // deselect all other rows if neither modifier key is pressed
     this.deselectAll();
@@ -99,7 +97,7 @@ export class RowSelectionStrategy extends SelectionStrategy {
    * 2. If a start item has been selected - select all in between
    * 3. If a start and end item have been selected clear the range and then select the new range
    */
-  protected multipleSelect(data: any): void {
+  protected multipleSelect(data: T): void {
 
     // if no selection currently exists then perform initial selection
     if (!this._selection.start) {
@@ -127,7 +125,7 @@ export class RowSelectionStrategy extends SelectionStrategy {
    * Set the selection start point. If there was previously a
    * selection end point then clear it as this is a new selection
    */
-  private setSelectionStart(data: any): void {
+  private setSelectionStart(data: T): void {
     this._selection.start = data;
     this._selection.end = null;
 
@@ -138,7 +136,7 @@ export class RowSelectionStrategy extends SelectionStrategy {
   /**
    * Set the selection end point
    */
-  private setSelectionEnd(data: any): void {
+  private setSelectionEnd(data: T): void {
     this._selection.end = data;
 
     // activate the item
@@ -164,7 +162,7 @@ export class RowSelectionStrategy extends SelectionStrategy {
    * Note that the end point may be above the start point so
    * we need to account for this.
    */
-  private getSelectedItems(): any[] {
+  private getSelectedItems(): T[] {
 
     // get the latest dataset
     const { dataset } = this.selectionService;
@@ -180,7 +178,7 @@ export class RowSelectionStrategy extends SelectionStrategy {
   /**
    * Activate the sibling item when arrow keys are pressed
    */
-  private navigate(event: KeyboardEvent, data: any): void {
+  private navigate(event: KeyboardEvent, data: T): void {
 
     // determine which modifier keys are pressed
     const { ctrlKey, shiftKey } = event;
@@ -207,7 +205,7 @@ export class RowSelectionStrategy extends SelectionStrategy {
   }
 }
 
-export interface Selection {
-  start: any;
-  end: any;
+export interface Selection<T> {
+  start: T;
+  end: T;
 }

--- a/src/directives/selection/strategies/selection.strategy.ts
+++ b/src/directives/selection/strategies/selection.strategy.ts
@@ -1,37 +1,37 @@
 import { SelectionService } from '../selection.service';
 
-export class SelectionStrategy {
+export class SelectionStrategy<T = any> {
 
-  constructor(protected selectionService?: SelectionService) { }
+  constructor(protected selectionService?: SelectionService<T>) { }
 
-  setSelectionService(selectionService: SelectionService): void {
+  setSelectionService(selectionService: SelectionService<T>): void {
     this.selectionService = selectionService;
   }
 
-  mousedown(event: MouseEvent, data: any): void { }
+  mousedown(event: MouseEvent, data: T): void { }
 
-  click(event: MouseEvent, data: any): void { }
+  click(event: MouseEvent, data: T): void { }
 
-  keydown(event: KeyboardEvent, data: any): void { }
+  keydown(event: KeyboardEvent, data: T): void { }
 
   /**
    * Select the item - default behavior
    */
-  select(...data: any[]): void {
+  select(...data: T[]): void {
     this.selectionService.select(...data);
   }
 
   /**
    * Toggle the item's selected state - default behavior
    */
-  toggle(...data: any[]): void {
+  toggle(...data: T[]): void {
     this.selectionService.toggle(...data);
   }
 
   /**
    * Deselect the item - default behavior
    */
-  deselect(...data: any[]): void {
+  deselect(...data: T[]): void {
     this.selectionService.deselect(...data);
   }
 

--- a/src/directives/selection/strategies/simple-selection.strategy.ts
+++ b/src/directives/selection/strategies/simple-selection.strategy.ts
@@ -1,12 +1,12 @@
 import { DOWN_ARROW, SPACE, UP_ARROW } from '@angular/cdk/keycodes';
 import { SelectionStrategy } from './selection.strategy';
 
-export class SimpleSelectionStrategy extends SelectionStrategy {
+export class SimpleSelectionStrategy<T> extends SelectionStrategy<T> {
 
   /**
    * When the item is clicked simply toggle the current selected state
    */
-  click(_event: MouseEvent, data: any): void {
+  click(_event: MouseEvent, data: T): void {
     this.toggle(data);
   }
 
@@ -14,17 +14,19 @@ export class SimpleSelectionStrategy extends SelectionStrategy {
    * Add basic keyboard support for navigating
    * and selecting/deselecting items
    */
-  keydown(event: KeyboardEvent, data: any): void {
+  keydown(event: KeyboardEvent, data: T): void {
 
     switch (event.which) {
 
       case UP_ARROW:
         event.preventDefault();
-        return this.selectionService.activateSibling(true);
+        this.selectionService.activateSibling(true);
+        return;
 
       case DOWN_ARROW:
         event.preventDefault();
-        return this.selectionService.activateSibling(false);
+        this.selectionService.activateSibling(false);
+        return;
 
       case SPACE:
         event.preventDefault();
@@ -35,7 +37,7 @@ export class SimpleSelectionStrategy extends SelectionStrategy {
   /**
    * Override the standard toggle function to always activate the item
    */
-  toggle(data: any): void {
+  toggle(data: T): void {
     super.toggle(data);
     this.selectionService.activate(data);
   }

--- a/src/directives/tree-grid/index.ts
+++ b/src/directives/tree-grid/index.ts
@@ -1,7 +1,7 @@
 export * from './tree-grid-indent.directive';
 export * from './tree-grid-item.interface';
 export * from './tree-grid-load-function.type';
+export * from './tree-grid-row.directive';
 export * from './tree-grid-state.class';
 export * from './tree-grid.directive';
 export * from './tree-grid.module';
-

--- a/src/hybrid/index.ts
+++ b/src/hybrid/index.ts
@@ -18,17 +18,20 @@ export * from './components/select-table/select-table.component';
 export * from './components/slider-chart/slider-chart.directive';
 export * from './components/social-chart/social-chart.component';
 export * from './components/sort-direction-toggle/sort-direction-toggle.component';
-export * from './components/tree-grid/tree-grid.component';
 export * from './components/thumbnail/thumbnail.component';
-
+export * from './components/tree-grid/tree-grid.component';
+export * from './hybrid.module';
+export * from './services/navigation-menu/navigation-menu.interface';
 export * from './services/navigation-menu/navigation-menu.service';
-export * from './services/pdf/pdf.service';
-export * from './services/time-ago/time-ago.service';
-
+export * from './services/pdf/pdf.interface';
 /**
  * Export Interfaces
  */
-export { PdfOptions, PdfColumns, PdfDocument } from './services/pdf/pdf.interface';
+export { PdfColumns, PdfDocument, PdfOptions } from './services/pdf/pdf.interface';
+export * from './services/pdf/pdf.service';
+export * from './services/time-ago/time-ago.interface';
 export { TimeAgoLocalizedTimes } from './services/time-ago/time-ago.interface';
+export * from './services/time-ago/time-ago.service';
 
-export * from './hybrid.module';
+
+

--- a/src/tsconfig-build.json
+++ b/src/tsconfig-build.json
@@ -1,25 +1,32 @@
 {
     "compilerOptions": {
-        "declaration": true,
-        "target": "es5",
+        "target": "es2015",
         "module": "es2015",
-        "baseUrl": ".",
-        "stripInternal": true,
-        "experimentalDecorators": true,
         "moduleResolution": "node",
-        "outDir": "../dist/lib",
-        "rootDir": ".",
-        "lib": ["es2015", "dom"],
-        "skipLibCheck": true,
-        "suppressImplicitAnyIndexErrors": true,
+        "declaration": true,
+        "sourceMap": true,
+        "inlineSources": true,
         "emitDecoratorMetadata": true,
+        "experimentalDecorators": true,
+        "importHelpers": true,
+        "lib": [
+            "dom",
+            "es2018"
+        ],
+        "baseUrl": ".",
+        "outDir": "../dist/lib",
+        "suppressImplicitAnyIndexErrors": true,
         "typeRoots": [
             "../node_modules/@types"
         ]
     },
     "angularCompilerOptions": {
+        "annotateForClosureCompiler": true,
+        "skipTemplateCodegen": true,
         "strictMetadataEmit": true,
-        "skipTemplateCodegen": true
+        "fullTemplateTypeCheck": true,
+        "strictInjectionParameters": true,
+        "enableResourceInlining": true
     },
     "files": [
         "./index.ts"


### PR DESCRIPTION
- Select list now updates selected items when the input changes
- Now using `tick` operator to avoid expression changed error

Also made a few additional changes:

- Removed the use of `any` and instead used a generic for all selection classes to help typescript flow types better. For example, as we were using `any` TypeScript was not able to detect that one of our selection strategies did not correctly follow the base Selection Strategy api, which I have corrected.
- After yesterdays release issue I went through our public API and found a few things that were not getting exported (note these were never getting exported so it is not a regression) but some directives for example were not getting exported so consuming applications could not use `@ViewChildren` to reference these directives if they needed to.
- Updated our libraries tsconfig file to match the latest recommended properties (they now match what is produced by the CLI if I run `ng g library ...`