### PR TITLE
EL-3286 - Split Button Dropdown

### DIFF
--- a/docs/app/app.component.ts
+++ b/docs/app/app.component.ts
@@ -1,6 +1,5 @@
-import { Component, OnInit, NgZone } from '@angular/core';
-import { ActivatedRoute, NavigationEnd, Router, RoutesRecognized } from '@angular/router';
-
+import { Component, NgZone, OnInit } from '@angular/core';
+import { ActivatedRoute, NavigationEnd, Router } from '@angular/router';
 import { NavigationService } from './services/navigation/navigation.service';
 
 @Component({

--- a/docs/app/data/components-page.json
+++ b/docs/app/data/components-page.json
@@ -141,6 +141,42 @@
                     "deprecated": true
                 },
                 {
+                    "title": "Split Button Dropdowns",
+                    "component": "ComponentsSplitButtonDropdownsComponent",
+                    "version": "Angular",
+                    "externalUrl": "http://valor-software.com/ngx-bootstrap/#/dropdowns",
+                    "usage": [
+                        {
+                            "title": "Selector",
+                            "content": "dropdown, dropdownToggle, dropdownMenu"
+                        },
+                        {
+                            "title": "Module",
+                            "content": "BsDropdownModule"
+                        },
+                        {
+                            "title": "Import As",
+                            "content": "BsDropdownModule.forRoot()"
+                        },
+                        {
+                            "title": "Library",
+                            "content": "ngx-bootstrap"
+                        },
+                        {
+                            "title": "Selector",
+                            "content": "uxMenuNavigation, uxMenuNavigationToggle, uxMenuNavigationItem"
+                        },
+                        {
+                            "title": "Module",
+                            "content": "MenuNavigationModule"
+                        },
+                        {
+                            "title": "Library",
+                            "content": "@ux-aspects/ux-aspects"
+                        }
+                    ]
+                },
+                {
                     "title": "Checkbox Buttons",
                     "component": "ComponentsCheckboxButtonsNg1Component",
                     "version": "AngularJS",

--- a/docs/app/data/css-page.json
+++ b/docs/app/data/css-page.json
@@ -27,11 +27,13 @@
                 },
                 {
                     "title": "Button Dropdowns",
-                    "component": "CssButtonDropdownsComponent"
+                    "component": "CssButtonDropdownsComponent",
+                    "deprecated": true
                 },
                 {
                     "title": "Split Button Dropdowns",
-                    "component": "CssSplitButtonDropdownsComponent"
+                    "component": "CssSplitButtonDropdownsComponent",
+                    "deprecated": true
                 }
             ]
         },
@@ -107,7 +109,8 @@
             "sections": [
                 {
                     "title": "Page Title",
-                    "component": "CssPageTitleComponent"
+                    "component": "CssPageTitleComponent",
+                    "version": "AngularJS"
                 }
             ]
         },
