### PR TITLE
EL-3299 - Tree Grid Selection

### DIFF
--- a/docs/app/pages/components/components-sections/tree-view/tree-grid-ng1/tree-grid-ng1.component.html
+++ b/docs/app/pages/components/components-sections/tree-view/tree-grid-ng1/tree-grid-ng1.component.html
@@ -111,7 +111,7 @@
     <tr uxd-api-property name="options" type="object" binding="variable" required="true">
       Configuration options which can be used to customise the appearance and behaviour of the tree grid. Most importantly, the property which contains child nodes can be set here. This is also where the icon set and expander graphics can be customised.
     </tr>
-    <tr uxd-api-property name="selectionManager" type="MultipleSelectProvider" binding="expression">
+    <tr uxd-api-property name="selection-manager" type="MultipleSelectProvider" binding="expression">
       This expression will be executed when the component initializes. A <code>$selection</code> variable will be emitted which can be stored and used to directly manipulate the selected items.
     </tr>
 </uxd-api-properties>

--- a/docs/app/pages/components/components-sections/tree-view/tree-grid-ng1/tree-grid-ng1.component.html
+++ b/docs/app/pages/components/components-sections/tree-view/tree-grid-ng1/tree-grid-ng1.component.html
@@ -111,6 +111,9 @@
     <tr uxd-api-property name="options" type="object" binding="variable" required="true">
       Configuration options which can be used to customise the appearance and behaviour of the tree grid. Most importantly, the property which contains child nodes can be set here. This is also where the icon set and expander graphics can be customised.
     </tr>
+    <tr uxd-api-property name="selectionManager" type="MultipleSelectProvider" binding="expression">
+      This expression will be executed when the component initializes. A <code>$selection</code> variable will be emitted which can be stored and used to directly manipulate the selected items.
+    </tr>
 </uxd-api-properties>
 
 <h4>Column Definition</h4>

