### PR TITLE
Fixed angular-split version in the library dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@angular/router": "^6.0.9",
     "@angular/upgrade": "^6.0.9",
     "angular": "~1.3.2",
-    "angular-split": "^1.0.0-rc.3",
+    "angular-split": "1.0.0-rc.3",
     "angular-tree-component": "^5.2.1",
     "bootstrap": "^3.3.7",
     "chance": "^1.0.10",

--- a/src/package.json
+++ b/src/package.json
@@ -54,7 +54,7 @@
   "homepage": "https://uxaspects.github.io/UXAspects",
   "dependencies": {
     "@angular/cdk": "5.2.5",
-    "angular-split": "^1.0.0-rc.3",
+    "angular-split": "1.0.0-rc.3",
     "chart.js": "~2.6.0",
     "dragula": "^3.7.2",
     "ng2-charts": "^1.6.0",


### PR DESCRIPTION
If consumers pick up the latest version of angular-split with removed `minSize` property on `SplitAreaDirective` then our accessibility directive will not work.

https://github.com/bertrandg/angular-split/commit/896f923896029750733c31806d6fe647ebcac6d3#diff-45d2b69149c3063c36bd7d65505d25a8