### PR TITLE
EL-3274 - WCAG charts

### DIFF
--- a/docs/app/pages/charts/charts-sections/bar-charts/bar-chart/bar-chart.component.html
+++ b/docs/app/pages/charts/charts-sections/bar-charts/bar-chart/bar-chart.component.html
@@ -1,4 +1,5 @@
 <div class="demo-chart-container">
+
     <canvas aria-label="Bar chart showing file type totals"
         baseChart
         [datasets]="barChartData"
@@ -24,6 +25,7 @@
         </table>
 
     </canvas>
+
 </div>
 
 <hr>
@@ -32,8 +34,6 @@
     Bar Charts can be added using the <code>ng2-charts</code> library.
     The <code>chart.js</code> library needs to be imported and the <code>ChartsModule</code> needs to be added to the appropriate NgModule.
 </p>
-
-<br>
 
 <p>The <code>baseChart</code> directive should be added to a <code>canvas</code> element and the following attributes can be used to customize the chart behavior and appearance:</p>
 

--- a/docs/app/pages/charts/charts-sections/bar-charts/bar-chart/bar-chart.component.html
+++ b/docs/app/pages/charts/charts-sections/bar-charts/bar-chart/bar-chart.component.html
@@ -1,15 +1,35 @@
 <div class="demo-chart-container">
+    <canvas aria-label="Bar chart showing file type totals"
+        baseChart
+        [datasets]="barChartData"
+        [labels]="barChartLabels"
+        [options]="barChartOptions"
+        [legend]="barChartLegend"
+        [colors]="barChartColors"
+        chartType="bar">
 
-    <canvas baseChart [datasets]="barChartData" [labels]="barChartLabels" [options]="barChartOptions" [legend]="barChartLegend"
-        [colors]="barChartColors" chartType="bar">
+        <table aria-label="Chart data">
+            <thead>
+                <tr>
+                    <th>File Type</th>
+                    <th>Number of Files</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr *ngFor="let label of barChartLabels; let idx = index">
+                    <td>{{label}}</td>
+                    <td>{{barChartData[0].data[idx]}}</td>
+                </tr>
+            </tbody>
+        </table>
+
     </canvas>
-
 </div>
 
 <hr>
 
 <p>
-    Bar Charts can be added using the <code>ng2-charts</code> library. 
+    Bar Charts can be added using the <code>ng2-charts</code> library.
     The <code>chart.js</code> library needs to be imported and the <code>ChartsModule</code> needs to be added to the appropriate NgModule.
 </p>
 
@@ -70,7 +90,7 @@
 
     <p class="m-b-nil">
         <b>Dependencies: </b>
-        <a class="hyperlink" href="https://www.npmjs.com/package/ng2-charts">ng2-charts</a>, 
+        <a class="hyperlink" href="https://www.npmjs.com/package/ng2-charts">ng2-charts</a>,
         <a class="hyperlink" href="https://www.npmjs.com/package/chart.js">chart.js</a>
     </p>
 
@@ -87,7 +107,7 @@
 
     <p class="m-b-nil">
         <b>Documentation: </b>
-        <a class="hyperlink" href="http://valor-software.com/ng2-charts/">Angular Directive Documentation</a>, 
+        <a class="hyperlink" href="http://valor-software.com/ng2-charts/">Angular Directive Documentation</a>,
         <a class="hyperlink" href="http://www.chartjs.org/docs/">Chart Library Documentation</a>
     </p>
 </blockquote>

--- a/docs/app/pages/charts/charts-sections/bar-charts/bar-chart/snippets/app.html
+++ b/docs/app/pages/charts/charts-sections/bar-charts/bar-chart/snippets/app.html
@@ -1,4 +1,5 @@
 <div class="demo-chart-container">
+
     <canvas aria-label="Bar chart showing file type totals"
         baseChart
         [datasets]="barChartData"
@@ -24,4 +25,5 @@
         </table>
 
     </canvas>
+
 </div>

--- a/docs/app/pages/charts/charts-sections/bar-charts/bar-chart/snippets/app.html
+++ b/docs/app/pages/charts/charts-sections/bar-charts/bar-chart/snippets/app.html
@@ -1,12 +1,27 @@
 <div class="demo-chart-container">
+    <canvas aria-label="Bar chart showing file type totals"
+        baseChart
+        [datasets]="barChartData"
+        [labels]="barChartLabels"
+        [options]="barChartOptions"
+        [legend]="barChartLegend"
+        [colors]="barChartColors"
+        chartType="bar">
 
-    <canvas baseChart 
-            [datasets]="barChartData" 
-            [labels]="barChartLabels" 
-            [options]="barChartOptions" 
-            [legend]="barChartLegend"
-            [colors]="barChartColors" 
-            chartType="bar">
+        <table>
+            <thead>
+                <tr>
+                    <th>File Type</th>
+                    <th>Number of Files</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr *ngFor="let label of barChartLabels; let idx = index">
+                    <td>{{label}}</td>
+                    <td>{{barChartData[0].data[idx]}}</td>
+                </tr>
+            </tbody>
+        </table>
+
     </canvas>
-
 </div>

--- a/docs/app/pages/charts/charts-sections/bar-charts/bar-charts.module.ts
+++ b/docs/app/pages/charts/charts-sections/bar-charts/bar-charts.module.ts
@@ -1,3 +1,4 @@
+import { CommonModule } from '@angular/common';
 import { ComponentFactoryResolver, NgModule } from '@angular/core';
 import { RouterModule } from '@angular/router';
 import { ChartsModule } from 'ng2-charts';
@@ -14,8 +15,6 @@ import { ChartsHorizontalBarChartNg1Component } from './horizontal-bar-chart-ng1
 import { ChartsHorizontalBarChartComponent } from './horizontal-bar-chart/horizontal-bar-chart.component';
 import { ChartsStackedBarChartNg1Component } from './stacked-bar-chart-ng1/stacked-bar-chart-ng1.component';
 import { ChartsStackedBarChartComponent } from './stacked-bar-chart/stacked-bar-chart.component';
