### PR TITLE
EL-3291 - fixing errors when ngModel is null/undefined

### DIFF
--- a/docs/app/pages/components/components-sections/search/search-builder-ng1/snippets/custodianComponent.html
+++ b/docs/app/pages/components/components-sections/search/search-builder-ng1/snippets/custodianComponent.html
@@ -1,7 +1,7 @@
 <search-component ng-controller="CustodianComponentCtrl as vm">
   <label class="form-label">Custodian</label>
   <div class="input-group">
-    <dynamic-select multiple ng-model="model" source="vm.custodians" options="vm.selectOptions">
+    <dynamic-select multiple ng-model="model" source="vm.custodians" select-as="name" track-by="id" options="vm.selectOptions">
     </dynamic-select>
     <span class="input-group-addon show-panel-btn" ng-click="vm.showPanel()"><span class="hpe-icon hpe-menu text-black"></span></span>
   </div>

--- a/docs/app/pages/components/components-sections/search/search-builder-ng1/snippets/custodianComponent.js
+++ b/docs/app/pages/components/components-sections/search/search-builder-ng1/snippets/custodianComponent.js
@@ -12,7 +12,7 @@ function CustodianComponentCtrl($scope, searchBuilderPanel) {
         placeholder: 'Select Custodians'
     };
 
