### PR TITLE
EL-3311 - Select List Event Emitter Fix

### DIFF
--- a/src/components/select-list/select-list.component.ts
+++ b/src/components/select-list/select-list.component.ts
@@ -2,9 +2,9 @@ import { AfterContentInit, Component, ContentChildren, EventEmitter, Input, OnDe
 import { takeUntil } from 'rxjs/operators';
 import { Subject } from 'rxjs/Subject';
 import { SelectionService } from '../../directives/selection/selection.service';
-import { MultipleSelectListStrategy } from './multiple-select-list.strategy';
+import { MultipleSelectListStrategy } from './strategies/multiple-select-list.strategy';
 import { SelectListItemComponent } from './select-list-item/select-list-item.component';
-import { SingleSelectListStrategy } from './single-select-list.strategy';
+import { SingleSelectListStrategy } from './strategies/single-select-list.strategy';
 
 @Component({
     selector: 'ux-select-list',
@@ -35,14 +35,11 @@ export class SelectListComponent<T> implements AfterContentInit, OnDestroy {
             return;
         }
 
-        // deselect all currently selected items
-        this._selection.deselectAll();
-
         // select only the specified items
         if (Array.isArray(selected)) {
-            this._selection.select(...selected);
+            this._selection.selectOnly(...selected);
         } else {
-            this._selection.select(selected);
+            this._selection.selectOnly(selected);
         }
     }
 

--- a/src/components/select-list/select-list.component.ts
+++ b/src/components/select-list/select-list.component.ts
@@ -25,6 +25,16 @@ export class SelectListComponent<T> implements AfterContentInit, OnDestroy {
     /** Set the selected items */
     @Input() set selected(selected: T | T[]) {
 
+        // if the selection entered is the same as the current selection then do nothing
+        if (this._selection.selection$.value === selected) {
+            return;
+        }
+
+        // if selected is an array and has not items and there are no items currently selected also do nothing
+        if (Array.isArray(selected) && selected.length === 0 && this._selection.selection$.value.length === 0) {
+            return;
+        }
+
         // deselect all currently selected items
         this._selection.deselectAll();
 

--- a/src/components/select-list/strategies/multiple-select-list.strategy.ts
+++ b/src/components/select-list/strategies/multiple-select-list.strategy.ts
@@ -1,5 +1,5 @@
 import { DOWN_ARROW, ENTER, SPACE, UP_ARROW } from '@angular/cdk/keycodes';
-import { SelectionStrategy } from '../../directives/selection/strategies/selection.strategy';
+import { SelectionStrategy } from '../../../directives/selection/index';
 
 export class MultipleSelectListStrategy<T> extends SelectionStrategy<T> {
 

--- a/src/components/select-list/strategies/single-select-list.strategy.ts
+++ b/src/components/select-list/strategies/single-select-list.strategy.ts
@@ -1,20 +1,19 @@
 import { DOWN_ARROW, ENTER, SPACE, UP_ARROW } from '@angular/cdk/keycodes';
-import { SelectionStrategy } from '../../directives/selection/strategies/selection.strategy';
+import { SelectionStrategy } from '../../../directives/selection/index';
 
 export class SingleSelectListStrategy<T> extends SelectionStrategy<T> {
 
     click(_event: MouseEvent, data: T): void {
 
-        if (!this.selectionService.isSelected(data)) {
-            // deselect all other items
-            this.deselectAll();
-        }
-
         // activate the clicked item
         this.selectionService.activate(data);
 
         // toggle the selected state of the item
-        this.toggle(data);
+        if (!this.selectionService.isSelected(data)) {
+            this.selectOnly(data);
+        } else {
+            this.deselect(data);
+        }
     }
 
     keydown(event: KeyboardEvent, data: T): void {

--- a/src/directives/selection/selection.service.ts
+++ b/src/directives/selection/selection.service.ts
@@ -10,213 +10,228 @@ import { SimpleSelectionStrategy } from './strategies/simple-selection.strategy'
 @Injectable()
 export class SelectionService<T> implements OnDestroy {
 
-  set dataset(dataset: ReadonlyArray<T>) {
-    this._dataset = dataset;
-    if (this._dataset.indexOf(this._active) === -1) {
-      this.setFirstItemFocusable();
-    }
-  }
-
-  get dataset(): ReadonlyArray<T> {
-    return this._dataset;
-  }
-
-  strategy: SelectionStrategy<T> = new SimpleSelectionStrategy<T>(this);
-  isEnabled: boolean = true;
-  isClickEnabled: boolean = true;
-  isKeyboardEnabled: boolean = true;
-
-  focus$ = new BehaviorSubject<T>(null);
-  active$ = new BehaviorSubject<T>(null);
-  selection$ = new BehaviorSubject<T[]>([]);
-
-  private _active: T;
-  private _dataset: ReadonlyArray<T> = [];
-  private _selection = new Set();
-  private _strategyToDestroy: SelectionStrategy<T> = this.strategy;
-
-  ngOnDestroy(): void {
-    if (this._strategyToDestroy) {
-      this._strategyToDestroy.destroy();
-    }
-  }
-
-  /**
-   * If the item is not currently selected then add it
-   * to the list of selected items
-   */
-  select(...selections: T[]): void {
-
-    // add each selection to the set
-    selections.forEach(selection => this._selection.add(selection));
-
-    // propagate the changes
-    this.selectionHasMutated();
-  }
-
-  /**
-   * Remove an item from the list of selected items
-   */
-  deselect(...selections: T[]): void {
-    // remove each item from the set
-    selections.forEach(selection => this._selection.delete(selection));
-
-    // propagate the changes
-    this.selectionHasMutated();
-  }
-
-  /**
-   * Remove all items from the list of selected items
-   */
-  deselectAll(): void {
-    // remove all items in the array
-    this.deselect(...this._dataset);
-
-    // clear the set in case any items have been removed from the DOM but are still selected
-    this._selection.clear();
-  }
-
-  /**
-   * Toggle the selected state of any specified items
-   */
-  toggle(...selections: T[]): void {
-    selections.forEach(selection => this.isSelected(selection) ? this.deselect(selection) : this.select(selection));
-  }
-
-  /**
-   * Determine whether or not a specific item is currently selected
-   */
-  isSelected(data: T): boolean {
-    return this._selection.has(data);
-  }
-
-  /**
-   * Return an observable specifically for notifying the subscriber
-   * only when the selection state of a specific object has changed
-   */
-  getSelectionState(data: T): Observable<boolean> {
-    return this.selection$.pipe(map(() => this.isSelected(data)), distinctUntilChanged());
-  }
-
-  /**
-   * Define how selections should be performed.
-   * This allows us to use an strategy pattern to handle the various keyboard
-   * and mouse interactions while keeping each mode separated and
-   * easily extensible if we want to add more modes in future!
-   */
-  setStrategy(mode: SelectionMode | SelectionStrategy<T>): void {
-
-    if (this._strategyToDestroy) {
-      // Destroy previous strategy if it was created internally
-      this._strategyToDestroy.destroy();
-      this._strategyToDestroy = null;
+    set dataset(dataset: ReadonlyArray<T>) {
+        this._dataset = dataset;
+        if (this._dataset.indexOf(this._active) === -1) {
+            this.setFirstItemFocusable();
+        }
     }
 
-    if (mode instanceof SelectionStrategy) {
-
-      // Custom strategy - pass in the service instance
-      this.strategy = mode;
-      this.strategy.setSelectionService(this);
-
-    } else {
-
-      switch (mode.toLowerCase().trim()) {
-
-        case 'simple':
-          this.strategy = this._strategyToDestroy = new SimpleSelectionStrategy<T>(this);
-          break;
-
-        case 'row':
-          this.strategy = this._strategyToDestroy = new RowSelectionStrategy<T>(this);
-          break;
-
-        case 'row-alt':
-          this.strategy = this._strategyToDestroy = new RowAltSelectionStrategy<T>(this);
-          break;
-
-        default:
-          throw new Error(`The selection mode '${mode}' does not exist. Valid modes are 'simple', 'row', or 'row-alt'.`);
-      }
-    }
-  }
-
-  /**
-   * Set the current active item
-   */
-  activate(data: T): void {
-    this._active = data;
-    this.active$.next(this._active);
-  }
-
-  /**
-   * Deactive all items
-   */
-  deactivate(): void {
-    this._active = null;
-    this.active$.next(this._active);
-  }
-
-  /**
-   * Return the next or previous sibling of the current active item.
-   * @param previous If true, the previous sibling will be returned.
-   */
-  getSibling(previous: boolean = false): T {
-
-    // check if there is a current active item
-    if (!this._active) {
-      return;
+    get dataset(): ReadonlyArray<T> {
+        return this._dataset;
     }
 
-    // get the index of the current item
-    const idx = this.dataset.indexOf(this._active);
-    const target = this.dataset[previous ? idx - 1 : idx + 1];
+    strategy: SelectionStrategy<T> = new SimpleSelectionStrategy<T>(this);
+    isEnabled: boolean = true;
+    isClickEnabled: boolean = true;
+    isKeyboardEnabled: boolean = true;
 
-    return target;
-  }
+    focus$ = new BehaviorSubject<T>(null);
+    active$ = new BehaviorSubject<T>(null);
+    selection$ = new BehaviorSubject<T[]>([]);
 
-  /**
-   * Activate the sibling of the current active item.
-   * If previous is set to true the previous sibling will be activated
-   * rather than the next sibling. This function will also return the
-   * data of the newly activated sibling
-   */
-  activateSibling(previous: boolean = false): T {
+    private _active: T;
+    private _dataset: ReadonlyArray<T> = [];
+    private _selection = new Set();
+    private _strategyToDestroy: SelectionStrategy<T> = this.strategy;
 
-    const target = this.getSibling(previous);
-
-    // check if the target exists
-    if (target) {
-      this.activate(target);
+    ngOnDestroy(): void {
+        if (this._strategyToDestroy) {
+            this._strategyToDestroy.destroy();
+        }
     }
 
-    return target;
-  }
+    /**
+     * If the item is not currently selected then add it
+     * to the list of selected items
+     */
+    select(...selections: T[]): void {
 
-  setDisabled(disabled: boolean): void {
-    // store the current disabled state
-    this.isEnabled = !disabled;
+        // add each selection to the set
+        selections.forEach(selection => this._selection.add(selection));
 
-    // clear any stateful data
-    this._active = null;
-    this.active$.next(this._active);
-    this._selection.clear();
-
-    // emit the selection change information
-    this.selectionHasMutated();
-  }
-
-  private selectionHasMutated(): void {
-    this.selection$.next(Array.from(this._selection));
-  }
-
-  private setFirstItemFocusable(): void {
-    if (this._dataset.length > 0) {
-      this.focus$.next(this._dataset[0]);
-      this._active = this._dataset[0];
-    } else {
-      this._active = null;
+        // propagate the changes
+        this.selectionHasMutated();
     }
-  }
+
+    /**
+     * Deselect all currently selected items and replace with a new selection
+     */
+    selectOnly(...selection: T[]): void {
+
+        // remove all currently selected items
+        this._selection.clear();
+
+        // select only the specified item
+        selection.forEach(item => this._selection.add(item));
+
+        // emit the changes
+        this.selectionHasMutated();
+    }
+
+    /**
+     * Remove an item from the list of selected items
+     */
+    deselect(...selections: T[]): void {
+        // remove each item from the set
+        selections.forEach(selection => this._selection.delete(selection));
+
+        // propagate the changes
+        this.selectionHasMutated();
+    }
+
+    /**
+     * Remove all items from the list of selected items
+     */
+    deselectAll(): void {
+        // remove all items in the array
+        this.deselect(...this._dataset);
+
+        // clear the set in case any items have been removed from the DOM but are still selected
+        this._selection.clear();
+    }
+
+    /**
+     * Toggle the selected state of any specified items
+     */
+    toggle(...selections: T[]): void {
+        selections.forEach(selection => this.isSelected(selection) ? this.deselect(selection) : this.select(selection));
+    }
+
+    /**
+     * Determine whether or not a specific item is currently selected
+     */
+    isSelected(data: T): boolean {
+        return this._selection.has(data);
+    }
+
+    /**
+     * Return an observable specifically for notifying the subscriber
+     * only when the selection state of a specific object has changed
+     */
+    getSelectionState(data: T): Observable<boolean> {
+        return this.selection$.pipe(map(() => this.isSelected(data)), distinctUntilChanged());
+    }
+
+    /**
+     * Define how selections should be performed.
+     * This allows us to use an strategy pattern to handle the various keyboard
+     * and mouse interactions while keeping each mode separated and
+     * easily extensible if we want to add more modes in future!
+     */
+    setStrategy(mode: SelectionMode | SelectionStrategy<T>): void {
+
+        if (this._strategyToDestroy) {
+            // Destroy previous strategy if it was created internally
+            this._strategyToDestroy.destroy();
+            this._strategyToDestroy = null;
+        }
+
+        if (mode instanceof SelectionStrategy) {
+
+            // Custom strategy - pass in the service instance
+            this.strategy = mode;
+            this.strategy.setSelectionService(this);
+
+        } else {
+
+            switch (mode.toLowerCase().trim()) {
+
+                case 'simple':
+                    this.strategy = this._strategyToDestroy = new SimpleSelectionStrategy<T>(this);
+                    break;
+
+                case 'row':
+                    this.strategy = this._strategyToDestroy = new RowSelectionStrategy<T>(this);
+                    break;
+
+                case 'row-alt':
+                    this.strategy = this._strategyToDestroy = new RowAltSelectionStrategy<T>(this);
+                    break;
+
+                default:
+                    throw new Error(`The selection mode '${mode}' does not exist. Valid modes are 'simple', 'row', or 'row-alt'.`);
+            }
+        }
+    }
+
+    /**
+     * Set the current active item
+     */
+    activate(data: T): void {
+        this._active = data;
+        this.active$.next(this._active);
+    }
+
+    /**
+     * Deactive all items
+     */
+    deactivate(): void {
+        this._active = null;
+        this.active$.next(this._active);
+    }
+
+    /**
+     * Return the next or previous sibling of the current active item.
+     * @param previous If true, the previous sibling will be returned.
+     */
+    getSibling(previous: boolean = false): T {
+
+        // check if there is a current active item
+        if (!this._active) {
+            return;
+        }
+
+        // get the index of the current item
+        const idx = this.dataset.indexOf(this._active);
+        const target = this.dataset[previous ? idx - 1 : idx + 1];
+
+        return target;
+    }
+
+    /**
+     * Activate the sibling of the current active item.
+     * If previous is set to true the previous sibling will be activated
+     * rather than the next sibling. This function will also return the
+     * data of the newly activated sibling
+     */
+    activateSibling(previous: boolean = false): T {
+
+        const target = this.getSibling(previous);
+
+        // check if the target exists
+        if (target) {
+            this.activate(target);
+        }
+
+        return target;
+    }
+
+    setDisabled(disabled: boolean): void {
+        // store the current disabled state
+        this.isEnabled = !disabled;
+
+        // clear any stateful data
+        this._active = null;
+        this.active$.next(this._active);
+        this._selection.clear();
+
+        // emit the selection change information
+        this.selectionHasMutated();
+    }
+
+    private selectionHasMutated(): void {
+        this.selection$.next(Array.from(this._selection));
+    }
+
+    private setFirstItemFocusable(): void {
+        if (this._dataset.length > 0) {
+            this.focus$.next(this._dataset[0]);
+            this._active = this._dataset[0];
+        } else {
+            this._active = null;
+        }
+    }
 }
 
 export type SelectionMode = 'simple' | 'row' | 'row-alt';

--- a/src/directives/selection/strategies/selection.strategy.ts
+++ b/src/directives/selection/strategies/selection.strategy.ts
@@ -2,54 +2,61 @@ import { SelectionService } from '../selection.service';
 
 export class SelectionStrategy<T = any> {
 
-  constructor(protected selectionService?: SelectionService<T>) { }
+    constructor(protected selectionService?: SelectionService<T>) { }
 
-  setSelectionService(selectionService: SelectionService<T>): void {
-    this.selectionService = selectionService;
-  }
+    setSelectionService(selectionService: SelectionService<T>): void {
+        this.selectionService = selectionService;
+    }
 
-  mousedown(event: MouseEvent, data: T): void { }
+    mousedown(event: MouseEvent, data: T): void { }
 
-  click(event: MouseEvent, data: T): void { }
+    click(event: MouseEvent, data: T): void { }
 
-  keydown(event: KeyboardEvent, data: T): void { }
+    keydown(event: KeyboardEvent, data: T): void { }
 
-  /**
-   * Select the item - default behavior
-   */
-  select(...data: T[]): void {
-    this.selectionService.select(...data);
-  }
+    /**
+     * Select the item - default behavior
+     */
+    select(...data: T[]): void {
+        this.selectionService.select(...data);
+    }
 
-  /**
-   * Toggle the item's selected state - default behavior
-   */
-  toggle(...data: T[]): void {
-    this.selectionService.toggle(...data);
-  }
+    /**
+     * Replace the current selection with the list of items specified
+     */
+    selectOnly(...data: T[]): void {
+        this.selectionService.selectOnly(...data);
+    }
 
-  /**
-   * Deselect the item - default behavior
-   */
-  deselect(...data: T[]): void {
-    this.selectionService.deselect(...data);
-  }
+    /**
+     * Toggle the item's selected state - default behavior
+     */
+    toggle(...data: T[]): void {
+        this.selectionService.toggle(...data);
+    }
 
-  /**
-   * Select all items - default behavior
-   */
-  selectAll(): void {
-    this.select(...this.selectionService.dataset);
-  }
+    /**
+     * Deselect the item - default behavior
+     */
+    deselect(...data: T[]): void {
+        this.selectionService.deselect(...data);
+    }
 
-  /**
-   * Deselect all items - default behavior
-   */
-  deselectAll(): void {
+    /**
+     * Select all items - default behavior
+     */
+    selectAll(): void {
+        this.select(...this.selectionService.dataset);
+    }
 
-    // call deselect on all items in the dataset
-    this.selectionService.deselectAll();
-  }
+    /**
+     * Deselect all items - default behavior
+     */
+    deselectAll(): void {
 
-  destroy(): void { }
+        // call deselect on all items in the dataset
+        this.selectionService.deselectAll();
+    }
+
+    destroy(): void { }
 }


### PR DESCRIPTION
The setter was always calling deselectAll before storing the new selection whenever any change was made, which resulted in a large amount of events getting emitted.

Now we only deselect and update the selection whenever the selection has actually changed. Also added an additional check to see if the array are different but both have 0 items then also do nothing.

Now instead of like 80 events emitted each click, we get 1 during multiple selection and 2 in single selection (single selection must first deselect the previously selected item then select the new one which results in 2 emissions).