### PR TITLE
EL-3266 - SEPG release staging

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -29,19 +29,35 @@ module.exports = function(grunt) {
     grunt.registerTask('licenses', ['execute:licenses', 'usebanner:ng1']);
     grunt.registerTask('test', ['build:library', 'jasmine:ng1']);
     grunt.registerTask('webpack_import_cert', ['run:webpack_import_cert']);
+
     grunt.registerTask('package:ux-aspects', [
         'run:npm_pack_ux-aspects',
         'copy:npm_ux-aspects_tgz',
         'copy:artifactory_ux-aspects_tgz',
         'clean:ux-aspects_tgz'
     ]);
+
     grunt.registerTask('package:ux-aspects_bower', ['compress:bower']);
+
     grunt.registerTask('package:ux-aspects-docs', [
         'run:npm_pack_ux-aspects-docs',
         'copy:npm_ux-aspects-docs_tgz',
         'copy:artifactory_ux-aspects-docs_tgz',
         'clean:ux-aspects-docs_tgz'
     ]);
+
+    grunt.registerTask('package:release:ux-aspects', [
+        'run:npm_pack_ux-aspects',
+        'copy:staging_ux-aspects_tgz',
+        'clean:ux-aspects_tgz'
+    ]);
+
+    grunt.registerTask('package:release:ux-aspects-docs', [
+        'run:npm_pack_ux-aspects-docs',
+        'copy:staging_ux-aspects-docs_tgz',
+        'clean:ux-aspects-docs_tgz'
+    ]);
+
     grunt.registerTask('build:documentation', [
         'tslint:documentation',
         'clean:documentation',
@@ -72,6 +88,13 @@ module.exports = function(grunt) {
         'package:ux-aspects_bower',
         'package:ux-aspects-docs',
         'compress:documentation'
+    ]);
+
+    // package:release: update version to the release and
+    grunt.registerTask('package:release', [
+        'run:npm_setversion_release',
+        'package:release:ux-aspects',
+        'package:release:ux-aspects-docs'
     ]);
 
     // build: build and package for all targets.

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,8 +1,7 @@
 var path = require('path');
 var configLoader = require('load-grunt-config');
 
-module.exports = function (grunt) {
-
+module.exports = function(grunt) {
     // measures the time each task takes
     require('time-grunt')(grunt);
 
@@ -11,9 +10,9 @@ module.exports = function (grunt) {
         configPath: path.join(process.cwd(), 'grunt'),
         jitGrunt: {
             staticMappings: {
-                'usebanner': 'grunt-banner',
-                'protractor': 'grunt-protractor-runner',
-                'makeReport': 'grunt-istanbul'
+                usebanner: 'grunt-banner',
+                protractor: 'grunt-protractor-runner',
+                makeReport: 'grunt-istanbul'
             }
         }
     });
@@ -28,24 +27,73 @@ module.exports = function (grunt) {
     grunt.registerTask('iconset', ['webfont:iconset']);
     grunt.registerTask('minify', ['uglify:ng1', 'cssmin:styles']);
     grunt.registerTask('licenses', ['execute:licenses', 'usebanner:ng1']);
-    grunt.registerTask('test', ['build', 'jasmine:ng1']);
+    grunt.registerTask('test', ['build:library', 'jasmine:ng1']);
     grunt.registerTask('webpack_import_cert', ['run:webpack_import_cert']);
-    grunt.registerTask('package:library', ['run:npm_pack', 'copy:npm_tgz', 'copy:artifactory_tgz', 'clean:npm_tgz']);
-    grunt.registerTask('package:library_bower', ['compress:bower']);
-    grunt.registerTask('package:docs', ['run:npm_pack_docs', 'copy:npm_docs_tgz', 'copy:artifactory_docs_tgz', 'clean:npm_docs_tgz']);
+    grunt.registerTask('package:ux-aspects', [
+        'run:npm_pack_ux-aspects',
+        'copy:npm_ux-aspects_tgz',
+        'copy:artifactory_ux-aspects_tgz',
+        'clean:ux-aspects_tgz'
+    ]);
+    grunt.registerTask('package:ux-aspects_bower', ['compress:bower']);
+    grunt.registerTask('package:ux-aspects-docs', [
+        'run:npm_pack_ux-aspects-docs',
+        'copy:npm_ux-aspects-docs_tgz',
+        'copy:artifactory_ux-aspects-docs_tgz',
+        'clean:ux-aspects-docs_tgz'
+    ]);
+    grunt.registerTask('build:documentation', [
+        'tslint:documentation',
+        'clean:documentation',
+        'run:documentation_build'
+    ]);
 
-    grunt.registerTask('documentation:build', ['tslint:documentation', 'clean:documentation', 'run:documentation_build']);
-
+    // e2e: run the protractor tests
     grunt.registerTask('e2e', ['tslint:e2e', 'clean:e2e', 'execute:protractor', 'makeReport']);
 
-    // Tasks with larger chains of events
-    grunt.registerTask('compile', ['clean', 'lint', 'library', 'scripts', 'iconset', 'styles', 'documentation:build', 'minify', 'assets', 'licenses', 'execute:shim']);
-    grunt.registerTask('package', ['package:library', 'package:library_bower', 'package:docs', 'compress:documentation']);
+    // compile: build the library and documentation into `dist`.
+    grunt.registerTask('compile', [
+        'clean',
+        'lint',
+        'library',
+        'scripts',
+        'iconset',
+        'styles',
+        'build:documentation',
+        'minify',
+        'assets',
+        'licenses',
+        'execute:shim'
+    ]);
+
+    // package: compress the dist output for all targets into the `target` directory.
+    grunt.registerTask('package', [
+        'package:ux-aspects',
+        'package:ux-aspects_bower',
+        'package:ux-aspects-docs',
+        'compress:documentation'
+    ]);
+
+    // build: build and package for all targets.
     grunt.registerTask('build', ['compile', 'package']);
-    grunt.registerTask('build:library', ['clean', 'lint', 'library', 'scripts', 'iconset', 'styles', 'minify', 'assets:library', 'licenses', 'execute:shim', 'package:library', 'package:library_bower', 'package:docs']);
-    grunt.registerTask('releasebuild', ['build']);
 
-    // default task will run dev environment
+    // build:library: build and package the npm lib, npm docs lib, and bower lib.
+    grunt.registerTask('build:library', [
+        'clean',
+        'lint',
+        'library',
+        'scripts',
+        'iconset',
+        'styles',
+        'minify',
+        'assets:library',
+        'licenses',
+        'execute:shim',
+        'package:ux-aspects',
+        'package:ux-aspects_bower',
+        'package:ux-aspects-docs'
+    ]);
+
+    // default: run dev environment
     grunt.registerTask('default', ['build']);
-
 };

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "ux-aspects",
-  "version": "1.6.8",
+  "version": "1.7.0",
   "description": "Responsive UI Framework for Big Data Applications - CSS & Angular modules.",
   "keywords": [
     "js",

--- a/grunt/clean.js
+++ b/grunt/clean.js
@@ -32,5 +32,5 @@ module.exports = {
     md: 'dist/*.md',
     e2e: ['e2e/dist', 'e2e/_test-output', 'e2e/coverage', 'e2e/html', 'e2e/xml'],
     shim: 'dist/dist',
-    target: ['target/bower', 'target/npm', 'target/artifactory', 'target/docs']
+    target: ['target/bower', 'target/npm', 'target/artifactory', 'target/release-staging', 'target/docs']
 };

--- a/grunt/clean.js
+++ b/grunt/clean.js
@@ -20,8 +20,8 @@ module.exports = {
         'dist/ux-aspects.metadata.json',
         'dist/*.tgz'
     ],
-    npm_tgz: 'dist/ux-aspects-ux-aspects-*.*.*.tgz',
-    npm_docs_tgz: 'ux-aspects-ux-aspects-docs-*.*.*.tgz',
+    'ux-aspects_tgz': 'dist/ux-aspects-ux-aspects-*.*.*.tgz',
+    'ux-aspects-docs_tgz': 'ux-aspects-ux-aspects-docs-*.*.*.tgz',
     documentation: 'dist/docs',
     ng1: 'dist/ng1',
     styles: 'dist/styles',
@@ -32,8 +32,5 @@ module.exports = {
     md: 'dist/*.md',
     e2e: ['e2e/dist', 'e2e/_test-output', 'e2e/coverage', 'e2e/html', 'e2e/xml'],
     shim: 'dist/dist',
-    bower: 'target/bower',
-    npm: 'target/npm',
-    artifactory: 'target/artifactory',
-    docs: 'target/docs',
+    target: ['target/bower', 'target/npm', 'target/artifactory', 'target/docs']
 };

--- a/grunt/copy.js
+++ b/grunt/copy.js
@@ -26,25 +26,25 @@ module.exports = {
         dest: join(cwd(), 'dist', 'docs', 'assets', 'ng1'),
         expand: true
     },
-    'npm_tgz': {
+    'npm_ux-aspects_tgz': {
         cwd: join(cwd(), 'dist'),
         src: 'ux-aspects-ux-aspects-*.*.*.tgz',
         dest: join(cwd(), 'target', 'npm'),
         expand: true
     },
-    'npm_docs_tgz': {
+    'npm_ux-aspects-docs_tgz': {
         cwd: cwd(),
         src: 'ux-aspects-ux-aspects-docs-*.*.*.tgz',
         dest: join(cwd(), 'target', 'npm'),
         expand: true
     },
-    'artifactory_tgz': {
+    'artifactory_ux-aspects_tgz': {
         cwd: join(cwd(), 'dist'),
         src: 'ux-aspects-ux-aspects-*.*.*.tgz',
         dest: join(cwd(), 'target', 'artifactory', '@ux-aspects', 'ux-aspects', '-', '@ux-aspects'),
         expand: true
     },
-    'artifactory_docs_tgz': {
+    'artifactory_ux-aspects-docs_tgz': {
         cwd: cwd(),
         src: 'ux-aspects-ux-aspects-docs-*.*.*.tgz',
         dest: join(cwd(), 'target', 'artifactory', '@ux-aspects', 'ux-aspects-docs', '-', '@ux-aspects'),

--- a/grunt/copy.js
+++ b/grunt/copy.js
@@ -50,6 +50,18 @@ module.exports = {
         dest: join(cwd(), 'target', 'artifactory', '@ux-aspects', 'ux-aspects-docs', '-', '@ux-aspects'),
         expand: true
     },
+    'staging_ux-aspects_tgz': {
+        cwd: join(cwd(), 'dist'),
+        src: 'ux-aspects-ux-aspects-*.*.*.tgz',
+        dest: join(cwd(), 'target', 'release-staging', '@ux-aspects', 'ux-aspects', '-', '@ux-aspects'),
+        expand: true
+    },
+    'staging_ux-aspects-docs_tgz': {
+        cwd: cwd(),
+        src: 'ux-aspects-ux-aspects-docs-*.*.*.tgz',
+        dest: join(cwd(), 'target', 'release-staging', '@ux-aspects', 'ux-aspects-docs', '-', '@ux-aspects'),
+        expand: true
+    },
     'md': {
         cwd: cwd(),
         src: ['README.md', 'LICENSE.md'],

--- a/grunt/run.js
+++ b/grunt/run.js
@@ -14,6 +14,9 @@ module.exports = {
     documentation_build: {
         exec: 'node --max-old-space-size=4096 ./node_modules/webpack/bin/webpack.js --colors --config ./configs/webpack.docs.prod.config.js'
     },
+    npm_setversion_release: {
+        exec: 'node ./node_modules/@ux-aspects/ux-aspects-scripts/bin/setversion-release.js'
+    },
     'npm_pack_ux-aspects': {
         options: {
             cwd: join(cwd(), 'dist')

--- a/grunt/run.js
+++ b/grunt/run.js
@@ -14,13 +14,13 @@ module.exports = {
     documentation_build: {
         exec: 'node --max-old-space-size=4096 ./node_modules/webpack/bin/webpack.js --colors --config ./configs/webpack.docs.prod.config.js'
     },
-    npm_pack: {
+    'npm_pack_ux-aspects': {
         options: {
             cwd: join(cwd(), 'dist')
         },
         exec: 'npm pack --quiet'
     },
-    npm_pack_docs: {
+    'npm_pack_ux-aspects-docs': {
         exec: 'npm pack --quiet'
     },
     webpack_ng1: {

--- a/official-build.props
+++ b/official-build.props
@@ -4,3 +4,11 @@ SEPG_BUILD_ENV_IMAGE=cafinternal/prereleases:buildenv-1.0.0-SNAPSHOT
 GENERIC_TARGET_URL=${genericRepoMgr}/npm-dev-local/${path}/${filename}
 GENERIC_ARTIFACTS=target/artifactory/**/*.tgz
 GENERIC_EXPECTED_ARTIFACT_COUNT=2
+
+#GENERIC_0_TARGET_URL=${genericRepoMgr}/npm-prerelease-local/${path}/${filename}
+#GENERIC_0_ARTIFACTS=target/artifactory/**/*.tgz
+#GENERIC_0_EXPECTED_ARTIFACT_COUNT=2
+
+#GENERIC_1_TARGET_URL=${sepgStagingRepo}/npm-dev-local/${path}/${filename}
+#GENERIC_1_ARTIFACTS=target/release-staging/**/*.tgz
+#GENERIC_1_EXPECTED_ARTIFACT_COUNT=2

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ux-aspects/ux-aspects-docs",
-  "version": "1.6.8",
+  "version": "1.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3274,12 +3274,13 @@
       "dev": true
     },
     "@ux-aspects/ux-aspects-scripts": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@ux-aspects/ux-aspects-scripts/-/ux-aspects-scripts-1.0.4.tgz",
-      "integrity": "sha512-a5qV1Qo58e3LxnZnt0JNX74H9hFdVWRpHTEKVzykAVwj6ObppiHeq+PFXPKj2WSuKUVAHT2YD3aTR+1bIjvwkA==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@ux-aspects/ux-aspects-scripts/-/ux-aspects-scripts-1.0.5.tgz",
+      "integrity": "sha512-/Xu/OEwP8NKPWFw4cRdCTNmfthb8Je/vT7LYGVReHpvd78dYJM/KW7Fpnpp2KAok7c6F1miza9zJ5g2R8/n1oA==",
       "dev": true,
       "requires": {
         "fs-extra": "7.0.0",
+        "semver": "^5.6.0",
         "tar-stream": "1.6.2"
       },
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ux-aspects/ux-aspects-docs",
-  "version": "1.6.8",
+  "version": "1.7.0",
   "description": "Open source user interface framework for building modern, responsive, mobile big data applications",
   "main": "docs/app/app.module.ts",
   "contributors": [
@@ -23,6 +23,7 @@
     "build:library": "grunt build:library",
     "lint": "grunt lint",
     "package": "grunt package",
+    "package:release": "grunt package:release",
     "test": "grunt jasmine:ng1 && grunt e2e",
     "test:e2e": "grunt e2e"
   },
@@ -84,7 +85,7 @@
     "@types/prismjs": "1.6.5",
     "@types/semver": "5.5.0",
     "@types/webpack-env": "1.13.2",
-    "@ux-aspects/ux-aspects-scripts": "^1.0.1",
+    "@ux-aspects/ux-aspects-scripts": "^1.0.5",
     "angular-mocks": "1.3.2",
     "angular2-template-loader": "0.6.2",
     "awesome-typescript-loader": "5.2.1",

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,6 @@
                             <executable>npm</executable>
                             <arguments>
                                 <argument>ci</argument>
-                                <argument>--unsafe-perm=true</argument>
                             </arguments>
                         </configuration>
                     </execution>
@@ -126,6 +125,22 @@
                             <arguments>
                                 <argument>run</argument>
                                 <argument>package</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
+
+                    <!-- Stage for release -->
+                    <execution>
+                        <id>exec-npm-run-package-release</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>npm</executable>
+                            <arguments>
+                                <argument>run</argument>
+                                <argument>package:release</argument>
                             </arguments>
                         </configuration>
                     </execution>

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ux-aspects/ux-aspects",
-  "version": "1.6.8",
+  "version": "1.7.0",
   "description": "Open source user interface framework for building modern, responsive, mobile big data applications",
   "main": "dist/bundles/ux-aspects.umd.js",
   "files": [


### PR DESCRIPTION
* Renamed grunt tasks to more accurately identify what they do.
* Added release-staging task to pom.xml:
  * Strips prerelease identifier from the package.json for both built NPM packages.
  * Creates the release packages.
  * Moves the release packages to `target/release-staging`.
* Added new build properties (to be uncommented when implemented).
* Also bumped the version for the next release.

https://autjira.microfocus.com/browse/EL-3266