--- a/src/hybrid/components/tree-grid/tree-grid.component.ts
+++ b/src/hybrid/components/tree-grid/tree-grid.component.ts
@@ -13,10 +13,11 @@ export class TreeGridNg1Component extends UpgradeComponent {
     @Input() currentRow: any;
     @Input() options: TreeGridOptions;
 
-    @Output() optionsChange: EventEmitter<TreeGridOptions> = new EventEmitter<TreeGridOptions>();
-    @Output() selectedChange: EventEmitter<any[]> = new EventEmitter<any[]>();
-    @Output() currentRowChange: EventEmitter<any> = new EventEmitter<any>();
-    @Output() treeDataChange: EventEmitter<TreeGridData[]> = new EventEmitter<TreeGridData[]>();
+    @Output() optionsChange = new EventEmitter<TreeGridOptions>();
+    @Output() selectedChange = new EventEmitter<any[]>();
+    @Output() currentRowChange = new EventEmitter<any>();
+    @Output() treeDataChange = new EventEmitter<TreeGridData[]>();
+    @Output() selectionManager: EventEmitter<any>;
 
     constructor(elementRef: ElementRef, injector: Injector) {
         super('treegrid', elementRef, injector);

--- a/src/ng1/directives/multipleSelect/multipleSelect.provider.js
+++ b/src/ng1/directives/multipleSelect/multipleSelect.provider.js
@@ -1,3 +1,5 @@
+import { Subject } from 'rxjs/Subject';
+
 export default function multipleSelectProvider() {
 
     multipleSelectFactory.$inject = ["$timeout"];
@@ -51,6 +53,9 @@ class MultipleSelect {
         this.keyFn = null;
         this.nextComponentId = 0;
         this.componentInstances = {};
+
+        // emit whenever the selection changes
+        this.onSelectAll = new Subject();
     }
 
     getNextComponentId() {
@@ -149,6 +154,9 @@ class MultipleSelect {
         this.selectAllTotal = this.total;
         this.updateCount();
         this.onSelect({ item: null });
+
+        // emit the select all event
+        this.onSelectAll.next();
     }
 
     isSelected(item) {

--- a/src/ng1/directives/multipleSelect/multipleSelect.provider.js
+++ b/src/ng1/directives/multipleSelect/multipleSelect.provider.js
@@ -1,6 +1,5 @@
 export default function multipleSelectProvider() {
 
-
     multipleSelectFactory.$inject = ["$timeout"];
 
     function multipleSelectFactory($timeout) {
@@ -10,287 +9,266 @@ export default function multipleSelectProvider() {
 
 }
 
-function MultipleSelect($timeout) {
-    //$timeout for the display error
-    this.$timeout = $timeout;
-    this.showError = false;
+/**
+ * @param {ng.ITimeoutService} $timeout
+ */
+class MultipleSelect {
 
-    //state has to be an object so that when it changes
-    //all references to it in $scopes will trigger a change
-    this.state = {
-        selecting: false,
-        count: 0,
-        selectAllMode: false,
-        selectedFromButton: false,
-        selectedFromCheckBox: false
-
-    };
-    this.selectedItems = [];
-    this.deselectedItems = [];
-    this.currentSelectedRange = [];
-    //the multiple selection action ctrl that was clicked originally
-    this.action = null;
-    //called when item is selected (single item) pass null when selecting all
-    this.onSelect = null;
-    //called when item is deselected (single item) pass null when deselecting all
-    this.onDeselect = null;
-
-    //total count of items that should be displayed when select all is true
-    this.total = 0;
-    this.selectAllTotal = 0;
-
-    this.cancelText = "Cancel";
-    this.selectItemsText = "Select items or";
-    this.selectedItemsText = "Selected";
-    this.selectedItemsUnitText = "items.";
-    this.selectedItemUnitText = "item.";
-    this.selectAllText = "Select all";
-    this.selectNoneText = "Select none";
-    this.selectionInvalidText = "This selection is no longer valid";
-
-    //used for us to keep track of total items selected.
-    this.keyFn = null;
-
-    this.nextComponentId = 0;
-    this.componentInstances = {};
-
-}
-
-MultipleSelect.prototype.getNextComponentId = function() {
-    return this.nextComponentId++;
-};
-
-MultipleSelect.prototype.getComponentInstance = function(componentId) {
-    if (!this.componentInstances[componentId]) {
-        this.componentInstances[componentId] = new MultipleSelect(this.$timeout);
-    }
-
-    return this.componentInstances[componentId];
-};
-
-MultipleSelect.prototype.validateSelection = function() {
-    if (this.state.selectAllMode === true && this.state.selecting === true) {
-        this.selectNone();
-        this.displayError();
-    }
-};
-
-MultipleSelect.prototype.itemsSelected = function() {
-    //check we are selecting
-    if (this.state.selecting) {
-        //if we are in select all mode
-        if (this.state.selectAllMode) {
-            //we must check if everything is deselected
-            if (this.deselectedItems.length === this.selectAllTotal) {
-                //return false if everything is selected but then deselected
-                return false;
-            }
-            return true;
-        } else {
-            //return are there any items selected
-            return this.selectedItems.length > 0;
-        }
-    }
-    return false;
-};
-
-MultipleSelect.prototype.displayError = function() {
-    this.showError = true;
-    this.$timeout(function() {
+    constructor($timeout) {
+        //$timeout for the display error
+        this.$timeout = $timeout;
         this.showError = false;
-    }.bind(this), 2000);
-};
-
-MultipleSelect.prototype.reset = function() {
-    this.action = null;
-    this.state.selecting = false;
-    this.selectedItems = [];
-    this.deselectedItems = [];
-    this.currentSelectedRange = [];
-    this.state.count = this.selectAllTotal = 0;
-    this.state.selectAllMode = false;
-    this.state.selectedFromButton = false;
-    this.state.selectedFromCheckBox = false;
-};
-
-MultipleSelect.prototype.cancel = function() {
-    this.reset();
-    this.onDeselect({
-        item: null
-    });
-};
-
-MultipleSelect.prototype.proceed = function() {
-    this.action.callback();
-    this.reset();
-};
-
-MultipleSelect.prototype.updateCount = function() {
-    if (this.selectedItems.length) {
-        this.state.count = this.selectedItems.length;
-    } else if (this.state.selectAllMode) {
-        this.state.count = this.selectAllTotal - this.deselectedItems.length;
-    } else {
-        this.state.count = 0;
+        //state has to be an object so that when it changes
+        //all references to it in $scopes will trigger a change
+        this.state = {
+            selecting: false,
+            count: 0,
+            selectAllMode: false,
+            selectedFromButton: false,
+            selectedFromCheckBox: false
+        };
+        this.selectedItems = [];
+        this.deselectedItems = [];
+        this.currentSelectedRange = [];
+        //the multiple selection action ctrl that was clicked originally
+        this.action = null;
+        //called when item is selected (single item) pass null when selecting all
+        this.onSelect = null;
+        //called when item is deselected (single item) pass null when deselecting all
+        this.onDeselect = null;
+        //total count of items that should be displayed when select all is true
+        this.total = 0;
+        this.selectAllTotal = 0;
+        this.cancelText = "Cancel";
+        this.selectItemsText = "Select items or";
+        this.selectedItemsText = "Selected";
+        this.selectedItemsUnitText = "items.";
+        this.selectedItemUnitText = "item.";
+        this.selectAllText = "Select all";
+        this.selectNoneText = "Select none";
+        this.selectionInvalidText = "This selection is no longer valid";
+        //used for us to keep track of total items selected.
+        this.keyFn = null;
+        this.nextComponentId = 0;
+        this.componentInstances = {};
     }
-};
 
-MultipleSelect.prototype.selectNone = function() {
-    this.selectedItems = [];
-    this.deselectedItems = [];
-    this.currentSelectedRange = [];
-    this.state.count = this.selectAllTotal = 0;
-    this.state.selectAllMode = false;
-};
+    getNextComponentId() {
+        return this.nextComponentId++;
+    }
 
-MultipleSelect.prototype.selectAll = function() {
-    this.state.selectAllMode = true;
-    this.selectedItems = [];
-    this.deselectedItems = [];
-    this.currentSelectedRange = [];
-    this.selectAllTotal = this.total;
-    this.updateCount();
-    this.onSelect({
-        item: null
-    });
-};
-
-MultipleSelect.prototype.isSelected = function(item) {
-    if (this.keyFn) {
-        var key = this.keyFn({
-            item: item
-        });
-        if (key === undefined || key === null) {
-            return false;
+    /**
+     * @param {number|string} componentId
+     */
+    getComponentInstance(componentId) {
+        if (!this.componentInstances[componentId]) {
+            this.componentInstances[componentId] = new MultipleSelect(this.$timeout);
         }
+        return this.componentInstances[componentId];
+    }
 
-        //if selected items has length
-        //means we are selecting normally
+    validateSelection() {
+        if (this.state.selectAllMode === true && this.state.selecting === true) {
+            this.selectNone();
+            this.displayError();
+        }
+    }
+
+    itemsSelected() {
+        //check we are selecting
+        if (this.state.selecting) {
+            //if we are in select all mode
+            if (this.state.selectAllMode) {
+                //we must check if everything is deselected
+                if (this.deselectedItems.length === this.selectAllTotal) {
+                    //return false if everything is selected but then deselected
+                    return false;
+                }
+                return true;
+            }
+            else {
+                //return are there any items selected
+                return this.selectedItems.length > 0;
+            }
+        }
+        return false;
+    }
+
+    displayError() {
+        this.showError = true;
+        this.$timeout(() => this.showError = false, 2000);
+    }
+
+    reset() {
+        this.action = null;
+        this.state.selecting = false;
+        this.selectedItems = [];
+        this.deselectedItems = [];
+        this.currentSelectedRange = [];
+        this.state.count = this.selectAllTotal = 0;
+        this.state.selectAllMode = false;
+        this.state.selectedFromButton = false;
+        this.state.selectedFromCheckBox = false;
+    }
+
+    cancel() {
+        this.reset();
+        this.onDeselect({ item: null });
+    }
+
+    proceed() {
+        this.action.callback();
+        this.reset();
+    }
+
+    updateCount() {
         if (this.selectedItems.length) {
-            return this.selectedItems.indexOf(key) >= 0;
+            this.state.count = this.selectedItems.length;
         }
-        //if in selectAll mode then we are using the deselect items.
-        if (this.state.selectAllMode) {
-            return this.deselectedItems.indexOf(key) === -1;
+        else if (this.state.selectAllMode) {
+            this.state.count = this.selectAllTotal - this.deselectedItems.length;
         }
-
+        else {
+            this.state.count = 0;
+        }
     }
-    return false;
-};
 
-MultipleSelect.prototype.setSelected = function(item, isSelected) {
-    var currentState = this.isSelected(item);
-    if (isSelected !== undefined && isSelected !== currentState) {
-        this.itemClicked(item);
+    selectNone() {
+        this.selectedItems = [];
+        this.deselectedItems = [];
+        this.currentSelectedRange = [];
+        this.state.count = this.selectAllTotal = 0;
+        this.state.selectAllMode = false;
     }
-};
 
-/*
-  Method for selecting a range of necessarily contiguous items simultaneously
-*/
-MultipleSelect.prototype.rangeClicked = function(itemsCollection) {
-    if (this.keyFn) {
-        var keys = [];
-        for (var i in itemsCollection) {
-            var key = this.keyFn({
-                item: itemsCollection[i]
-            });
+    selectAll() {
+        this.state.selectAllMode = true;
+        this.selectedItems = [];
+        this.deselectedItems = [];
+        this.currentSelectedRange = [];
+        this.selectAllTotal = this.total;
+        this.updateCount();
+        this.onSelect({ item: null });
+    }
+
+    isSelected(item) {
+        if (this.keyFn) {
+            const key = this.keyFn({ item: item });
             if (key === undefined || key === null) {
                 return false;
-            } else {
-                keys.push(key);
+            }
+            //if selected items has length
+            //means we are selecting normally
+            if (this.selectedItems.length) {
+                return this.selectedItems.indexOf(key) >= 0;
+            }
+            //if in selectAll mode then we are using the deselect items.
+            if (this.state.selectAllMode) {
+                return this.deselectedItems.indexOf(key) === -1;
             }
         }
-
-        // Deselect the previous range selection, if any.
-        // This allows shift clicking to expand and contract a range without affecting selections elsewhere.
-        for (var c in this.currentSelectedRange) {
-            var index = this.selectedItems.indexOf(this.currentSelectedRange[c]);
-            if (index >= 0) {
-                this.selectedItems.splice(index, 1);
-            }
-        }
-        this.updateCount();
-
-        for (var j in keys) {
-            if (!~this.selectedItems.indexOf(keys[j])) {
-                this.selectedItems.push(keys[j]);
-                this.updateCount();
-                this.onSelect({
-                    item: itemsCollection[j]
-                });
-            }
-        }
-
-        this.currentSelectedRange = angular.copy(keys);
-
-        return true;
+        return false;
     }
 
-    return false;
-};
+    setSelected(item, isSelected) {
+        const currentState = this.isSelected(item);
+        if (isSelected !== undefined && isSelected !== currentState) {
+            this.itemClicked(item);
+        }
+    }
 
-MultipleSelect.prototype.itemClicked = function(item) {
-    if (this.keyFn) {
-        var key = this.keyFn({
-            item: item
-        });
-        if (key === undefined || key === null) {
-            return false;
-        }
-        this.currentSelectedRange = [];
-        //normal selection mode.
-        if (this.selectedItems.length) {
-            //we know that we are selecting items into the selected items array.
-            var index = this.selectedItems.indexOf(key);
-            if (index >= 0) {
-                this.selectedItems.splice(index, 1);
-                this.updateCount();
-                this.onDeselect({
-                    item: item
-                });
-                //deselect
-                return false;
-            } else {
-                this.selectedItems.push(key);
-                this.updateCount();
-                this.onSelect({
-                    item: item
-                });
-                return true;
+    /*
+      Method for selecting a range of necessarily contiguous items simultaneously
+    */
+    rangeClicked(itemsCollection) {
+        if (this.keyFn) {
+            const keys = [];
+            for (const i in itemsCollection) {
+                const key = this.keyFn({ item: itemsCollection[i] });
+                if (key === undefined || key === null) {
+                    return false;
+                }
+                else {
+                    keys.push(key);
+                }
             }
-        }
-        //select all mode
-        // keeps track of deselected items.
-        if (this.state.selectAllMode) {
-
-            var idx = this.deselectedItems.indexOf(key);
-            if (idx >= 0) {
-                this.deselectedItems.splice(idx, 1);
-                this.updateCount();
-                this.onSelect({
-                    item: item
-                });
-                //Select
-                return true;
-            } else {
-                this.deselectedItems.push(key);
-                this.updateCount();
-                this.onDeselect({
-                    item: item
-                });
-                return false;
+            // Deselect the previous range selection, if any.
+            // This allows shift clicking to expand and contract a range without affecting selections elsewhere.
+            for (const c in this.currentSelectedRange) {
+                const index = this.selectedItems.indexOf(this.currentSelectedRange[c]);
+                if (index >= 0) {
+                    this.selectedItems.splice(index, 1);
+                }
             }
-        }
-        //nothing in deselect or select items then start pushing on select items
-        if (!this.selectedItems.length && !this.state.selectAllMode) {
-            this.selectedItems.push(key);
             this.updateCount();
-            this.onSelect({
-                item: item
-            });
+            for (const j in keys) {
+                if (!~this.selectedItems.indexOf(keys[j])) {
+                    this.selectedItems.push(keys[j]);
+                    this.updateCount();
+                    this.onSelect({
+                        item: itemsCollection[j]
+                    });
+                }
+            }
+            this.currentSelectedRange = angular.copy(keys);
             return true;
         }
+        return false;
     }
-    return false;
-};
+
+    itemClicked(item) {
+        if (this.keyFn) {
+            const key = this.keyFn({ item: item });
+            if (key === undefined || key === null) {
+                return false;
+            }
+            this.currentSelectedRange = [];
+            //normal selection mode.
+            if (this.selectedItems.length) {
+                //we know that we are selecting items into the selected items array.
+                var index = this.selectedItems.indexOf(key);
+                if (index >= 0) {
+                    this.selectedItems.splice(index, 1);
+                    this.updateCount();
+                    this.onDeselect({ item: item });
+                    //deselect
+                    return false;
+                }
+                else {
+                    this.selectedItems.push(key);
+                    this.updateCount();
+                    this.onSelect({ item: item });
+                    return true;
+                }
+            }
+            //select all mode
+            // keeps track of deselected items.
+            if (this.state.selectAllMode) {
+                const idx = this.deselectedItems.indexOf(key);
+                if (idx >= 0) {
+                    this.deselectedItems.splice(idx, 1);
+                    this.updateCount();
+                    this.onSelect({ item: item });
+                    //Select
+                    return true;
+                }
+                else {
+                    this.deselectedItems.push(key);
+                    this.updateCount();
+                    this.onDeselect({
+                        item: item
+                    });
+                    return false;
+                }
+            }
+            //nothing in deselect or select items then start pushing on select items
+            if (!this.selectedItems.length && !this.state.selectAllMode) {
+                this.selectedItems.push(key);
+                this.updateCount();
+                this.onSelect({ item: item });
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/ng1/directives/pageTitle/pageTitle.directive.js
+++ b/src/ng1/directives/pageTitle/pageTitle.directive.js
@@ -17,3 +17,5 @@ export default function pageTitle($rootScope) {
     }
   };
 }
+
+pageTitle.$inject = ['$rootScope'];

--- a/src/ng1/directives/selectTable/selectTable.controller.js
+++ b/src/ng1/directives/selectTable/selectTable.controller.js
@@ -100,12 +100,13 @@ export default class SelectTableController {
 
             // if the item is selected but not visible then we should deselect it
             if (this.selected && !this.isVisible(this.selected)) {
-                this.deselect(this.selected);
 
                 // if we want to restore previously selected items if they become visible again, store it
                 if (this._reselectFilteredItems) {
                     this._filteredSelection = this.selected;
                 }
+
+                this.deselect(this.selected);
             }
 
             // if the item was previously selected and we want to restore selected items then reselect it

--- a/src/ng1/directives/selectTable/selectTable.spec.js
+++ b/src/ng1/directives/selectTable/selectTable.spec.js
@@ -1,63 +1,46 @@
 describe('Select table', function () {
     var $compile, $rootScope, $scope, $timeout;
     var vm = {};
-    var element, objectElement;
+    var element;
+
+    var authors = [
+        "Dale Holmes",
+        "Emily Cain",
+        "Marsha Glover",
+        "Vanessa Barrett",
+        "Sarah Lyons",
+        "Johanna Cobb",
+        "Greg Watson",
+        "Frankie Young",
+        "Phil Garcia",
+        "Levi Smith",
+        "Aaron Morgan",
+        "Lucy Gill"
+    ];
+
+    var users = [{
+            id: 1,
+            name: "Dale"
+        }, {
+            id: 2,
+            name: "Emily"
+        }, {
+            id: 3,
+            name: "Sarah"
+        },
+        {
+            id: 4,
+            name: "Phil"
+        }, {
+            id: 5,
+            name: "Frankie"
+        }, {
+            id: 6,
+            name: "Vanessa"
+        }
+    ];
 
     beforeEach(module("ux-aspects.selectTable"));
-
-    function getVM() {
-        var vm = {};
-        vm.clear = "clear";
-        vm.reselect = "reselect";
-        vm.selectedVal = "";
-        vm.tableId = "example-table";
-        vm.searchText = "";
-        vm.heading = "Select an author";
-        vm.selectKey = "name";
-        vm.authors = [
-            "Dale Holmes",
-            "Emily Cain",
-            "Marsha Glover",
-            "Vanessa Barrett",
-            "Sarah Lyons",
-            "Johanna Cobb",
-            "Greg Watson",
-            "Frankie Young",
-            "Phil Garcia",
-            "Levi Smith",
-            "Aaron Morgan",
-            "Lucy Gill"
-
-        ];
-        vm.users = [{
-                id: 1,
-                name: "Dale"
-            }, {
-                id: 2,
-                name: "Emily"
-            }, {
-                id: 3,
-                name: "Sarah"
-            },
-            {
-                id: 4,
-                name: "Phil"
-
-            }, {
-                id: 5,
-                name: "Frankie"
-
-            }, {
-                id: 6,
-                name: "Vanessa"
-
-            }, {
-
-            }
-        ];
-
-        return vm;
-    }
 
     beforeEach(inject(function (_$compile_, _$rootScope_, _$timeout_) {
         $compile = _$compile_;
@@ -68,28 +51,36 @@ describe('Select table', function () {
 
     describe("Select table control directive", function () {
 
-        beforeEach(function () {
-            vm = {};
-            vm = getVM();
+        function createSelectTable(values, mode, selectKey) {
+            vm = {
+                tableId: 'example-table',
+                heading: 'Select an author',
+                selectedVal: '',
+                searchText: '',
+                values,
+                selectKey,
+                mode
+            };
 
             $scope.scopeValues = vm;
 
-            var html = '<select-table values="scopeValues.authors" selected="scopeValues.selectedVal" id="scopeValues.tableId" search-text="scopeValues.searchText" table-height="300"></select-table>';
+            var html = '<select-table values="scopeValues.values" selected="scopeValues.selectedVal" id="scopeValues.tableId" search-text="scopeValues.searchText" select-key="scopeValues.selectKey" select-hidden-items="scopeValues.mode" table-height="300"></select-table>';
             element = $compile(html)($scope);
-            var objectHtml = '<select-table values="scopeValues.users" selected="scopeValues.selectedVal" id="scopeValues.tableId" select-key="scopeValues.selectKey" search-text="scopeValues.searchText" table-height="300"></select-table>';
-            objectElement = $compile(objectHtml)($scope);
             $timeout.flush();
             $scope.$digest();
-        });
+
+            return vm;
+        }
 
         it('should create the select table with options provided', function () {
+            createSelectTable(authors);
             expect(element.find('tr')[0].innerText.trim()).toBe("Dale Holmes");
             expect(element.find('tr')[3].innerText.trim()).toBe("Vanessa Barrett");
 
         });
 
         it('should update the selected value to the selected attribute', function () {
-
+            var vm = createSelectTable(authors);
             var e = document.createEvent('MouseEvents');
             e.initMouseEvent('click', true, true, window, 0, 0, 0, 0, 0, false, false, false, false, 0, null);
             element.find('tr')[4].dispatchEvent(e);
@@ -97,6 +88,9 @@ describe('Select table', function () {
         });
 
         it('should filter the options according to the search text', function () {
+
+            var vm = createSelectTable(authors);
+
             $scope.$apply(function () {
                 vm.searchText = "na";
             });
@@ -108,33 +102,23 @@ describe('Select table', function () {
         });
 
         it('should select items hidden by the text filter by default', function () {
-            expect(element.children().eq(0).scope().vm.selectFilteredItems).toBeTruthy();
+            createSelectTable(authors);
+            expect(element.children().eq(0).scope().vm._keepFilteredItemsSelected).toBeTruthy();
         });
 
         it('should deselect items hidden by the text filter by configuration', function () {
-            var html = '<select-table values="scopeValues.authors" selected="scopeValues.selectedVal" id="scopeValues.tableId" search-text="scopeValues.searchText" table-height="300" select-hidden-items="scopeValues.clear"></select-table>';
-            var element = $compile(html)($scope);
-            $timeout.flush();
-            $scope.$digest();
-
-            expect(element.children().eq(0).scope().vm.selectFilteredItems).toBeFalsy();
+            createSelectTable(authors, 'clear');
+            expect(element.children().eq(0).scope().vm._keepFilteredItemsSelected).toBeFalsy();
         });
 
         it('should reselect items hidden by the text filter by configuration', function () {
-            var html = '<select-table values="scopeValues.authors" selected="scopeValues.selectedVal" id="scopeValues.tableId" search-text="scopeValues.searchText" table-height="300" select-hidden-items="scopeValues.reselect"></select-table>';
-            var element = $compile(html)($scope);
-            $timeout.flush();
-            $scope.$digest();
-
-            expect(element.children().eq(0).scope().vm.selectFilteredItems).toBeFalsy();
-            expect(element.children().eq(0).scope().vm.reselectFilteredItems).toBeTruthy();
+            createSelectTable(authors, 'reselect');
+            expect(element.children().eq(0).scope().vm._keepFilteredItemsSelected).toBeFalsy();
+            expect(element.children().eq(0).scope().vm._reselectFilteredItems).toBeTruthy();
         });
 
         it('should, during filtering, deselect the selected value if no longer visible, when configured to do so', function () {
-            var html = '<select-table values="scopeValues.authors" selected="scopeValues.selectedVal" id="scopeValues.tableId" search-text="scopeValues.searchText" table-height="300" select-hidden-items="scopeValues.clear"></select-table>';
-            var element = $compile(html)($scope);
-            $timeout.flush();
-            $scope.$digest();
+            var vm = createSelectTable(authors, 'clear');
 
             var e = document.createEvent('MouseEvents');
             e.initMouseEvent('click', true, true, window, 0, 0, 0, 0, 0, false, false, false, false, 0, null);
@@ -150,14 +134,13 @@ describe('Select table', function () {
         });
 
         it('should reselect a filtered item if configured to do so', function () {
-            var html = '<select-table values="scopeValues.authors" selected="scopeValues.selectedVal" id="scopeValues.tableId" search-text="scopeValues.searchText" table-height="300" select-hidden-items="scopeValues.reselect"></select-table>';
-            var element = $compile(html)($scope);
-            $timeout.flush();
-            $scope.$digest();
+
+            var vm = createSelectTable(authors, 'reselect');
 
             var e = document.createEvent('MouseEvents');
             e.initMouseEvent('click', true, true, window, 0, 0, 0, 0, 0, false, false, false, false, 0, null);
             element.find('tr')[3].dispatchEvent(e);
+
             expect(vm.selectedVal).toBeTruthy();
 
             $scope.$apply(function () {
@@ -166,6 +149,7 @@ describe('Select table', function () {
 
             expect(vm.selectedVal).toBeFalsy();
 
+            debugger;
             $scope.$apply(function () {
                 vm.searchText = "";
             });
@@ -175,6 +159,8 @@ describe('Select table', function () {
         });
 
         it('should, during filtering, retain the selected value if no longer visible, when configured to do so', function () {
+            var vm = createSelectTable(authors);
+
             var e = document.createEvent('MouseEvents');
             e.initMouseEvent('click', true, true, window, 0, 0, 0, 0, 0, false, false, false, false, 0, null);
             element.find('tr')[3].dispatchEvent(e);
@@ -189,40 +175,47 @@ describe('Select table', function () {
         });
 
         it('should deselect the value when selected value is clicked again', function () {
+            var vm = createSelectTable(authors);
+
             //Select a value by clicking a row
             var e = document.createEvent('MouseEvents');
             e.initMouseEvent('click', true, true, window, 0, 0, 0, 0, 0, false, false, false, false, 0, null);
             element.find('tr')[3].dispatchEvent(e);
+
             expect(vm.selectedVal).toBe("Vanessa Barrett");
             //Click on the same row and check if it is deselected
             element.find('tr')[3].dispatchEvent(e);
-            expect(vm.selectedVal).toBe("");
+            expect(vm.selectedVal).toBeFalsy();
 
         });
 
         //Below are the unit tests for values passed as array of objects
 
         it('should create the select table with the values from select key provided', function () {
-            expect(objectElement.find('tr')[0].innerText.trim()).toBe("Dale");
-            expect(objectElement.find('tr')[3].innerText.trim()).toBe("Phil");
+            createSelectTable(users, '', 'name');
+
+            expect(element.find('tr')[0].innerText.trim()).toBe("Dale");
+            expect(element.find('tr')[3].innerText.trim()).toBe("Phil");
 
         });
 
         it('should update the selected value to the selected attribute when options are passed as array of objects', function () {
-
+            var vm = createSelectTable(users, '', 'name');
             var e = document.createEvent('MouseEvents');
             e.initMouseEvent('click', true, true, window, 0, 0, 0, 0, 0, false, false, false, false, 0, null);
-            objectElement.find('tr')[4].dispatchEvent(e);
+            element.find('tr')[4].dispatchEvent(e);
             expect(vm.selectedVal.id).toBe(5);
             expect(vm.selectedVal.name).toBe("Frankie");
 
         });
 
         it('should filter the options according to the search text when options are passed as array of objects', function () {
+            var vm = createSelectTable(users, '', 'name');
+
             $scope.$apply(function () {
                 vm.searchText = "ar";
             });
-            var filteredRows = objectElement.find('tr');
+            var filteredRows = element.find('tr');
             angular.forEach(filteredRows, function (row) {
                 expect(row.innerText.trim().toLowerCase()).toContain('ar');
             });
@@ -230,14 +223,16 @@ describe('Select table', function () {
         });
 
         it('should deselect the value when selected value is clicked again when options are passed as array of objects', function () {
+            var vm = createSelectTable(users, '', 'name');
+
             //Select a value by clicking a row
             var e = document.createEvent('MouseEvents');
             e.initMouseEvent('click', true, true, window, 0, 0, 0, 0, 0, false, false, false, false, 0, null);
-            objectElement.find('tr')[3].dispatchEvent(e);
+            element.find('tr')[3].dispatchEvent(e);
             expect(vm.selectedVal.name).toBe("Phil");
             //Click on the same row and check if it is deselected
-            objectElement.find('tr')[3].dispatchEvent(e);
-            expect(vm.selectedVal).toBe("");
+            element.find('tr')[3].dispatchEvent(e);
+            expect(vm.selectedVal).toBeFalsy();
 
         });
     });

--- a/src/ng1/directives/selectTable/selectTable.spec.js
+++ b/src/ng1/directives/selectTable/selectTable.spec.js
@@ -149,7 +149,6 @@ describe('Select table', function () {
 
             expect(vm.selectedVal).toBeFalsy();
 
-            debugger;
             $scope.$apply(function () {
                 vm.searchText = "";
             });

--- a/src/ng1/directives/treeView/treeView.spec.js
+++ b/src/ng1/directives/treeView/treeView.spec.js
@@ -82,8 +82,8 @@ describe('tree view', function () {
   });
 
   it('should assign the correct names to the nodes', function () {
-    expect(element.find('.title-readonly:first').text()).toBe("Documents");
-    expect(element.find('.title-readonly:last').text()).toBe("Alcazar");
+    expect(element.find('.title-readonly:first').text().trim()).toBe("Documents");
+    expect(element.find('.title-readonly:last').text().trim()).toBe("Alcazar");
   });
 
   it('should have the correct icon when showing or hiding children', function () {
@@ -129,22 +129,22 @@ describe('tree view', function () {
   });
 
   it('should add a new item', function () {
-    expect(element.find('.title-readonly:last').text()).toBe("Alcazar");
+    expect(element.find('.title-readonly:last').text().trim()).toBe("Alcazar");
     element.find('li:first ol:first .title-readonly:first').trigger("click");
     $scope.$digest();
     element.find('#add:first').trigger("click");
     $scope.$digest();
-    expect(element.find('.title-readonly:last').text()).toBe("New User Defined Item");
+    expect(element.find('.title-readonly:last').text().trim()).toBe("New User Defined Item");
   });
 
   it('should delete the last element', function (done) {
-    expect(element.find('.title-readonly:last').text()).toBe("Alcazar");
+    expect(element.find('.title-readonly:last').text().trim()).toBe("Alcazar");
     element.find('.title-readonly:last').trigger("click");
     $scope.$digest();
     element.find('#delete:first').trigger("click");
     $scope.$digest();
     $timeout(function () {
-      expect(element.find('.title-readonly:last').text()).toBe("Pictures");
+      expect(element.find('.title-readonly:last').text().trim()).toBe("Pictures");
       done();
     });
     $timeout.flush();

--- a/src/ng1/directives/treegrid/treegrid.controller.js
+++ b/src/ng1/directives/treegrid/treegrid.controller.js
@@ -73,6 +73,10 @@ export default function TreegridCtrl($scope, $q, multipleSelectProvider, $timeou
     // perform initial selection if there is any
     updateSelection(vm.selected);
 
+    if (vm.selectionManager) {
+      vm.selectionManager({ $selection: vm.multipleSelectInstance });
+    }
+
     $scope.$digest();
   };
 

--- a/src/ng1/directives/treegrid/treegrid.controller.js
+++ b/src/ng1/directives/treegrid/treegrid.controller.js
@@ -192,10 +192,7 @@ export default function TreegridCtrl($scope, $q, multipleSelectProvider, $timeou
   function updateView() {
     vm.loading = true;
     getTreeData(getChildren(), 0)
-      .then(function (rows) {
-        // Populate top level rows
-        vm.treeData = rows;
-      })
+      .then(rows => vm.treeData = rows)
       .then(function () {
         // Expand top level items if configured
         var promises = [];
@@ -212,12 +209,7 @@ export default function TreegridCtrl($scope, $q, multipleSelectProvider, $timeou
         vm.loading = false;
         console.error("Data load error: " + err);
       })
-      .finally(function () {
-        vm.loading = false;
-
-        // ensure any selected items get selected
-        updateSelection(vm.selected);
-      });
+      .finally(() => vm.loading = false);
   }
 
   // Get row data suitable for angular binding from an array of source data

--- a/src/ng1/directives/treegrid/treegrid.directive.js
+++ b/src/ng1/directives/treegrid/treegrid.directive.js
@@ -10,7 +10,8 @@ export default function TreegridDirective() {
             treeData: '=?',
             selected: '=?',
             currentRow: '=?',
-            options: '=?'
+            options: '=?',
+            selectionManager: '&?'
         }
     };
 }

--- a/src/ng1/directives/treegrid/treegrid.spec.js
+++ b/src/ng1/directives/treegrid/treegrid.spec.js
@@ -14,21 +14,24 @@ describe('treegrid', function () {
   describe("treegrid directive", function () {
 
     var DummyEvent = {
-      stopPropagation: function() {},
-      preventDefault: function() {}
+      stopPropagation: function () { },
+      preventDefault: function () { }
     };
 
-    it("should initialise with empty data", function() {
-      var ctrl = instantiateController({
+    it("should initialise with empty data", function (done) {
+      instantiateController({
         data: [],
         columns: [{ name: "test", value: "test" }]
+      }, function (ctrl) {
+        var rows = ctrl.getGridRows();
+        expect(rows).toEqual([]);
+        done();
       });
-      var rows = ctrl.getGridRows();
-      expect(rows).toEqual([]);
     });
 
-    it("should show top level items to start with", function() {
-      var ctrl = instantiateController({
+    it("should show top level items to start with", function (done) {
+
+      instantiateController({
         data: [{
           test: "Row 1",
           nodes: [{
@@ -39,17 +42,20 @@ describe('treegrid', function () {
           nodes: []
         }],
         columns: [{ name: "test", value: "test" }]
+      }, function (ctrl) {
+
+        var rows = ctrl.getGridRows();
+        expect(rows.length).toBe(2);
+        expect(rows[0].level).toBe(0);
+        expect(rows[0].canExpand).toBe(true);
+        expect(rows[0].expanded).toBe(false);
+        expect(rows[0].api.getValueForColumn(0)).toBe("Row 1");
+        done();
       });
-      var rows = ctrl.getGridRows();
-      expect(rows.length).toBe(2);
-      expect(rows[0].level).toBe(0);
-      expect(rows[0].canExpand).toBe(true);
-      expect(rows[0].expanded).toBe(false);
-      expect(rows[0].api.getValueForColumn(0)).toBe("Row 1");
     });
 
-    it("should include child rows when expanded", function(done) {
-      var ctrl = instantiateController({
+    it("should include child rows when expanded", function (done) {
+      instantiateController({
         data: [{
           test: "Row 1",
           nodes: [{
@@ -60,27 +66,29 @@ describe('treegrid', function () {
           nodes: []
         }],
         columns: [{ name: "test", value: "test" }]
+      }, function (ctrl) {
+        var rows = ctrl.getGridRows();
+        expect(rows.length).toBe(2);
+        // Expand "Row 1"
+        ctrl.expanderClick(rows[0], DummyEvent)
+          .then(function () {
+            rows = ctrl.getGridRows();
+            expect(rows.length).toBe(3);
+            expect(rows[0].expanded).toBe(true);
+            expect(rows[1].level).toBe(1);
+            expect(rows[1].canExpand).toBe(false);
+            expect(rows[1].expanded).toBe(false);
+            expect(rows[1].api.getValueForColumn(0)).toBe("Row 1.1");
+          })
+          .catch(failTest)
+          .finally(done);
+        $rootScope.$apply();
+
       });
-      var rows = ctrl.getGridRows();
-      expect(rows.length).toBe(2);
-      // Expand "Row 1"
-      ctrl.expanderClick(rows[0], DummyEvent)
-        .then(function () {
-          rows = ctrl.getGridRows();
-          expect(rows.length).toBe(3);
-          expect(rows[0].expanded).toBe(true);
-          expect(rows[1].level).toBe(1);
-          expect(rows[1].canExpand).toBe(false);
-          expect(rows[1].expanded).toBe(false);
-          expect(rows[1].api.getValueForColumn(0)).toBe("Row 1.1");
-        })
-        .catch(failTest)
-        .finally(done);
-      $rootScope.$apply();
     });
 
-    it("should exclude child rows when contracted", function(done) {
-      var ctrl = instantiateController({
+    it("should exclude child rows when contracted", function (done) {
+      instantiateController({
         data: [{
           test: "Row 1",
           nodes: [{
@@ -91,32 +99,33 @@ describe('treegrid', function () {
           nodes: []
         }],
         columns: [{ name: "test", value: "test" }]
+      }, function (ctrl) {
+        var rows = ctrl.getGridRows();
+        expect(rows.length).toBe(2);
+        // Expand "Row 1"
+        ctrl.expanderClick(rows[0], DummyEvent)
+          .then(function () {
+            rows = ctrl.getGridRows();
+            expect(rows.length).toBe(3);
+            expect(rows[0].expanded).toBe(true);
+            expect(rows[1].api.getValueForColumn(0)).toBe("Row 1.1");
+          })
+          // Contract "Row 1"
+          .then(function () { return ctrl.expanderClick(rows[0], DummyEvent); })
+          .then(function () {
+            rows = ctrl.getGridRows();
+            expect(rows.length).toBe(2);
+            expect(rows[0].expanded).toBe(false);
+            expect(rows[1].api.getValueForColumn(0)).toBe("Row 2");
+          })
+          .catch(failTest)
+          .finally(done);
+        $rootScope.$apply();
       });
-      var rows = ctrl.getGridRows();
-      expect(rows.length).toBe(2);
-      // Expand "Row 1"
-      ctrl.expanderClick(rows[0], DummyEvent)
-        .then(function () {
-          rows = ctrl.getGridRows();
-          expect(rows.length).toBe(3);
-          expect(rows[0].expanded).toBe(true);
-          expect(rows[1].api.getValueForColumn(0)).toBe("Row 1.1");
-        })
-        // Contract "Row 1"
-        .then(function() { return ctrl.expanderClick(rows[0], DummyEvent); })
-        .then(function () {
-          rows = ctrl.getGridRows();
-          expect(rows.length).toBe(2);
-          expect(rows[0].expanded).toBe(false);
-          expect(rows[1].api.getValueForColumn(0)).toBe("Row 2");
-        })
-        .catch(failTest)
-        .finally(done);
-      $rootScope.$apply();
     });
 
-    it("should use the configured property to identify child nodes", function(done) {
-      var ctrl = instantiateController({
+    it("should use the configured property to identify child nodes", function (done) {
+      instantiateController({
         data: [{
           test: "Row 1",
           nodes: [],
@@ -131,35 +140,36 @@ describe('treegrid', function () {
         }],
         columns: [{ name: "test", value: "test" }],
         options: { childrenProperty: "children" }
+      }, function (ctrl) {
+        var rows = ctrl.getGridRows();
+        expect(rows.length).toBe(2);
+        expect(rows[0].canExpand).toBe(true);
+        expect(rows[1].canExpand).toBe(false);
+        // Expand "Row 1"
+        ctrl.expanderClick(rows[0], DummyEvent)
+          .then(function () {
+            rows = ctrl.getGridRows();
+            expect(rows.length).toBe(3);
+            expect(rows[0].expanded).toBe(true);
+            expect(rows[1].level).toBe(1);
+            expect(rows[1].canExpand).toBe(false);
+            expect(rows[1].expanded).toBe(false);
+            expect(rows[1].api.getValueForColumn(0)).toBe("Row 1.1");
+          })
+          // Expand "Row 2" (should do nothing)
+          .then(function () { return ctrl.expanderClick(rows[2], DummyEvent); })
+          .then(function () {
+            rows = ctrl.getGridRows();
+            expect(rows.length).toBe(3);
+          })
+          .catch(failTest)
+          .finally(done);
+        $rootScope.$apply();
       });
-      var rows = ctrl.getGridRows();
-      expect(rows.length).toBe(2);
-      expect(rows[0].canExpand).toBe(true);
-      expect(rows[1].canExpand).toBe(false);
-      // Expand "Row 1"
-      ctrl.expanderClick(rows[0], DummyEvent)
-        .then(function () {
-          rows = ctrl.getGridRows();
-          expect(rows.length).toBe(3);
-          expect(rows[0].expanded).toBe(true);
-          expect(rows[1].level).toBe(1);
-          expect(rows[1].canExpand).toBe(false);
-          expect(rows[1].expanded).toBe(false);
-          expect(rows[1].api.getValueForColumn(0)).toBe("Row 1.1");
-        })
-        // Expand "Row 2" (should do nothing)
-        .then(function() { return ctrl.expanderClick(rows[2], DummyEvent); })
-        .then(function () {
-          rows = ctrl.getGridRows();
-          expect(rows.length).toBe(3);
-        })
-        .catch(failTest)
-        .finally(done);
-      $rootScope.$apply();
     });
 
-    it("should format values with provided function", function() {
-      var ctrl = instantiateController({
+    it("should format values with provided function", function (done) {
+      instantiateController({
         data: [{
           test: "Row 1",
           nodes: []
@@ -169,31 +179,35 @@ describe('treegrid', function () {
         }],
         columns: [{
           name: "format test",
-          value: function(item) {
+          value: function (item) {
             return item.test.replace("Row", "Formatted");
           }
         }]
+      }, function (ctrl) {
+        var rows = ctrl.getGridRows();
+        expect(rows.length).toBe(2);
+        expect(rows[0].api.getValueForColumn(0)).toBe("Formatted 1");
+        expect(rows[1].api.getValueForColumn(0)).toBe("Formatted 2");
+        done();
       });
-      var rows = ctrl.getGridRows();
-      expect(rows.length).toBe(2);
-      expect(rows[0].api.getValueForColumn(0)).toBe("Formatted 1");
-      expect(rows[1].api.getValueForColumn(0)).toBe("Formatted 2");
     });
 
-    it("should show nothing if property is missing", function() {
-      var ctrl = instantiateController({
+    it("should show nothing if property is missing", function (done) {
+      instantiateController({
         data: [{
           nodes: []
         }],
         columns: [{ name: "test", value: "test" }]
+      }, function (ctrl) {
+        var rows = ctrl.getGridRows();
+        expect(rows.length).toBe(1);
+        expect(rows[0].api.getValueForColumn(0)).toBe("");
+        done();
       });
-      var rows = ctrl.getGridRows();
-      expect(rows.length).toBe(1);
-      expect(rows[0].api.getValueForColumn(0)).toBe("");
     });
 
-    it("should limit expansion depth to the configured maxDepth", function(done) {
-      var ctrl = instantiateController({
+    it("should limit expansion depth to the configured maxDepth", function (done) {
+      instantiateController({
         data: [{
           test: "Row 1",
           nodes: [{
@@ -209,40 +223,41 @@ describe('treegrid', function () {
         }],
         columns: [{ name: "test", value: "test" }],
         options: { maxDepth: 2 }
+      }, function (ctrl) {
+        var rows = ctrl.getGridRows();
+        expect(rows.length).toBe(1);
+        expect(rows[0].level).toBe(0);
+        expect(rows[0].canExpand).toBe(true);
+        // Expand "Row 1"
+        ctrl.expanderClick(rows[0], DummyEvent)
+          .then(function () {
+            rows = ctrl.getGridRows();
+            expect(rows.length).toBe(2);
+            expect(rows[1].level).toBe(1);
+            expect(rows[1].canExpand).toBe(true);
+          })
+          // Expand "Row 1.1"
+          .then(function () { return ctrl.expanderClick(rows[1], DummyEvent); })
+          .then(function () {
+            rows = ctrl.getGridRows();
+            expect(rows.length).toBe(3);
+            expect(rows[2].level).toBe(2);
+            expect(rows[2].canExpand).toBe(false);
+          })
+          // Expand "Row 1.1.1" (should do nothing)
+          .then(function () { return ctrl.expanderClick(rows[2], DummyEvent); })
+          .then(function () {
+            rows = ctrl.getGridRows();
+            expect(rows.length).toBe(3);
+          })
+          .catch(failTest)
+          .finally(done);
+        $rootScope.$apply();
       });
-      var rows = ctrl.getGridRows();
-      expect(rows.length).toBe(1);
-      expect(rows[0].level).toBe(0);
-      expect(rows[0].canExpand).toBe(true);
-      // Expand "Row 1"
-      ctrl.expanderClick(rows[0], DummyEvent)
-        .then(function () {
-          rows = ctrl.getGridRows();
-          expect(rows.length).toBe(2);
-          expect(rows[1].level).toBe(1);
-          expect(rows[1].canExpand).toBe(true);
-        })
-        // Expand "Row 1.1"
-        .then(function() { return ctrl.expanderClick(rows[1], DummyEvent); })
-        .then(function () {
-          rows = ctrl.getGridRows();
-          expect(rows.length).toBe(3);
-          expect(rows[2].level).toBe(2);
-          expect(rows[2].canExpand).toBe(false);
-        })
-        // Expand "Row 1.1.1" (should do nothing)
-        .then(function() { return ctrl.expanderClick(rows[2], DummyEvent); })
-        .then(function () {
-          rows = ctrl.getGridRows();
-          expect(rows.length).toBe(3);
-        })
-        .catch(failTest)
-        .finally(done);
-      $rootScope.$apply();
     });
 
-    it("should should sort according to sort option", function() {
-      var ctrl = instantiateController({
+    it("should should sort according to sort option", function (done) {
+      instantiateController({
         data: [{
           test: "Row 2",
           num: 1,
@@ -272,30 +287,32 @@ describe('treegrid', function () {
           value: "num"
         }],
         options: {
-          sort: function(a, b) {
+          sort: function (a, b) {
             // Sort by 'test' ascending
             var at = a.dataItem.test;
             var bt = b.dataItem.test;
             return at < bt ? -1 : (at > bt ? 1 : 0);
           }
         }
+      }, function (ctrl) {
+        var rows = ctrl.getGridRows();
+        expect(rows.length).toBe(5);
+        expect(rows[0].api.getValueForColumn(0)).toBe("");
+        expect(rows[0].api.getValueForColumn(1)).toBe(5);
+        expect(rows[1].api.getValueForColumn(0)).toBe("A");
+        expect(rows[1].api.getValueForColumn(1)).toBe(3);
+        expect(rows[2].api.getValueForColumn(0)).toBe("AA");
+        expect(rows[2].api.getValueForColumn(1)).toBe(4);
+        expect(rows[3].api.getValueForColumn(0)).toBe("Row 1");
+        expect(rows[3].api.getValueForColumn(1)).toBe(2);
+        expect(rows[4].api.getValueForColumn(0)).toBe("Row 2");
+        expect(rows[4].api.getValueForColumn(1)).toBe(1);
+        done();
       });
-      var rows = ctrl.getGridRows();
-      expect(rows.length).toBe(5);
-      expect(rows[0].api.getValueForColumn(0)).toBe("");
-      expect(rows[0].api.getValueForColumn(1)).toBe(5);
-      expect(rows[1].api.getValueForColumn(0)).toBe("A");
-      expect(rows[1].api.getValueForColumn(1)).toBe(3);
-      expect(rows[2].api.getValueForColumn(0)).toBe("AA");
-      expect(rows[2].api.getValueForColumn(1)).toBe(4);
-      expect(rows[3].api.getValueForColumn(0)).toBe("Row 1");
-      expect(rows[3].api.getValueForColumn(1)).toBe(2);
-      expect(rows[4].api.getValueForColumn(0)).toBe("Row 2");
-      expect(rows[4].api.getValueForColumn(1)).toBe(1);
     });
 
-    it("should should sort dates correctly", function() {
-      var ctrl = instantiateController({
+    it("should should sort dates correctly", function (done) {
+      instantiateController({
         data: [{
           test: new Date('2015-08-03'),
           nodes: []
@@ -311,24 +328,26 @@ describe('treegrid', function () {
         }],
         columns: [{ name: "test", value: "test" }],
         options: {
-          sort: function(a, b) {
+          sort: function (a, b) {
             // Sort by 'test' ascending
             var at = a.dataItem.test;
             var bt = b.dataItem.test;
             return at < bt ? -1 : (at > bt ? 1 : 0);
           }
         }
+      }, function (ctrl) {
+        var rows = ctrl.getGridRows();
+        expect(rows.length).toBe(4);
+        expect(rows[0].api.getValueForColumn(0)).toEqual(new Date('2014-08-03'));
+        expect(rows[1].api.getValueForColumn(0)).toEqual(new Date('2015-01-01'));
+        expect(rows[2].api.getValueForColumn(0)).toEqual(new Date('2015-03-08'));
+        expect(rows[3].api.getValueForColumn(0)).toEqual(new Date('2015-08-03'));
+        done();
       });
-      var rows = ctrl.getGridRows();
-      expect(rows.length).toBe(4);
-      expect(rows[0].api.getValueForColumn(0)).toEqual(new Date('2014-08-03'));
-      expect(rows[1].api.getValueForColumn(0)).toEqual(new Date('2015-01-01'));
-      expect(rows[2].api.getValueForColumn(0)).toEqual(new Date('2015-03-08'));
-      expect(rows[3].api.getValueForColumn(0)).toEqual(new Date('2015-08-03'));
     });
 
-    it("should should sort child rows independently", function(done) {
-      var ctrl = instantiateController({
+    it("should should sort child rows independently", function (done) {
+      instantiateController({
         data: [{
           test: "D",
           nodes: []
@@ -344,34 +363,35 @@ describe('treegrid', function () {
         }],
         columns: [{ name: "test", value: "test" }],
         options: {
-          sort: function(a, b) {
+          sort: function (a, b) {
             // Sort by 'test' ascending
             var at = a.dataItem.test;
             var bt = b.dataItem.test;
             return at < bt ? -1 : (at > bt ? 1 : 0);
           }
         }
+      }, function (ctrl) {
+        var rows = ctrl.getGridRows();
+        expect(rows.length).toBe(2);
+        expect(rows[0].api.getValueForColumn(0)).toBe("C");
+        // Expand "C"
+        ctrl.expanderClick(rows[0], DummyEvent)
+          .then(function () {
+            rows = ctrl.getGridRows();
+            expect(rows.length).toBe(4);
+            expect(rows[0].api.getValueForColumn(0)).toBe("C");
+            expect(rows[1].api.getValueForColumn(0)).toBe("A");
+            expect(rows[2].api.getValueForColumn(0)).toBe("B");
+            expect(rows[3].api.getValueForColumn(0)).toBe("D");
+          })
+          .catch(failTest)
+          .finally(done);
+        $rootScope.$apply();
       });
-      var rows = ctrl.getGridRows();
-      expect(rows.length).toBe(2);
-      expect(rows[0].api.getValueForColumn(0)).toBe("C");
-      // Expand "C"
-      ctrl.expanderClick(rows[0], DummyEvent)
-        .then(function () {
-          rows = ctrl.getGridRows();
-          expect(rows.length).toBe(4);
-          expect(rows[0].api.getValueForColumn(0)).toBe("C");
-          expect(rows[1].api.getValueForColumn(0)).toBe("A");
-          expect(rows[2].api.getValueForColumn(0)).toBe("B");
-          expect(rows[3].api.getValueForColumn(0)).toBe("D");
-        })
-        .catch(failTest)
-        .finally(done);
-      $rootScope.$apply();
     });
 
-    it("should use the rowClass property to apply a class to the table row", function(done) {
-      var ctrl = instantiateController({
+    it("should use the rowClass property to apply a class to the table row", function (done) {
+      instantiateController({
         data: [{
           test: "Row 1",
           myClass: "medium",
@@ -385,28 +405,29 @@ describe('treegrid', function () {
         }],
         columns: [{ name: "test", value: "test" }],
         options: { rowClass: "myClass" }
+      }, function (ctrl) {
+        var rows = ctrl.getGridRows();
+        expect(rows.length).toBe(2);
+        // Expand "Row 2"
+        ctrl.expanderClick(rows[1], DummyEvent)
+          .then(function () {
+            rows = ctrl.getGridRows();
+            expect(rows.length).toBe(3);
+            expect(rows[0].api.getValueForColumn(0)).toBe("Row 1");
+            expect(rows[0].rowClass).toBe("medium");
+            expect(rows[1].api.getValueForColumn(0)).toBe("Row 2");
+            expect(rows[1].rowClass).toBe(null);
+            expect(rows[2].api.getValueForColumn(0)).toBe("Row 2.1");
+            expect(rows[2].rowClass).toBe("high");
+          })
+          .catch(failTest)
+          .finally(done);
+        $rootScope.$apply();
       });
-      var rows = ctrl.getGridRows();
-      expect(rows.length).toBe(2);
-      // Expand "Row 2"
-      ctrl.expanderClick(rows[1], DummyEvent)
-        .then(function () {
-          rows = ctrl.getGridRows();
-          expect(rows.length).toBe(3);
-          expect(rows[0].api.getValueForColumn(0)).toBe("Row 1");
-          expect(rows[0].rowClass).toBe("medium");
-          expect(rows[1].api.getValueForColumn(0)).toBe("Row 2");
-          expect(rows[1].rowClass).toBe(null);
-          expect(rows[2].api.getValueForColumn(0)).toBe("Row 2.1");
-          expect(rows[2].rowClass).toBe("high");
-        })
-        .catch(failTest)
-        .finally(done);
-      $rootScope.$apply();
     });
 
-    it("should use the rowClass function to apply a class to the table row", function(done) {
-      var ctrl = instantiateController({
+    it("should use the rowClass function to apply a class to the table row", function (done) {
+      instantiateController({
         data: [{
           test: "Row 1",
           nodes: []
@@ -418,36 +439,37 @@ describe('treegrid', function () {
         }],
         columns: [{ name: "test", value: "test" }],
         options: {
-          rowClass: function(dataItem) {
+          rowClass: function (dataItem) {
             return dataItem.test.toLowerCase().replace(/[^\w]/g, '-');
           }
         }
+      }, function (ctrl) {
+        var rows = ctrl.getGridRows();
+        expect(rows.length).toBe(2);
+        // Expand "Row 2"
+        ctrl.expanderClick(rows[1], DummyEvent)
+          .then(function () {
+            rows = ctrl.getGridRows();
+            expect(rows.length).toBe(3);
+            expect(rows[0].api.getValueForColumn(0)).toBe("Row 1");
+            expect(rows[0].rowClass).toBe("row-1");
+            expect(rows[1].api.getValueForColumn(0)).toBe("Row 2");
+            expect(rows[1].rowClass).toBe("row-2");
+            expect(rows[2].api.getValueForColumn(0)).toBe("Row 2.1");
+            expect(rows[2].rowClass).toBe("row-2-1");
+          })
+          .catch(failTest)
+          .finally(done);
+        $rootScope.$apply();
       });
-      var rows = ctrl.getGridRows();
-      expect(rows.length).toBe(2);
-      // Expand "Row 2"
-      ctrl.expanderClick(rows[1], DummyEvent)
-        .then(function () {
-          rows = ctrl.getGridRows();
-          expect(rows.length).toBe(3);
-          expect(rows[0].api.getValueForColumn(0)).toBe("Row 1");
-          expect(rows[0].rowClass).toBe("row-1");
-          expect(rows[1].api.getValueForColumn(0)).toBe("Row 2");
-          expect(rows[1].rowClass).toBe("row-2");
-          expect(rows[2].api.getValueForColumn(0)).toBe("Row 2.1");
-          expect(rows[2].rowClass).toBe("row-2-1");
-        })
-        .catch(failTest)
-        .finally(done);
-      $rootScope.$apply();
     });
 
   });
 
-  describe("api", function() {
+  describe("api", function () {
 
-    it("should expand child rows on expand() call", function(done) {
-      var ctrl = instantiateController({
+    it("should expand child rows on expand() call", function (done) {
+      instantiateController({
         data: [{
           test: "Row 1",
           nodes: [{
@@ -458,27 +480,28 @@ describe('treegrid', function () {
           nodes: []
         }],
         columns: [{ name: "test", value: "test" }]
+      }, function (ctrl) {
+        var rows = ctrl.getGridRows();
+        expect(rows.length).toBe(2);
+        // Expand "Row 1"
+        rows[0].api.expand()
+          .then(function () {
+            rows = ctrl.getGridRows();
+            expect(rows.length).toBe(3);
+            expect(rows[0].expanded).toBe(true);
+            expect(rows[1].level).toBe(1);
+            expect(rows[1].canExpand).toBe(false);
+            expect(rows[1].expanded).toBe(false);
+            expect(rows[1].api.getValueForColumn(0)).toBe("Row 1.1");
+          })
+          .catch(failTest)
+          .finally(done);
+        $rootScope.$apply();
       });
-      var rows = ctrl.getGridRows();
-      expect(rows.length).toBe(2);
-      // Expand "Row 1"
-      rows[0].api.expand()
-        .then(function () {
-          rows = ctrl.getGridRows();
-          expect(rows.length).toBe(3);
-          expect(rows[0].expanded).toBe(true);
-          expect(rows[1].level).toBe(1);
-          expect(rows[1].canExpand).toBe(false);
-          expect(rows[1].expanded).toBe(false);
-          expect(rows[1].api.getValueForColumn(0)).toBe("Row 1.1");
-        })
-        .catch(failTest)
-        .finally(done);
-      $rootScope.$apply();
     });
 
-    it("should contract child rows on contract() call", function(done) {
-      var ctrl = instantiateController({
+    it("should contract child rows on contract() call", function (done) {
+      instantiateController({
         data: [{
           test: "Row 1",
           nodes: [{
@@ -489,33 +512,34 @@ describe('treegrid', function () {
           nodes: []
         }],
         columns: [{ name: "test", value: "test" }]
+      }, function (ctrl) {
+        var rows = ctrl.getGridRows();
+        expect(rows.length).toBe(2);
+        // Expand "Row 1"
+        rows[0].api.expand()
+          .then(function () {
+            rows = ctrl.getGridRows();
+            expect(rows.length).toBe(3);
+            expect(rows[0].expanded).toBe(true);
+            expect(rows[1].api.getValueForColumn(0)).toBe("Row 1.1");
+          })
+          // Contract "Row 1"
+          .then(function () {
+            rows[0].api.contract();
+            rows = ctrl.getGridRows();
+            expect(rows.length).toBe(2);
+            expect(rows[0].expanded).toBe(false);
+            expect(rows[1].api.getValueForColumn(0)).toBe("Row 2");
+          })
+          .catch(failTest)
+          .finally(done);
+        $rootScope.$apply();
       });
-      var rows = ctrl.getGridRows();
-      expect(rows.length).toBe(2);
-      // Expand "Row 1"
-      rows[0].api.expand()
-        .then(function () {
-          rows = ctrl.getGridRows();
-          expect(rows.length).toBe(3);
-          expect(rows[0].expanded).toBe(true);
-          expect(rows[1].api.getValueForColumn(0)).toBe("Row 1.1");
-        })
-        // Contract "Row 1"
-        .then(function () {
-          rows[0].api.contract();
-          rows = ctrl.getGridRows();
-          expect(rows.length).toBe(2);
-          expect(rows[0].expanded).toBe(false);
-          expect(rows[1].api.getValueForColumn(0)).toBe("Row 2");
-        })
-        .catch(failTest)
-        .finally(done);
-      $rootScope.$apply();
     });
 
   });
 
-  function instantiateController(props) {
+  function instantiateController(props, callback) {
 
     // create a new scope
     $scope = $rootScope.$new();
@@ -539,8 +563,14 @@ describe('treegrid', function () {
     // perform initial digest
     $scope.$digest();
 
-    return ctrl;
-}
+    const initFunction = ctrl.onInit;
+
+    // wait for the component to initialise
+    ctrl.onInit = function () {
+      initFunction();
+      callback(ctrl);
+    };
+  }
 
   function failTest(error) {
     expect(error).toBeUndefined();

--- a/src/styles/tables.less
+++ b/src/styles/tables.less
@@ -262,7 +262,6 @@ table {
 .list-hover-actions {
     position: relative;
     margin-top: 3px;
-    background-color: @table-hover-bg;
     box-shadow: -2px 0 4px @table-hover-bg;
 
     a.list-hover-action {
@@ -488,7 +487,6 @@ table {
         background-color: @shift-select-selected-light;
 
         & > td.item-actions .list-hover-actions {
-            background-color: @shift-select-selected-light;
             box-shadow: none;
         }
 
@@ -499,7 +497,6 @@ table {
             background-color: @shift-select-selected-hover-light;
 
             & > td.item-actions .list-hover-actions {
-                background-color: @shift-select-selected-hover-light;
                 box-shadow: none;
             }
         }


### PR DESCRIPTION
- Adding 2 way binding to tree view selected property
- Exposing the multipleSelectProvider instance
- List hover actions - I noticed when hovering on a focused and selected item in the tree grid the list hover actions got the wrong background colour. While looking into this we had styles setting the background colour to match the various states. This was completely unnecessary, removing the background colour all together ensures they will not differ from the table row colour
- Fixing up unit tests (they all should now pass)
- Found two minor issues when fixing unit tests - page header didn't explicitly state its injectable which causes it not to work when minified and select table reselect option didn't work as it was clearing the selection before storing it.