@@ -117,7 +120,8 @@
             "sections": [
                 {
                     "title": "Navigation Header",
-                    "component": "CssNavigationHeaderComponent"
+                    "component": "CssNavigationHeaderComponent",
+                    "version": "AngularJS"
                 },
                 {
                     "title": "Breadcrumb",
@@ -125,23 +129,28 @@
                 },
                 {
                     "title": "Breadcrumb from States",
-                    "component": "CssBreadcrumbFromStatesComponent"
+                    "component": "CssBreadcrumbFromStatesComponent",
+                    "version": "AngularJS"
                 },
                 {
                     "title": "Breadcrumb with Tab State",
-                    "component": "CssBreadcrumbWithTabStateComponent"
+                    "component": "CssBreadcrumbWithTabStateComponent",
+                    "version": "AngularJS"
                 },
                 {
                     "title": "Condensed Header",
-                    "component": "CssCondensedHeaderComponent"
+                    "component": "CssCondensedHeaderComponent",
+                    "version": "AngularJS"
                 },
                 {
                     "title": "Condensed Header & Toolbar",
-                    "component": "CssCondensedHeaderToolbarComponent"
+                    "component": "CssCondensedHeaderToolbarComponent",
+                    "version": "AngularJS"
                 },
                 {
                     "title": "Standard Header",
-                    "component": "CssStandardHeaderComponent"
+                    "component": "CssStandardHeaderComponent",
+                    "version": "AngularJS"
                 },
                 {
                     "title": "Product Name and Logo",
@@ -149,27 +158,33 @@
                 },
                 {
                     "title": "Header Content Panel",
-                    "component": "CssHeaderContentPanelComponent"
+                    "component": "CssHeaderContentPanelComponent",
+                    "version": "AngularJS"
                 },
                 {
                     "title": "Back Button",
-                    "component": "CssBackButtonComponent"
+                    "component": "CssBackButtonComponent",
+                    "version": "AngularJS"
                 },
                 {
                     "title": "Dynamic Name Callout",
-                    "component": "CssDynamicNameCalloutComponent"
+                    "component": "CssDynamicNameCalloutComponent",
+                    "version": "AngularJS"
                 },
                 {
                     "title": "Standard Header & Toolbar",
-                    "component": "CssStandardHeaderToolbarComponent"
+                    "component": "CssStandardHeaderToolbarComponent",
+                    "version": "AngularJS"
                 },
                 {
                     "title": "Header with Navigation Tab & Toolbar",
-                    "component": "CssHeaderNavTabToolbarComponent"
+                    "component": "CssHeaderNavTabToolbarComponent",
+                    "version": "AngularJS"
                 },
                 {
                     "title": "Page Header Example",
-                    "component": "CssPageHeaderExampleComponent"
+                    "component": "CssPageHeaderExampleComponent",
+                    "version": "AngularJS"
                 }
             ]
         },

