### PR TITLE
EL-3316 - AngularJS Fixing Minification Issue

### DIFF
--- a/configs/webpack.dev.config.js
+++ b/configs/webpack.dev.config.js
@@ -9,6 +9,5 @@ const ng1AssetsConfig = require('./webpack.ng1-assets.dev.config.js');
 docsConfig.mode = 'development';
 cssAssetsConfig.mode = 'development';
 libAssetsConfig.mode = 'development';
-ng1AssetsConfig.mode = 'development';
 
 module.exports = [docsConfig, cssAssetsConfig, libAssetsConfig, ng1AssetsConfig];

--- a/configs/webpack.ng1-assets.dev.config.js
+++ b/configs/webpack.ng1-assets.dev.config.js
@@ -4,7 +4,7 @@ const { cwd } = require('process');
 
 module.exports = {
 
-    mode: 'production',
+    mode: 'development',
 
     entry: {
         'ux-aspects-ng1': join(cwd(), 'src', 'ng1', 'ux-aspects-ng1.module.js'),

--- a/configs/webpack.ng1.config.js
+++ b/configs/webpack.ng1.config.js
@@ -4,7 +4,7 @@ const { IgnorePlugin } = require('webpack');
 
 module.exports = {
 
-    mode: 'production',
+    mode: 'development',
 
     entry: {
         'ux-aspects-ng1': join(cwd(), 'src', 'ng1', 'ux-aspects-ng1.module.js'),


### PR DESCRIPTION
- Webpack `mode` was set to production which minifies the bundle by default
- Now set to development mode and lets the existing grunt task minify the bundle as it used to