### PR TITLE
EL-3293 - tree grid expand state

### DIFF
--- a/docs/app/pages/components/components-sections/tree-view/tree-grid-ng1/snippets/sample.html
+++ b/docs/app/pages/components/components-sections/tree-view/tree-grid-ng1/snippets/sample.html
@@ -1,5 +1,8 @@
-<treegrid data="vm.data" columns="vm.columns" selected="vm.selected"
-    current-row="vm.currentRow" options="vm.options">
+<treegrid data="vm.data"
+    columns="vm.columns"
+    selected="vm.selected"
+    current-row="vm.currentRow"
+    options="vm.options">
 </treegrid>
 
 <p class="m-t-md">

--- a/docs/app/pages/components/components-sections/tree-view/tree-grid-ng1/snippets/sample.js
+++ b/docs/app/pages/components/components-sections/tree-view/tree-grid-ng1/snippets/sample.js
@@ -66,6 +66,7 @@ function TreeGridCtrl($scope, $displayPanel) {
     title: 'Emails',
     date: new Date('2013-03-17'),
     type: 'folder',
+    expanded: true,
     nodes: [{
       id: 21,
       title: 'Inbox',
@@ -109,7 +110,8 @@ function TreeGridCtrl($scope, $displayPanel) {
   vm.selected = null;
 
   vm.options = {
-    childrenProperty: "nodes"
+    childrenProperty: "nodes",
+    expandedProperty: "expanded"
   };
 
   // Display Panel

--- a/docs/app/pages/components/components-sections/tree-view/tree-grid-ng1/tree-grid-ng1.component.html
+++ b/docs/app/pages/components/components-sections/tree-view/tree-grid-ng1/tree-grid-ng1.component.html
@@ -1,9 +1,14 @@
-<treegrid [data]="data" [columns]="columns" [(selected)]="selected" [options]="options" [(currentRow)]="currentRow"></treegrid>
+<treegrid [data]="data"
+    [columns]="columns"
+    [(selected)]="selected"
+    [options]="options"
+    [(currentRow)]="currentRow">
+</treegrid>
 
-<p class="m-t-md">Selected items:
-  <span *ngFor="let item of selected; let last = last">{{ item.title + (last ? '.' : ', ') }}</span>
-  <em *ngIf="selected?.length === 0">none</em></p>
-<hr>
+<p class="m-t-md">
+    Selected items: <span *ngFor="let item of selected; let last = last">{{ item.title + (last ? '.' : ', ') }}</span>
+    <em *ngIf="selected?.length === 0">none</em>
+</p>
 
 <div class="row uxd-customize-example">
     <div class="col-md-12">
@@ -22,13 +27,18 @@
                         <ux-checkbox [(ngModel)]="options.select.check">select.check</ux-checkbox>
                     </div>
                     <div class="col-md-4 col-sm-12">
-                        <ux-checkbox [(ngModel)]="!options.select.row && options.select.selectChildren" [disabled]="options.select.row">select.selectChildren</ux-checkbox>
+                        <ux-checkbox
+                            [(ngModel)]="!options.select.row && options.select.selectChildren"
+                            [disabled]="options.select.row">select.selectChildren</ux-checkbox>
                     </div>
                 </div>
                 <div class="row uxd-customize-row">
                     <div class="col-md-6 col-sm-12">
                         <label for="select-rowClass">select.rowClass</label>
-                        <input type="text" name="select-rowClass" class="form-control" [(ngModel)]="options.select.rowClass">
+                        <input type="text"
+                            name="select-rowClass"
+                            class="form-control"
+                            [(ngModel)]="options.select.rowClass" />
                     </div>
                 </div>
             </ux-accordion-panel>
@@ -36,83 +46,103 @@
     </div>
 </div>
 
-<p>The tree grid component allows hierarchical data to be displayed and navigated along with the benefits of a tabular
-  presentation. It shares familiar functionality with the list views, such as keyboard navigation and multiple
-  selection, as well as the ability to configure columns to fit the source data.</p>
+<hr>
+
+<p>
+    The tree grid component allows hierarchical data to be displayed and navigated along with the benefits of a tabular
+    presentation. It shares familiar functionality with the list views, such as keyboard navigation and multiple
+    selection, as well as the ability to configure columns to fit the source data.
+</p>
 
 <p>The source for the example above is as follows:</p>
 
 <ux-tabset [minimal]="false">
-  <ux-tab heading="HTML">
-    <uxd-snippet [content]="snippets.compiled.sampleHtml"></uxd-snippet>
-  </ux-tab>
-  <ux-tab heading="JavaScript">
-    <uxd-snippet language="javascript" [content]="snippets.compiled.sampleJs"></uxd-snippet>
-  </ux-tab>
+    <ux-tab heading="HTML">
+        <uxd-snippet [content]="snippets.compiled.sampleHtml"></uxd-snippet>
+    </ux-tab>
+    <ux-tab heading="JavaScript">
+        <uxd-snippet language="javascript" [content]="snippets.compiled.sampleJs"></uxd-snippet>
+    </ux-tab>
 </ux-tabset>
 
 <h4>Actions</h4>
 
 <ux-tabset [minimal]="false">
-  <ux-tab heading="HTML">
-    <uxd-snippet [code]="actionsHtml"></uxd-snippet>
-  </ux-tab>
-  <ux-tab heading="JavaScript">
-    <uxd-snippet language="javascript" [content]="snippets.compiled.actionsJs"></uxd-snippet>
-  </ux-tab>
+    <ux-tab heading="HTML">
+        <uxd-snippet [code]="actionsHtml"></uxd-snippet>
+    </ux-tab>
+    <ux-tab heading="JavaScript">
+        <uxd-snippet language="javascript" [content]="snippets.compiled.actionsJs"></uxd-snippet>
+    </ux-tab>
 </ux-tabset>
 
 <h4>Display Panel</h4>
 
 <ux-tabset [minimal]="false">
-  <ux-tab heading="Display Panel HTML">
-    <uxd-snippet [code]="displayPanel"></uxd-snippet>
-  </ux-tab>
-  <ux-tab heading="Display Panel Footer HTML">
-    <uxd-snippet [code]="displayPanelFooter"></uxd-snippet>
-  </ux-tab>
+    <ux-tab heading="Display Panel HTML">
+        <uxd-snippet [code]="displayPanel"></uxd-snippet>
+    </ux-tab>
+    <ux-tab heading="Display Panel Footer HTML">
+        <uxd-snippet [code]="displayPanelFooter"></uxd-snippet>
+    </ux-tab>
 </ux-tabset>
 
 <p>The attributes which can be applied to the <code>treegrid</code> directive are described in more detail below.</p>
 
-
 <uxd-api-properties>
     <tr uxd-api-property name="data" type="array or function" binding="variable" required="true">
-      <span>The data source of the tree grid. For smaller data sets, the entire hierachy may be loaded and passed to
-          the <code>data</code> attribute as an array of objects. Each object may have an array of child objects;
-          the name of the property containing this array must be specified in the <code>options</code> parameter.
-          Any other properties may be mapped to columns in the tree grid using the <code>columns</code> configuration.</span>
-        <span>For larger data sets, the tree grid can load the children of an item asynchronously. In this case, a function
-          may be provided to the <code>data</code> attribute. The argument to this function is the parent object
-          for which children should be loaded; this will be undefined when loading the top level of items. The
-          return value should be either an array of objects or a promise which resolves to an array of objects,
-          representing the immediate children of the parent. In this mode, the <code>hasChildren</code> function
-          must be defined in the <code>options</code> parameter, to determine which rows may be expanded.</span>
+        <p>
+            The data source of the tree grid. For smaller data sets, the entire hierachy may be loaded and passed to
+            the <code>data</code> attribute as an array of objects. Each object may have an array of child objects; the
+            name of the property containing this array must be specified in the <code>options</code> parameter. Any
+            other properties may be mapped to columns in the tree grid using the
+            <code>columns</code> configuration.
+        </p>
+        <p>
+            For larger data sets, the tree grid can load the children of an item asynchronously. In this case, a
+            function may be provided to the <code>data</code> attribute. The argument to this function is the parent
+            object for which children should be loaded; this will be undefined when loading the top level of items. The
+            return value should be either an array of objects or a promise which resolves to an array of objects,
+            representing the immediate children of the parent. In this mode, the <code>hasChildren</code> function must
+            be defined in the <code>options</code> parameter, to determine which rows may be expanded.
+        </p>
     </tr>
     <tr uxd-api-property name="columns" type="array" binding="variable" required="true">
-      A list of the columns to be presented in the tree grid, along with details of how to present the data in that column. It is important to define at least one column, since there is no default behaviour.
+        A list of the columns to be presented in the tree grid, along with details of how to present the data in that
+        column. It is important to define at least one column, since there is no default behaviour.
     </tr>
     <tr uxd-api-property name="tree-data" type="array" binding="variable" required="true">
-      This will be bound to a hierarchy of objects representing the current tree state. It can be used to access the data objects which are currently loaded into the grid, which is useful in asynchronous mode since items dynamically retrieved from a web service do not have to be manually tracked in the controller. It also provides information on the state of the item's row in the tree grid.
+        This will be bound to a hierarchy of objects representing the current tree state. It can be used to access the
+        data objects which are currently loaded into the grid, which is useful in asynchronous mode since items
+        dynamically retrieved from a web service do not have to be manually tracked in the controller. It also provides
+        information on the state of the item's row in the tree grid.
     </tr>
     <tr uxd-api-property name="selected" type="array" binding="variable">
-      This array will contain the objects currently selected in the tree grid. This is a standard multiple selection
-        component, so the techniques described in <a routerLink="/components/tables" fragment="multiple-select-actions-ng1">Multiple Selection Actions</a> may also be applied to the tree grid.
+        This array will contain the objects currently selected in the tree grid. This is a standard multiple selection
+        component, so the techniques described in
+        <a routerLink="/components/tables" fragment="multiple-select-actions-ng1">Multiple Selection Actions</a>
+        may also be applied to the tree grid.
     </tr>
     <tr uxd-api-property name="current-row" type="object" binding="variable">
-      <span>This object is bound to the row in the tree grid with focus. The current row is the most recently clicked,
-        or the row which is highlighted when using keyboard navigation. The object contains the following properties:</span>
-      <ul>
-        <li><code>element</code> - the <code>tr</code> element representing the current row in the tree grid.</li>
-        <li><code>item</code> - the source data item for the current row.</li>
-        <li><code>row</code> - the row object with the properties described in the Tree Data section.</li>
-      </ul>
+        <p>
+            This object is bound to the row in the tree grid with focus. The current row is the most recently clicked,
+            or the row which is highlighted when using keyboard navigation. The object contains the following
+            properties:
+        </p>
+        <ul>
+            <li><code>element</code> - the <code>tr</code> element representing the current row in the tree grid.</li>
+            <li><code>item</code> - the source data item for the current row.</li>
+            <li><code>row</code> - the row object with the properties described in the Tree Data section.</li>
+        </ul>
     </tr>
     <tr uxd-api-property name="options" type="object" binding="variable" required="true">
-      Configuration options which can be used to customise the appearance and behaviour of the tree grid. Most importantly, the property which contains child nodes can be set here. This is also where the icon set and expander graphics can be customised.
+        Configuration options which can be used to customise the appearance and behaviour of the tree grid. Most
+        importantly, the property which contains child nodes can be set here. This is also where the icon set and
+        expander graphics can be customised.
     </tr>
     <tr uxd-api-property name="selection-manager" type="MultipleSelectProvider" binding="expression">
-      This expression will be executed when the component initializes. A <code>$selection</code> variable will be emitted which can be stored and used to directly manipulate the selected items.
+        This expression will be executed when the component initializes. A <code>$selection</code>
+        variable will be emitted which can be stored and used to directly manipulate the selected items.
     </tr>
 </uxd-api-properties>
 
@@ -122,40 +152,42 @@
 
 <uxd-api-properties>
     <tr uxd-api-property name="name" type="string" required="true">
-      The text which appears in the column header.
+        The text which appears in the column header.
     </tr>
     <tr uxd-api-property name="value" type="string or function">
-      <ul>
-        <li>As a string, the name of a property in the source data object to display in the column.</li>
-        <li>As a function, this will be called to provide the value to display in the column. The argument to the
-          function will be the data object to render, and the return value should be a string.</li>
-      </ul>
+        <ul>
+            <li>As a string, the name of a property in the source data object to display in the column.</li>
+            <li>
+                As a function, this will be called to provide the value to display in the column. The argument to the
+                function will be the data object to render, and the return value should be a string.
+            </li>
+        </ul>
     </tr>
     <tr uxd-api-property name="template" type="string">
-      Instead of the <code>value</code> property, this may specify the URL or identifier of an Angular template
-        to render in the column. In the scope of the template, the <code>item</code> property will contain the
-        data object to render. The <code>row</code> property is also available with the properties described in
-        the Tree Data section. If controller logic is required in the template, the Angular <code>ng-controller</code>
-        attribute may be used within the template markup. Note that the first column should not be a template.
+        Instead of the <code>value</code> property, this may specify the URL or identifier of an Angular template to
+        render in the column. In the scope of the template, the <code>item</code> property will contain the data object
+        to render. The <code>row</code> property is also available with the properties described in the Tree Data
+        section. If controller logic is required in the template, the Angular <code>ng-controller</code> attribute may
+        be used within the template markup. Note that the first column should not be a template.
     </tr>
     <tr uxd-api-property name="headerClass" type="string">
-      One or more (space-separated) CSS classes to apply to the header <code>th</code> element. A common use may
-      be to align the text using the built-in <code>text-center</code> or <code>text-right</code> classes.
+        One or more (space-separated) CSS classes to apply to the header <code>th</code> element. A common use may be to
+        align the text using the built-in <code>text-center</code> or <code>text-right</code> classes.
     </tr>
     <tr uxd-api-property name="cellClass" type="string">
-      One or more (space-separated) CSS classes to apply to the <code>td</code> elements in the column. A common
-      use may be to align the text using the built-in <code>text-center</code> or <code>text-right</code> classes.
+        One or more (space-separated) CSS classes to apply to the <code>td</code> elements in the column. A common use
+        may be to align the text using the built-in <code>text-center</code> or <code>text-right</code> classes.
     </tr>
     <tr uxd-api-property name="width" type="string">
-      The width of the column. Values which are valid on the CSS <code>width</code> property are accepted here.
-      This is provided as an alternative to specifying width in CSS via the <code>headerClass</code> property.
+        The width of the column. Values which are valid on the CSS <code>width</code> property are accepted here. This
+        is provided as an alternative to specifying width in CSS via the <code>headerClass</code> property.
     </tr>
     <tr uxd-api-property name="tooltip" type="string">
-      Text to display as a tooltip when hovering over cells in this column. The source data object is available
-      as <code>item</code> for the purposes of binding.
+        Text to display as a tooltip when hovering over cells in this column. The source data object is available as
+        <code>item</code> for the purposes of binding.
     </tr>
     <tr uxd-api-property name="tooltipPlacement" type="string">
-      Position of the tooltip relative to the cell. Value may be "top", "bottom", "left", or "right".
+        Position of the tooltip relative to the cell. Value may be "top", "bottom", "left", or "right".
     </tr>
 </uxd-api-properties>
 
@@ -165,32 +197,39 @@
 
 <uxd-api-properties>
     <tr uxd-api-property name="dataItem" type="onject" required="true">
-      A reference to the custom data object representing the row in the tree grid.
+        A reference to the custom data object representing the row in the tree grid.
     </tr>
     <tr uxd-api-property name="children" type="array" required="true">
-      An array containing objects of the same format describing the child items of the row. This property 
-      is read only; to add or remove rows in the tree grid, update the source data and reload.
+        An array containing objects of the same format describing the child items of the row. This property is read
+        only; to add or remove rows in the tree grid, update the source data and reload.
     </tr>
     <tr uxd-api-property name="expanded" type="boolean" required="true">
-      Whether the row is expanded in the tree grid. This will be true when the row has been expanded and 
-      child items have completed loading. This property is read only.
+        Whether the row is expanded in the tree grid. This will be true when the row has been expanded and child items
+        have completed loading. This property is read only.
     </tr>
     <tr uxd-api-property name="expanding" type="boolean" required="true">
-      Whether the row is currently loading children; applies in asynchronous mode. This property is read only.
+        Whether the row is currently loading children; applies in asynchronous mode. This property is read only.
     </tr>
     <tr uxd-api-property name="level" type="number" required="true">
-      	The depth of the row in the tree grid. The top level items will have the value 0. This property is read only.
+        The depth of the row in the tree grid. The top level items will have the value 0. This property is read only.
     </tr>
     <tr uxd-api-property name="api" type="object" required="true">
-      <span>Contains functions which may be used to control the row. The following functions are available:</span>
-      <ul>
-        <li><code>expand()</code> - expands the row, if not already expanded. Returns a promise which resolves when
-          the child rows are fully loaded.</li>
-        <li><code>contract()</code> - contracts the row, if expanded.</li>
-        <li><code>reload()</code> - reloads the child items, expanding the row if not already expanded. Returns a
-          promise which resolves when the child rows are fully loaded.</li>
-        <li><code>getValueForColumn(colIndex)</code> - returns the row display value for the column at <code>colIndex</code>            (0-based index).</li>
-      </ul>
+        <span>Contains functions which may be used to control the row. The following functions are available:</span>
+        <ul>
+            <li>
+                <code>expand()</code> - expands the row, if not already expanded. Returns a promise which resolves when
+                the child rows are fully loaded.
+            </li>
+            <li><code>contract()</code> - contracts the row, if expanded.</li>
+            <li>
+                <code>reload()</code> - reloads the child items, expanding the row if not already expanded. Returns a
+                promise which resolves when the child rows are fully loaded.
+            </li>
+            <li>
+                <code>getValueForColumn(colIndex)</code> - returns the row display value for the column at
+                <code>colIndex</code> (0-based index).
+            </li>
+        </ul>
     </tr>
 </uxd-api-properties>
 
@@ -204,78 +243,108 @@
 
 <uxd-api-properties>
     <tr uxd-api-property name="childrenProperty" type="string">
-      If the value of the <code>data</code> attribute is an array, then this must be set to the name of an array
-        property on the source data objects which contains the child objects, defining the hierarchy. If the array
-        is present and contains items, an expander will be rendered on the corresponding row to show or hide the
-        children.
+        If the value of the <code>data</code> attribute is an array, then this must be set to the name of an array
+        property on the source data objects which contains the child objects, defining the hierarchy. If the array is
+        present and contains items, an expander will be rendered on the corresponding row to show or hide the children.
+    </tr>
+    <tr uxd-api-property name="expandedProperty" type="string">
+        This can be set to the name of a boolean property on the source data objects. If that property is initally true,
+        the node will be expanded. Additionally, when rows are expanded or collapsed, the property will be updated
+        accordingly. This can be used to persist the expanded state of nodes in the tree grid after reloading.
     </tr>
     <tr uxd-api-property name="hasChildren" type="function">
-      If the value of the <code>data</code> attribute is a function (asynchronous operation), then this must be
-        set to a function which returns true if the provided object may have children and should therefore display
-        an expander on its row.
+        If the value of the <code>data</code> attribute is a function (asynchronous operation), then this must be set to
+        a function which returns true if the provided object may have children and should therefore display an expander
+        on its row.
     </tr>
     <tr uxd-api-property name="maxDepth" type="number" defaultValue="5">
-      The expansion depth limit. After this is reached, expanders will not display even if the data object contains
+        The expansion depth limit. After this is reached, expanders will not display even if the data object contains
         children.
     </tr>
     <tr uxd-api-property name="expandTopLevel" type="boolean" defaultValue="false">
-      Set to true if the top-level rows should initially appear expanded.
+        Set to true if the top-level rows should initially appear expanded.
     </tr>
     <tr uxd-api-property name="select" type="object">
-      <span>Defines the functionality of row selection. This object contains the following properties:
-      </span>
-      <ul>
-        <li><code>row</code> (boolean) - when set to true, rows are selected by clicking anywhere on them. The selection can be extended by shift-clicking, and non-continuous rows can be added to the selection by control-clicking. Default is true.</li>
-        <li><code>check</code> (boolean) - when set to true, rows can be selected by checkboxes. Default is false.</li>
-        <li><code>selectChildren</code> (boolean) - when set to true, selecting a row also selects its currently-loaded children. This should be used in conjunction with the <code>check</code> option. Default is false.</li>
-        <li><code>rowClass</code> (string) - the name of a class which will be applied to the row while it is selected. To remove the default appearance, set this to null or an empty string.</li>
-      </ul>
+        <p>Defines the functionality of row selection. This object contains the following properties: </p>
+        <ul>
+            <li>
+                <code>row</code> (boolean) - when set to true, rows are selected by clicking anywhere on them. The
+                selection can be extended by shift-clicking, and non-continuous rows can be added to the selection by
+                control-clicking. Default is true.
+            </li>
+            <li>
+                <code>check</code> (boolean) - when set to true, rows can be selected by checkboxes. Default is false.
+            </li>
+            <li>
+                <code>selectChildren</code> (boolean) - when set to true, selecting a row also selects its
+                currently-loaded children. This should be used in conjunction with the <code>check</code> option.
+                Default is false.
+            </li>
+            <li>
+                <code>rowClass</code> (string) - the name of a class which will be applied to the row while it is
+                selected. To remove the default appearance, set this to null or an empty string.
+            </li>
+        </ul>
     </tr>
     <tr uxd-api-property name="expander" type="object">
-      <span>Defines the appearance of the expanders (buttons which toggle display of child rows). This object contains
-        the following properties:
-      </span>
-      <ul>
-        <li><code>type</code> - the type of image to display, either <code>class</code> to use one of the standard
-          <a routerLink="/css/icons">UX Aspects Icons</a> or <code>url</code> to use an icon image.</li>
-        <li><code>contracted</code> - the image to show when the row is in a contracted state. Either a CSS class
-          or an image URL, according to the <code>type</code>.</li>
-        <li><code>expanded</code> - the image to show when the row is in a expanded state. Either a CSS class or
-          an image URL, according to the <code>type</code>.</li>
-        <li><code>expanding</code> - the image to show when the the row is loading children in asynchronous mode.
-          Either a CSS class or an image URL, according to the <code>type</code>.</li>
-      </ul>
+        <p>
+            Defines the appearance of the expanders (buttons which toggle display of child rows). This object contains
+            the following properties:
+        </p>
+        <ul>
+            <li>
+                <code>type</code> - the type of image to display, either <code>class</code> to use one of the standard
+                <a routerLink="/css/icons">UX Aspects Icons</a> or <code>url</code> to use an icon image.
+            </li>
+            <li>
+                <code>contracted</code> - the image to show when the row is in a contracted state. Either a CSS class or
+                an image URL, according to the <code>type</code>.
+            </li>
+            <li>
+                <code>expanded</code> - the image to show when the row is in a expanded state. Either a CSS class or an
+                image URL, according to the <code>type</code>.
+            </li>
+            <li>
+                <code>expanding</code> - the image to show when the the row is loading children in asynchronous mode.
+                Either a CSS class or an image URL, according to the <code>type</code>.
+            </li>
+        </ul>
     </tr>
     <tr uxd-api-property name="icons" type="object">
-      <span>Configures the set of icons which appear on the left of the first column. This object contains the following
-        properties:</span>
-      <ul>
-        <li><code>type</code> - the type of image to display, either <code>class</code> to use one of the standard
-          <a routerLink="/css/icons">UX Aspects Icons</a> or <code>url</code> to use an icon image.</li>
-        <li><code>get</code> - a function which returns the appropriate icon for the data object. The first argument
-          is the data object itself, and the second is a boolean indicating whether the row is expanded or not.
-          The function should return either a CSS class or an image URL, according to the <code>type</code>.</li>
-      </ul>
+        <p>
+            Configures the set of icons which appear on the left of the first column. This object contains the
+            following properties:
+        </p>
+        <ul>
+            <li>
+                <code>type</code> - the type of image to display, either <code>class</code> to use one of the standard
+                <a routerLink="/css/icons">UX Aspects Icons</a> or <code>url</code> to use an icon image.
+            </li>
+            <li>
+                <code>get</code> - a function which returns the appropriate icon for the data object. The first argument
+                is the data object itself, and the second is a boolean indicating whether the row is expanded or not.
+                The function should return either a CSS class or an image URL, according to the <code>type</code>.
+            </li>
+        </ul>
     </tr>
     <tr uxd-api-property name="rowClass" type="string or function" required="true">
-      If a string is provided, this is used as the name of a property on the source data object to bind as 
-      a class on the corresponding tree grid row. If a function is provided, this is called with the source 
-      data object as an argument, and the return value is bound as a class on the corresponding tree grid row.
+        If a string is provided, this is used as the name of a property on the source data object to bind as a class on
+        the corresponding tree grid row. If a function is provided, this is called with the source data object as an
+        argument, and the return value is bound as a class on the corresponding tree grid row.
     </tr>
     <tr uxd-api-property name="sort" type="function" required="true">
-      <span>
-        Defines the sort order of the rows at each level. This function takes two parameters <code>a</code> and <code>b</code>
-        representing a pair of rows in the grid, and should return: -1 if <code>a</code> is ordered before <code>b</code>;
-        0 if <code>a</code> and <code>b</code> are of equal order; 1 if <code>a</code> is ordered after <code>b</code>.
-      </span>
-      <span>
-        The function parameters are of the type described above in Tree Data Definition. Therefore the sort function
-        can access the source data object's properties via the <code>dataItem</code> property.
-      </span>
-      <span>
-        See below for an example sorting function suitable for the tree grid:
-      </span>
-      <uxd-snippet [content]="snippets.compiled.sortSnippetJs" language="javascript"></uxd-snippet>
+        <span>
+            Defines the sort order of the rows at each level. This function takes two parameters <code>a</code> and
+            <code>b</code> representing a pair of rows in the grid, and should return: -1 if <code>a</code> is ordered
+            before <code>b</code>; 0 if <code>a</code> and <code>b</code> are of equal order; 1 if <code>a</code> is
+            ordered after <code>b</code>.
+        </span>
+        <span>
+            The function parameters are of the type described above in Tree Data Definition. Therefore the sort function
+            can access the source data object's properties via the <code>dataItem</code> property.
+        </span>
+        <span> See below for an example sorting function suitable for the tree grid: </span>
+        <uxd-snippet [content]="snippets.compiled.sortSnippetJs" language="javascript"></uxd-snippet>
     </tr>
 </uxd-api-properties>
 
@@ -294,7 +363,3 @@
 <p>To reload the tree grid to its initial state, issue the <code>treegrid.reload</code> event.</p>
 
 <uxd-snippet language="javascript" [content]="snippets.compiled.code4Js"></uxd-snippet>
-
-<blockquote>
-    <p><strong>Note</strong>: This component can be used in an Angular application by importing the HybridModule.</p>
-</blockquote>

--- a/docs/app/pages/components/components-sections/tree-view/tree-grid-ng1/tree-grid-ng1.component.ts
+++ b/docs/app/pages/components/components-sections/tree-view/tree-grid-ng1/tree-grid-ng1.component.ts
@@ -76,6 +76,7 @@ export class ComponentsTreeGridNg1Component extends BaseDocumentationSection imp
         title: 'Emails',
         date: new Date('2013-03-17'),
         type: 'folder',
+        expanded: true,
         nodes: [{
             id: 21,
             title: 'Inbox',
@@ -149,6 +150,7 @@ export class ComponentsTreeGridNg1Component extends BaseDocumentationSection imp
 
     options = {
         childrenProperty: 'nodes',
+        expandedProperty: 'expanded',
         select: {
             row: true,
             check: false,

--- a/docs/app/pages/components/components-sections/tree-view/tree-grid-ng1/wrapper/actions.html
+++ b/docs/app/pages/components/components-sections/tree-view/tree-grid-ng1/wrapper/actions.html
@@ -1,7 +1,10 @@
 <div ng-controller="TreeGridActionsCtrl as vm" class="item-actions">
     <list-hover-actions>
-        <list-hover-action name="Share" icon="hpe-share" click="vm.share(item)"></list-hover-action>
-        <list-hover-action name="View Details" icon="hpe-view" click="vm.goToDetails(item)"></list-hover-action>
-        <list-hover-action name="Delete" icon="hpe-trash" click="vm.delete(item)"></list-hover-action>
+        <list-hover-action name="Share" icon="hpe-share" click="vm.share(item)">
+        </list-hover-action>
+        <list-hover-action name="View Details" icon="hpe-view" click="vm.goToDetails(item)">
+        </list-hover-action>
+        <list-hover-action name="Delete" icon="hpe-trash" click="vm.delete(item)">
+        </list-hover-action>
     </list-hover-actions>
 </div>

--- a/docs/app/pages/components/components-sections/tree-view/tree-grid-ng1/wrapper/displayPanelFooter.html
+++ b/docs/app/pages/components/components-sections/tree-view/tree-grid-ng1/wrapper/displayPanelFooter.html
@@ -1,6 +1,10 @@
 <div class="pull-right p-b-md">
     <span class="btn-pair">
-    <button class="btn button-secondary" ng-disabled="!previousBtnStatus" ng-click="previous()" tabindex="1"><i class="hpe-icon hpe-previous"></i>Previous</button>
-    <button class="btn button-secondary" ng-disabled="!nextBtnStatus" ng-click="next()" tabindex="1">Next<i class="hpe-icon hpe-next"></i></button>
-  </span>
+        <button class="btn button-secondary" ng-disabled="!previousBtnStatus" ng-click="previous()">
+            <i class="hpe-icon hpe-previous"></i> Previous
+        </button>
+        <button class="btn button-secondary" ng-disabled="!nextBtnStatus" ng-click="next()">
+            Next <i class="hpe-icon hpe-next"></i>
+        </button>
+    </span>
 </div>

--- a/src/ng1/directives/treegrid/treegrid.controller.js
+++ b/src/ng1/directives/treegrid/treegrid.controller.js
@@ -214,14 +214,9 @@ export default function TreegridCtrl($scope, $q, multipleSelectProvider, $timeou
       .then(rows => vm.treeData = rows)
       .then(function () {
         // Expand top level items if configured
-        var promises = [];
-        if (vm.allOptions.expandTopLevel) {
-          for (var i = 0; i < vm.treeData.length; i += 1) {
-            if (vm.treeData[i].canExpand) {
-              promises.push(expand(vm.treeData[i]));
-            }
-          }
-        }
+        var promises = vm.treeData
+          .filter(row => row.canExpand && (vm.allOptions.expandTopLevel || row.expanded))
+          .map(row => expand(row));
         return $q.all(promises);
       })
       .catch(function (err) {
@@ -258,17 +253,7 @@ export default function TreegridCtrl($scope, $q, multipleSelectProvider, $timeou
           dataItem: data[i],
           children: []
         };
-
-        // Link the `expanded` property to the data object property if defined
-        if (vm.allOptions.expandedProperty) {
-          Object.defineProperty(row, 'expanded', {
-            get: () => this.dataItem[vm.allOptions.expandedProperty],
-            set: (value) => this.dataItem[vm.allOptions.expandedProperty] = value
-          });
-        } else {
-          row.expanded = false;
-        }
-
+        configureRowExpandedProperty(row);
         row.api = rowApi(row);
         rows.push(row);
       }
@@ -277,6 +262,22 @@ export default function TreegridCtrl($scope, $q, multipleSelectProvider, $timeou
       }
       return rows;
     });
+  }
+
+  function configureRowExpandedProperty(row) {
+    // Link the `expanded` property to the dataItem property if defined
+    if (vm.allOptions.expandedProperty) {
+      Object.defineProperty(row, 'expanded', {
+        get: function() {
+          return this.dataItem[vm.allOptions.expandedProperty];
+        },
+        set: function(value) {
+          this.dataItem[vm.allOptions.expandedProperty] = value;
+        }
+      });
+    } else {
+      row.expanded = false;
+    }
   }
 
   // Set up functions for the row
@@ -353,8 +354,9 @@ export default function TreegridCtrl($scope, $q, multipleSelectProvider, $timeou
       .then(function (newRows) {
         row.children = newRows;
         row.expanded = true;
-        return $q.all(newRows.filter(row => row.expanded).map(row => expand(row))).then(() => row);
-        // return row;
+        // Expand any child rows
+        var promises = newRows.filter(row => row.canExpand && row.expanded).map(row => expand(row));
+        return $q.all(promises).then(() => row);
       })
       .catch(function (err) {
         console.error("Data load error: " + err);

--- a/src/ng1/directives/treegrid/treegrid.controller.js
+++ b/src/ng1/directives/treegrid/treegrid.controller.js
@@ -244,7 +244,6 @@ export default function TreegridCtrl($scope, $q, multipleSelectProvider, $timeou
           levelClass: "treegrid-level-" + level,
           rowClass: getRowClass(data[i]),
           canExpand: canExpand,
-          expanded: false,
           expanding: false,
           expander: {
             type: vm.allOptions.expander.type,
@@ -259,6 +258,17 @@ export default function TreegridCtrl($scope, $q, multipleSelectProvider, $timeou
           dataItem: data[i],
           children: []
         };
+
+        // Link the `expanded` property to the data object property if defined
+        if (vm.allOptions.expandedProperty) {
+          Object.defineProperty(row, 'expanded', {
+            get: () => this.dataItem[vm.allOptions.expandedProperty],
+            set: (value) => this.dataItem[vm.allOptions.expandedProperty] = value
+          });
+        } else {
+          row.expanded = false;
+        }
+
         row.api = rowApi(row);
         rows.push(row);
       }
@@ -343,7 +353,8 @@ export default function TreegridCtrl($scope, $q, multipleSelectProvider, $timeou
       .then(function (newRows) {
         row.children = newRows;
         row.expanded = true;
-        return row;
+        return $q.all(newRows.filter(row => row.expanded).map(row => expand(row))).then(() => row);
+        // return row;
       })
       .catch(function (err) {
         console.error("Data load error: " + err);

--- a/src/ng1/directives/treegrid/treegrid.spec.js
+++ b/src/ng1/directives/treegrid/treegrid.spec.js
@@ -464,6 +464,35 @@ describe('treegrid', function () {
       });
     });
 
+    it("should initially expand nodes according to the expandedProperty configuration", function (done) {
+      instantiateController({
+        data: [{
+          test: "Row 1",
+          expanded: false,
+          nodes: [{
+            test: "Row 1.1"
+          }]
+        }, {
+          test: "Row 2",
+          expanded: true,
+          nodes: [{
+            test: "Row 2.1"
+          }]
+        }],
+        columns: [{ name: "test", value: "test" }],
+        options: {
+          expandedProperty: "expanded"
+        }
+      }, function (ctrl) {
+        var rows = ctrl.getGridRows();
+        expect(rows.length).toBe(3);
+        expect(rows[0].api.getValueForColumn(0)).toBe("Row 1");
+        expect(rows[1].api.getValueForColumn(0)).toBe("Row 2");
+        expect(rows[2].api.getValueForColumn(0)).toBe("Row 2.1");
+        done();
+      });
+    });
+
   });
 
   describe("api", function () {


### PR DESCRIPTION
* Added `expandedProperty` option which allows binding a source data property to the `row.expanded` property, thus allowing the initial expanded state to be provided and changes to be persisted.
* Update the documentation with the above.
* Cleaned up some snippets to avoid overflow.

Testing plunkers:
https://codepen.io/donnamarijne/pen/QJrLZj?editors=1010
https://codepen.io/donnamarijne/pen/PxeqWx?editors=1010

https://autjira.microfocus.com/browse/EL-3293