--- a/docs/app/data/team-page.json
+++ b/docs/app/data/team-page.json
@@ -2,7 +2,7 @@
     "team": [
         {
             "name": "Ashley Hunter",
-            "email": "ashley-glenn.hunter@hpe.com",
+            "email": "ashley-glenn.hunter@microfocus.com",
             "avatar": "assets/img/team/ashley.jpg",
             "social": [
                 {
@@ -11,7 +11,7 @@
                 },
                 {
                     "icon": "hpe-mail",
-                    "url": "mailto:ashley-glenn.hunter@hpe.com"
+                    "url": "mailto:ashley-glenn.hunter@microfocus.com"
                 },
                 {
                     "icon": "hpe-social-github",
@@ -21,18 +21,18 @@
         },
         {
             "name": "Donna Worby",
-            "email": "donna.worby@hpe.com",
+            "email": "donna.worby@microfocus.com",
             "avatar": "assets/img/team/donna.jpg",
             "social": [
                 {
                     "icon": "hpe-mail",
-                    "url": "mailto:donna.worby@hpe.com"
+                    "url": "mailto:donna.worby@microfocus.com"
                 }
             ]
         },
         {
             "name": "Alastair McKee",
-            "email": "alastair.ian.mckee@hpe.com",
+            "email": "alastair.ian.mckee@microfocus.com",
             "avatar": "assets/img/team/alastair.jpg",
             "social": [
                 {
@@ -41,7 +41,7 @@
                 },
                 {
                     "icon": "hpe-mail",
-                    "url": "mailto:alastair.ian.mckee@hpe.com"
+                    "url": "mailto:alastair.ian.mckee@microfocus.com"
                 },
                 {
                     "icon": "hpe-social-github",
@@ -51,23 +51,23 @@
         },
         {
             "name": "Pearse McMurray",
-            "email": "pearse.mcmurray@hpe.com",
+            "email": "pearse.mcmurray@microfocus.com",
             "avatar": "assets/img/team/user.png",
             "social": [
                 {
                     "icon": "hpe-mail",
-                    "url": "mailto:pearse.mcmurray@hpe.com"
+                    "url": "mailto:pearse.mcmurray@microfocus.com"
                 }
             ]
         },
         {
             "name": "Roland Penny",
-            "email": "roland.penny@hpe.com",
+            "email": "roland.penny@microfocus.com",
             "avatar": "assets/img/team/roland.jpg",
             "social": [
                 {
                     "icon": "hpe-mail",
-                    "url": "mailto:roland.penny@hpe.com"
+                    "url": "mailto:roland.penny@microfocus.com"
                 }
             ]
         }

--- a/docs/app/pages/components/components-sections/buttons/buttons.module.ts
+++ b/docs/app/pages/components/components-sections/buttons/buttons.module.ts
@@ -5,7 +5,7 @@ import { RouterModule } from '@angular/router';
 import { ButtonsModule } from 'ngx-bootstrap/buttons';
 import { BsDropdownModule } from 'ngx-bootstrap/dropdown';
 import { HybridModule } from '../../../../../../src/hybrid/hybrid.module';
-import { AccordionModule, FloatingActionButtonsModule, PaginationModule, RadioButtonModule, TabsetModule, TooltipModule } from '../../../../../../src/index';
+import { AccordionModule, FloatingActionButtonsModule, MenuNavigationModule, PaginationModule, RadioButtonModule, TabsetModule, TooltipModule } from '../../../../../../src/index';
 import { DocumentationComponentsModule } from '../../../../components/components.module';
 import { DocumentationCategoryComponent } from '../../../../components/documentation-category/documentation-category.component';
 import { DocumentationPage, ResolverService } from '../../../../services/resolver/resolver.service';
@@ -22,6 +22,7 @@ import { ComponentsPaginationComponent } from './pagination/pagination.component
 import { ComponentsRadioButtonsNg1Component } from './radio-buttons-ng1/radio-buttons-ng1.component';
 import { ComponentsRadioButtonsComponent } from './radio-buttons/radio-buttons.component';
 import { ComponentsSingleToggleButtonNg1Component } from './single-toggle-button-ng1/single-toggle-button-ng1.component';
+import { ComponentsSplitButtonDropdownsComponent } from './split-button-dropdowns/split-button-dropdowns.component';
 import { ComponentsThumbnailNg1Component } from './thumbnail-ng1/thumbnail-ng1.component';
 import { ComponentsToggleButtonsNg1Component } from './toggle-buttons-ng1/toggle-buttons-ng1.component';
 import { ComponentsToggleButtonsComponent } from './toggle-buttons/toggle-buttons.component';
@@ -40,7 +41,8 @@ const SECTIONS = [
     ComponentsCheckboxButtonsNg1Component,
     ComponentsRadioButtonsNg1Component,
     ComponentsDropdownNg1Component,
-    ComponentsThumbnailNg1Component
+    ComponentsThumbnailNg1Component,
+    ComponentsSplitButtonDropdownsComponent
 ];
 
 const ROUTES = [
@@ -59,7 +61,7 @@ const ROUTES = [
         HybridModule,
         WrappersModule,
         TabsetModule,
-        AccordionModule  ,
+        AccordionModule,
         DocumentationComponentsModule,
         RouterModule.forChild(ROUTES),
         RadioButtonModule,
@@ -69,7 +71,8 @@ const ROUTES = [
         BsDropdownModule,
         StringFilterModule,
         FloatingActionButtonsModule,
-        TooltipModule
+        TooltipModule,
+        MenuNavigationModule
     ],
     exports: SECTIONS,
     declarations: SECTIONS,

--- a/docs/app/pages/components/components-sections/buttons/split-button-dropdowns/snippets/app.html
+++ b/docs/app/pages/components/components-sections/buttons/split-button-dropdowns/snippets/app.html
@@ -1,0 +1,68 @@
+<div class="btn-group" dropdown #dropdown="bs-dropdown" [autoClose]="true">
+    <!-- Standalone Action Buttons -->
+    <button type="button" class="btn button-secondary">Action</button>
+
+    <!-- Dropdown Toggle Button -->
+    <button #toggle
+        id="split-button-toggle"
+        dropdownToggle
+        tabindex="0"
+        class="btn button-secondary dropdown-toggle"
+        aria-label="Toggle Dropdown"
+        aria-haspopup="true"
+        [attr.aria-expanded]="dropdown.isOpen"
+        uxMenuNavigationToggle
+        [(menuOpen)]="dropdown.isOpen"
+        #menuNavigationToggle="uxMenuNavigationToggle">
+
+        <span class="hpe-icon hpe-down"></span>
+    </button>
+
+    <!-- Dropdown Menu -->
+    <ul *dropdownMenu
+        class="dropdown-menu"
+        aria-labelledby="split-button-toggle"
+        role="menu"
+        uxMenuNavigation
+        [toggleButton]="menuNavigationToggle"
+        toggleButtonPosition="top">
+
+        <li role="menuitem">
+            <a (click)="toggle.focus()"
+                (keydown.enter)="toggle.focus()"
+                (keydown.escape)="toggle.focus()"
+                uxMenuNavigationItem
+                tabindex="-1">
+                Action
+            </a>
+        </li>
+        <li role="menuitem">
+            <a (click)="toggle.focus()"
+                (keydown.enter)="toggle.focus()"
+                (keydown.escape)="toggle.focus()"
+                uxMenuNavigationItem
+                tabindex="-1">
+                Another action
+            </a>
+        </li>
+        <li role="menuitem">
+            <a (click)="toggle.focus()"
+                (keydown.enter)="toggle.focus()"
+                (keydown.escape)="toggle.focus()"
+                uxMenuNavigationItem
+                tabindex="-1">
+                Something else here
+            </a>
+        </li>
+        <li class="divider"></li>
+        <li role="menuitem">
+            <a (click)="toggle.focus()"
+                (keydown.enter)="toggle.focus()"
+                (keydown.escape)="toggle.focus()"
+                uxMenuNavigationItem
+                tabindex="-1">
+                Separated link
+            </a>
+        </li>
+    </ul>
+</div>

--- a/docs/app/pages/components/components-sections/buttons/split-button-dropdowns/snippets/app.ts
+++ b/docs/app/pages/components/components-sections/buttons/split-button-dropdowns/snippets/app.ts
@@ -1,0 +1,7 @@
+import { Component } from '@angular/core';
+
+@Component({
+    selector: 'app',
+    templateUrl: './app.component.html'
+})
+export class AppComponent {}

--- a/docs/app/pages/components/components-sections/buttons/split-button-dropdowns/split-button-dropdowns.component.html
+++ b/docs/app/pages/components/components-sections/buttons/split-button-dropdowns/split-button-dropdowns.component.html
@@ -1,0 +1,92 @@
+<div class="btn-group" dropdown #dropdown="bs-dropdown" [autoClose]="true">
+    <!-- Standalone Action Buttons -->
+    <button type="button" class="btn button-secondary">Action</button>
+
+    <!-- Dropdown Toggle Button -->
+    <button #toggle
+        id="split-button-toggle"
+        dropdownToggle
+        tabindex="0"
+        class="btn button-secondary dropdown-toggle"
+        aria-label="Toggle Dropdown"
+        aria-haspopup="true"
+        [attr.aria-expanded]="dropdown.isOpen"
+        uxMenuNavigationToggle
+        [(menuOpen)]="dropdown.isOpen"
+        #menuNavigationToggle="uxMenuNavigationToggle">
+
+        <span class="hpe-icon hpe-down"></span>
+    </button>
+
+    <!-- Dropdown Menu -->
+    <ul *dropdownMenu
+        class="dropdown-menu"
+        aria-labelledby="split-button-toggle"
+        role="menu"
+        uxMenuNavigation
+        [toggleButton]="menuNavigationToggle"
+        toggleButtonPosition="top">
+
+        <li role="menuitem">
+            <a (click)="toggle.focus()"
+                (keydown.enter)="toggle.focus()"
+                (keydown.escape)="toggle.focus()"
+                uxMenuNavigationItem
+                tabindex="-1">
+                Action
+            </a>
+        </li>
+        <li role="menuitem">
+            <a (click)="toggle.focus()"
+                (keydown.enter)="toggle.focus()"
+                (keydown.escape)="toggle.focus()"
+                uxMenuNavigationItem
+                tabindex="-1">
+                Another action
+            </a>
+        </li>
+        <li role="menuitem">
+            <a (click)="toggle.focus()"
+                (keydown.enter)="toggle.focus()"
+                (keydown.escape)="toggle.focus()"
+                uxMenuNavigationItem
+                tabindex="-1">
+                Something else here
+            </a>
+        </li>
+        <li class="divider"></li>
+        <li role="menuitem">
+            <a (click)="toggle.focus()"
+                (keydown.enter)="toggle.focus()"
+                (keydown.escape)="toggle.focus()"
+                uxMenuNavigationItem
+                tabindex="-1">
+                Separated link
+            </a>
+        </li>
+    </ul>
+</div>
+
+<hr>
+
+<p>
+    Split buttons are rendered as two separate buttons, one with the button text and the other drops down to open the menu.
+</p>
+
+<p>
+    Split button dropdowns use the <code>.btn-group</code> class to group the button and the dropdown icon.
+    The menu is contained in the <code>.dropdown-menu</code> class.
+</p>
+
+<p>
+    The ngx-bootstrap dropdown functionality can be used to create the dropdown.
+    See <a routerLink="/components/buttons" fragment="dropdowns">Dropdowns</a> for more information.
+</p>
+
+<p>The example above can be created using the following code:</p>
+
+<ux-tabset [minimal]="false">
+    <ux-tab heading="HTML">
+        <uxd-snippet [content]="snippets.compiled.appHtml"></uxd-snippet>
+    </ux-tab>
+</ux-tabset>

--- a/docs/app/pages/components/components-sections/buttons/split-button-dropdowns/split-button-dropdowns.component.ts
+++ b/docs/app/pages/components/components-sections/buttons/split-button-dropdowns/split-button-dropdowns.component.ts
@@ -1,0 +1,35 @@
+import { Component } from '@angular/core';
+import { BaseDocumentationSection } from '../../../../../components/base-documentation-section/base-documentation-section';
+import { DocumentationSectionComponent } from '../../../../../decorators/documentation-section-component';
+import { IPlunk } from '../../../../../interfaces/IPlunk';
+import { IPlunkProvider } from '../../../../../interfaces/IPlunkProvider';
+
+@Component({
+    selector: 'uxd-components-buttons-split-button-dropdowns',
+    templateUrl: './split-button-dropdowns.component.html'
+})
+@DocumentationSectionComponent('ComponentsSplitButtonDropdownsComponent')
+export class ComponentsSplitButtonDropdownsComponent extends BaseDocumentationSection implements IPlunkProvider {
+
+    plunk: IPlunk = {
+        files: {
+            'app.component.html': this.snippets.raw.appHtml,
+            'app.component.ts': this.snippets.raw.appTs,
+        },
+        modules: [
+            {
+                library: 'ngx-bootstrap/dropdown',
+                imports: ['BsDropdownModule'],
+                providers: ['BsDropdownModule.forRoot()']
+            },
+            {
+                imports: ['MenuNavigationModule'],
+                library: '@ux-aspects/ux-aspects'
+            }
+        ]
+    };
+
+    constructor() {
+        super(require.context('./snippets/', false, /\.(html|css|js|ts)$/));
+    }
+}


### PR DESCRIPTION
- Adding Split Button Dropdown section to buttons section on components page
- Deprecating Button Dropdowns and Split Button Dropdowns on CSS page as these are using Bootstrap.js, not even Angular
- Marking a lot of sections in CSS as AngularJS as the example code is using AngularJS and this could be confusing if someone using Angular copies and pastes the code and it doesn't work.
- Updating our email addresses on Team page to be `@microfocus.com`

Related Pr: https://github.houston.softwaregrp.net/caf/ux-aspects-micro-focus/pull/293