-
-
 
 const SECTIONS = [
     ChartsBarChartComponent,
@@ -38,6 +37,7 @@ const ROUTES = [
 
 @NgModule({
     imports: [
+        CommonModule,
         DocumentationComponentsModule,
         TabsetModule,
         WrappersModule,

--- a/docs/app/pages/charts/charts-sections/bar-charts/bar-charts.module.ts
+++ b/docs/app/pages/charts/charts-sections/bar-charts/bar-charts.module.ts
@@ -37,14 +37,14 @@ const ROUTES = [
 
 @NgModule({
     imports: [
+        ChartsModule,
+        ColorServiceModule,
         CommonModule,
         DocumentationComponentsModule,
+        HybridModule,
+        RouterModule.forChild(ROUTES),
         TabsetModule,
         WrappersModule,
-        HybridModule,
-        ChartsModule,
-        RouterModule.forChild(ROUTES),
-        ColorServiceModule
     ],
     exports: SECTIONS,
     declarations: SECTIONS,

--- a/docs/app/pages/charts/charts-sections/bar-charts/horizontal-bar-chart/horizontal-bar-chart.component.html
+++ b/docs/app/pages/charts/charts-sections/bar-charts/horizontal-bar-chart/horizontal-bar-chart.component.html
@@ -1,20 +1,35 @@
 <div class="demo-chart-container">
+    <canvas aria-label="Horizontal bar chart showing file type totals"
+        baseChart
+        [datasets]="barChartData"
+        [labels]="barChartLabels"
+        [options]="barChartOptions"
+        [legend]="barChartLegend"
+        [colors]="barChartColors"
+        chartType="horizontalBar">
 
-    <canvas baseChart 
-            [datasets]="barChartData"
-            [labels]="barChartLabels"
-            [options]="barChartOptions"
-            [legend]="barChartLegend"
-            [colors]="barChartColors"
-            chartType="horizontalBar">
+        <table aria-label="Chart data">
+            <thead>
+                <tr>
+                    <th>File Type</th>
+                    <th>Number of Files</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr *ngFor="let label of barChartLabels; let idx = index">
+                    <td>{{label}}</td>
+                    <td>{{barChartData[0].data[idx]}}</td>
+                </tr>
+            </tbody>
+        </table>
+
     </canvas>
-
 </div>
 
 <hr>
 
 <p>
-    Horizontal Bar Charts can be added using the <code>ng2-charts</code> library. 
+    Horizontal Bar Charts can be added using the <code>ng2-charts</code> library.
     The <code>chart.js</code> library needs to be imported and the <code>ChartsModule</code> needs to be added to the appropriate NgModule.
 </p>
 
@@ -75,7 +90,7 @@
 
     <p class="m-b-nil">
         <b>Dependencies: </b>
-        <a class="hyperlink" href="https://www.npmjs.com/package/ng2-charts">ng2-charts</a>, 
+        <a class="hyperlink" href="https://www.npmjs.com/package/ng2-charts">ng2-charts</a>,
         <a class="hyperlink" href="https://www.npmjs.com/package/chart.js">chart.js</a>
     </p>
 
@@ -92,7 +107,7 @@
 
     <p class="m-b-nil">
         <b>Documentation: </b>
-        <a class="hyperlink" href="http://valor-software.com/ng2-charts/">Angular Directive Documentation</a>, 
+        <a class="hyperlink" href="http://valor-software.com/ng2-charts/">Angular Directive Documentation</a>,
         <a class="hyperlink" href="http://www.chartjs.org/docs/">Chart Library Documentation</a>
     </p>
 </blockquote>

--- a/docs/app/pages/charts/charts-sections/bar-charts/horizontal-bar-chart/horizontal-bar-chart.component.html
+++ b/docs/app/pages/charts/charts-sections/bar-charts/horizontal-bar-chart/horizontal-bar-chart.component.html
@@ -1,4 +1,5 @@
 <div class="demo-chart-container">
+
     <canvas aria-label="Horizontal bar chart showing file type totals"
         baseChart
         [datasets]="barChartData"
@@ -24,6 +25,7 @@
         </table>
 
     </canvas>
+
 </div>
 
 <hr>
@@ -32,8 +34,6 @@
     Horizontal Bar Charts can be added using the <code>ng2-charts</code> library.
     The <code>chart.js</code> library needs to be imported and the <code>ChartsModule</code> needs to be added to the appropriate NgModule.
 </p>
-
-<br>
 
 <p>The <code>baseChart</code> directive should be added to a <code>canvas</code> element and the following attributes can be used to customize the chart behavior and appearance:</p>
 

--- a/docs/app/pages/charts/charts-sections/bar-charts/horizontal-bar-chart/snippets/app.html
+++ b/docs/app/pages/charts/charts-sections/bar-charts/horizontal-bar-chart/snippets/app.html
@@ -1,12 +1,27 @@
 <div class="demo-chart-container">
+    <canvas aria-label="Horizontal bar chart showing file type totals"
+        baseChart
+        [datasets]="barChartData"
+        [labels]="barChartLabels"
+        [options]="barChartOptions"
+        [legend]="barChartLegend"
+        [colors]="barChartColors"
+        chartType="horizontalBar">
 
-    <canvas baseChart 
-            [datasets]="barChartData"
-            [labels]="barChartLabels"
-            [options]="barChartOptions"
-            [legend]="barChartLegend"
-            [colors]="barChartColors"
-            chartType="horizontalBar">
+        <table aria-label="Chart data">
+            <thead>
+                <tr>
+                    <th>File Type</th>
+                    <th>Number of Files</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr *ngFor="let label of barChartLabels; let idx = index">
+                    <td>{{label}}</td>
+                    <td>{{barChartData[0].data[idx]}}</td>
+                </tr>
+            </tbody>
+        </table>
+
     </canvas>
-
 </div>

--- a/docs/app/pages/charts/charts-sections/bar-charts/horizontal-bar-chart/snippets/app.html
+++ b/docs/app/pages/charts/charts-sections/bar-charts/horizontal-bar-chart/snippets/app.html
@@ -1,4 +1,5 @@
 <div class="demo-chart-container">
+
     <canvas aria-label="Horizontal bar chart showing file type totals"
         baseChart
         [datasets]="barChartData"
@@ -24,4 +25,5 @@
         </table>
 
     </canvas>
+
 </div>

--- a/docs/app/pages/charts/charts-sections/bar-charts/stacked-bar-chart/snippets/app.html
+++ b/docs/app/pages/charts/charts-sections/bar-charts/stacked-bar-chart/snippets/app.html
@@ -1,12 +1,33 @@
 <div class="demo-chart-container-stack">
 
-    <canvas baseChart 
-            [datasets]="barChartData"
-            [labels]="barChartLabels"
-            [options]="barChartOptions"
-            [legend]="barChartLegend"
-            [colors]="barChartColors"
-            chartType="bar">
+    <canvas aria-label="Stacked bar chart showing financial breakdown"
+        baseChart
+        [datasets]="barChartData"
+        [labels]="barChartLabels"
+        [options]="barChartOptions"
+        [legend]="barChartLegend"
+        [colors]="barChartColors"
+        chartType="bar">
+
+        <table aria-label="Chart data">
+            <thead>
+                <tr>
+                    <th>Week</th>
+                    <th>Marketing</th>
+                    <th>R&amp;D</th>
+                    <th>Logistics</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr *ngFor="let label of barChartLabels; let idx = index">
+                    <td>{{label}}</td>
+                    <td>&euro;{{barChartData[0].data[idx]}}</td>
+                    <td>&euro;{{barChartData[1].data[idx]}}</td>
+                    <td>&euro;{{barChartData[2].data[idx]}}</td>
+                </tr>
+            </tbody>
+        </table>
+
     </canvas>
 
 </div>

--- a/docs/app/pages/charts/charts-sections/bar-charts/stacked-bar-chart/stacked-bar-chart.component.html
+++ b/docs/app/pages/charts/charts-sections/bar-charts/stacked-bar-chart/stacked-bar-chart.component.html
@@ -39,8 +39,6 @@
     The <code>chart.js</code> library needs to be imported and the <code>ChartsModule</code> needs to be added to the appropriate NgModule.
 </p>
 
-<br>
-
 <p>The <code>baseChart</code> directive should be added to a <code>canvas</code> element and the following attributes can be used to customize the chart behavior and appearance:</p>
 
 <uxd-api-properties tableTitle="Inputs">

--- a/docs/app/pages/charts/charts-sections/bar-charts/stacked-bar-chart/stacked-bar-chart.component.html
+++ b/docs/app/pages/charts/charts-sections/bar-charts/stacked-bar-chart/stacked-bar-chart.component.html
@@ -1,12 +1,33 @@
 <div class="demo-chart-container-stack">
 
-    <canvas baseChart 
-            [datasets]="barChartData"
-            [labels]="barChartLabels"
-            [options]="barChartOptions"
-            [legend]="barChartLegend"
-            [colors]="barChartColors"
-            chartType="bar">
+    <canvas aria-label="Stacked bar chart showing financial breakdown"
+        baseChart
+        [datasets]="barChartData"
+        [labels]="barChartLabels"
+        [options]="barChartOptions"
+        [legend]="barChartLegend"
+        [colors]="barChartColors"
+        chartType="bar">
+
+        <table aria-label="Chart data">
+            <thead>
+                <tr>
+                    <th>Week</th>
+                    <th>Marketing</th>
+                    <th>R&amp;D</th>
+                    <th>Logistics</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr *ngFor="let label of barChartLabels; let idx = index">
+                    <td>{{label}}</td>
+                    <td>&euro;{{barChartData[0].data[idx]}}</td>
+                    <td>&euro;{{barChartData[1].data[idx]}}</td>
+                    <td>&euro;{{barChartData[2].data[idx]}}</td>
+                </tr>
+            </tbody>
+        </table>
+
     </canvas>
 
 </div>
@@ -14,7 +35,7 @@
 <hr>
 
 <p>
-    Stacked Bar Charts can be added using the <code>ng2-charts</code> library. 
+    Stacked Bar Charts can be added using the <code>ng2-charts</code> library.
     The <code>chart.js</code> library needs to be imported and the <code>ChartsModule</code> needs to be added to the appropriate NgModule.
 </p>
 
@@ -75,7 +96,7 @@
 
     <p class="m-b-nil">
         <b>Dependencies: </b>
-        <a class="hyperlink" href="https://www.npmjs.com/package/ng2-charts">ng2-charts</a>, 
+        <a class="hyperlink" href="https://www.npmjs.com/package/ng2-charts">ng2-charts</a>,
         <a class="hyperlink" href="https://www.npmjs.com/package/chart.js">chart.js</a>
     </p>
 
@@ -92,7 +113,7 @@
 
     <p class="m-b-nil">
         <b>Documentation: </b>
-        <a class="hyperlink" href="http://valor-software.com/ng2-charts/">Angular Directive Documentation</a>, 
+        <a class="hyperlink" href="http://valor-software.com/ng2-charts/">Angular Directive Documentation</a>,
         <a class="hyperlink" href="http://www.chartjs.org/docs/">Chart Library Documentation</a>
     </p>
 </blockquote>

--- a/docs/app/pages/charts/charts-sections/donut-charts/donut-chart/donut-chart.component.html
+++ b/docs/app/pages/charts/charts-sections/donut-charts/donut-chart/donut-chart.component.html
@@ -1,12 +1,29 @@
 <div class="demo-chart-container">
 
-    <canvas baseChart 
-            [datasets]="donutChartData"
-            [labels]="donutChartLabels"
-            [options]="donutChartOptions"
-            [legend]="donutChartLegend"
-            [colors]="donutChartColors"
-            chartType="doughnut">
+    <canvas aria-label="Donut chart showing sales"
+        baseChart
+        [datasets]="donutChartData"
+        [labels]="donutChartLabels"
+        [options]="donutChartOptions"
+        [legend]="donutChartLegend"
+        [colors]="donutChartColors"
+        chartType="doughnut">
+
+        <table aria-label="Chart data">
+            <thead>
+                <tr>
+                    <th>Sales</th>
+                    <th>Percentage</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr *ngFor="let label of donutChartLabels; let idx = index">
+                    <td>{{label}}</td>
+                    <td>{{donutChartData[0].data[idx]}}%</td>
+                </tr>
+            </tbody>
+        </table>
+
     </canvas>
 
 </div>
@@ -14,11 +31,9 @@
 <hr>
 
 <p>
-    Donut Charts can be added using the <code>ng2-charts</code> library. 
+    Donut Charts can be added using the <code>ng2-charts</code> library.
     The <code>chart.js</code> library needs to be imported and the <code>ChartsModule</code> needs to be added to the appropriate NgModule.
 </p>
-
-<br>
 
 <p>The <code>baseChart</code> directive should be added to a <code>canvas</code> element and the following attributes can be used to customize the chart behavior and appearance:</p>
 
@@ -75,7 +90,7 @@
 
     <p class="m-b-nil">
         <b>Dependencies: </b>
-        <a class="hyperlink" href="https://www.npmjs.com/package/ng2-charts">ng2-charts</a>, 
+        <a class="hyperlink" href="https://www.npmjs.com/package/ng2-charts">ng2-charts</a>,
         <a class="hyperlink" href="https://www.npmjs.com/package/chart.js">chart.js</a>
     </p>
 
@@ -92,7 +107,7 @@
 
     <p class="m-b-nil">
         <b>Documentation: </b>
-        <a class="hyperlink" href="http://valor-software.com/ng2-charts/">Angular Directive Documentation</a>, 
+        <a class="hyperlink" href="http://valor-software.com/ng2-charts/">Angular Directive Documentation</a>,
         <a class="hyperlink" href="http://www.chartjs.org/docs/">Chart Library Documentation</a>
     </p>
 </blockquote>

--- a/docs/app/pages/charts/charts-sections/donut-charts/donut-chart/snippets/app.html
+++ b/docs/app/pages/charts/charts-sections/donut-charts/donut-chart/snippets/app.html
@@ -1,12 +1,29 @@
 <div class="demo-chart-container">
 
-    <canvas baseChart 
-            [datasets]="donutChartData"
-            [labels]="donutChartLabels"
-            [options]="donutChartOptions"
-            [legend]="donutChartLegend"
-            [colors]="donutChartColors"
-            chartType="doughnut">
+    <canvas aria-label="Donut chart showing sales"
+        baseChart
+        [datasets]="donutChartData"
+        [labels]="donutChartLabels"
+        [options]="donutChartOptions"
+        [legend]="donutChartLegend"
+        [colors]="donutChartColors"
+        chartType="doughnut">
+
+        <table aria-label="Chart data">
+            <thead>
+                <tr>
+                    <th>Sales</th>
+                    <th>Percentage</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr *ngFor="let label of donutChartLabels; let idx = index">
+                    <td>{{label}}</td>
+                    <td>{{donutChartData[0].data[idx]}}%</td>
+                </tr>
+            </tbody>
+        </table>
+
     </canvas>
 
 </div>

--- a/docs/app/pages/charts/charts-sections/donut-charts/donut-charts.module.ts
+++ b/docs/app/pages/charts/charts-sections/donut-charts/donut-charts.module.ts
@@ -1,3 +1,4 @@
+import { CommonModule } from '@angular/common';
 import { ComponentFactoryResolver, NgModule } from '@angular/core';
 import { RouterModule } from '@angular/router';
 import { ChartsModule } from 'ng2-charts';
@@ -11,7 +12,6 @@ import { WrappersModule } from '../../../../wrappers/wrappers.module';
 import { ChartsDonutChartNg1Component } from './donut-chart-ng1/donut-chart-ng1.component';
 import { ChartsDonutChartComponent } from './donut-chart/donut-chart.component';
 import { ChartsNestedDonutChartNg1Component } from './nested-donut-chart-ng1/nested-donut-chart-ng1.component';
-
 
 const SECTIONS = [
     ChartsDonutChartNg1Component,
@@ -31,13 +31,14 @@ const ROUTES = [
 
 @NgModule({
     imports: [
+        ChartsModule,
+        ColorServiceModule,
+        CommonModule,
         DocumentationComponentsModule,
+        HybridModule,
+        RouterModule.forChild(ROUTES),
         TabsetModule,
         WrappersModule,
-        HybridModule,
-        ChartsModule,
-        RouterModule.forChild(ROUTES),
-        ColorServiceModule
     ],
     exports: SECTIONS,
     declarations: SECTIONS,

--- a/docs/app/pages/charts/charts-sections/line-charts/line-chart/line-chart.component.html
+++ b/docs/app/pages/charts/charts-sections/line-charts/line-chart/line-chart.component.html
@@ -1,25 +1,39 @@
 <div class="demo-chart-container">
 
-    <canvas baseChart 
-            [datasets]="lineChartData"
-            [labels]="lineChartLabels"
-            [options]="lineChartOptions"
-            [legend]="lineChartLegend"
-            [colors]="lineChartColors"
-            chartType="line">
+    <canvas aria-label="Line chart showing sales volume by week"
+        baseChart
+        [datasets]="lineChartData"
+        [labels]="lineChartLabels"
+        [options]="lineChartOptions"
+        [legend]="lineChartLegend"
+        [colors]="lineChartColors"
+        chartType="line">
+
+        <table aria-label="Chart data">
+            <thead>
+                <tr>
+                    <th>Week</th>
+                    <th>Volume</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr *ngFor="let label of lineChartLabels; let idx = index">
+                    <td>{{label}}</td>
+                    <td>{{lineChartData[0].data[idx]}}</td>
+                </tr>
+            </tbody>
+        </table>
+
     </canvas>
 
 </div>
 
-
 <hr>
 
 <p>
-    Line Charts can be added using the <code>ng2-charts</code> library. 
+    Line Charts can be added using the <code>ng2-charts</code> library.
     The <code>chart.js</code> library needs to be imported and the <code>ChartsModule</code> needs to be added to the appropriate NgModule.
 </p>
-
-<br>
 
 <p>The <code>baseChart</code> directive should be added to a <code>canvas</code> element and the following attributes can be used to customize the chart behavior and appearance:</p>
 
@@ -76,7 +90,7 @@
 
     <p class="m-b-nil">
         <b>Dependencies: </b>
-        <a class="hyperlink" href="https://www.npmjs.com/package/ng2-charts">ng2-charts</a>, 
+        <a class="hyperlink" href="https://www.npmjs.com/package/ng2-charts">ng2-charts</a>,
         <a class="hyperlink" href="https://www.npmjs.com/package/chart.js">chart.js</a>
     </p>
 
@@ -93,7 +107,7 @@
 
     <p class="m-b-nil">
         <b>Documentation: </b>
-        <a class="hyperlink" href="http://valor-software.com/ng2-charts/">Angular Directive Documentation</a>, 
+        <a class="hyperlink" href="http://valor-software.com/ng2-charts/">Angular Directive Documentation</a>,
         <a class="hyperlink" href="http://www.chartjs.org/docs/">Chart Library Documentation</a>
     </p>
 </blockquote>

--- a/docs/app/pages/charts/charts-sections/line-charts/line-chart/snippets/line-chart.html
+++ b/docs/app/pages/charts/charts-sections/line-charts/line-chart/snippets/line-chart.html
@@ -1,12 +1,29 @@
 <div class="demo-chart-container">
 
-    <canvas baseChart 
-            [datasets]="lineChartData"
-            [labels]="lineChartLabels"
-            [options]="lineChartOptions"
-            [legend]="lineChartLegend"
-            [colors]="lineChartColors"
-            chartType="line">
+    <canvas aria-label="Line chart showing sales volume by week"
+        baseChart
+        [datasets]="lineChartData"
+        [labels]="lineChartLabels"
+        [options]="lineChartOptions"
+        [legend]="lineChartLegend"
+        [colors]="lineChartColors"
+        chartType="line">
+
+        <table aria-label="Chart data">
+            <thead>
+                <tr>
+                    <th>Week</th>
+                    <th>Volume</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr *ngFor="let label of lineChartLabels; let idx = index">
+                    <td>{{label}}</td>
+                    <td>{{lineChartData[0].data[idx]}}</td>
+                </tr>
+            </tbody>
+        </table>
+
     </canvas>
 
 </div>

--- a/docs/app/pages/charts/charts-sections/line-charts/line-charts.module.ts
+++ b/docs/app/pages/charts/charts-sections/line-charts/line-charts.module.ts
@@ -1,3 +1,4 @@
+import { CommonModule } from '@angular/common';
 import { ComponentFactoryResolver, NgModule } from '@angular/core';
 import { RouterModule } from '@angular/router';
 import { ChartsModule } from 'ng2-charts';
@@ -14,7 +15,6 @@ import { ChartsMultipleAxisLineChartNg1Component } from './multiple-axis-line-ch
 import { ChartsMultipleAxisLineChartComponent } from './multiple-axis-line-chart/multiple-axis-line-chart.component';
 import { ChartsStackedLineChartNg1Component } from './stacked-line-chart-ng1/stacked-line-chart-ng1.component';
 import { ChartsStackedLineChartComponent } from './stacked-line-chart/stacked-line-chart.component';
-
 
 const SECTIONS = [
     ChartsLineChartNg1Component,
@@ -37,13 +37,14 @@ const ROUTES = [
 
 @NgModule({
     imports: [
-        TabsetModule,
-        WrappersModule,
-        HybridModule,
-        DocumentationComponentsModule,
         ChartsModule,
         ColorServiceModule,
-        RouterModule.forChild(ROUTES)
+        CommonModule,
+        DocumentationComponentsModule,
+        HybridModule,
+        RouterModule.forChild(ROUTES),
+        TabsetModule,
+        WrappersModule,
     ],
     exports: SECTIONS,
     declarations: SECTIONS,

--- a/docs/app/pages/charts/charts-sections/line-charts/multiple-axis-line-chart/multiple-axis-line-chart.component.html
+++ b/docs/app/pages/charts/charts-sections/line-charts/multiple-axis-line-chart/multiple-axis-line-chart.component.html
@@ -1,25 +1,41 @@
 <div class="demo-chart-container">
 
-    <canvas baseChart 
-            [datasets]="lineChartData"
-            [options]="lineChartOptions"
-            [legend]="lineChartLegend"
-            [colors]="lineChartColors"
-            chartType="line">
+    <canvas baseChart
+        [datasets]="lineChartData"
+        [options]="lineChartOptions"
+        [legend]="lineChartLegend"
+        [colors]="lineChartColors"
+        chartType="line">
+
+        <table *ngFor="let dataset of lineChartData" attr.aria-label="{{dataset.label}} chart data">
+            <thead>
+                <tr>
+                    <th>Date</th>
+                    <th>{{dataset.label}}</th>
+                </tr>
+            </thead>
+            <tbody>
+                <ng-container *ngFor="let row of dataset.data; let idx = index">
+                    <tr *ngIf="idx % 10 === 0">
+                        <td>{{formatDate(row.x)}}</td>
+                        <td>{{row.y}}</td>
+                    </tr>
+                </ng-container>
+            </tbody>
+        </table>
+
     </canvas>
 
-    <div class="multi-axis-legend" [innerHtml]="lineChartLegendContents"></div>
+    <div class="multi-axis-legend" [innerHtml]="lineChartLegendContents" aria-hidden="true"></div>
 
 </div>
 
 <hr>
 
 <p>
-    Multiple Axis Line Charts can be added using the <code>ng2-charts</code> library. 
+    Multiple Axis Line Charts can be added using the <code>ng2-charts</code> library.
     The <code>chart.js</code> library needs to be imported and the <code>ChartsModule</code> needs to be added to the appropriate NgModule.
 </p>
-
-<br>
 
 <p>The <code>baseChart</code> directive should be added to a <code>canvas</code> element and the following attributes can be used to customize the chart behavior and appearance:</p>
 
@@ -76,7 +92,7 @@
 
     <p class="m-b-nil">
         <b>Dependencies: </b>
-        <a class="hyperlink" href="https://www.npmjs.com/package/ng2-charts">ng2-charts</a>, 
+        <a class="hyperlink" href="https://www.npmjs.com/package/ng2-charts">ng2-charts</a>,
         <a class="hyperlink" href="https://www.npmjs.com/package/chart.js">chart.js</a>
     </p>
 
@@ -93,7 +109,7 @@
 
     <p class="m-b-nil">
         <b>Documentation: </b>
-        <a class="hyperlink" href="http://valor-software.com/ng2-charts/">Angular Directive Documentation</a>, 
+        <a class="hyperlink" href="http://valor-software.com/ng2-charts/">Angular Directive Documentation</a>,
         <a class="hyperlink" href="http://www.chartjs.org/docs/">Chart Library Documentation</a>
     </p>
 </blockquote>

--- a/docs/app/pages/charts/charts-sections/line-charts/multiple-axis-line-chart/multiple-axis-line-chart.component.ts
+++ b/docs/app/pages/charts/charts-sections/line-charts/multiple-axis-line-chart/multiple-axis-line-chart.component.ts
@@ -105,7 +105,7 @@ export class ChartsMultipleAxisLineChartComponent extends BaseDocumentationSecti
 
                 let sets = chart.data.datasets.map((dataset: Chart.ChartDataSets) => {
                     return `<li class="multi-axis-legend-list-item">
-                                <span class="multi-axis-legend-box" style="background-color: ${dataset.backgroundColor}; border-color: ${dataset.borderColor}"></span> 
+                                <span class="multi-axis-legend-box" style="background-color: ${dataset.backgroundColor}; border-color: ${dataset.borderColor}"></span>
                                 <span class="multi-axis-legend-text">${dataset.label}</span>
                             </li>`;
                 });
@@ -208,6 +208,10 @@ export class ChartsMultipleAxisLineChartComponent extends BaseDocumentationSecti
         setTimeout(() => {
             this.lineChartLegendContents = this.sanitizer.bypassSecurityTrustHtml(this.baseChart.chart.generateLegend());
         });
+    }
+
+    formatDate(date: number): string {
+        return new Date(date).toLocaleDateString();
     }
 
 }

--- a/docs/app/pages/charts/charts-sections/line-charts/multiple-axis-line-chart/snippets/line-chart.html
+++ b/docs/app/pages/charts/charts-sections/line-charts/multiple-axis-line-chart/snippets/line-chart.html
@@ -1,13 +1,31 @@
 <div class="demo-chart-container">
 
-    <canvas baseChart 
-            [datasets]="lineChartData"
-            [options]="lineChartOptions"
-            [legend]="lineChartLegend"
-            [colors]="lineChartColors"
-            chartType="line">
+    <canvas baseChart
+        [datasets]="lineChartData"
+        [options]="lineChartOptions"
+        [legend]="lineChartLegend"
+        [colors]="lineChartColors"
+        chartType="line">
+
+        <table *ngFor="let dataset of lineChartData" attr.aria-label="{{dataset.label}} chart data">
+            <thead>
+                <tr>
+                    <th>Date</th>
+                    <th>{{dataset.label}}</th>
+                </tr>
+            </thead>
+            <tbody>
+                <ng-container *ngFor="let row of dataset.data; let idx = index">
+                    <tr *ngIf="idx % 10 === 0">
+                        <td>{{formatDate(row.x)}}</td>
+                        <td>{{row.y}}</td>
+                    </tr>
+                </ng-container>
+            </tbody>
+        </table>
+
     </canvas>
 
-    <div class="multi-axis-legend" [innerHtml]="lineChartLegendContents"></div>
+    <div class="multi-axis-legend" [innerHtml]="lineChartLegendContents" aria-hidden="true"></div>
 
 </div>

--- a/docs/app/pages/charts/charts-sections/line-charts/multiple-axis-line-chart/snippets/line-chart.ts
+++ b/docs/app/pages/charts/charts-sections/line-charts/multiple-axis-line-chart/snippets/line-chart.ts
@@ -82,7 +82,7 @@ export class AppComponent implements AfterViewInit {
 
                 let sets = chart.data.datasets.map((dataset: Chart.ChartDataSets) => {
                     return `<li class="multi-axis-legend-list-item">
-                                <span class="multi-axis-legend-box" style="background-color: ${dataset.backgroundColor}; border-color: ${dataset.borderColor}"></span> 
+                                <span class="multi-axis-legend-box" style="background-color: ${dataset.backgroundColor}; border-color: ${dataset.borderColor}"></span>
                                 <span class="multi-axis-legend-text">${dataset.label}</span>
                             </li>`;
                 });
@@ -184,6 +184,10 @@ export class AppComponent implements AfterViewInit {
         setTimeout(() => {
             this.lineChartLegendContents = this.sanitizer.bypassSecurityTrustHtml(this.baseChart.chart.generateLegend());
         });
+    }
+
+    formatDate(date: number): string {
+        return new Date(date).toLocaleDateString();
     }
 
 }

--- a/docs/app/pages/charts/charts-sections/line-charts/stacked-line-chart/snippets/line-chart.html
+++ b/docs/app/pages/charts/charts-sections/line-charts/stacked-line-chart/snippets/line-chart.html
@@ -1,12 +1,33 @@
 <div class="demo-chart-container-stack">
 
-    <canvas baseChart 
-            [datasets]="lineChartData"
-            [labels]="lineChartLabels"
-            [options]="lineChartOptions"
-            [legend]="lineChartLegend"
-            [colors]="lineChartColors"
-            chartType="line">
+    <canvas aria-label="Line chart showing sales volume by week"
+        baseChart
+        [datasets]="lineChartData"
+        [labels]="lineChartLabels"
+        [options]="lineChartOptions"
+        [legend]="lineChartLegend"
+        [colors]="lineChartColors"
+        chartType="line">
+
+        <table aria-label="Chart data">
+            <thead>
+                <tr>
+                    <th>Week</th>
+                    <th>Sales 1</th>
+                    <th>Sales 2</th>
+                    <th>Sales 3</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr *ngFor="let label of lineChartLabels; let idx = index">
+                    <td>{{label}}</td>
+                    <td>&euro;{{lineChartData[0].data[idx]}}</td>
+                    <td>&euro;{{lineChartData[1].data[idx]}}</td>
+                    <td>&euro;{{lineChartData[2].data[idx]}}</td>
+                </tr>
+            </tbody>
+        </table>
+
     </canvas>
 
 </div>

--- a/docs/app/pages/charts/charts-sections/line-charts/stacked-line-chart/stacked-line-chart.component.html
+++ b/docs/app/pages/charts/charts-sections/line-charts/stacked-line-chart/stacked-line-chart.component.html
@@ -1,25 +1,43 @@
 <div class="demo-chart-container-stack">
 
-    <canvas baseChart 
-            [datasets]="lineChartData"
-            [labels]="lineChartLabels"
-            [options]="lineChartOptions"
-            [legend]="lineChartLegend"
-            [colors]="lineChartColors"
-            chartType="line">
+    <canvas aria-label="Line chart showing sales volume by week"
+        baseChart
+        [datasets]="lineChartData"
+        [labels]="lineChartLabels"
+        [options]="lineChartOptions"
+        [legend]="lineChartLegend"
+        [colors]="lineChartColors"
+        chartType="line">
+
+        <table aria-label="Chart data">
+            <thead>
+                <tr>
+                    <th>Week</th>
+                    <th>Sales 1</th>
+                    <th>Sales 2</th>
+                    <th>Sales 3</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr *ngFor="let label of lineChartLabels; let idx = index">
+                    <td>{{label}}</td>
+                    <td>&euro;{{lineChartData[0].data[idx]}}</td>
+                    <td>&euro;{{lineChartData[1].data[idx]}}</td>
+                    <td>&euro;{{lineChartData[2].data[idx]}}</td>
+                </tr>
+            </tbody>
+        </table>
+
     </canvas>
 
 </div>
 
-
 <hr>
 
 <p>
-    Stacked Line Charts can be added using the <code>ng2-charts</code> library. 
+    Stacked Line Charts can be added using the <code>ng2-charts</code> library.
     The <code>chart.js</code> library needs to be imported and the <code>ChartsModule</code> needs to be added to the appropriate NgModule.
 </p>
-
-<br>
 
 <p>The <code>baseChart</code> directive should be added to a <code>canvas</code> element and the following attributes can be used to customize the chart behavior and appearance:</p>
 
@@ -76,7 +94,7 @@
 
     <p class="m-b-nil">
         <b>Dependencies: </b>
-        <a class="hyperlink" href="https://www.npmjs.com/package/ng2-charts">ng2-charts</a>, 
+        <a class="hyperlink" href="https://www.npmjs.com/package/ng2-charts">ng2-charts</a>,
         <a class="hyperlink" href="https://www.npmjs.com/package/chart.js">chart.js</a>
     </p>
 
@@ -93,7 +111,7 @@
 
     <p class="m-b-nil">
         <b>Documentation: </b>
-        <a class="hyperlink" href="http://valor-software.com/ng2-charts/">Angular Directive Documentation</a>, 
+        <a class="hyperlink" href="http://valor-software.com/ng2-charts/">Angular Directive Documentation</a>,
         <a class="hyperlink" href="http://www.chartjs.org/docs/">Chart Library Documentation</a>
     </p>
 </blockquote>

--- a/docs/app/pages/charts/charts-sections/scrollable-chart/scrollable-chart/scrollable-chart.component.html
+++ b/docs/app/pages/charts/charts-sections/scrollable-chart/scrollable-chart/scrollable-chart.component.html
@@ -1,20 +1,43 @@
 <div class="demo-chart-container">
 
-    <div class="chart-scroll-previous-btn" *ngIf="hasPreviousPage()" (click)="goToPreviousPage()">
+    <div *ngIf="hasPreviousPage()"
+        aria-label="Scroll to previous chart page"
+        class="chart-scroll-previous-btn"
+        (click)="goToPreviousPage()">
         <i class="hpe-icon hpe-previous"></i>
     </div>
 
-    <canvas baseChart 
-            [datasets]="barChartData"
-            [labels]="barChartLabels"
-            [options]="barChartOptions"
-            [legend]="barChartLegend"
-            [colors]="barChartColors"
-            chartType="bar">
+    <canvas aria-label="Bar chart showing file type totals"
+        baseChart
+        [datasets]="barChartData"
+        [labels]="barChartLabels"
+        [options]="barChartOptions"
+        [legend]="barChartLegend"
+        [colors]="barChartColors"
+        chartType="bar">
+
+        <table aria-label="Chart data">
+            <thead>
+                <tr>
+                    <th>File Type</th>
+                    <th>Number of Files</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr *ngFor="let label of barChartLabels; let idx = index">
+                    <td>{{label}}</td>
+                    <td>{{barChartData[0].data[idx]}}</td>
+                </tr>
+            </tbody>
+        </table>
+
     </canvas>
 
-    <div class="chart-scroll-next-btn" *ngIf="hasNextPage()" (click)="goToNextPage()">
-        <i class="hpe-icon hpe-next"></i>        
+    <div *ngIf="hasNextPage()"
+        aria-label="Scroll to previous chart page"
+        class="chart-scroll-next-btn"
+        (click)="goToNextPage()">
+        <i class="hpe-icon hpe-next"></i>
     </div>
 
 </div>
@@ -22,11 +45,9 @@
 <hr>
 
 <p>
-    Scrollable Charts can be added using the <code>ng2-charts</code> library. 
+    Scrollable Charts can be added using the <code>ng2-charts</code> library.
     The <code>chart.js</code> library needs to be imported and the <code>ChartsModule</code> needs to be added to the appropriate NgModule.
 </p>
-
-<br>
 
 <p>The <code>baseChart</code> directive should be added to a <code>canvas</code> element and the following attributes can be used to customize the chart behavior and appearance:</p>
 
@@ -80,12 +101,12 @@
 <br>
 
 <p>
-    The effect of scrolling on a chart can be achieved by simply displaying only a subset of the dataset at a time. 
+    The effect of scrolling on a chart can be achieved by simply displaying only a subset of the dataset at a time.
     We can add 'previous' and 'next' buttons to allow easy navigation between the different pages of data.
 </p>
 
 <p>
-    In the example above, we store the entire dataset in an array. We also store an array containing all the labels for each data point. 
+    In the example above, we store the entire dataset in an array. We also store an array containing all the labels for each data point.
     By defining several variables (<code>pageSize</code> &amp; <code>pageNumber</code>) we can easily control the datasets shown.
 </p>
 
@@ -105,7 +126,7 @@
 
     <p class="m-b-nil">
         <b>Dependencies: </b>
-        <a class="hyperlink" href="https://www.npmjs.com/package/ng2-charts">ng2-charts</a>, 
+        <a class="hyperlink" href="https://www.npmjs.com/package/ng2-charts">ng2-charts</a>,
         <a class="hyperlink" href="https://www.npmjs.com/package/chart.js">chart.js</a>
     </p>
 
@@ -122,7 +143,7 @@
 
     <p class="m-b-nil">
         <b>Documentation: </b>
-        <a class="hyperlink" href="http://valor-software.com/ng2-charts/">Angular Directive Documentation</a>, 
+        <a class="hyperlink" href="http://valor-software.com/ng2-charts/">Angular Directive Documentation</a>,
         <a class="hyperlink" href="http://www.chartjs.org/docs/">Chart Library Documentation</a>
     </p>
 </blockquote>

--- a/docs/app/pages/charts/charts-sections/scrollable-chart/scrollable-chart/snippets/scrollable-chart.html
+++ b/docs/app/pages/charts/charts-sections/scrollable-chart/scrollable-chart/snippets/scrollable-chart.html
@@ -1,20 +1,43 @@
 <div class="demo-chart-container">
 
-    <div class="chart-scroll-previous-btn" *ngIf="hasPreviousPage()" (click)="goToPreviousPage()">
+    <div *ngIf="hasPreviousPage()"
+        aria-label="Scroll to previous chart page"
+        class="chart-scroll-previous-btn"
+        (click)="goToPreviousPage()">
         <i class="hpe-icon hpe-previous"></i>
     </div>
 
-    <canvas baseChart 
-            [datasets]="barChartData"
-            [labels]="barChartLabels"
-            [options]="barChartOptions"
-            [legend]="barChartLegend"
-            [colors]="barChartColors"
-            chartType="bar">
+    <canvas aria-label="Bar chart showing file type totals"
+        baseChart
+        [datasets]="barChartData"
+        [labels]="barChartLabels"
+        [options]="barChartOptions"
+        [legend]="barChartLegend"
+        [colors]="barChartColors"
+        chartType="bar">
+
+        <table aria-label="Chart data">
+            <thead>
+                <tr>
+                    <th>File Type</th>
+                    <th>Number of Files</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr *ngFor="let label of barChartLabels; let idx = index">
+                    <td>{{label}}</td>
+                    <td>{{barChartData[0].data[idx]}}</td>
+                </tr>
+            </tbody>
+        </table>
+
     </canvas>
 
-    <div class="chart-scroll-next-btn" *ngIf="hasNextPage()" (click)="goToNextPage()">
-        <i class="hpe-icon hpe-next"></i>        
+    <div *ngIf="hasNextPage()"
+        aria-label="Scroll to previous chart page"
+        class="chart-scroll-next-btn"
+        (click)="goToNextPage()">
+        <i class="hpe-icon hpe-next"></i>
     </div>
 
 </div>

--- a/src/components/spark/spark.component.html
+++ b/src/components/spark/spark.component.html
@@ -10,7 +10,16 @@
             <div class="ux-spark-label-top-right" *ngIf="topRightLabel" [innerHtml]="topRightLabel"></div>
         </div>
 
-        <div class="ux-spark ux-inline ux-spark-theme-{{theme}}" [style.height.px]="barHeight" [style.backgroundColor]="trackColor" [uxTooltip]="tooltip">
+        <div role="progressbar"
+            [attr.aria-label]="ariaLabel || tooltip"
+            [attr.aria-description]="ariaDescription"
+            aria-valuemin="0"
+            aria-valuemax="100"
+            [attr.aria-valuenow]="values.length === 1 ? values[0] : undefined"
+            class="ux-spark ux-inline ux-spark-theme-{{theme}}"
+            [style.height.px]="barHeight"
+            [style.backgroundColor]="trackColor"
+            [uxTooltip]="tooltip">
             <div class="ux-spark-bar" *ngFor="let line of values; let idx = index;" [style.width.%]="line" [style.backgroundColor]="barColor[idx]"></div>
         </div>
 
@@ -26,14 +35,23 @@
 
 
 <!-- Non Inline Spark Chart -->
-<div *ngIf="!inlineLabel">
+<div *ngIf="!inlineLabel" [attr.aria-label]="ariaLabel" [attr.aria-description]="ariaDescription">
 
     <div class="ux-spark-top-container" *ngIf="topLeftLabel || topRightLabel">
         <div class="ux-spark-label-top-left" *ngIf="topLeftLabel" [innerHtml]="topLeftLabel"></div>
         <div class="ux-spark-label-top-right" *ngIf="topRightLabel" [innerHtml]="topRightLabel"></div>
     </div>
 
-    <div class="ux-spark ux-spark-theme-{{theme}}" [class.ux-spark-multi-value]="values.length > 1" [style.height.px]="barHeight" [style.backgroundColor]="trackColor"
+    <div role="progressbar"
+        [attr.aria-label]="ariaLabel || tooltip"
+        [attr.aria-description]="ariaDescription"
+        aria-valuemin="0"
+        aria-valuemax="100"
+        [attr.aria-valuenow]="values.length === 1 ? values[0] : undefined"
+        class="ux-spark ux-spark-theme-{{theme}}"
+        [class.ux-spark-multi-value]="values.length > 1"
+        [style.height.px]="barHeight"
+        [style.backgroundColor]="trackColor"
         [uxTooltip]="tooltip">
         <div class="ux-spark-bar" *ngFor="let line of value; let idx = index;" [style.width.%]="line" [style.backgroundColor]="barColor[idx]"></div>
     </div>

--- a/src/components/spark/spark.component.ts
+++ b/src/components/spark/spark.component.ts
@@ -18,12 +18,14 @@ export class SparkComponent {
     @Input() bottomLeftLabel: string;
     @Input() bottomRightLabel: string;
     @Input() tooltip: string;
+    @Input('aria-label') ariaLabel: string;
+    @Input('aria-description') ariaDescription: string;
 
     private _trackColor: string;
-    private _theme: ColorIdentifier = 'primary';    
+    private _theme: ColorIdentifier = 'primary';
     private _barColor: string | string[] = [];
-    
-    @Input() 
+
+    @Input()
     set theme(value: string) {
         this._theme = this._colorService.resolveColorName(value);
     }
@@ -32,7 +34,7 @@ export class SparkComponent {
         return this._theme;
     }
 
-    @Input() 
+    @Input()
     set trackColor(value: string) {
         this._trackColor = this._colorService.resolve(value);
     }
@@ -41,7 +43,7 @@ export class SparkComponent {
         return this._trackColor;
     }
 
-    @Input() 
+    @Input()
     set barColor(value: string | string[]) {
 
         if (Array.isArray(value)) {


### PR DESCRIPTION
Added a data table as fallback for the canvas element on all Angular charts except live chart; this is read by the screen reader. Also added aria labels to the canvases.

For spark I have added `role="progressbar"` and related attributes, with the exception of valuenow when the spark has more than one value. The progressbar element also gets aria-label and aria-description from the component inputs.

https://autjira.microfocus.com/browse/EL-3274