-    vm.custodians = [
+    var names = [
         'Flora Morris',
         'Micheal Gilbert',
         'Isabella Goodman',
@@ -29,6 +29,9 @@ function CustodianComponentCtrl($scope, searchBuilderPanel) {
         'Rena Gomes',
         'Ann Garcia'
     ];
+    vm.custodians = names.map(function(name, i) {
+        return { id: i, name: name };
+    });
 
     vm.showPanel = function () {
         searchBuilderPanel.setPanelHeader('Select Custodians');

--- a/docs/app/pages/components/components-sections/search/search-builder-ng1/snippets/custodianPanel.html
+++ b/docs/app/pages/components/components-sections/search/search-builder-ng1/snippets/custodianPanel.html
@@ -1,8 +1,8 @@
 <div class="m-sm" ng-controller="CustodianPanelCtrl as vm">
   <input type="text" placeholder="Find a custodian" class="form-control" ng-model="vm.filterText" force-focus>
   <ul class="add-field-list" list-item-filter filter-text="vm.filterText">
-    <li class="field-name" ng-repeat="custodian in vm.custodians" key="{{ custodian.name }}" ng-click="vm.selectCustodian(custodian)" ng-class="{ 'option-deselected': !custodian.checked, 'option-selected': custodian.checked }">
-      <span class="hpe-icon hpe-checkmark text-accent option-check"></span> {{ custodian.name }}
+    <li class="field-name" ng-repeat="custodian in vm.custodians" key="{{ custodian.data.id }}" ng-click="vm.selectCustodian(custodian)" ng-class="{ 'option-deselected': !custodian.checked, 'option-selected': custodian.checked }">
+      <span class="hpe-icon hpe-checkmark text-accent option-check"></span> {{ custodian.data.name }}
     </li>
   </ul>
 </div>

--- a/docs/app/pages/components/components-sections/search/search-builder-ng1/snippets/custodianPanel.js
+++ b/docs/app/pages/components/components-sections/search/search-builder-ng1/snippets/custodianPanel.js
@@ -25,7 +25,7 @@ function CustodianPanelCtrl($scope, searchBuilderPanel) {
         var custodians = [];
 
         selectedCustodians.forEach(function (custodian) {
-            custodians.push(custodian.name);
+            custodians.push(custodian.data);
         });
 
         if (deferred) deferred.resolve(custodians);
@@ -41,7 +41,7 @@ function CustodianPanelCtrl($scope, searchBuilderPanel) {
 
         custodians.forEach(function (custodian) {
             vm.custodians.push({
-                name: custodian,
+                data: custodian,
                 checked: false
             });
         });
@@ -52,7 +52,7 @@ function CustodianPanelCtrl($scope, searchBuilderPanel) {
         data.selected.forEach(function (selected) {
             vm.custodians.forEach(function (custodian) {
                 //if it is a match set the checked value to true
-                if (custodian.name === selected) custodian.checked = true;
+                if (custodian.data.id === selected.id) { custodian.checked = true; }
             });
         });
     }

--- a/docs/app/pages/components/components-sections/search/search-builder-ng1/wrapper/search-builder-wrapper.directive.ts
+++ b/docs/app/pages/components/components-sections/search/search-builder-ng1/wrapper/search-builder-wrapper.directive.ts
@@ -226,7 +226,7 @@ function CustodianComponentCtrl($scope: ng.IScope, searchBuilderPanel: any) {
         placeholder: 'Select Custodians'
     };
 
-    vm.custodians = [
+    var names = [
         'Flora Morris',
         'Micheal Gilbert',
         'Isabella Goodman',
@@ -243,6 +243,9 @@ function CustodianComponentCtrl($scope: ng.IScope, searchBuilderPanel: any) {
         'Rena Gomes',
         'Ann Garcia'
     ];
+    vm.custodians = names.map(function(name, i) {
+        return { id: i, name: name };
+    });
 
     vm.showPanel = function () {
         searchBuilderPanel.setPanelHeader('Select Custodians');

--- a/docs/app/pages/components/components-sections/search/search-builder-ng1/wrapper/search-builder-wrapper.directive.ts
+++ b/docs/app/pages/components/components-sections/search/search-builder-ng1/wrapper/search-builder-wrapper.directive.ts
@@ -441,7 +441,7 @@ function CustodianPanelCtrl($scope: ng.IScope, searchBuilderPanel: any) {
         var custodians: any = [];
 
         selectedCustodians.forEach(function (custodian: any) {
-            custodians.push(custodian.name);
+            custodians.push(custodian.data);
         });
 
         if (deferred) { deferred.resolve(custodians); }
@@ -457,7 +457,7 @@ function CustodianPanelCtrl($scope: ng.IScope, searchBuilderPanel: any) {
 
         custodians.forEach(function (custodian: any) {
             vm.custodians.push({
-                name: custodian,
+                data: custodian,
                 checked: false
             });
         });
@@ -468,7 +468,7 @@ function CustodianPanelCtrl($scope: ng.IScope, searchBuilderPanel: any) {
         data.selected.forEach(function (selected: any) {
             vm.custodians.forEach(function (custodian: any) {
                 // if it is a match set the checked value to true
-                if (custodian.name === selected) { custodian.checked = true; }
+                if (custodian.data.id === selected.id) { custodian.checked = true; }
             });
         });
     }

--- a/docs/app/pages/components/components-sections/select/select-ng1/snippets/sample.html
+++ b/docs/app/pages/components/components-sections/select/select-ng1/snippets/sample.html
@@ -2,7 +2,8 @@
     <div class="col-sm-6 col-xs-12">
         <h4>Single Select</h4>
         <div class="form-group m-nil">
-            <dynamic-select ng-model="vm.singleSelectLocation" source="vm.locations" options="vm.singleSelectOptions" ng-disabled="vm.disabled">
+            <dynamic-select ng-model="vm.singleSelectLocation" source="vm.locations"
+                options="vm.singleSelectOptions" ng-disabled="vm.disabled">
             </dynamic-select>
         </div>
         <p class="m-t">
@@ -12,13 +13,16 @@
     <div class="col-sm-6 col-xs-12">
         <div class="form-group m-nil">
             <h4>Multiple Select</h4>
-            <dynamic-select multiple ng-model="vm.multipleSelectLocations" source="vm.locationObjects" select-as="country" track-by="id"
-                options="vm.multipleSelectOptions" ng-disabled="vm.disabled">
+            <dynamic-select multiple ng-model="vm.multipleSelectLocations" source="vm.locationObjects"
+                select-as="country" track-by="id" options="vm.multipleSelectOptions"
+                ng-disabled="vm.disabled">
             </dynamic-select>
         </div>
         <p class="m-t">
             Selected locations:
-            <span ng-repeat="loc in vm.multipleSelectLocations" ng-bind="loc.country + ($last ? '' : ', ')"></span>
+            <span ng-repeat="loc in vm.multipleSelectLocations"
+                ng-bind="loc.country + ($last ? '' : ', ')">
+            </span>
         </p>
     </div>
 </div>
@@ -26,7 +30,8 @@
     <div class="col-sm-6 col-xs-12">
         <h4>Single Select with Paging</h4>
         <div class="form-group m-nil">
-            <dynamic-select ng-model="vm.singleSelectPagingLocation" source="vm.locationPageFn" options="vm.singleSelectOptions" ng-disabled="vm.disabled">
+            <dynamic-select ng-model="vm.singleSelectPagingLocation" source="vm.locationPageFn"
+                options="vm.singleSelectOptions" ng-disabled="vm.disabled">
             </dynamic-select>
         </div>
         <p class="m-t">
@@ -36,13 +41,15 @@
     <div class="col-sm-6 col-xs-12">
         <div class="form-group m-nil">
             <h4>Multiple Select with Paging</h4>
-            <dynamic-select multiple ng-model="vm.multipleSelectPagingLocations" source="vm.locationObjectPageFn" select-as="country"
-                track-by="id" options="vm.multipleSelectOptions" ng-disabled="vm.disabled">
+            <dynamic-select multiple ng-model="vm.multipleSelectPagingLocations"
+                source="vm.locationObjectPageFn" select-as="country" track-by="id"
+                options="vm.multipleSelectOptions" ng-disabled="vm.disabled">
             </dynamic-select>
         </div>
         <p class="m-t">
             Selected locations:
-            <span ng-repeat="loc in vm.multipleSelectPagingLocations" ng-bind="loc.country + ($last ? '' : ', ')"></span>
+            <span ng-repeat="loc in vm.multipleSelectPagingLocations"
+                ng-bind="loc.country + ($last ? '' : ', ')"></span>
         </p>
     </div>
 </div>

--- a/src/ng1/directives/dynamicSelect/dynamicSelect.controller.js
+++ b/src/ng1/directives/dynamicSelect/dynamicSelect.controller.js
@@ -261,8 +261,14 @@ export default class DynamicSelectCtrl {
     }
 
     if (!this.isPaging) {
+
+      let repeatExpr = 'item in filteredItems = (vm.source | filter: vm.dropdownFilterFn)';
+      if (this.trackBy) {
+        repeatExpr += ` track by item.${this.trackBy}`;
+      }
+
       const li = angular.element('<li/>', {
-        'ng-repeat'    : 'item in filteredItems = (vm.source | filter: vm.dropdownFilterFn)',
+        'ng-repeat'    : repeatExpr,
         'class'        : 'el-dynamicselect-dropdown-item',
         'ng-class'     : '{ "selected": vm.itemApi.isSelected(item), "highlighted": vm.itemApi.isHighlighted(item) }',
         'data-key'     : '{{ vm.itemApi.getKey(item) }}',

--- a/src/ng1/directives/dynamicSelect/dynamicSelect.controller.js
+++ b/src/ng1/directives/dynamicSelect/dynamicSelect.controller.js
@@ -89,7 +89,7 @@ export default class DynamicSelectCtrl {
     // Update UI when model changes
     this.watchers.push($scope.$watch(() => this.ngModel, query => {
       if (this.multiple) {
-        this.tagsModel = this.initTagsModel(query);
+        this.tagsModel = this.initTagsModel(query || []);
       }
       else {
         if (query !== null) {
@@ -311,7 +311,7 @@ export default class DynamicSelectCtrl {
    * @param {string} key
    */
   getModelIndex(key) {
-    return this.ngModel.findIndex(item => this.getItemKey(item) === key);
+    return Array.isArray(this.ngModel) ? this.ngModel.findIndex(item => this.getItemKey(item) === key) : -1;
   }
 
   select(item) {


### PR DESCRIPTION
Updated the Search Builder example to use objects for Custodians to demonstrate this use case.
Added track by to avoid adding the $$hashKey to the source object.

https://autjira.microfocus.com/browse/EL-3291