### PR TITLE
EL-3327 - E2E Avoid Reload

### DIFF
--- a/e2e/pages/app/checkbox/checkbox.testpage.component.html
+++ b/e2e/pages/app/checkbox/checkbox.testpage.component.html
@@ -44,8 +44,12 @@
         Set Option2 to indeterminate state
     </button>
 
-    <button id="button3" class="btn button-accent"
+    <button id="button3" class="btn button-accent m-r-xs"
         (click)="simplified = !simplified">
         {{ simplified ? 'Disable Simplified Style' : 'Enable Simplified Style' }}
+    </button>
+
+    <button id="button4" class="btn button-accent" (click)="reset()">
+        Reset
     </button>
 </div>

--- a/e2e/pages/app/checkbox/checkbox.testpage.component.ts
+++ b/e2e/pages/app/checkbox/checkbox.testpage.component.ts
@@ -1,10 +1,11 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'checkbox-app',
-  templateUrl: './checkbox.testpage.component.html',
+    selector: 'checkbox-app',
+    templateUrl: './checkbox.testpage.component.html',
 })
 export class CheckboxTestPageComponent {
+
     checkModel: CheckboxValues = {
         option1: true,
         option2: false,
@@ -15,6 +16,19 @@ export class CheckboxTestPageComponent {
     simplified = false;
     indeterminateValue = -1;
     disableCheck = false;
+
+    reset(): void {
+        this.checkModel = {
+            option1: true,
+            option2: false,
+            option3: false,
+            option4: false
+        };
+
+        this.simplified = false;
+        this.indeterminateValue = -1;
+        this.disableCheck = false;
+    }
 }
 
 export interface CheckboxValues {

--- a/e2e/pages/app/pagination/pagination.module.ts
+++ b/e2e/pages/app/pagination/pagination.module.ts
@@ -1,14 +1,14 @@
 import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { RouterModule } from '@angular/router';
-import { PaginationModule } from 'ngx-bootstrap/pagination';
-
+import { PaginationModule } from '@ux-aspects/ux-aspects';
 import { PaginationTestPageComponent } from './pagination.testpage.component';
+
 
 @NgModule({
     imports: [
         FormsModule,
-        PaginationModule.forRoot(),
+        PaginationModule,
         RouterModule.forChild([
             {
                 path: '',

--- a/e2e/pages/app/pagination/pagination.testpage.component.html
+++ b/e2e/pages/app/pagination/pagination.testpage.component.html
@@ -1,6 +1,13 @@
-<pagination id="pagination" [(ngModel)]="currentPage" [totalItems]="totalItems" [itemsPerPage]="itemsPerPage"
-    [maxSize]="maxSize" (numPages)="totalPages = $event"
-    [previousText]="previousButton" [nextText]="nextButton">
-</pagination>
+<ux-pagination id="pagination"
+    [(page)]="currentPage"
+    [totalItems]="totalItems"
+    [itemsPerPage]="itemsPerPage"
+    [maxSize]="maxSize"
+    (numPages)="totalPages = $event">
+</ux-pagination>
 
-<p id="text">Page {{currentPage}} of {{totalPages}}</p>
+<p id="text">Page {{ currentPage }} of {{ totalPages }}</p>
+
+<br>
+
+<button id="reset-button" class="btn button-primary" (click)="reset()">Reset</button>

--- a/e2e/pages/app/pagination/pagination.testpage.component.ts
+++ b/e2e/pages/app/pagination/pagination.testpage.component.ts
@@ -10,6 +10,11 @@ export class PaginationTestPageComponent {
     itemsPerPage: number = 10;
     totalPages: number;
     maxSize: number = 5;
-    previousButton = `<i class="hpe-icon hpe-previous" aria-label="previous page"></i>`;
-    nextButton = `<i class="hpe-icon hpe-next" aria-label="next page"></i>`;
+
+    reset(): void {
+        this.currentPage = 1;
+        this.totalItems = 100;
+        this.itemsPerPage = 10;
+        this.maxSize = 5;
+    }
 }

--- a/e2e/pages/app/select-list/select-list.testpage.component.html
+++ b/e2e/pages/app/select-list/select-list.testpage.component.html
@@ -12,4 +12,5 @@
 
 <br>
 
-<button id="toggle-btn" class="btn button-primary" (click)="multiple = !multiple">Toggle Multiple</button>
+<button id="toggle-btn" class="btn button-primary m-r-xs" (click)="multiple = !multiple">Toggle Multiple</button>
+<button id="reset-btn" class="btn button-primary" (click)="reset()">Reset</button>

--- a/e2e/pages/app/select-list/select-list.testpage.component.ts
+++ b/e2e/pages/app/select-list/select-list.testpage.component.ts
@@ -42,4 +42,12 @@ export class SelectListTestPageComponent {
     search(): void {
         this.authors = this._authors.filter(author => author.toLowerCase().indexOf(this.query.toLowerCase()) !== -1);
     }
+
+    reset(): void {
+        this.multiple = false;
+        this.selected = [];
+        this.authors = [];
+        this.query = '';
+        this.search();
+    }
 }

--- a/e2e/pages/app/timeline/timeline.testpage.component.html
+++ b/e2e/pages/app/timeline/timeline.testpage.component.html
@@ -7,7 +7,7 @@
                 <div class="m-b-sm">
                     <span>
                         <i class="hpe-icon hpe-document-time"></i>
-                        <span>{{event.date | date:'EEEE, MMMM d, y, h:mm:ss a'}}</span>        
+                        <span>{{event.date | date:'EEEE, MMMM d, y, h:mm:ss a'}}</span>
                     </span>
                 </div>
                 <p class="m-b-nil">Ticket
@@ -19,3 +19,5 @@
         </ux-timeline>
     </div>
 </div>
+
+<button id="reset-btn" class="btn button-primary" (click)="reset()">Reset</button>

--- a/e2e/pages/app/timeline/timeline.testpage.component.ts
+++ b/e2e/pages/app/timeline/timeline.testpage.component.ts
@@ -10,36 +10,38 @@ export class TimelineTestPageComponent {
     private _now = Date.now();
     private _dayInMilliSeconds = 24 * 60 * 60 * 1000;
     private _daysAfterFirstEvent = 3;
-    
+
     events: TimelineEvent[] = [{
         color: 'accent',
         date: new Date(this._now + (this._dayInMilliSeconds * 3)),
         url: '#',
-        id: chance.integer({min: 1000, max: 9999}),
+        id: chance.integer({ min: 1000, max: 9999 }),
         action: 'tested',
         assignee: chance.name()
     }, {
         color: 'alternate2',
         date: new Date(this._now + (this._dayInMilliSeconds * 2)),
         url: '#',
-        id: chance.integer({min: 1000, max: 9999}),
+        id: chance.integer({ min: 1000, max: 9999 }),
         action: 'reviewed',
         assignee: chance.name()
     }, {
         color: 'grey4',
         date: new Date(this._now + this._dayInMilliSeconds),
         url: '#',
-        id: chance.integer({min: 1000, max: 9999}),
+        id: chance.integer({ min: 1000, max: 9999 }),
         action: 'developed',
         assignee: chance.name()
     }, {
         color: 'primary',
         date: new Date(this._now),
         url: '#',
-        id: chance.integer({min: 1000, max: 9999}),
+        id: chance.integer({ min: 1000, max: 9999 }),
         action: 'recorded',
         assignee: chance.name()
     }];
+
+    private _events = [...this.events];
 
     addEvent(): void {
         this._daysAfterFirstEvent++;
@@ -47,10 +49,15 @@ export class TimelineTestPageComponent {
             color: 'grey4',
             date: new Date(this._now + (this._dayInMilliSeconds * this._daysAfterFirstEvent)),
             url: '#',
-            id: chance.integer({min: 1000, max: 9999}),
+            id: chance.integer({ min: 1000, max: 9999 }),
             action: 'updated',
             assignee: chance.name()
         });
+    }
+
+    reset(): void {
+        this.events = [...this._events];
+        this._daysAfterFirstEvent = 3;
     }
 }
 

--- a/e2e/pages/app/toggleswitches/toggleswitches.testpage.component.html
+++ b/e2e/pages/app/toggleswitches/toggleswitches.testpage.component.html
@@ -30,6 +30,8 @@
 
 <br>
 
-<button id="button1" class="btn button-primary" (click)="toggleSwitchDisable = !toggleSwitchDisable">
+<button id="button1" class="btn button-primary m-r-xs" (click)="toggleSwitchDisable = !toggleSwitchDisable">
   {{toggleSwitchDisable ? 'Click to enable Toggle 1' : 'Click to disable Toggle 1'}}
 </button>
+
+<button id="reset-button" class="btn button-primary" (click)="reset()">Reset</button>

--- a/e2e/pages/app/toggleswitches/toggleswitches.testpage.component.ts
+++ b/e2e/pages/app/toggleswitches/toggleswitches.testpage.component.ts
@@ -1,15 +1,20 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'toggleswitches-app',
-  templateUrl: './toggleswitches.testpage.component.html',
+    selector: 'toggleswitches-app',
+    templateUrl: './toggleswitches.testpage.component.html',
 })
 export class ToggleSwitchesTestPageComponent {
-    public toggleSwitches: any;
-    public toggleSwitchDisable: boolean;
+    toggleSwitches = {
+        option1: true,
+        option2: false,
+        option3: false,
+        option4: false
+    };
 
-    constructor() {
+    toggleSwitchDisable: boolean = false;
 
+    reset(): void {
         this.toggleSwitches = {
             option1: true,
             option2: false,

--- a/e2e/pages/app/tooltips/tooltips.testpage.component.html
+++ b/e2e/pages/app/tooltips/tooltips.testpage.component.html
@@ -32,6 +32,7 @@
 <button id="programmatically-show-btn" class="btn button-secondary" (click)="tooltip.show()">Programatically Show</button>
 <button id="programmatically-hide-btn" class="btn button-secondary" (click)="tooltip.hide()">Programatically Hide</button>
 <button id="programmatically-toggle-btn" class="btn button-secondary" (click)="tooltip.toggle()">Programatically Toggle</button>
+<button id="reset-btn" class="btn button-secondary" (click)="tooltip.hide(); reset()">Reset</button>
 
 <ng-template #template>
     My Template Here

--- a/e2e/pages/app/tooltips/tooltips.testpage.component.ts
+++ b/e2e/pages/app/tooltips/tooltips.testpage.component.ts
@@ -8,4 +8,10 @@ export class TooltipsTestPageComponent {
     placement: string;
     customClass: string;
     content: string | TemplateRef<any> = 'Some content here';
+
+    reset(): void {
+        this.placement = undefined;
+        this.customClass = undefined;
+        this.content = 'Some content here';
+    }
 }

--- a/e2e/tests/components/checkbox/checkbox.e2e-spec.ts
+++ b/e2e/tests/components/checkbox/checkbox.e2e-spec.ts
@@ -3,119 +3,134 @@ import { CheckBoxesPage } from './checkbox.po.spec';
 
 describe('Checkbox Tests', () => {
 
-  let page: CheckBoxesPage;
-
-  beforeEach(() => {
-    page = new CheckBoxesPage();
+    let page: CheckBoxesPage = new CheckBoxesPage();
     page.getPage();
-  });
 
-  it('should have correct initial states', () => {
-    
-    // Initial values.
-    expect(page.confirmIsChecked(page.checkbox1)).toBeTruthy();
-    expect(page.confirmIsChecked(page.checkbox2)).toBeFalsy();
-    expect(page.confirmIsChecked(page.checkbox3)).toBeFalsy();
-    expect(page.confirmIsChecked(page.checkbox4)).toBeFalsy();
-    expect<any>(page.text1.getText()).toBe('true');
-    expect<any>(page.text2.getText()).toBe('false');
-    expect<any>(page.text3.getText()).toBe('false');
-    expect<any>(page.text4.getText()).toBe('false');
+    it('should have correct initial states', () => {
 
-    // All enabled.
-    expect(page.confirmIsDisabled(page.checkbox1)).toBeFalsy();
-    expect(page.confirmIsDisabled(page.checkbox2)).toBeFalsy();
-    expect(page.confirmIsDisabled(page.checkbox3)).toBeFalsy();
-    expect(page.confirmIsDisabled(page.checkbox4)).toBeFalsy();
+        // Initial values.
+        expect(page.confirmIsChecked(page.checkbox1)).toBeTruthy();
+        expect(page.confirmIsChecked(page.checkbox2)).toBeFalsy();
+        expect(page.confirmIsChecked(page.checkbox3)).toBeFalsy();
+        expect(page.confirmIsChecked(page.checkbox4)).toBeFalsy();
+        expect<any>(page.text1.getText()).toBe('true');
+        expect<any>(page.text2.getText()).toBe('false');
+        expect<any>(page.text3.getText()).toBe('false');
+        expect<any>(page.text4.getText()).toBe('false');
 
-    // None indeterminate.
-    expect(page.confirmIsIndeterminate(page.checkbox1)).toBeFalsy();
-    expect(page.confirmIsIndeterminate(page.checkbox2)).toBeFalsy();
-    expect(page.confirmIsIndeterminate(page.checkbox3)).toBeFalsy();
-    expect(page.confirmIsIndeterminate(page.checkbox4)).toBeFalsy();
+        // All enabled.
+        expect(page.confirmIsDisabled(page.checkbox1)).toBeFalsy();
+        expect(page.confirmIsDisabled(page.checkbox2)).toBeFalsy();
+        expect(page.confirmIsDisabled(page.checkbox3)).toBeFalsy();
+        expect(page.confirmIsDisabled(page.checkbox4)).toBeFalsy();
 
-    // None with simplified style.
-    expect(page.confirmIsSimplified(page.checkbox1)).toBeFalsy();
-    expect(page.confirmIsSimplified(page.checkbox2)).toBeFalsy();
-    expect(page.confirmIsSimplified(page.checkbox3)).toBeFalsy();
-    expect(page.confirmIsSimplified(page.checkbox4)).toBeFalsy();
-  });
+        // None indeterminate.
+        expect(page.confirmIsIndeterminate(page.checkbox1)).toBeFalsy();
+        expect(page.confirmIsIndeterminate(page.checkbox2)).toBeFalsy();
+        expect(page.confirmIsIndeterminate(page.checkbox3)).toBeFalsy();
+        expect(page.confirmIsIndeterminate(page.checkbox4)).toBeFalsy();
 
-  it('should react to clicks', () => {
-    page.checkbox2.click();
-    page.checkbox3.click();
+        // None with simplified style.
+        expect(page.confirmIsSimplified(page.checkbox1)).toBeFalsy();
+        expect(page.confirmIsSimplified(page.checkbox2)).toBeFalsy();
+        expect(page.confirmIsSimplified(page.checkbox3)).toBeFalsy();
+        expect(page.confirmIsSimplified(page.checkbox4)).toBeFalsy();
+    });
 
-    expect(page.confirmIsChecked(page.checkbox1)).toBeTruthy();
-    expect(page.confirmIsChecked(page.checkbox2)).toBeTruthy();
-    expect(page.confirmIsChecked(page.checkbox3)).toBeTruthy();
-    expect(page.confirmIsChecked(page.checkbox4)).toBeFalsy();
-    expect<any>(page.text1.getText()).toBe('true');
-    expect<any>(page.text2.getText()).toBe('true');
-    expect<any>(page.text3.getText()).toBe('true');
-    expect<any>(page.text4.getText()).toBe('false');
+    it('should react to clicks', async () => {
 
-    page.checkbox1.click();
-    page.checkbox4.click();
+        // reset the state
+        await page.resetBtn.click();
 
-    expect(page.confirmIsChecked(page.checkbox1)).toBeFalsy();
-    expect(page.confirmIsChecked(page.checkbox2)).toBeTruthy();
-    expect(page.confirmIsChecked(page.checkbox3)).toBeTruthy();
-    expect(page.confirmIsChecked(page.checkbox4)).toBeTruthy();
-    expect<any>(page.text1.getText()).toBe('false');
-    expect<any>(page.text2.getText()).toBe('true');
-    expect<any>(page.text3.getText()).toBe('true');
-    expect<any>(page.text4.getText()).toBe('true');
-  });
+        page.checkbox2.click();
+        page.checkbox3.click();
 
-  it('should react to disabling', () => {
-    page.disableButton.click();
+        expect(page.confirmIsChecked(page.checkbox1)).toBeTruthy();
+        expect(page.confirmIsChecked(page.checkbox2)).toBeTruthy();
+        expect(page.confirmIsChecked(page.checkbox3)).toBeTruthy();
+        expect(page.confirmIsChecked(page.checkbox4)).toBeFalsy();
+        expect<any>(page.text1.getText()).toBe('true');
+        expect<any>(page.text2.getText()).toBe('true');
+        expect<any>(page.text3.getText()).toBe('true');
+        expect<any>(page.text4.getText()).toBe('false');
 
-    expect(page.confirmIsDisabled(page.checkbox1)).toBeTruthy();
-    expect(page.confirmIsDisabled(page.checkbox2)).toBeFalsy();
-    expect(page.confirmIsDisabled(page.checkbox3)).toBeFalsy();
-    expect(page.confirmIsDisabled(page.checkbox4)).toBeFalsy();
+        page.checkbox1.click();
+        page.checkbox4.click();
 
-    page.checkbox1.click();
-    page.checkbox4.click();
+        expect(page.confirmIsChecked(page.checkbox1)).toBeFalsy();
+        expect(page.confirmIsChecked(page.checkbox2)).toBeTruthy();
+        expect(page.confirmIsChecked(page.checkbox3)).toBeTruthy();
+        expect(page.confirmIsChecked(page.checkbox4)).toBeTruthy();
+        expect<any>(page.text1.getText()).toBe('false');
+        expect<any>(page.text2.getText()).toBe('true');
+        expect<any>(page.text3.getText()).toBe('true');
+        expect<any>(page.text4.getText()).toBe('true');
+    });
 
-    expect(page.confirmIsChecked(page.checkbox1)).toBeTruthy();
-    expect(page.confirmIsChecked(page.checkbox2)).toBeFalsy();
-    expect(page.confirmIsChecked(page.checkbox3)).toBeFalsy();
-    expect(page.confirmIsChecked(page.checkbox4)).toBeTruthy();
-    expect<any>(page.text1.getText()).toBe('true');
-    expect<any>(page.text2.getText()).toBe('false');
-    expect<any>(page.text3.getText()).toBe('false');
-    expect<any>(page.text4.getText()).toBe('true');
-  });
+    it('should react to disabling', async () => {
 
-  it('should react to setting to indeterminate state', () => {
-    page.setToIndeterminateState.click();
+        // reset the state
+        await page.resetBtn.click();
 
-    expect(page.confirmIsIndeterminate(page.checkbox1)).toBeFalsy();
-    expect(page.confirmIsIndeterminate(page.checkbox2)).toBeTruthy();
-    expect(page.confirmIsIndeterminate(page.checkbox3)).toBeFalsy();
-    expect(page.confirmIsIndeterminate(page.checkbox4)).toBeFalsy();
-    expect<any>(page.text1.getText()).toBe('true');
-    expect<any>(page.text2.getText()).toBe('-1');
-    expect<any>(page.text3.getText()).toBe('false');
-    expect<any>(page.text4.getText()).toBe('false');
-  });
+        page.disableButton.click();
 
-  it('should react to setting to simplified style', () => {
-    page.changeToSimplified.click();
+        expect(page.confirmIsDisabled(page.checkbox1)).toBeTruthy();
+        expect(page.confirmIsDisabled(page.checkbox2)).toBeFalsy();
+        expect(page.confirmIsDisabled(page.checkbox3)).toBeFalsy();
+        expect(page.confirmIsDisabled(page.checkbox4)).toBeFalsy();
 
-    expect(page.confirmIsSimplified(page.checkbox1)).toBeTruthy();
-    expect(page.confirmIsSimplified(page.checkbox2)).toBeTruthy();
-    expect(page.confirmIsSimplified(page.checkbox3)).toBeTruthy();
-    expect(page.confirmIsSimplified(page.checkbox4)).toBeTruthy();
-  });
+        page.checkbox1.click();
+        page.checkbox4.click();
 
-  it('should toggle the checkbox when pressing space', () => { 
-    
-    page.toggleByKey(page.checkbox1, Key.SPACE);
-    page.toggleByKey(page.checkbox2, Key.SPACE);
+        expect(page.confirmIsChecked(page.checkbox1)).toBeTruthy();
+        expect(page.confirmIsChecked(page.checkbox2)).toBeFalsy();
+        expect(page.confirmIsChecked(page.checkbox3)).toBeFalsy();
+        expect(page.confirmIsChecked(page.checkbox4)).toBeTruthy();
+        expect<any>(page.text1.getText()).toBe('true');
+        expect<any>(page.text2.getText()).toBe('false');
+        expect<any>(page.text3.getText()).toBe('false');
+        expect<any>(page.text4.getText()).toBe('true');
+    });
 
-    expect(page.confirmIsChecked(page.checkbox1)).toBeFalsy();
-    expect(page.confirmIsChecked(page.checkbox2)).toBeTruthy();
-  });
+    it('should react to setting to indeterminate state', async () => {
+
+        // reset the state
+        await page.resetBtn.click();
+
+        page.setToIndeterminateState.click();
+
+        expect(page.confirmIsIndeterminate(page.checkbox1)).toBeFalsy();
+        expect(page.confirmIsIndeterminate(page.checkbox2)).toBeTruthy();
+        expect(page.confirmIsIndeterminate(page.checkbox3)).toBeFalsy();
+        expect(page.confirmIsIndeterminate(page.checkbox4)).toBeFalsy();
+        expect<any>(page.text1.getText()).toBe('true');
+        expect<any>(page.text2.getText()).toBe('-1');
+        expect<any>(page.text3.getText()).toBe('false');
+        expect<any>(page.text4.getText()).toBe('false');
+    });
+
+    it('should react to setting to simplified style', async () => {
+
+        // reset the state
+        await page.resetBtn.click();
+
+        page.changeToSimplified.click();
+
+        expect(page.confirmIsSimplified(page.checkbox1)).toBeTruthy();
+        expect(page.confirmIsSimplified(page.checkbox2)).toBeTruthy();
+        expect(page.confirmIsSimplified(page.checkbox3)).toBeTruthy();
+        expect(page.confirmIsSimplified(page.checkbox4)).toBeTruthy();
+    });
+
+    it('should toggle the checkbox when pressing space', async () => {
+
+        // reset the state
+        await page.resetBtn.click();
+
+        page.toggleByKey(page.checkbox1, Key.SPACE);
+        page.toggleByKey(page.checkbox2, Key.SPACE);
+
+        expect(page.confirmIsChecked(page.checkbox1)).toBeFalsy();
+        expect(page.confirmIsChecked(page.checkbox2)).toBeTruthy();
+    });
 });

--- a/e2e/tests/components/checkbox/checkbox.po.spec.ts
+++ b/e2e/tests/components/checkbox/checkbox.po.spec.ts
@@ -1,11 +1,11 @@
-import { ElementFinder, browser, by, element } from 'protractor';
+import { browser, by, element, ElementFinder } from 'protractor';
 
 export class CheckBoxesPage {
-        
+
     getPage(): void {
         browser.get('#/checkboxes');
     }
-    
+
     checkbox1 = element(by.id('checkbox1'));
     checkbox2 = element(by.id('checkbox2'));
     checkbox3 = element(by.id('checkbox3'));
@@ -13,27 +13,28 @@ export class CheckBoxesPage {
     text1 = element(by.id('text1'));
     text2 = element(by.id('text2'));
     text3 = element(by.id('text3'));
-    text4 = element(by.id('text4'));        
+    text4 = element(by.id('text4'));
     disableButton = element(by.id('button1'));
     setToIndeterminateState = element(by.id('button2'));
     changeToSimplified = element(by.id('button3'));
-    
-    confirmIsChecked(checkbox: ElementFinder) {    
+    resetBtn = element(by.id('button4'));
+
+    confirmIsChecked(checkbox: ElementFinder) {
         return checkbox.$('.ux-checkbox-checked').isPresent();
     }
-    
+
     confirmIsDisabled(checkbox: ElementFinder) {
         return checkbox.$('.ux-checkbox-disabled').isPresent();
     }
-    
+
     confirmIsIndeterminate(checkbox: ElementFinder) {
         return checkbox.$('.ux-checkbox-indeterminate').isPresent();
     }
-    
+
     confirmIsSimplified(checkbox: ElementFinder) {
         return checkbox.$('.ux-checkbox-simplified').isPresent();
     }
-    
+
     toggleByKey(checkbox: ElementFinder, key: string) {
         checkbox.$('.ux-checkbox').sendKeys(key);
     }

--- a/e2e/tests/components/conduits/conduits.e2e-spec.ts
+++ b/e2e/tests/components/conduits/conduits.e2e-spec.ts
@@ -2,8 +2,12 @@ import { ConduitsPage, Zone } from './conduits.po.spec';
 
 describe('Conduit Tests', () => {
 
-    let page: ConduitsPage = new ConduitsPage();
-    page.getPage();
+    let page: ConduitsPage;
+
+    beforeEach(() => {
+        page = new ConduitsPage();
+        page.getPage();
+    });
 
     it('should have correct initial states', async () => {
         expect(await page.getConduitValue(Zone.One)).toBe('');

--- a/e2e/tests/components/conduits/conduits.e2e-spec.ts
+++ b/e2e/tests/components/conduits/conduits.e2e-spec.ts
@@ -2,12 +2,8 @@ import { ConduitsPage, Zone } from './conduits.po.spec';
 
 describe('Conduit Tests', () => {
 
-    let page: ConduitsPage;
-
-    beforeEach(() => {
-        page = new ConduitsPage();
-        page.getPage();
-    });
+    let page: ConduitsPage = new ConduitsPage();
+    page.getPage();
 
     it('should have correct initial states', async () => {
         expect(await page.getConduitValue(Zone.One)).toBe('');
@@ -56,6 +52,7 @@ describe('Conduit Tests', () => {
     });
 
     it('should still receive input from other zones when producesOutput is set to false', async () => {
+
         await page.setConduitValue(Zone.One, 'UX Aspects');
 
         expect(await page.getConduitValue(Zone.One)).toBe('UX Aspects');

--- a/e2e/tests/components/custom-facet/custom-facet.e2e-spec.ts
+++ b/e2e/tests/components/custom-facet/custom-facet.e2e-spec.ts
@@ -2,115 +2,119 @@ import { CustomFacetPage } from './custom-facet.po.spec';
 
 describe('Custom Facet Tests', () => {
 
-  let page: CustomFacetPage;
-
-  beforeEach(() => {
-    page = new CustomFacetPage();
+    let page: CustomFacetPage = new CustomFacetPage();
     page.getPage();
-  });
 
-  it('should start with no facets', () => {
+    it('should start with no facets', () => {
 
-    expect<any>(page.getNumberOfFacets()).toEqual(0);
-    expect(page.getClearAllButton().isPresent()).toBeFalsy();
-    expect(page.getNoItemsLabel().isPresent()).toBeTruthy();
-    expect(page.confirmIsChecked(0)).toBeFalsy();
-    expect(page.confirmIsChecked(1)).toBeFalsy();
-    expect(page.confirmIsChecked(2)).toBeFalsy();
+        expect<any>(page.getNumberOfFacets()).toEqual(0);
+        expect(page.getClearAllButton().isPresent()).toBeFalsy();
+        expect(page.getNoItemsLabel().isPresent()).toBeTruthy();
+        expect(page.confirmIsChecked(0)).toBeFalsy();
+        expect(page.confirmIsChecked(1)).toBeFalsy();
+        expect(page.confirmIsChecked(2)).toBeFalsy();
 
-  });
+    });
 
-  it('should allow addition of facets', () => {
+    it('should allow addition of facets', async () => {
 
-    // Add first facet
-    page.getCheckbox(0).click();
-    expect(page.getClearAllButton().isPresent()).toBeTruthy();
-    expect(page.getNoItemsLabel().isPresent()).toBeFalsy();
+        // Add first facet
+        page.getCheckbox(0).click();
+        expect(page.getClearAllButton().isPresent()).toBeTruthy();
+        expect(page.getNoItemsLabel().isPresent()).toBeFalsy();
 
-    // Add the others
-    page.getCheckbox(1).click();
-    page.getCheckbox(2).click();
-    expect<any>(page.getNumberOfFacets()).toEqual(3);
+        // Add the others
+        page.getCheckbox(1).click();
+        page.getCheckbox(2).click();
+        expect<any>(page.getNumberOfFacets()).toEqual(3);
 
-    // Confirm facets are visible and checkboxes are checked
-    expect(page.getFacetName(0)).toMatch('Components');
-    expect(page.getFacetName(1)).toMatch('Charts');
-    expect(page.getFacetName(2)).toMatch('CSS');
-    expect(page.confirmIsChecked(0)).toBeTruthy();
-    expect(page.confirmIsChecked(1)).toBeTruthy();
-    expect(page.confirmIsChecked(2)).toBeTruthy();
+        // Confirm facets are visible and checkboxes are checked
+        expect(page.getFacetName(0)).toMatch('Components');
+        expect(page.getFacetName(1)).toMatch('Charts');
+        expect(page.getFacetName(2)).toMatch('CSS');
+        expect(page.confirmIsChecked(0)).toBeTruthy();
+        expect(page.confirmIsChecked(1)).toBeTruthy();
+        expect(page.confirmIsChecked(2)).toBeTruthy();
 
-  });
+        // deselect any facets
+        await page.getClearAllButton().click();
 
-  it('should allow deletion of facets one by one by clicking on the facets', () => {
+    });
 
-    // Add all the facets
-    page.getCheckbox(0).click();
-    page.getCheckbox(1).click();
-    page.getCheckbox(2).click();
-    expect<any>(page.getNumberOfFacets()).toEqual(3);
-    expect(page.confirmIsChecked(0)).toBeTruthy();
-    expect(page.confirmIsChecked(1)).toBeTruthy();
-    expect(page.confirmIsChecked(2)).toBeTruthy();
+    it('should allow deletion of facets one by one by clicking on the facets', async () => {
 
-    // Close a couple of facets, testing the number displayed
-    page.closeFacet(2);
-    expect<any>(page.getNumberOfFacets()).toEqual(2);
-    page.closeFacet(0);
-    expect<any>(page.getNumberOfFacets()).toEqual(1);
+        // Add all the facets
+        await page.getCheckbox(0).click();
+        await page.getCheckbox(1).click();
+        await page.getCheckbox(2).click();
 
-    // Confirm the checkbox for the remaining facet is checked
-    expect(page.confirmIsChecked(0)).toBeFalsy();
-    expect(page.confirmIsChecked(1)).toBeTruthy();
-    expect(page.confirmIsChecked(2)).toBeFalsy();
+        expect<any>(await page.getNumberOfFacets()).toEqual(3);
+        expect(await page.confirmIsChecked(0)).toBeTruthy();
+        expect(await page.confirmIsChecked(1)).toBeTruthy();
+        expect(await page.confirmIsChecked(2)).toBeTruthy();
 
-  });
+        // Close a couple of facets, testing the number displayed
+        await page.closeFacet(2);
+        expect<any>(await page.getNumberOfFacets()).toEqual(2);
 
-  it('should allow deletion of facets one by one by clicking on the checkboxes', () => {
+        await page.closeFacet(0);
+        expect<any>(await page.getNumberOfFacets()).toEqual(1);
 
-    // Add all the facets
-    page.getCheckbox(2).click();
-    page.getCheckbox(1).click();
-    page.getCheckbox(0).click();
-    expect<any>(page.getNumberOfFacets()).toEqual(3);
-    expect(page.getFacetName(0)).toMatch('CSS');
-    expect(page.getFacetName(1)).toMatch('Charts');
-    expect(page.getFacetName(2)).toMatch('Components');
+        // Confirm the checkbox for the remaining facet is checked
+        expect(await page.confirmIsChecked(0)).toBeFalsy();
+        expect(await page.confirmIsChecked(1)).toBeTruthy();
+        expect(await page.confirmIsChecked(2)).toBeFalsy();
 
-    // Close the facets by clicking the corresponding checkboxes, testing those still displayed
-    page.getCheckbox(1).click();
-    expect<any>(page.getNumberOfFacets()).toEqual(2);
-    expect(page.getFacetName(0)).toMatch('CSS');
-    expect(page.getFacetName(1)).toMatch('Components');
-    page.getCheckbox(0).click();
-    expect<any>(page.getNumberOfFacets()).toEqual(1);
-    expect(page.getFacetName(0)).toMatch('CSS');
-    page.getCheckbox(2).click();
-    expect<any>(page.getNumberOfFacets()).toEqual(0);
+        // deselect any facets
+        await page.getClearAllButton().click();
 
-    // Confirm all the checkboxes are unchecked
-    expect(page.confirmIsChecked(0)).toBeFalsy();
-    expect(page.confirmIsChecked(1)).toBeFalsy();
-    expect(page.confirmIsChecked(2)).toBeFalsy();
-  });
+    });
 
-  it('should allow deletion of all facets', () => {
+    it('should allow deletion of facets one by one by clicking on the checkboxes', async () => {
 
-    // Add all the facets
-    page.getCheckbox(0).click();
-    page.getCheckbox(1).click();
-    page.getCheckbox(2).click();
-    expect<any>(page.getNumberOfFacets()).toEqual(3);
+        // Add all the facets
+        await page.getCheckbox(2).click();
+        await page.getCheckbox(1).click();
+        await page.getCheckbox(0).click();
+        expect<any>(await page.getNumberOfFacets()).toEqual(3);
+        expect(await page.getFacetName(0)).toMatch('CSS');
+        expect(await page.getFacetName(1)).toMatch('Charts');
+        expect(await page.getFacetName(2)).toMatch('Components');
 
-    // Remove all the facets by clicking on the Clear All button
-    page.getClearAllButton().click();
-    expect<any>(page.getNumberOfFacets()).toEqual(0);
-    expect(page.getClearAllButton().isPresent()).toBeFalsy();
-    expect(page.getNoItemsLabel().isPresent()).toBeTruthy();
+        // Close the facets by clicking the corresponding checkboxes, testing those still displayed
+        await page.getCheckbox(1).click();
+        expect<any>(await page.getNumberOfFacets()).toEqual(2);
+        expect(await page.getFacetName(0)).toMatch('CSS');
+        expect(await page.getFacetName(1)).toMatch('Components');
+        await page.getCheckbox(0).click();
+        expect<any>(await page.getNumberOfFacets()).toEqual(1);
+        expect(await page.getFacetName(0)).toMatch('CSS');
+        await page.getCheckbox(2).click();
+        expect<any>(await page.getNumberOfFacets()).toEqual(0);
 
-    // Confirm all the checkboxes are unchecked
-    expect(page.confirmIsChecked(0)).toBeFalsy();
-    expect(page.confirmIsChecked(1)).toBeFalsy();
-    expect(page.confirmIsChecked(2)).toBeFalsy();
-  });
+        // Confirm all the checkboxes are unchecked
+        expect(await page.confirmIsChecked(0)).toBeFalsy();
+        expect(await page.confirmIsChecked(1)).toBeFalsy();
+        expect(await page.confirmIsChecked(2)).toBeFalsy();
+    });
+
+    it('should allow deletion of all facets', async () => {
+
+        // Add all the facets
+        page.getCheckbox(0).click();
+        page.getCheckbox(1).click();
+        page.getCheckbox(2).click();
+        expect<any>(page.getNumberOfFacets()).toEqual(3);
+
+        // Remove all the facets by clicking on the Clear All button
+        page.getClearAllButton().click();
+        expect<any>(page.getNumberOfFacets()).toEqual(0);
+        expect(page.getClearAllButton().isPresent()).toBeFalsy();
+        expect(page.getNoItemsLabel().isPresent()).toBeTruthy();
+
+        // Confirm all the checkboxes are unchecked
+        expect(page.confirmIsChecked(0)).toBeFalsy();
+        expect(page.confirmIsChecked(1)).toBeFalsy();
+        expect(page.confirmIsChecked(2)).toBeFalsy();
+    });
 });

--- a/e2e/tests/components/custom-facet/custom-facet.po.spec.ts
+++ b/e2e/tests/components/custom-facet/custom-facet.po.spec.ts
@@ -26,7 +26,7 @@ export class CustomFacetPage {
     }
 
     closeFacet(index: number) {
-        this.container.$('div.facets-selected-container').$('div.facets-selected-list').$$('div.facet-selected-tag').get(index).$('.facet-selected-remove-btn').click();
+        return this.container.$('div.facets-selected-container').$('div.facets-selected-list').$$('div.facet-selected-tag').get(index).$('.facet-selected-remove-btn').click();
     }
 
     getNoItemsLabel() {

--- a/e2e/tests/components/expanding-text-area/expanding-text-area.e2e-spec.ts
+++ b/e2e/tests/components/expanding-text-area/expanding-text-area.e2e-spec.ts
@@ -2,58 +2,63 @@ import { ExpandingTextAreaPage } from './expanding-text-area.po.spec';
 
 describe('Expanding Text Area Tests', () => {
 
-  let page: ExpandingTextAreaPage;
-
-  const height: number = 33;
-
-  beforeEach(() => {
-    page = new ExpandingTextAreaPage();
+    let page: ExpandingTextAreaPage = new ExpandingTextAreaPage();
     page.getPage();
-  });
 
-  it('should have correct initial states', async () => {
-    expect(await page.getHeight()).toBe(height);
-    expect(await page.getText()).toBe('');
-  });
+    const height: number = 33;
 
-  it('should not grow when one line has been entered', async () => {
-    expect(await page.getHeight()).toBe(height);
-    expect(await page.getText()).toBe('');
+    it('should have correct initial states', async () => {
+        expect(await page.getHeight()).toBe(height);
+        expect(await page.getText()).toBe('');
+    });
 
-    await page.setText('A single line of text');
+    it('should not grow when one line has been entered', async () => {
+        expect(await page.getHeight()).toBe(height);
+        expect(await page.getText()).toBe('');
 
-    expect(await page.getHeight()).toBe(height);
-    expect(await page.getText()).toBe('A single line of text');
-  });
+        await page.setText('A single line of text');
 
-  it('should grow when two lines has been entered', async () => {
-    expect(await page.getHeight()).toBe(height);
-    expect(await page.getText()).toBe('');
+        expect(await page.getHeight()).toBe(height);
+        expect(await page.getText()).toBe('A single line of text');
 
-    await page.setText('A first line of text\nA second line of text');
+        // clear text content
+        await page.clear();
+    });
 
-    expect(await page.getHeight()).toBe(58);
-    expect(await page.getText()).toBe('A first line of text\nA second line of text');
-  });
+    it('should grow when two lines has been entered', async () => {
 
-  it('should grow when three lines have been entered', async () => {
-    expect(await page.getHeight()).toBe(height);
-    expect(await page.getText()).toBe('');
+        expect(await page.getHeight()).toBe(height);
+        expect(await page.getText()).toBe('');
 
-    await page.setText('A first line of text\nA second line of text\nA third line of text');
+        await page.setText('A first line of text\nA second line of text');
 
-    expect(await page.getHeight()).toBe(83);
-    expect(await page.getText()).toBe('A first line of text\nA second line of text\nA third line of text');
-  });
+        expect(await page.getHeight()).toBe(58);
+        expect(await page.getText()).toBe('A first line of text\nA second line of text');
 
-  it('should not grow when four lines have been entered', async () => {
-    expect(await page.getHeight()).toBe(height);
-    expect(await page.getText()).toBe('');
+        // clear text content
+        await page.clear();
+    });
 
-    await page.setText('A first line of text\nA second line of text\nA third line of text\nA fourth line of text');
+    it('should grow when three lines have been entered', async () => {
 
-    expect(await page.getHeight()).toBe(83);
-    expect(await page.getText()).toBe('A first line of text\nA second line of text\nA third line of text\nA fourth line of text');
-  });
+        await page.setText('A first line of text\nA second line of text\nA third line of text');
+
+        expect(await page.getHeight()).toBe(83);
+        expect(await page.getText()).toBe('A first line of text\nA second line of text\nA third line of text');
+
+        // clear text content
+        await page.clear();
+    });
+
+    it('should not grow when four lines have been entered', async () => {
+
+        await page.setText('A first line of text\nA second line of text\nA third line of text\nA fourth line of text');
+
+        expect(await page.getHeight()).toBe(83);
+        expect(await page.getText()).toBe('A first line of text\nA second line of text\nA third line of text\nA fourth line of text');
+
+        // clear text content
+        await page.clear();
+    });
 
 });

--- a/e2e/tests/components/expanding-text-area/expanding-text-area.po.spec.ts
+++ b/e2e/tests/components/expanding-text-area/expanding-text-area.po.spec.ts
@@ -1,7 +1,7 @@
 import { browser, by, element } from 'protractor';
 
 export class ExpandingTextAreaPage {
-        
+
     textarea = element(by.tagName('textarea'));
 
     getPage(): void {
@@ -18,5 +18,9 @@ export class ExpandingTextAreaPage {
 
     async getHeight(): Promise<number> {
         return (await this.textarea.getSize()).height;
+    }
+
+    async clear(): Promise<void> {
+        return this.textarea.clear();
     }
 }

--- a/e2e/tests/components/facet-check-list/facet-check-list.e2e-spec.ts
+++ b/e2e/tests/components/facet-check-list/facet-check-list.e2e-spec.ts
@@ -2,87 +2,85 @@ import { FacetCheckListPage } from './facet-check-list.po.spec';
 
 describe('FacetCheckListPage Tests', () => {
 
-  let page: FacetCheckListPage;
-
-  beforeEach(() => {
-    page = new FacetCheckListPage();
+    let page: FacetCheckListPage = new FacetCheckListPage();
     page.getPage();
-  });
 
-  it('should start with no facets', () => {
-    
-    // No facets should be visible.
-    expect<any>(page.getNumberOfFacets()).toEqual(0);
-    expect(page.getClearAllButton().isPresent()).toBeFalsy();
-    expect(page.getNoItemsLabel().isPresent()).toBeTruthy();
-    
-    // No items in the list should be checked.
-    expect<any>(page.getNumberOfFacetsInCheckList()).toEqual(30);
-    expect(page.confirmCheckListScrollbarExists()).toBeTruthy();
-    expect(page.confirmCheckListFacetIsTicked(0)).toBeFalsy();
-    
-  });
-  
-  it('should allow addition of facets', () => {
-    
-    // Check list items, confirming that the corresponding facets are created.
-    page.getFacetFromCheckList(3).click();
-    expect(page.getClearAllButton().isPresent()).toBeTruthy();
-    expect(page.getNoItemsLabel().isPresent()).toBeFalsy();
-    
-    expect(page.confirmCheckListFacetIsTicked(3)).toBeTruthy();
-    expect(page.getFacetName(0)).toEqual(page.getFacetNameFromCheckList(3));
-    
-    page.getFacetFromCheckList(13).click();
-    expect(page.confirmCheckListFacetIsTicked(13)).toBeTruthy();
-    expect(page.getFacetName(1)).toEqual(page.getFacetNameFromCheckList(13));
+    it('should start with no facets', () => {
 
-    page.getFacetFromCheckList(23).click();
-    expect(page.confirmCheckListFacetIsTicked(23)).toBeTruthy();
-    expect(page.getFacetName(2)).toEqual(page.getFacetNameFromCheckList(23));
-    
-    expect<any>(page.getNumberOfFacets()).toEqual(3);
-    expect<any>(page.getNumberOfFacetsInCheckList()).toEqual(30);
-    
-  });
-  
-  it('should allow deletion of facets one by one', () => {
-    
-    // Create some facets.
-    page.getFacetFromCheckList(0).click();
-    page.getFacetFromCheckList(15).click();
-    page.getFacetFromCheckList(29).click();
-    expect<any>(page.getNumberOfFacets()).toEqual(3);
-    
-    // Close the facets and then confirm that the corresponding list items are unchecked.
-    page.closeFacet(2); 
-    expect<any>(page.getNumberOfFacets()).toEqual(2);
-    page.closeFacet(0);    
-    expect<any>(page.getNumberOfFacets()).toEqual(1);
-    page.closeFacet(0);    
-    expect<any>(page.getNumberOfFacets()).toEqual(0);
-    
-    expect(page.confirmCheckListFacetIsTicked(0)).toBeFalsy();
-    expect(page.confirmCheckListFacetIsTicked(15)).toBeFalsy();
-    expect(page.confirmCheckListFacetIsTicked(29)).toBeFalsy();
-    
-  });
-  
-  it('should allow deletion of all facets', () => {
-    
-    // Create some facets.
-    page.getFacetFromCheckList(23).click();
-    page.getFacetFromCheckList(1).click();
-    page.getFacetFromCheckList(9).click();
-    expect<any>(page.getNumberOfFacets()).toEqual(3);
-    
-    // Close all the facets and then confirm that the corresponding list items are unchecked.
-    page.getClearAllButton().click();
-    expect<any>(page.getNumberOfFacets()).toEqual(0);
-    
-    expect(page.confirmCheckListFacetIsTicked(23)).toBeFalsy();
-    expect(page.confirmCheckListFacetIsTicked(1)).toBeFalsy();
-    expect(page.confirmCheckListFacetIsTicked(9)).toBeFalsy();
-    
-  });
+        // No facets should be visible.
+        expect<any>(page.getNumberOfFacets()).toEqual(0);
+        expect(page.getClearAllButton().isPresent()).toBeFalsy();
+        expect(page.getNoItemsLabel().isPresent()).toBeTruthy();
+
+        // No items in the list should be checked.
+        expect<any>(page.getNumberOfFacetsInCheckList()).toEqual(30);
+        expect(page.confirmCheckListScrollbarExists()).toBeTruthy();
+        expect(page.confirmCheckListFacetIsTicked(0)).toBeFalsy();
+
+    });
+
+    it('should allow addition of facets', async () => {
+
+        // Check list items, confirming that the corresponding facets are created.
+        page.getFacetFromCheckList(3).click();
+        expect(page.getClearAllButton().isPresent()).toBeTruthy();
+        expect(page.getNoItemsLabel().isPresent()).toBeFalsy();
+
+        expect(page.confirmCheckListFacetIsTicked(3)).toBeTruthy();
+        expect(page.getFacetName(0)).toEqual(page.getFacetNameFromCheckList(3));
+
+        page.getFacetFromCheckList(13).click();
+        expect(page.confirmCheckListFacetIsTicked(13)).toBeTruthy();
+        expect(page.getFacetName(1)).toEqual(page.getFacetNameFromCheckList(13));
+
+        page.getFacetFromCheckList(23).click();
+        expect(page.confirmCheckListFacetIsTicked(23)).toBeTruthy();
+        expect(page.getFacetName(2)).toEqual(page.getFacetNameFromCheckList(23));
+
+        expect<any>(page.getNumberOfFacets()).toEqual(3);
+        expect<any>(page.getNumberOfFacetsInCheckList()).toEqual(30);
+
+        await page.getClearAllButton().click();
+
+    });
+
+    it('should allow deletion of facets one by one', () => {
+
+        // Create some facets.
+        page.getFacetFromCheckList(0).click();
+        page.getFacetFromCheckList(15).click();
+        page.getFacetFromCheckList(29).click();
+        expect<any>(page.getNumberOfFacets()).toEqual(3);
+
+        // Close the facets and then confirm that the corresponding list items are unchecked.
+        page.closeFacet(2);
+        expect<any>(page.getNumberOfFacets()).toEqual(2);
+        page.closeFacet(0);
+        expect<any>(page.getNumberOfFacets()).toEqual(1);
+        page.closeFacet(0);
+        expect<any>(page.getNumberOfFacets()).toEqual(0);
+
+        expect(page.confirmCheckListFacetIsTicked(0)).toBeFalsy();
+        expect(page.confirmCheckListFacetIsTicked(15)).toBeFalsy();
+        expect(page.confirmCheckListFacetIsTicked(29)).toBeFalsy();
+
+    });
+
+    it('should allow deletion of all facets', () => {
+
+        // Create some facets.
+        page.getFacetFromCheckList(23).click();
+        page.getFacetFromCheckList(1).click();
+        page.getFacetFromCheckList(9).click();
+        expect<any>(page.getNumberOfFacets()).toEqual(3);
+
+        // Close all the facets and then confirm that the corresponding list items are unchecked.
+        page.getClearAllButton().click();
+        expect<any>(page.getNumberOfFacets()).toEqual(0);
+
+        expect(page.confirmCheckListFacetIsTicked(23)).toBeFalsy();
+        expect(page.confirmCheckListFacetIsTicked(1)).toBeFalsy();
+        expect(page.confirmCheckListFacetIsTicked(9)).toBeFalsy();
+
+    });
 });

--- a/e2e/tests/components/facet-container/facet-container.e2e-spec.ts
+++ b/e2e/tests/components/facet-container/facet-container.e2e-spec.ts
@@ -2,65 +2,64 @@ import { FacetContainerPage } from './facet-container.po.spec';
 
 describe('FacetContainerPage Tests', () => {
 
-  let page: FacetContainerPage;
-
-  beforeEach(() => {
-    page = new FacetContainerPage();
+    let page: FacetContainerPage = new FacetContainerPage();
     page.getPage();
-  });
 
-  it('should start with no facets', () => {
+    it('should start with no facets', () => {
 
-    // No facets should be visible.
-    expect<any>(page.getNumberOfFacets()).toEqual(0);
-    expect(page.getClearAllButton().isPresent()).toBeFalsy();
-    expect(page.getNoItemsLabel().isPresent()).toBeTruthy();
+        // No facets should be visible.
+        expect<any>(page.getNumberOfFacets()).toEqual(0);
+        expect(page.getClearAllButton().isPresent()).toBeFalsy();
+        expect(page.getNoItemsLabel().isPresent()).toBeTruthy();
 
-  });
+    });
 
-  it('should allow addition of facets', () => {
+    it('should allow addition of facets', async () => {
 
-    // Create facets, checking the number displayed.
-    page.addFacet.click();
-    expect(page.getClearAllButton().isPresent()).toBeTruthy();
-    expect(page.getNoItemsLabel().isPresent()).toBeFalsy();
+        // Create facets, checking the number displayed.
+        page.addFacet.click();
+        expect(page.getClearAllButton().isPresent()).toBeTruthy();
+        expect(page.getNoItemsLabel().isPresent()).toBeFalsy();
 
-    page.addFacet.click();
-    page.addFacet.click();
-    expect<any>(page.getNumberOfFacets()).toEqual(3);
+        page.addFacet.click();
+        page.addFacet.click();
+        expect<any>(page.getNumberOfFacets()).toEqual(3);
 
-    expect(page.getFacetName(0)).toMatch('\\w+\\d*\\w*');
-    expect(page.getFacetName(1)).toMatch('\\w+\\d*\\w*');
-    expect(page.getFacetName(2)).toMatch('\\w+\\d*\\w*');
+        expect(page.getFacetName(0)).toMatch('\\w+\\d*\\w*');
+        expect(page.getFacetName(1)).toMatch('\\w+\\d*\\w*');
+        expect(page.getFacetName(2)).toMatch('\\w+\\d*\\w*');
 
-  });
+        await page.getClearAllButton().click();
+    });
 
-  it('should allow deletion of facets one by one', () => {
+    it('should allow deletion of facets one by one', async () => {
 
-    // Create some facets.
-    page.addFacet.click();
-    page.addFacet.click();
-    page.addFacet.click();
-    expect<any>(page.getNumberOfFacets()).toEqual(3);
+        // Create some facets.
+        page.addFacet.click();
+        page.addFacet.click();
+        page.addFacet.click();
+        expect<any>(page.getNumberOfFacets()).toEqual(3);
 
-    // Close the facets and confirm that the corresponding list items are unchecked.
-    page.closeFacet(2);
-    expect<any>(page.getNumberOfFacets()).toEqual(2);
-    page.closeFacet(0);
-    expect<any>(page.getNumberOfFacets()).toEqual(1);
-  });
+        // Close the facets and confirm that the corresponding list items are unchecked.
+        page.closeFacet(2);
+        expect<any>(page.getNumberOfFacets()).toEqual(2);
+        page.closeFacet(0);
+        expect<any>(page.getNumberOfFacets()).toEqual(1);
 
-  it('should allow deletion of all facets', () => {
+        await page.getClearAllButton().click();
+    });
 
-    // Create some facets.
-    page.addFacet.click();
-    page.addFacet.click();
-    page.addFacet.click();
-    expect<any>(page.getNumberOfFacets()).toEqual(3);
+    it('should allow deletion of all facets', () => {
 
-    // Close all the facets and then confirm that the corresponding list items are unchecked.
-    page.getClearAllButton().click();
-    expect<any>(page.getNumberOfFacets()).toEqual(0);
+        // Create some facets.
+        page.addFacet.click();
+        page.addFacet.click();
+        page.addFacet.click();
+        expect<any>(page.getNumberOfFacets()).toEqual(3);
 
-  });
+        // Close all the facets and then confirm that the corresponding list items are unchecked.
+        page.getClearAllButton().click();
+        expect<any>(page.getNumberOfFacets()).toEqual(0);
+
+    });
 });

--- a/e2e/tests/components/flippable-cards/flippable-cards.e2e-spec.ts
+++ b/e2e/tests/components/flippable-cards/flippable-cards.e2e-spec.ts
@@ -3,171 +3,167 @@ import { FlippableCardsPage } from './flippable-cards.po.spec';
 
 describe('Flippable Cards Tests', () => {
 
-  // Time, in milliseconds, to pause while waiting for the a card to flip.
-  const FLIP_DELAY_MS = 2000;
-  
-  let page: FlippableCardsPage;
+    // Time, in milliseconds, to pause while waiting for the a card to flip.
+    const FLIP_DELAY_MS = 2000;
 
-  beforeEach(() => {
-    page = new FlippableCardsPage();
+    let page: FlippableCardsPage = new FlippableCardsPage();
     page.getPage();
-  });
 
-  it('should have correct initial states', () => {
-    
-    // Initial values.
-    expect(page.confirmIsFlipped(page.flippableCard1)).toBeFalsy();
-    expect(page.confirmIsFlipped(page.flippableCard2)).toBeFalsy();
-    expect(page.confirmIsFlipped(page.flippableCard3)).toBeFalsy();
-    
-  });
+    it('should have correct initial states', () => {
 
-  it('should only be possible to flip card 1 by clicking on the icon', () => {
-    
-    // Click at the top left of the card.
-    page.clickOnCard(page.flippableCard1, {x: 0, y: 0}).then(() => {
-        browser.sleep(FLIP_DELAY_MS);
-        expect(page.confirmIsFlipped(page.flippableCard1)).toBeFalsy();    // Front
-    });
-    
-    // Click at the middle of the card.
-    page.getCardDimension(page.flippableCard1, 'height').then(function(height: string) {
-        page.getCardDimension(page.flippableCard1, 'width').then(function(width: string) {
-            page.clickOnCard(page.flippableCard1, {x: (Number(width) / 2), y: (Number(height) / 2)}).then(() => {
-                browser.sleep(FLIP_DELAY_MS);
-                expect(page.confirmIsFlipped(page.flippableCard1)).toBeFalsy();    // Front
-            });
-        });
-    });
-    
-    // Click at the bottom right of the card.
-    page.getCardDimension(page.flippableCard1, 'height').then(function(height: string) {
-        page.getCardDimension(page.flippableCard1, 'width').then(function(width: string) {
-            page.clickOnCard(page.flippableCard1, {x: (Number(width) - 1), y: (Number(height) - 1)}).then(() => {
-                browser.sleep(FLIP_DELAY_MS);
-                expect(page.confirmIsFlipped(page.flippableCard1)).toBeFalsy();    // Front
-            });
-        });
-    });
-    
-    // Click beyond the bottom right of the card.
-    page.getCardDimension(page.flippableCard1, 'height').then(function(height: string) {
-        page.getCardDimension(page.flippableCard1, 'width').then(function(width: string) {
-            page.clickOnCard(page.flippableCard1, {x: (Number(width) * 2), y: Number(height)}).then(() => {
-                browser.sleep(FLIP_DELAY_MS);
-                expect(page.confirmIsFlipped(page.flippableCard1)).toBeFalsy();    // Front
-            });
-        });
-    });
-    
-    // Click on the icon.
-    page.clickOnCardIcon(page.flippableCard1).then(() => {
-        browser.sleep(FLIP_DELAY_MS);
-        expect(page.confirmIsFlipped(page.flippableCard1)).toBeTruthy();    // Back
+        // Initial values.
+        expect(page.confirmIsFlipped(page.flippableCard1)).toBeFalsy();
+        expect(page.confirmIsFlipped(page.flippableCard2)).toBeFalsy();
+        expect(page.confirmIsFlipped(page.flippableCard3)).toBeFalsy();
+
     });
 
-    // Click on the icon again.
-    page.clickOnCardIcon(page.flippableCard1).then(() => {
-        browser.sleep(FLIP_DELAY_MS);
-        expect(page.confirmIsFlipped(page.flippableCard1)).toBeFalsy();    // Front
-    });
-    
-  });
+    it('should only be possible to flip card 1 by clicking on the icon', () => {
 
-  it('should be possible to flip card 2 by hovering over it', () => {
-    
-    // Hover over the top left of the card.
-    page.hoverOverCard(page.flippableCard2, {x: 0, y: 0}).then(() => {
-        browser.sleep(FLIP_DELAY_MS);
-        expect(page.confirmIsFlipped(page.flippableCard2)).toBeTruthy();    // Back   
+        // Click at the top left of the card.
+        page.clickOnCard(page.flippableCard1, { x: 0, y: 0 }).then(() => {
+            browser.sleep(FLIP_DELAY_MS);
+            expect(page.confirmIsFlipped(page.flippableCard1)).toBeFalsy();    // Front
+        });
+
+        // Click at the middle of the card.
+        page.getCardDimension(page.flippableCard1, 'height').then(function (height: string) {
+            page.getCardDimension(page.flippableCard1, 'width').then(function (width: string) {
+                page.clickOnCard(page.flippableCard1, { x: (Number(width) / 2), y: (Number(height) / 2) }).then(() => {
+                    browser.sleep(FLIP_DELAY_MS);
+                    expect(page.confirmIsFlipped(page.flippableCard1)).toBeFalsy();    // Front
+                });
+            });
+        });
+
+        // Click at the bottom right of the card.
+        page.getCardDimension(page.flippableCard1, 'height').then(function (height: string) {
+            page.getCardDimension(page.flippableCard1, 'width').then(function (width: string) {
+                page.clickOnCard(page.flippableCard1, { x: (Number(width) - 1), y: (Number(height) - 1) }).then(() => {
+                    browser.sleep(FLIP_DELAY_MS);
+                    expect(page.confirmIsFlipped(page.flippableCard1)).toBeFalsy();    // Front
+                });
+            });
+        });
+
+        // Click beyond the bottom right of the card.
+        page.getCardDimension(page.flippableCard1, 'height').then(function (height: string) {
+            page.getCardDimension(page.flippableCard1, 'width').then(function (width: string) {
+                page.clickOnCard(page.flippableCard1, { x: (Number(width) * 2), y: Number(height) }).then(() => {
+                    browser.sleep(FLIP_DELAY_MS);
+                    expect(page.confirmIsFlipped(page.flippableCard1)).toBeFalsy();    // Front
+                });
+            });
+        });
+
+        // Click on the icon.
+        page.clickOnCardIcon(page.flippableCard1).then(() => {
+            browser.sleep(FLIP_DELAY_MS);
+            expect(page.confirmIsFlipped(page.flippableCard1)).toBeTruthy();    // Back
+        });
+
+        // Click on the icon again.
+        page.clickOnCardIcon(page.flippableCard1).then(() => {
+            browser.sleep(FLIP_DELAY_MS);
+            expect(page.confirmIsFlipped(page.flippableCard1)).toBeFalsy();    // Front
+        });
+
     });
 
-    // Hover to the left of the card.
-    page.hoverOverCard(page.flippableCard2, {x: -10, y: 0}).then(() => {
-        browser.sleep(FLIP_DELAY_MS);
-        expect(page.confirmIsFlipped(page.flippableCard2)).toBeFalsy();    // Front    
-    });
-    
-    // Hover over the middle of the card.
-    page.getCardDimension(page.flippableCard2, 'height').then(function(height: string) {
-        page.getCardDimension(page.flippableCard2, 'width').then(function(width: string) {
-            page.hoverOverCard(page.flippableCard2, {x: (Number(width) / 2), y: (Number(height) / 2)}).then(() => {
-                browser.sleep(FLIP_DELAY_MS);
-                expect(page.confirmIsFlipped(page.flippableCard2)).toBeTruthy();    // Back
-            });
-        });
-    });
-    // Hover to the left of the card.
-    page.hoverOverCard(page.flippableCard2, {x: -10, y: 0}).then(() => {
-        browser.sleep(FLIP_DELAY_MS);
-        expect(page.confirmIsFlipped(page.flippableCard2)).toBeFalsy();    // Front    
-    });
-    
-    // Hover over the bottom right of the card.
-    page.getCardDimension(page.flippableCard2, 'height').then(function(height: string) {
-        page.getCardDimension(page.flippableCard2, 'width').then(function(width: string) {
-            page.hoverOverCard(page.flippableCard2, {x: (Number(width) - 1), y: (Number(height) - 1)}).then(() => {
-                browser.sleep(FLIP_DELAY_MS);
-                expect(page.confirmIsFlipped(page.flippableCard2)).toBeTruthy();    // Back
-            });
-        });
-    });
-    
-    // Hover to the left of the card.
-    page.hoverOverCard(page.flippableCard2, {x: -10, y: 0}).then(() => {
-        browser.sleep(FLIP_DELAY_MS);
-        expect(page.confirmIsFlipped(page.flippableCard2)).toBeFalsy();    // Front    
-    });
-    
-    // Hover beyond the bottom right of the card.
-    page.getCardDimension(page.flippableCard2, 'height').then(function(height: string) {
-        page.getCardDimension(page.flippableCard2, 'width').then(function(width: string) {
-            page.clickOnCard(page.flippableCard2, {x: (Number(width) * 2), y: Number(height)}).then(() => {
-                browser.sleep(FLIP_DELAY_MS);
-                expect(page.confirmIsFlipped(page.flippableCard2)).toBeFalsy();    // Front
-            });
-        });
-    });
-    
-  });
+    it('should be possible to flip card 2 by hovering over it', () => {
 
-  it('should be possible to flip card 3 by clicking anywhere on the card', () => {
-    
-    // Click at the top left of the card.
-    page.clickOnCard(page.flippableCard3, {x: 0, y: 0}).then(() => {
-        browser.sleep(FLIP_DELAY_MS);
-        expect(page.confirmIsFlipped(page.flippableCard3)).toBeTruthy();    // Front
-    });
-    
-    // Click at the middle of the card.
-    page.getCardDimension(page.flippableCard3, 'height').then(function(height: string) {
-        page.getCardDimension(page.flippableCard3, 'width').then(function(width: string) {
-            page.clickOnCard(page.flippableCard3, {x: (Number(width) / 2), y: (Number(height) / 2)}).then(() => {
-                browser.sleep(FLIP_DELAY_MS);
-                expect(page.confirmIsFlipped(page.flippableCard3)).toBeFalsy();    // Back
+        // Hover over the top left of the card.
+        page.hoverOverCard(page.flippableCard2, { x: 0, y: 0 }).then(() => {
+            browser.sleep(FLIP_DELAY_MS);
+            expect(page.confirmIsFlipped(page.flippableCard2)).toBeTruthy();    // Back
+        });
+
+        // Hover to the left of the card.
+        page.hoverOverCard(page.flippableCard2, { x: -10, y: 0 }).then(() => {
+            browser.sleep(FLIP_DELAY_MS);
+            expect(page.confirmIsFlipped(page.flippableCard2)).toBeFalsy();    // Front
+        });
+
+        // Hover over the middle of the card.
+        page.getCardDimension(page.flippableCard2, 'height').then(function (height: string) {
+            page.getCardDimension(page.flippableCard2, 'width').then(function (width: string) {
+                page.hoverOverCard(page.flippableCard2, { x: (Number(width) / 2), y: (Number(height) / 2) }).then(() => {
+                    browser.sleep(FLIP_DELAY_MS);
+                    expect(page.confirmIsFlipped(page.flippableCard2)).toBeTruthy();    // Back
+                });
             });
         });
-    });
-    
-    // Click at the bottom right of the card.
-    page.getCardDimension(page.flippableCard3, 'height').then(function(height: string) {
-        page.getCardDimension(page.flippableCard3, 'width').then(function(width: string) {
-            page.clickOnCard(page.flippableCard3, {x: (Number(width) - 1), y: (Number(height) - 1)}).then(() => {
-                browser.sleep(FLIP_DELAY_MS);
-                expect(page.confirmIsFlipped(page.flippableCard3)).toBeTruthy();    // Front
+        // Hover to the left of the card.
+        page.hoverOverCard(page.flippableCard2, { x: -10, y: 0 }).then(() => {
+            browser.sleep(FLIP_DELAY_MS);
+            expect(page.confirmIsFlipped(page.flippableCard2)).toBeFalsy();    // Front
+        });
+
+        // Hover over the bottom right of the card.
+        page.getCardDimension(page.flippableCard2, 'height').then(function (height: string) {
+            page.getCardDimension(page.flippableCard2, 'width').then(function (width: string) {
+                page.hoverOverCard(page.flippableCard2, { x: (Number(width) - 1), y: (Number(height) - 1) }).then(() => {
+                    browser.sleep(FLIP_DELAY_MS);
+                    expect(page.confirmIsFlipped(page.flippableCard2)).toBeTruthy();    // Back
+                });
             });
         });
-    });
-    
-    // Click beyond the bottom right of the card.
-    page.getCardDimension(page.flippableCard3, 'height').then(function(height: string) {
-        page.getCardDimension(page.flippableCard3, 'width').then(function(width: string) {
-            page.clickOnCard(page.flippableCard3, {x: (Number(width) + 1), y: (Number(height) + 1)}).then(() => {
-                browser.sleep(FLIP_DELAY_MS);
-                expect(page.confirmIsFlipped(page.flippableCard3)).toBeTruthy();    // Front
+
+        // Hover to the left of the card.
+        page.hoverOverCard(page.flippableCard2, { x: -10, y: 0 }).then(() => {
+            browser.sleep(FLIP_DELAY_MS);
+            expect(page.confirmIsFlipped(page.flippableCard2)).toBeFalsy();    // Front
+        });
+
+        // Hover beyond the bottom right of the card.
+        page.getCardDimension(page.flippableCard2, 'height').then(function (height: string) {
+            page.getCardDimension(page.flippableCard2, 'width').then(function (width: string) {
+                page.clickOnCard(page.flippableCard2, { x: (Number(width) * 2), y: Number(height) }).then(() => {
+                    browser.sleep(FLIP_DELAY_MS);
+                    expect(page.confirmIsFlipped(page.flippableCard2)).toBeFalsy();    // Front
+                });
             });
         });
+
     });
-    
-  });
+
+    it('should be possible to flip card 3 by clicking anywhere on the card', () => {
+
+        // Click at the top left of the card.
+        page.clickOnCard(page.flippableCard3, { x: 0, y: 0 }).then(() => {
+            browser.sleep(FLIP_DELAY_MS);
+            expect(page.confirmIsFlipped(page.flippableCard3)).toBeTruthy();    // Front
+        });
+
+        // Click at the middle of the card.
+        page.getCardDimension(page.flippableCard3, 'height').then(function (height: string) {
+            page.getCardDimension(page.flippableCard3, 'width').then(function (width: string) {
+                page.clickOnCard(page.flippableCard3, { x: (Number(width) / 2), y: (Number(height) / 2) }).then(() => {
+                    browser.sleep(FLIP_DELAY_MS);
+                    expect(page.confirmIsFlipped(page.flippableCard3)).toBeFalsy();    // Back
+                });
+            });
+        });
+
+        // Click at the bottom right of the card.
+        page.getCardDimension(page.flippableCard3, 'height').then(function (height: string) {
+            page.getCardDimension(page.flippableCard3, 'width').then(function (width: string) {
+                page.clickOnCard(page.flippableCard3, { x: (Number(width) - 1), y: (Number(height) - 1) }).then(() => {
+                    browser.sleep(FLIP_DELAY_MS);
+                    expect(page.confirmIsFlipped(page.flippableCard3)).toBeTruthy();    // Front
+                });
+            });
+        });
+
+        // Click beyond the bottom right of the card.
+        page.getCardDimension(page.flippableCard3, 'height').then(function (height: string) {
+            page.getCardDimension(page.flippableCard3, 'width').then(function (width: string) {
+                page.clickOnCard(page.flippableCard3, { x: (Number(width) + 1), y: (Number(height) + 1) }).then(() => {
+                    browser.sleep(FLIP_DELAY_MS);
+                    expect(page.confirmIsFlipped(page.flippableCard3)).toBeTruthy();    // Front
+                });
+            });
+        });
+
+    });
 });

--- a/e2e/tests/components/floating-action-buttons/floating-action-buttons.e2e-spec.ts
+++ b/e2e/tests/components/floating-action-buttons/floating-action-buttons.e2e-spec.ts
@@ -3,221 +3,217 @@ import { FloatingActionButtonsPage } from './floating-action-buttons.po.spec';
 
 describe('Floating Action Button Tests', () => {
 
-  let page: FloatingActionButtonsPage;
-  let constants = new Constants();
-  let functions = new Functions();
-
-  beforeEach(() => {
-
-    page = new FloatingActionButtonsPage();
+    let page: FloatingActionButtonsPage = new FloatingActionButtonsPage();
     page.getPage();
-  });
 
-  it('should have correct initial states', () => {
+    let constants = new Constants();
+    let functions = new Functions();
 
-    // Vertical (bottom) button
-    expect<any>(functions.getElementColourHex(page.fabBottomTrigger, 'background-color')).toBe(constants.PRIMARY_BACKGROUND_COLOR);
-    expect<any>(functions.getElementColourHex(page.fabBottomTrigger, 'color')).toBe(constants.PRIMARY_COLOR);
+    it('should have correct initial states', () => {
 
-    // there should only be the trigger button visible
-    expect<any>(page.fabBottom.$$('ux-floating-action-button').count()).toBe(1);
+        // Vertical (bottom) button
+        expect<any>(functions.getElementColourHex(page.fabBottomTrigger, 'background-color')).toBe(constants.PRIMARY_BACKGROUND_COLOR);
+        expect<any>(functions.getElementColourHex(page.fabBottomTrigger, 'color')).toBe(constants.PRIMARY_COLOR);
 
-    // // Horizontal (right) button
-    expect<any>(functions.getElementColourHex(page.fabRightTrigger, 'background-color')).toBe(constants.PRIMARY_BACKGROUND_COLOR);
-    expect<any>(functions.getElementColourHex(page.fabRightTrigger, 'color')).toBe(constants.PRIMARY_COLOR);
+        // there should only be the trigger button visible
+        expect<any>(page.fabBottom.$$('ux-floating-action-button').count()).toBe(1);
 
-    // there should only be the trigger button visible
-    expect<any>(page.fabRight.$$('ux-floating-action-button').count()).toBe(1);
+        // // Horizontal (right) button
+        expect<any>(functions.getElementColourHex(page.fabRightTrigger, 'background-color')).toBe(constants.PRIMARY_BACKGROUND_COLOR);
+        expect<any>(functions.getElementColourHex(page.fabRightTrigger, 'color')).toBe(constants.PRIMARY_COLOR);
 
-    // // Vertical (up) button
-    expect<any>(functions.getElementColourHex(page.fabUpTrigger, 'background-color')).toBe(constants.PRIMARY_BACKGROUND_COLOR);
-    expect<any>(functions.getElementColourHex(page.fabUpTrigger, 'color')).toBe(constants.PRIMARY_COLOR);
+        // there should only be the trigger button visible
+        expect<any>(page.fabRight.$$('ux-floating-action-button').count()).toBe(1);
 
-    // there should only be the trigger button visible
-    expect<any>(page.fabUp.$$('ux-floating-action-button').count()).toBe(1);
+        // // Vertical (up) button
+        expect<any>(functions.getElementColourHex(page.fabUpTrigger, 'background-color')).toBe(constants.PRIMARY_BACKGROUND_COLOR);
+        expect<any>(functions.getElementColourHex(page.fabUpTrigger, 'color')).toBe(constants.PRIMARY_COLOR);
 
-    // // Horizontal (left) button
-    expect<any>(functions.getElementColourHex(page.fabLeftTrigger, 'background-color')).toBe(constants.PRIMARY_BACKGROUND_COLOR);
-    expect<any>(functions.getElementColourHex(page.fabLeftTrigger, 'color')).toBe(constants.PRIMARY_COLOR);
+        // there should only be the trigger button visible
+        expect<any>(page.fabUp.$$('ux-floating-action-button').count()).toBe(1);
 
-    // there should only be the trigger button visible
-    expect<any>(page.fabLeft.$$('ux-floating-action-button').count()).toBe(1);
+        // // Horizontal (left) button
+        expect<any>(functions.getElementColourHex(page.fabLeftTrigger, 'background-color')).toBe(constants.PRIMARY_BACKGROUND_COLOR);
+        expect<any>(functions.getElementColourHex(page.fabLeftTrigger, 'color')).toBe(constants.PRIMARY_COLOR);
 
-  });
+        // there should only be the trigger button visible
+        expect<any>(page.fabLeft.$$('ux-floating-action-button').count()).toBe(1);
 
-  it('should change the vertical (bottom) button\'s colour upon hover', () => {
-
-    functions.moveToElement(page.fabBottomTriggerIcon);
-
-    expect<any>(functions.getElementColourHex(page.fabBottomTrigger, 'background-color')).toBe(constants.PRIMARY_BACKGROUND_HOVER_COLOR);
-    expect<any>(functions.getElementColourHex(page.fabBottomTrigger, 'color')).toBe(constants.PRIMARY_COLOR);
-
-  });
-
-  it('should display action buttons when the vertical (bottom) button is clicked', () => {
-
-    page.fabBottom.click();
-
-    const buttons = page.fabBottom.$$('ux-floating-action-button');
-
-    expect<any>(buttons.count()).toBe(4);
-
-    // check the icons are correct on each button
-    expect(buttons.get(1).$('.hpe-icon').getAttribute('class')).toContain('hpe-add');
-    expect(buttons.get(2).$('.hpe-icon').getAttribute('class')).toContain('hpe-analytics');
-    expect(buttons.get(3).$('.hpe-icon').getAttribute('class')).toContain('hpe-app');
-
-  });
-
-  it('should display action buttons in the correct position when the vertical (bottom) button is clicked', () => {
-
-    page.fabBottom.click();
-
-    const buttons = page.fabBottom.$$('ux-floating-action-button');
-
-    buttons.get(1).getLocation().then((location0: object) => {
-      buttons.get(2).getLocation().then((location1: object) => {
-        buttons.get(3).getLocation().then((location2: object) => {
-          expect(Number(location0['x'])).toBe(Number(location1['x']));
-          expect(Number(location1['x'])).toBe(Number(location2['x']));
-
-          expect(Number(location0['y'])).toBeLessThan(Number(location1['y']));
-          expect(Number(location1['y'])).toBeLessThan(Number(location2['y']));
-        });
-      });
     });
 
-  });
+    it('should change the vertical (bottom) button\'s colour upon hover', () => {
 
-  it('should change the horizontal (right) button\'s colour upon hover', () => {
+        functions.moveToElement(page.fabBottomTriggerIcon);
 
-    functions.moveToElement(page.fabRightTriggerIcon);
+        expect<any>(functions.getElementColourHex(page.fabBottomTrigger, 'background-color')).toBe(constants.PRIMARY_BACKGROUND_HOVER_COLOR);
+        expect<any>(functions.getElementColourHex(page.fabBottomTrigger, 'color')).toBe(constants.PRIMARY_COLOR);
 
-    expect<any>(functions.getElementColourHex(page.fabRightTrigger, 'background-color')).toBe(constants.PRIMARY_BACKGROUND_HOVER_COLOR);
-    expect<any>(functions.getElementColourHex(page.fabRightTrigger, 'color')).toBe(constants.PRIMARY_COLOR);
-
-  });
-
-  it('should display action buttons when the horizontal (right) button is clicked', () => {
-
-    page.fabRight.click();
-
-    const buttons = page.fabRight.$$('ux-floating-action-button');
-
-    expect<any>(buttons.count()).toBe(4);
-
-    // check the icons are correct on each button
-    expect(buttons.get(1).$('.hpe-icon').getAttribute('class')).toContain('hpe-add');
-    expect(buttons.get(2).$('.hpe-icon').getAttribute('class')).toContain('hpe-analytics');
-    expect(buttons.get(3).$('.hpe-icon').getAttribute('class')).toContain('hpe-app');
-
-  });
-
-  it('should display action buttons in the correct position when the horizontal (right) button is clicked', () => {
-
-    page.fabRight.click();
-
-    const buttons = page.fabRight.$$('ux-floating-action-button');
-
-    buttons.get(1).getLocation().then((location0: object) => {
-      buttons.get(2).getLocation().then((location1: object) => {
-        buttons.get(3).getLocation().then((location2: object) => {
-          expect(Number(location0['x'])).toBeLessThan(Number(location1['x']));
-          expect(Number(location1['x'])).toBeLessThan(Number(location2['x']));
-
-          expect(Number(location0['y'])).toBe(Number(location1['y']));
-          expect(Number(location1['y'])).toBe(Number(location2['y']));
-        });
-      });
     });
 
-  });
+    it('should display action buttons when the vertical (bottom) button is clicked', () => {
 
-  it('should change the vertical (up) button\'s colour upon hover', () => {
+        page.fabBottom.click();
 
-    functions.moveToElement(page.fabUpTriggerIcon);
+        const buttons = page.fabBottom.$$('ux-floating-action-button');
 
-    expect<any>(functions.getElementColourHex(page.fabUpTrigger, 'background-color')).toBe(constants.PRIMARY_BACKGROUND_HOVER_COLOR);
-    expect<any>(functions.getElementColourHex(page.fabUpTrigger, 'color')).toBe(constants.PRIMARY_COLOR);
+        expect<any>(buttons.count()).toBe(4);
 
-  });
+        // check the icons are correct on each button
+        expect(buttons.get(1).$('.hpe-icon').getAttribute('class')).toContain('hpe-add');
+        expect(buttons.get(2).$('.hpe-icon').getAttribute('class')).toContain('hpe-analytics');
+        expect(buttons.get(3).$('.hpe-icon').getAttribute('class')).toContain('hpe-app');
 
-  it('should display action buttons when the vertical (up) button is clicked', () => {
-
-    page.fabUp.click();
-
-    const buttons = page.fabUp.$$('ux-floating-action-button');
-
-    expect<any>(buttons.count()).toBe(4);
-
-    // check the icons are correct on each button
-    expect(buttons.get(1).$('.hpe-icon').getAttribute('class')).toContain('hpe-add');
-    expect(buttons.get(2).$('.hpe-icon').getAttribute('class')).toContain('hpe-analytics');
-    expect(buttons.get(3).$('.hpe-icon').getAttribute('class')).toContain('hpe-app');
-
-  });
-
-  it('should display action buttons in the correct position when the vertical (up) button is clicked', () => {
-
-    page.fabUp.click();
-
-    const buttons = page.fabUp.$$('ux-floating-action-button');    
-
-    buttons.get(1).getLocation().then((location0: object) => {
-      buttons.get(2).getLocation().then((location1: object) => {
-        buttons.get(3).getLocation().then((location2: object) => {
-          expect(Number(location0['x'])).toBe(Number(location1['x']));
-          expect(Number(location1['x'])).toBe(Number(location2['x']));
-
-          expect(Number(location1['y'])).toBeLessThan(Number(location0['y']));
-          expect(Number(location2['y'])).toBeLessThan(Number(location1['y']));
-        });
-      });
     });
 
-  });
+    it('should display action buttons in the correct position when the vertical (bottom) button is clicked', () => {
 
-  it('should change the horizontal (left) button\'s colour upon hover', () => {
+        page.fabBottom.click();
 
-    functions.moveToElement(page.fabLeftTriggerIcon);
+        const buttons = page.fabBottom.$$('ux-floating-action-button');
 
-    expect<any>(functions.getElementColourHex(page.fabLeftTrigger, 'background-color')).toBe(constants.PRIMARY_BACKGROUND_HOVER_COLOR);
-    expect<any>(functions.getElementColourHex(page.fabLeftTrigger, 'color')).toBe(constants.PRIMARY_COLOR);
+        buttons.get(1).getLocation().then((location0: object) => {
+            buttons.get(2).getLocation().then((location1: object) => {
+                buttons.get(3).getLocation().then((location2: object) => {
+                    expect(Number(location0['x'])).toBe(Number(location1['x']));
+                    expect(Number(location1['x'])).toBe(Number(location2['x']));
 
-  });
-
-  it('should display action buttons when the horizontal (left) button is clicked', () => {
-
-    page.fabLeft.click();
-
-    const buttons = page.fabLeft.$$('ux-floating-action-button');
-
-    expect<any>(buttons.count()).toBe(4);
-
-    // check the icons are correct on each button
-    expect(buttons.get(1).$('.hpe-icon').getAttribute('class')).toContain('hpe-add');
-    expect(buttons.get(2).$('.hpe-icon').getAttribute('class')).toContain('hpe-analytics');
-    expect(buttons.get(3).$('.hpe-icon').getAttribute('class')).toContain('hpe-app');
-
-  });
-
-  it('should display action buttons in the correct position when the horizontal (left) button is clicked', () => {
-
-    page.fabLeft.click();
-
-    const buttons = page.fabLeft.$$('ux-floating-action-button');    
-
-    buttons.get(1).getLocation().then((location0: object) => {
-      buttons.get(2).getLocation().then((location1: object) => {
-        buttons.get(3).getLocation().then((location2: object) => {
-          expect(Number(location1['x'])).toBeLessThan(Number(location0['x']));
-          expect(Number(location2['x'])).toBeLessThan(Number(location1['x']));
-
-          expect(Number(location0['y'])).toBe(Number(location1['y']));
-          expect(Number(location1['y'])).toBe(Number(location2['y']));
+                    expect(Number(location0['y'])).toBeLessThan(Number(location1['y']));
+                    expect(Number(location1['y'])).toBeLessThan(Number(location2['y']));
+                });
+            });
         });
-      });
+
     });
 
-  });
+    it('should change the horizontal (right) button\'s colour upon hover', () => {
+
+        functions.moveToElement(page.fabRightTriggerIcon);
+
+        expect<any>(functions.getElementColourHex(page.fabRightTrigger, 'background-color')).toBe(constants.PRIMARY_BACKGROUND_HOVER_COLOR);
+        expect<any>(functions.getElementColourHex(page.fabRightTrigger, 'color')).toBe(constants.PRIMARY_COLOR);
+
+    });
+
+    it('should display action buttons when the horizontal (right) button is clicked', () => {
+
+        page.fabRight.click();
+
+        const buttons = page.fabRight.$$('ux-floating-action-button');
+
+        expect<any>(buttons.count()).toBe(4);
+
+        // check the icons are correct on each button
+        expect(buttons.get(1).$('.hpe-icon').getAttribute('class')).toContain('hpe-add');
+        expect(buttons.get(2).$('.hpe-icon').getAttribute('class')).toContain('hpe-analytics');
+        expect(buttons.get(3).$('.hpe-icon').getAttribute('class')).toContain('hpe-app');
+
+    });
+
+    it('should display action buttons in the correct position when the horizontal (right) button is clicked', () => {
+
+        page.fabRight.click();
+
+        const buttons = page.fabRight.$$('ux-floating-action-button');
+
+        buttons.get(1).getLocation().then((location0: object) => {
+            buttons.get(2).getLocation().then((location1: object) => {
+                buttons.get(3).getLocation().then((location2: object) => {
+                    expect(Number(location0['x'])).toBeLessThan(Number(location1['x']));
+                    expect(Number(location1['x'])).toBeLessThan(Number(location2['x']));
+
+                    expect(Number(location0['y'])).toBe(Number(location1['y']));
+                    expect(Number(location1['y'])).toBe(Number(location2['y']));
+                });
+            });
+        });
+
+    });
+
+    it('should change the vertical (up) button\'s colour upon hover', () => {
+
+        functions.moveToElement(page.fabUpTriggerIcon);
+
+        expect<any>(functions.getElementColourHex(page.fabUpTrigger, 'background-color')).toBe(constants.PRIMARY_BACKGROUND_HOVER_COLOR);
+        expect<any>(functions.getElementColourHex(page.fabUpTrigger, 'color')).toBe(constants.PRIMARY_COLOR);
+
+    });
+
+    it('should display action buttons when the vertical (up) button is clicked', () => {
+
+        page.fabUp.click();
+
+        const buttons = page.fabUp.$$('ux-floating-action-button');
+
+        expect<any>(buttons.count()).toBe(4);
+
+        // check the icons are correct on each button
+        expect(buttons.get(1).$('.hpe-icon').getAttribute('class')).toContain('hpe-add');
+        expect(buttons.get(2).$('.hpe-icon').getAttribute('class')).toContain('hpe-analytics');
+        expect(buttons.get(3).$('.hpe-icon').getAttribute('class')).toContain('hpe-app');
+
+    });
+
+    it('should display action buttons in the correct position when the vertical (up) button is clicked', () => {
+
+        page.fabUp.click();
+
+        const buttons = page.fabUp.$$('ux-floating-action-button');
+
+        buttons.get(1).getLocation().then((location0: object) => {
+            buttons.get(2).getLocation().then((location1: object) => {
+                buttons.get(3).getLocation().then((location2: object) => {
+                    expect(Number(location0['x'])).toBe(Number(location1['x']));
+                    expect(Number(location1['x'])).toBe(Number(location2['x']));
+
+                    expect(Number(location1['y'])).toBeLessThan(Number(location0['y']));
+                    expect(Number(location2['y'])).toBeLessThan(Number(location1['y']));
+                });
+            });
+        });
+
+    });
+
+    it('should change the horizontal (left) button\'s colour upon hover', () => {
+
+        functions.moveToElement(page.fabLeftTriggerIcon);
+
+        expect<any>(functions.getElementColourHex(page.fabLeftTrigger, 'background-color')).toBe(constants.PRIMARY_BACKGROUND_HOVER_COLOR);
+        expect<any>(functions.getElementColourHex(page.fabLeftTrigger, 'color')).toBe(constants.PRIMARY_COLOR);
+
+    });
+
+    it('should display action buttons when the horizontal (left) button is clicked', () => {
+
+        page.fabLeft.click();
+
+        const buttons = page.fabLeft.$$('ux-floating-action-button');
+
+        expect<any>(buttons.count()).toBe(4);
+
+        // check the icons are correct on each button
+        expect(buttons.get(1).$('.hpe-icon').getAttribute('class')).toContain('hpe-add');
+        expect(buttons.get(2).$('.hpe-icon').getAttribute('class')).toContain('hpe-analytics');
+        expect(buttons.get(3).$('.hpe-icon').getAttribute('class')).toContain('hpe-app');
+
+    });
+
+    it('should display action buttons in the correct position when the horizontal (left) button is clicked', () => {
+
+        page.fabLeft.click();
+
+        const buttons = page.fabLeft.$$('ux-floating-action-button');
+
+        buttons.get(1).getLocation().then((location0: object) => {
+            buttons.get(2).getLocation().then((location1: object) => {
+                buttons.get(3).getLocation().then((location2: object) => {
+                    expect(Number(location1['x'])).toBeLessThan(Number(location0['x']));
+                    expect(Number(location2['x'])).toBeLessThan(Number(location1['x']));
+
+                    expect(Number(location0['y'])).toBe(Number(location1['y']));
+                    expect(Number(location1['y'])).toBe(Number(location2['y']));
+                });
+            });
+        });
+
+    });
 });

--- a/e2e/tests/components/hierarchy-bar/hierarchy-bar.e2e-spec.ts
+++ b/e2e/tests/components/hierarchy-bar/hierarchy-bar.e2e-spec.ts
@@ -3,14 +3,10 @@ import { HierarchyBarPage } from './hierarchy-bar.po.spec';
 
 describe('Hierarchy Bar Tests', () => {
 
-    let page: HierarchyBarPage;
+    let page: HierarchyBarPage = new HierarchyBarPage();
+    page.getPage();
 
-    beforeEach(() => {
-        page = new HierarchyBarPage();
-        page.getPage();
-    });
-
-      it('should have correct initial states', async () => {
+    it('should have correct initial states', async () => {
 
         // should initially only select the root node
         expect(await page.getNodeCount()).toBe(1);
@@ -18,9 +14,9 @@ describe('Hierarchy Bar Tests', () => {
         // ensure that the selected change event emits the select node
         expect(await page.getSelectedNodeTitle()).toBe('Theresa Chandler');
 
-      });
+    });
 
-      it('can programmatically set the selected node', async () => {
+    it('can programmatically set the selected node', async () => {
 
         // set the selected input
         await page.selectButton.click();
@@ -31,14 +27,14 @@ describe('Hierarchy Bar Tests', () => {
         // ensure that the selected change event emits the select node
         expect(await page.getSelectedNodeTitle()).toBe('Leroy Rose');
 
-      });
+    });
 
-      it('should display arrow when item has children', async () => {
+    it('should display arrow when item has children', async () => {
 
         // check if the arrow appears on the root node
         expect(await page.nodeHasChildren(0)).toBe(true);
 
-      });
+    });
 
     it('should display children in popover', async () => {
         const titles = await page.getNodeChildrenTitles(0);
@@ -82,7 +78,7 @@ describe('Hierarchy Bar Tests', () => {
     });
 
     it('should show overflow indicator when overflow occurs', async () => {
-        
+
         // select many children
         await page.selectPopoverNode(0, 1);
         await page.selectPopoverNode(1, 0);
@@ -100,19 +96,19 @@ describe('Hierarchy Bar Tests', () => {
 
         // get the overflow nodes
         const titles = await page.getOverflowNodeTitles();
-        
+
         // expect there to be nodes in the overflow popover
         expect(JSON.stringify(titles)).toBe(JSON.stringify(['Theresa Chandler']));
 
         // increase browser size
         await browser.driver.manage().window().setSize(1000, 700);
-        
+
         // overflow indicator should no longer be visible
         expect(await page.isOverflowIndicatorVisible()).toBe(false);
-        
+
         // restore window
         await browser.driver.manage().window().maximize();
-        
+
     });
 
 });

--- a/e2e/tests/components/hierarchy-bar/hierarchy-bar.e2e-spec.ts
+++ b/e2e/tests/components/hierarchy-bar/hierarchy-bar.e2e-spec.ts
@@ -3,8 +3,12 @@ import { HierarchyBarPage } from './hierarchy-bar.po.spec';
 
 describe('Hierarchy Bar Tests', () => {
 
-    let page: HierarchyBarPage = new HierarchyBarPage();
-    page.getPage();
+    let page: HierarchyBarPage;
+
+    beforeEach(() => {
+        page = new HierarchyBarPage();
+        page.getPage();
+    });
 
     it('should have correct initial states', async () => {
 

--- a/e2e/tests/components/number-picker/number-picker.e2e-spec.ts
+++ b/e2e/tests/components/number-picker/number-picker.e2e-spec.ts
@@ -2,150 +2,146 @@ import { NumberPickerPage } from './number-picker.po.spec';
 
 describe('Number Picker Tests', () => {
 
-  let page: NumberPickerPage;
-
-  beforeEach(() => {
-    page = new NumberPickerPage();
+    let page: NumberPickerPage = new NumberPickerPage();
     page.getPage();
-  });
 
-  it('should have correct initial states', () => {
-  
-    // Initial values.
-    expect(page.numberPicker1.isPresent()).toBeTruthy();
-    expect(page.numberPicker1.$('input').isPresent()).toBeTruthy();
-    expect<any>(page.getNumberPickerMinimum(page.numberPicker1)).toEqual('-10');
-    expect<any>(page.getNumberPickerMaximum(page.numberPicker1)).toEqual('10');
-    expect<any>(page.getNumberPickerStep(page.numberPicker1)).toEqual('1');
-    expect<any>(page.getNumberPickerValue(page.numberPicker1)).toEqual('0');
-    expect(page.confirmUpDownControlIsDisabled(page.numberPicker1, 'up')).toBeFalsy();
-    expect(page.confirmUpDownControlIsDisabled(page.numberPicker1, 'down')).toBeFalsy();
-    expect(page.confirmErrorMessage1IsVisible()).toBeFalsy();
-    
-    expect(page.numberPicker2.isPresent()).toBeTruthy();
-    expect(page.numberPicker2.$('input').isPresent()).toBeTruthy();
-    expect<any>(page.getNumberPickerMinimum(page.numberPicker2)).toEqual('0');
-    expect<any>(page.getNumberPickerMaximum(page.numberPicker2)).toEqual('10');
-    expect<any>(page.getNumberPickerStep(page.numberPicker2)).toEqual('0.5');
-    expect<any>(page.getNumberPickerValue(page.numberPicker2)).toEqual('0');
-    expect(page.confirmUpDownControlIsDisabled(page.numberPicker2, 'up')).toBeFalsy();
-    expect(page.confirmUpDownControlIsDisabled(page.numberPicker2, 'down')).toBeTruthy();
-    expect(page.confirmErrorMessage2IsVisible()).toBeFalsy();
-    
-  });
-  
-  it('should allow changes to the value by clicking', () => {
-      
-    // Number Picker 1
-    page.incrementNumberPickerValue(page.numberPicker1);
-    expect<any>(page.getNumberPickerValue(page.numberPicker1)).toEqual('1');
-    page.incrementNumberPickerValue(page.numberPicker1);
-    page.incrementNumberPickerValue(page.numberPicker1);
-    page.incrementNumberPickerValue(page.numberPicker1);
-    expect<any>(page.getNumberPickerValue(page.numberPicker1)).toEqual('4');
-    page.decrementNumberPickerValue(page.numberPicker1);
-    page.decrementNumberPickerValue(page.numberPicker1);
-    page.decrementNumberPickerValue(page.numberPicker1);
-    page.decrementNumberPickerValue(page.numberPicker1);
-    page.decrementNumberPickerValue(page.numberPicker1);
-    page.decrementNumberPickerValue(page.numberPicker1);
-    expect<any>(page.getNumberPickerValue(page.numberPicker1)).toEqual('-2');
-    page.incrementNumberPickerValue(page.numberPicker1);
-    page.incrementNumberPickerValue(page.numberPicker1);
-    page.incrementNumberPickerValue(page.numberPicker1);
-    expect<any>(page.getNumberPickerValue(page.numberPicker1)).toEqual('1');
-      
-    // Number Picker 2
-    page.incrementNumberPickerValue(page.numberPicker2);
-    expect<any>(page.getNumberPickerValue(page.numberPicker2)).toEqual('0.5');
-    page.incrementNumberPickerValue(page.numberPicker2);
-    page.incrementNumberPickerValue(page.numberPicker2);
-    page.incrementNumberPickerValue(page.numberPicker2);
-    expect<any>(page.getNumberPickerValue(page.numberPicker2)).toEqual('2');
-    page.decrementNumberPickerValue(page.numberPicker2);
-    page.decrementNumberPickerValue(page.numberPicker2);
-    page.decrementNumberPickerValue(page.numberPicker2);
-    expect<any>(page.getNumberPickerValue(page.numberPicker2)).toEqual('0.5');
-    page.decrementNumberPickerValue(page.numberPicker2);
-    expect<any>(page.getNumberPickerValue(page.numberPicker2)).toEqual('0');
-      
-  });
-  
-  it('should allow changes to the value by text entry', () => {
-      
-    // Number Picker 1
-    page.setNumberPickerValue(page.numberPicker1, '5');
-    expect<any>(page.getNumberPickerValue(page.numberPicker1)).toEqual('5');
-    page.setNumberPickerValue(page.numberPicker1, '10');
-    expect<any>(page.getNumberPickerValue(page.numberPicker1)).toEqual('10');
-    page.setNumberPickerValue(page.numberPicker1, '-10');
-    expect<any>(page.getNumberPickerValue(page.numberPicker1)).toEqual('-10');
-    page.setNumberPickerValue(page.numberPicker1, '15');
-    expect<any>(page.getNumberPickerValue(page.numberPicker1)).toEqual('15');
+    it('should have correct initial states', () => {
 
-    // Number Picker 2
-    page.setNumberPickerValue(page.numberPicker1, '5');
-    expect<any>(page.getNumberPickerValue(page.numberPicker1)).toEqual('5');
-    page.setNumberPickerValue(page.numberPicker1, '15');
-    expect<any>(page.getNumberPickerValue(page.numberPicker1)).toEqual('15');
-    page.setNumberPickerValue(page.numberPicker1, '-10');
-    expect<any>(page.getNumberPickerValue(page.numberPicker1)).toEqual('-10');
-      
-  });
-  
-  it('should display an error is the minimum limit is breached', () => {
-      
-    // Number Picker 1
-    page.setNumberPickerValue(page.numberPicker1, '-11');
-    expect(page.confirmErrorMessage1IsVisible()).toBeTruthy();
+        // Initial values.
+        expect(page.numberPicker1.isPresent()).toBeTruthy();
+        expect(page.numberPicker1.$('input').isPresent()).toBeTruthy();
+        expect<any>(page.getNumberPickerMinimum(page.numberPicker1)).toEqual('-10');
+        expect<any>(page.getNumberPickerMaximum(page.numberPicker1)).toEqual('10');
+        expect<any>(page.getNumberPickerStep(page.numberPicker1)).toEqual('1');
+        expect<any>(page.getNumberPickerValue(page.numberPicker1)).toEqual('0');
+        expect(page.confirmUpDownControlIsDisabled(page.numberPicker1, 'up')).toBeFalsy();
+        expect(page.confirmUpDownControlIsDisabled(page.numberPicker1, 'down')).toBeFalsy();
+        expect(page.confirmErrorMessage1IsVisible()).toBeFalsy();
 
-    // Number Picker 2
-    page.setNumberPickerValue(page.numberPicker2, '-0.5');
-    expect(page.confirmErrorMessage2IsVisible()).toBeTruthy();
-      
-  });
-  
-  it('should display an error is the maximum limit is breached', () => {
-      
-    // Number Picker 1
-    page.setNumberPickerValue(page.numberPicker1, '11');
-    expect(page.confirmErrorMessage1IsVisible()).toBeTruthy();
+        expect(page.numberPicker2.isPresent()).toBeTruthy();
+        expect(page.numberPicker2.$('input').isPresent()).toBeTruthy();
+        expect<any>(page.getNumberPickerMinimum(page.numberPicker2)).toEqual('0');
+        expect<any>(page.getNumberPickerMaximum(page.numberPicker2)).toEqual('10');
+        expect<any>(page.getNumberPickerStep(page.numberPicker2)).toEqual('0.5');
+        expect<any>(page.getNumberPickerValue(page.numberPicker2)).toEqual('0');
+        expect(page.confirmUpDownControlIsDisabled(page.numberPicker2, 'up')).toBeFalsy();
+        expect(page.confirmUpDownControlIsDisabled(page.numberPicker2, 'down')).toBeTruthy();
+        expect(page.confirmErrorMessage2IsVisible()).toBeFalsy();
 
-    // Number Picker 2
-    page.setNumberPickerValue(page.numberPicker2, '10.5');
-    expect(page.confirmErrorMessage2IsVisible()).toBeTruthy();
-      
-  });
-  
-  it('should prevent changes by clicking if the minimum limit has been reached', () => {
-      
-    // Number Picker 1
-    page.setNumberPickerValue(page.numberPicker1, '-9');
-    page.decrementNumberPickerValue(page.numberPicker1);
-    expect(page.confirmUpDownControlIsDisabled(page.numberPicker1, 'up')).toBeFalsy();
-    expect(page.confirmUpDownControlIsDisabled(page.numberPicker1, 'down')).toBeTruthy();
+    });
 
-    // Number Picker 2
-    page.setNumberPickerValue(page.numberPicker2, '0.5');
-    page.decrementNumberPickerValue(page.numberPicker2);
-    expect(page.confirmUpDownControlIsDisabled(page.numberPicker2, 'up')).toBeFalsy();
-    expect(page.confirmUpDownControlIsDisabled(page.numberPicker2, 'down')).toBeTruthy();
-      
-  });
-  
-  it('should prevent changes by clicking if the maximum limit has been reached', () => {
-      
-    // Number Picker 1
-    page.setNumberPickerValue(page.numberPicker1, '9');
-    page.incrementNumberPickerValue(page.numberPicker1);
-    expect(page.confirmUpDownControlIsDisabled(page.numberPicker1, 'up')).toBeTruthy();
-    expect(page.confirmUpDownControlIsDisabled(page.numberPicker1, 'down')).toBeFalsy();
+    it('should allow changes to the value by clicking', () => {
 
-    // Number Picker 2
-    page.setNumberPickerValue(page.numberPicker2, '9.5');
-    page.incrementNumberPickerValue(page.numberPicker2);
-    expect(page.confirmUpDownControlIsDisabled(page.numberPicker2, 'up')).toBeTruthy();
-    expect(page.confirmUpDownControlIsDisabled(page.numberPicker2, 'down')).toBeFalsy();
-      
-  });
+        // Number Picker 1
+        page.incrementNumberPickerValue(page.numberPicker1);
+        expect<any>(page.getNumberPickerValue(page.numberPicker1)).toEqual('1');
+        page.incrementNumberPickerValue(page.numberPicker1);
+        page.incrementNumberPickerValue(page.numberPicker1);
+        page.incrementNumberPickerValue(page.numberPicker1);
+        expect<any>(page.getNumberPickerValue(page.numberPicker1)).toEqual('4');
+        page.decrementNumberPickerValue(page.numberPicker1);
+        page.decrementNumberPickerValue(page.numberPicker1);
+        page.decrementNumberPickerValue(page.numberPicker1);
+        page.decrementNumberPickerValue(page.numberPicker1);
+        page.decrementNumberPickerValue(page.numberPicker1);
+        page.decrementNumberPickerValue(page.numberPicker1);
+        expect<any>(page.getNumberPickerValue(page.numberPicker1)).toEqual('-2');
+        page.incrementNumberPickerValue(page.numberPicker1);
+        page.incrementNumberPickerValue(page.numberPicker1);
+        page.incrementNumberPickerValue(page.numberPicker1);
+        expect<any>(page.getNumberPickerValue(page.numberPicker1)).toEqual('1');
+
+        // Number Picker 2
+        page.incrementNumberPickerValue(page.numberPicker2);
+        expect<any>(page.getNumberPickerValue(page.numberPicker2)).toEqual('0.5');
+        page.incrementNumberPickerValue(page.numberPicker2);
+        page.incrementNumberPickerValue(page.numberPicker2);
+        page.incrementNumberPickerValue(page.numberPicker2);
+        expect<any>(page.getNumberPickerValue(page.numberPicker2)).toEqual('2');
+        page.decrementNumberPickerValue(page.numberPicker2);
+        page.decrementNumberPickerValue(page.numberPicker2);
+        page.decrementNumberPickerValue(page.numberPicker2);
+        expect<any>(page.getNumberPickerValue(page.numberPicker2)).toEqual('0.5');
+        page.decrementNumberPickerValue(page.numberPicker2);
+        expect<any>(page.getNumberPickerValue(page.numberPicker2)).toEqual('0');
+
+    });
+
+    it('should allow changes to the value by text entry', () => {
+
+        // Number Picker 1
+        page.setNumberPickerValue(page.numberPicker1, '5');
+        expect<any>(page.getNumberPickerValue(page.numberPicker1)).toEqual('5');
+        page.setNumberPickerValue(page.numberPicker1, '10');
+        expect<any>(page.getNumberPickerValue(page.numberPicker1)).toEqual('10');
+        page.setNumberPickerValue(page.numberPicker1, '-10');
+        expect<any>(page.getNumberPickerValue(page.numberPicker1)).toEqual('-10');
+        page.setNumberPickerValue(page.numberPicker1, '15');
+        expect<any>(page.getNumberPickerValue(page.numberPicker1)).toEqual('15');
+
+        // Number Picker 2
+        page.setNumberPickerValue(page.numberPicker1, '5');
+        expect<any>(page.getNumberPickerValue(page.numberPicker1)).toEqual('5');
+        page.setNumberPickerValue(page.numberPicker1, '15');
+        expect<any>(page.getNumberPickerValue(page.numberPicker1)).toEqual('15');
+        page.setNumberPickerValue(page.numberPicker1, '-10');
+        expect<any>(page.getNumberPickerValue(page.numberPicker1)).toEqual('-10');
+
+    });
+
+    it('should display an error is the minimum limit is breached', () => {
+
+        // Number Picker 1
+        page.setNumberPickerValue(page.numberPicker1, '-11');
+        expect(page.confirmErrorMessage1IsVisible()).toBeTruthy();
+
+        // Number Picker 2
+        page.setNumberPickerValue(page.numberPicker2, '-0.5');
+        expect(page.confirmErrorMessage2IsVisible()).toBeTruthy();
+
+    });
+
+    it('should display an error is the maximum limit is breached', () => {
+
+        // Number Picker 1
+        page.setNumberPickerValue(page.numberPicker1, '11');
+        expect(page.confirmErrorMessage1IsVisible()).toBeTruthy();
+
+        // Number Picker 2
+        page.setNumberPickerValue(page.numberPicker2, '10.5');
+        expect(page.confirmErrorMessage2IsVisible()).toBeTruthy();
+
+    });
+
+    it('should prevent changes by clicking if the minimum limit has been reached', () => {
+
+        // Number Picker 1
+        page.setNumberPickerValue(page.numberPicker1, '-9');
+        page.decrementNumberPickerValue(page.numberPicker1);
+        expect(page.confirmUpDownControlIsDisabled(page.numberPicker1, 'up')).toBeFalsy();
+        expect(page.confirmUpDownControlIsDisabled(page.numberPicker1, 'down')).toBeTruthy();
+
+        // Number Picker 2
+        page.setNumberPickerValue(page.numberPicker2, '0.5');
+        page.decrementNumberPickerValue(page.numberPicker2);
+        expect(page.confirmUpDownControlIsDisabled(page.numberPicker2, 'up')).toBeFalsy();
+        expect(page.confirmUpDownControlIsDisabled(page.numberPicker2, 'down')).toBeTruthy();
+
+    });
+
+    it('should prevent changes by clicking if the maximum limit has been reached', () => {
+
+        // Number Picker 1
+        page.setNumberPickerValue(page.numberPicker1, '9');
+        page.incrementNumberPickerValue(page.numberPicker1);
+        expect(page.confirmUpDownControlIsDisabled(page.numberPicker1, 'up')).toBeTruthy();
+        expect(page.confirmUpDownControlIsDisabled(page.numberPicker1, 'down')).toBeFalsy();
+
+        // Number Picker 2
+        page.setNumberPickerValue(page.numberPicker2, '9.5');
+        page.incrementNumberPickerValue(page.numberPicker2);
+        expect(page.confirmUpDownControlIsDisabled(page.numberPicker2, 'up')).toBeTruthy();
+        expect(page.confirmUpDownControlIsDisabled(page.numberPicker2, 'down')).toBeFalsy();
+
+    });
 });

--- a/e2e/tests/components/pagination/pagination.e2e-spec.ts
+++ b/e2e/tests/components/pagination/pagination.e2e-spec.ts
@@ -2,170 +2,171 @@ import { PaginationPage } from './pagination.po.spec';
 
 describe('Pagination Tests', () => {
 
-  let page: PaginationPage;
-
-  beforeEach(() => {
-    page = new PaginationPage();
+    let page: PaginationPage = new PaginationPage();
     page.getPage();
-  });
 
-  it('should have correct initial states', () => {
-      
-    // button states
-    expect(page.confirmButtonIsDisabled(page.getButton(0))).toBeTruthy();
-    expect(page.confirmButtonIsActive(page.getButton(1))).toBeTruthy();
-    expect(page.confirmButtonIsActive(page.getButton(2))).toBeFalsy();
-    expect(page.confirmButtonIsActive(page.getButton(3))).toBeFalsy();
-    expect(page.confirmButtonIsActive(page.getButton(4))).toBeFalsy();
-    expect(page.confirmButtonIsActive(page.getButton(5))).toBeFalsy();
-    expect(page.confirmButtonIsDisabled(page.getButton(6))).toBeFalsy();
+    it('should have correct initial states', async () => {
 
-    // button numbers
-    expect<any>(page.getButton(1).getText()).toBe('1');
-    expect<any>(page.getButton(2).getText()).toBe('2');
-    expect<any>(page.getButton(3).getText()).toBe('3');
-    expect<any>(page.getButton(4).getText()).toBe('4');
-    expect<any>(page.getButton(5).getText()).toBe('5');
-    
-    // page number
-    expect<any>(page.text.getText()).toBe('Page 1 of 10');
-    
-  });
+        // button states
+        expect(page.confirmButtonIsDisabled(page.getButton(0))).toBeTruthy();
+        expect(page.confirmButtonIsActive(page.getButton(1))).toBeTruthy();
+        expect(page.confirmButtonIsActive(page.getButton(2))).toBeFalsy();
+        expect(page.confirmButtonIsActive(page.getButton(3))).toBeFalsy();
+        expect(page.confirmButtonIsActive(page.getButton(4))).toBeFalsy();
+        expect(page.confirmButtonIsActive(page.getButton(5))).toBeFalsy();
+        expect(page.confirmButtonIsDisabled(page.getButton(6))).toBeFalsy();
 
-  it('should react to arrow clicks', () => {
-      
-    page.clickButton(6);
-    page.clickButton(6);
-    page.clickButton(6);
-    expect(page.confirmButtonIsActive(page.getButton(1))).toBeFalsy();
-    expect(page.confirmButtonIsActive(page.getButton(2))).toBeFalsy();
-    expect(page.confirmButtonIsActive(page.getButton(3))).toBeTruthy();
-    expect(page.confirmButtonIsActive(page.getButton(4))).toBeFalsy();
-    expect(page.confirmButtonIsActive(page.getButton(5))).toBeFalsy();
-    expect<any>(page.text.getText()).toBe('Page 4 of 10');
-    
-    page.clickButton(0);
-    page.clickButton(0);
-    expect(page.confirmButtonIsActive(page.getButton(1))).toBeFalsy();
-    expect(page.confirmButtonIsActive(page.getButton(2))).toBeTruthy();
-    expect(page.confirmButtonIsActive(page.getButton(3))).toBeFalsy();
-    expect(page.confirmButtonIsActive(page.getButton(4))).toBeFalsy();
-    expect(page.confirmButtonIsActive(page.getButton(5))).toBeFalsy();
-    expect<any>(page.text.getText()).toBe('Page 2 of 10');
-    
-  });
+        // button numbers
+        expect<any>(page.getButton(1).getText()).toBe('1');
+        expect<any>(page.getButton(2).getText()).toBe('2');
+        expect<any>(page.getButton(3).getText()).toBe('3');
+        expect<any>(page.getButton(4).getText()).toBe('4');
+        expect<any>(page.getButton(5).getText()).toBe('5');
 
-  it('should react to numbered button clicks', () => {
-      
-    page.clickButton(2);
-    expect(page.confirmButtonIsActive(page.getButton(1))).toBeFalsy();
-    expect(page.confirmButtonIsActive(page.getButton(2))).toBeTruthy();
-    expect(page.confirmButtonIsActive(page.getButton(3))).toBeFalsy();
-    expect(page.confirmButtonIsActive(page.getButton(4))).toBeFalsy();
-    expect(page.confirmButtonIsActive(page.getButton(5))).toBeFalsy();
-    expect<any>(page.text.getText()).toBe('Page 2 of 10');
+        // page number
+        expect<any>(page.text.getText()).toBe('Page 1 of 10');
 
-    page.clickButton(1);
-    expect(page.confirmButtonIsActive(page.getButton(1))).toBeTruthy();
-    expect(page.confirmButtonIsActive(page.getButton(2))).toBeFalsy();
-    expect(page.confirmButtonIsActive(page.getButton(3))).toBeFalsy();
-    expect(page.confirmButtonIsActive(page.getButton(4))).toBeFalsy();
-    expect(page.confirmButtonIsActive(page.getButton(5))).toBeFalsy();
-    expect<any>(page.text.getText()).toBe('Page 1 of 10');
+        await page.resetBtn.click();
+    });
 
-    page.clickButton(3);
-    page.clickButton(5);
-    page.clickButton(4);
-    expect(page.confirmButtonIsActive(page.getButton(1))).toBeFalsy();
-    expect(page.confirmButtonIsActive(page.getButton(2))).toBeFalsy();
-    expect(page.confirmButtonIsActive(page.getButton(3))).toBeTruthy();
-    expect(page.confirmButtonIsActive(page.getButton(4))).toBeFalsy();
-    expect(page.confirmButtonIsActive(page.getButton(5))).toBeFalsy();
-    expect<any>(page.text.getText()).toBe('Page 6 of 10');
-    
-  });
+    it('should react to arrow clicks', async () => {
 
-  it('should disable arrow buttons when appropriate', () => {
-      
-    page.clickButton(2);
-    page.clickButton(1);
-    expect(page.confirmButtonIsDisabled(page.getButton(0))).toBeTruthy();
-    expect(page.confirmButtonIsDisabled(page.getButton(6))).toBeFalsy();
+        page.clickButton(6);
+        page.clickButton(6);
+        page.clickButton(6);
+        expect(page.confirmButtonIsActive(page.getButton(1))).toBeFalsy();
+        expect(page.confirmButtonIsActive(page.getButton(2))).toBeFalsy();
+        expect(page.confirmButtonIsActive(page.getButton(3))).toBeTruthy();
+        expect(page.confirmButtonIsActive(page.getButton(4))).toBeFalsy();
+        expect(page.confirmButtonIsActive(page.getButton(5))).toBeFalsy();
+        expect<any>(page.text.getText()).toBe('Page 4 of 10');
 
-    page.clickButton(5);
-    page.clickButton(5);
-    page.clickButton(5);
-    page.clickButton(5);
-    expect(page.confirmButtonIsDisabled(page.getButton(0))).toBeFalsy();
-    expect(page.confirmButtonIsDisabled(page.getButton(6))).toBeTruthy();
-    
-  });
+        page.clickButton(0);
+        page.clickButton(0);
+        expect(page.confirmButtonIsActive(page.getButton(1))).toBeFalsy();
+        expect(page.confirmButtonIsActive(page.getButton(2))).toBeTruthy();
+        expect(page.confirmButtonIsActive(page.getButton(3))).toBeFalsy();
+        expect(page.confirmButtonIsActive(page.getButton(4))).toBeFalsy();
+        expect(page.confirmButtonIsActive(page.getButton(5))).toBeFalsy();
+        expect<any>(page.text.getText()).toBe('Page 2 of 10');
 
-  it('should move the selected number to the centre when possible', () => {
-      
-    // page 2
-    page.clickButton(2);
-    expect<any>(page.getButton(1).getText()).toBe('1');
-    expect<any>(page.getButton(2).getText()).toBe('2');
-    expect<any>(page.getButton(3).getText()).toBe('3');
-    expect<any>(page.getButton(4).getText()).toBe('4');
-    expect<any>(page.getButton(5).getText()).toBe('5');
-    
-    // page 3
-    page.clickButton(3);
-    expect<any>(page.getButton(1).getText()).toBe('1');
-    expect<any>(page.getButton(2).getText()).toBe('2');
-    expect<any>(page.getButton(3).getText()).toBe('3');
-    expect<any>(page.getButton(4).getText()).toBe('4');
-    expect<any>(page.getButton(5).getText()).toBe('5');
-    
-    // page 4
-    page.clickButton(4);
-    expect<any>(page.getButton(1).getText()).toBe('2');
-    expect<any>(page.getButton(2).getText()).toBe('3');
-    expect<any>(page.getButton(3).getText()).toBe('4');
-    expect<any>(page.getButton(4).getText()).toBe('5');
-    expect<any>(page.getButton(5).getText()).toBe('6');
-    
-    // page 6
-    page.clickButton(5);
-    expect<any>(page.getButton(1).getText()).toBe('4');
-    expect<any>(page.getButton(2).getText()).toBe('5');
-    expect<any>(page.getButton(3).getText()).toBe('6');
-    expect<any>(page.getButton(4).getText()).toBe('7');
-    expect<any>(page.getButton(5).getText()).toBe('8');
-    
-    // page 8
-    page.clickButton(5);
-    expect<any>(page.getButton(1).getText()).toBe('6');
-    expect<any>(page.getButton(2).getText()).toBe('7');
-    expect<any>(page.getButton(3).getText()).toBe('8');
-    expect<any>(page.getButton(4).getText()).toBe('9');
-    expect<any>(page.getButton(5).getText()).toBe('10');
-    
-    // page 10
-    page.clickButton(5);
-    expect<any>(page.getButton(1).getText()).toBe('6');
-    expect<any>(page.getButton(2).getText()).toBe('7');
-    expect<any>(page.getButton(3).getText()).toBe('8');
-    expect<any>(page.getButton(4).getText()).toBe('9');
-    expect<any>(page.getButton(5).getText()).toBe('10');
-    
-    // page 9
-    page.clickButton(4);
-    expect<any>(page.getButton(1).getText()).toBe('6');
-    expect<any>(page.getButton(2).getText()).toBe('7');
-    expect<any>(page.getButton(3).getText()).toBe('8');
-    expect<any>(page.getButton(4).getText()).toBe('9');
-    expect<any>(page.getButton(5).getText()).toBe('10');
-    
-    // page 6
-    page.clickButton(1);
-    expect<any>(page.getButton(1).getText()).toBe('4');
-    expect<any>(page.getButton(2).getText()).toBe('5');
-    expect<any>(page.getButton(3).getText()).toBe('6');
-    expect<any>(page.getButton(4).getText()).toBe('7');
-    expect<any>(page.getButton(5).getText()).toBe('8');
-    
-  });
+        await page.resetBtn.click();
+    });
+
+    it('should react to numbered button clicks', async () => {
+
+        page.clickButton(2);
+        expect(page.confirmButtonIsActive(page.getButton(1))).toBeFalsy();
+        expect(page.confirmButtonIsActive(page.getButton(2))).toBeTruthy();
+        expect(page.confirmButtonIsActive(page.getButton(3))).toBeFalsy();
+        expect(page.confirmButtonIsActive(page.getButton(4))).toBeFalsy();
+        expect(page.confirmButtonIsActive(page.getButton(5))).toBeFalsy();
+        expect<any>(page.text.getText()).toBe('Page 2 of 10');
+
+        page.clickButton(1);
+        expect(page.confirmButtonIsActive(page.getButton(1))).toBeTruthy();
+        expect(page.confirmButtonIsActive(page.getButton(2))).toBeFalsy();
+        expect(page.confirmButtonIsActive(page.getButton(3))).toBeFalsy();
+        expect(page.confirmButtonIsActive(page.getButton(4))).toBeFalsy();
+        expect(page.confirmButtonIsActive(page.getButton(5))).toBeFalsy();
+        expect<any>(page.text.getText()).toBe('Page 1 of 10');
+
+        page.clickButton(3);
+        page.clickButton(5);
+        page.clickButton(4);
+        expect(page.confirmButtonIsActive(page.getButton(1))).toBeFalsy();
+        expect(page.confirmButtonIsActive(page.getButton(2))).toBeFalsy();
+        expect(page.confirmButtonIsActive(page.getButton(3))).toBeTruthy();
+        expect(page.confirmButtonIsActive(page.getButton(4))).toBeFalsy();
+        expect(page.confirmButtonIsActive(page.getButton(5))).toBeFalsy();
+        expect<any>(page.text.getText()).toBe('Page 6 of 10');
+
+        await page.resetBtn.click();
+    });
+
+    it('should disable arrow buttons when appropriate', async () => {
+
+        page.clickButton(2);
+        page.clickButton(1);
+        expect(page.confirmButtonIsDisabled(page.getButton(0))).toBeTruthy();
+        expect(page.confirmButtonIsDisabled(page.getButton(6))).toBeFalsy();
+
+        page.clickButton(5);
+        page.clickButton(5);
+        page.clickButton(5);
+        page.clickButton(5);
+        expect(page.confirmButtonIsDisabled(page.getButton(0))).toBeFalsy();
+        expect(page.confirmButtonIsDisabled(page.getButton(6))).toBeTruthy();
+
+        await page.resetBtn.click();
+    });
+
+    it('should move the selected number to the centre when possible', async () => {
+
+        // page 2
+        page.clickButton(2);
+        expect<any>(page.getButton(1).getText()).toBe('1');
+        expect<any>(page.getButton(2).getText()).toBe('2');
+        expect<any>(page.getButton(3).getText()).toBe('3');
+        expect<any>(page.getButton(4).getText()).toBe('4');
+        expect<any>(page.getButton(5).getText()).toBe('5');
+
+        // page 3
+        page.clickButton(3);
+        expect<any>(page.getButton(1).getText()).toBe('1');
+        expect<any>(page.getButton(2).getText()).toBe('2');
+        expect<any>(page.getButton(3).getText()).toBe('3');
+        expect<any>(page.getButton(4).getText()).toBe('4');
+        expect<any>(page.getButton(5).getText()).toBe('5');
+
+        // page 4
+        page.clickButton(4);
+        expect<any>(page.getButton(1).getText()).toBe('2');
+        expect<any>(page.getButton(2).getText()).toBe('3');
+        expect<any>(page.getButton(3).getText()).toBe('4');
+        expect<any>(page.getButton(4).getText()).toBe('5');
+        expect<any>(page.getButton(5).getText()).toBe('6');
+
+        // page 6
+        page.clickButton(5);
+        expect<any>(page.getButton(1).getText()).toBe('4');
+        expect<any>(page.getButton(2).getText()).toBe('5');
+        expect<any>(page.getButton(3).getText()).toBe('6');
+        expect<any>(page.getButton(4).getText()).toBe('7');
+        expect<any>(page.getButton(5).getText()).toBe('8');
+
+        // page 8
+        page.clickButton(5);
+        expect<any>(page.getButton(1).getText()).toBe('6');
+        expect<any>(page.getButton(2).getText()).toBe('7');
+        expect<any>(page.getButton(3).getText()).toBe('8');
+        expect<any>(page.getButton(4).getText()).toBe('9');
+        expect<any>(page.getButton(5).getText()).toBe('10');
+
+        // page 10
+        page.clickButton(5);
+        expect<any>(page.getButton(1).getText()).toBe('6');
+        expect<any>(page.getButton(2).getText()).toBe('7');
+        expect<any>(page.getButton(3).getText()).toBe('8');
+        expect<any>(page.getButton(4).getText()).toBe('9');
+        expect<any>(page.getButton(5).getText()).toBe('10');
+
+        // page 9
+        page.clickButton(4);
+        expect<any>(page.getButton(1).getText()).toBe('6');
+        expect<any>(page.getButton(2).getText()).toBe('7');
+        expect<any>(page.getButton(3).getText()).toBe('8');
+        expect<any>(page.getButton(4).getText()).toBe('9');
+        expect<any>(page.getButton(5).getText()).toBe('10');
+
+        // page 6
+        page.clickButton(1);
+        expect<any>(page.getButton(1).getText()).toBe('4');
+        expect<any>(page.getButton(2).getText()).toBe('5');
+        expect<any>(page.getButton(3).getText()).toBe('6');
+        expect<any>(page.getButton(4).getText()).toBe('7');
+        expect<any>(page.getButton(5).getText()).toBe('8');
+
+        await page.resetBtn.click();
+    });
 });

--- a/e2e/tests/components/pagination/pagination.po.spec.ts
+++ b/e2e/tests/components/pagination/pagination.po.spec.ts
@@ -1,33 +1,28 @@
-import { browser, element, by , ElementFinder} from 'protractor';
+import { browser, by, element, ElementFinder } from 'protractor';
 
 export class PaginationPage {
-        
+
     getPage(): void {
         browser.get('#/pagination');
     }
 
     pagination = element(by.id('pagination'));
     text = element(by.id('text'));
+    resetBtn = element(by.id('reset-button'));
 
-    confirmButtonClassExists(item: ElementFinder, soughtClass: string) {
-        return item.getAttribute('class').then(function(classes: string) {
-            var allClasses = classes.split(' ');
-            if (allClasses.indexOf(soughtClass) > -1) {
-                return true;
-            } else {
-                return false;
-            }
-        });
+    async confirmButtonClassExists(item: ElementFinder, soughtClass: string) {
+        const classes = await item.getAttribute('class');
+        return classes.split(' ').indexOf(soughtClass) > -1;
     }
-   
+
     confirmButtonIsActive(item: ElementFinder) {
         return this.confirmButtonClassExists(item, 'active');
     }
-    
+
     confirmButtonIsDisabled(item: ElementFinder) {
         return this.confirmButtonClassExists(item, 'disabled');
     }
-    
+
     getButton(index: number) {
         return this.pagination.$('ul.pagination').$$('li.page-item').get(index);
     }

--- a/e2e/tests/components/radiobuttons/radiobuttons.e2e-spec.ts
+++ b/e2e/tests/components/radiobuttons/radiobuttons.e2e-spec.ts
@@ -3,120 +3,116 @@ import { RadioButtonsPage } from './radiobuttons.po.spec';
 
 describe('RadioButton Tests', () => {
 
-  let page: RadioButtonsPage;
-
-  beforeEach(() => {
-    page = new RadioButtonsPage();
+    let page: RadioButtonsPage = new RadioButtonsPage();
     page.getPage();
-  });
 
-  it('should have correct initial states', () => {
-  
-    // Initial values.
-    expect(page.confirmIsChecked(page.radiobutton1)).toBeTruthy();
-    expect(page.confirmIsChecked(page.radiobutton2)).toBeFalsy();
-    expect(page.confirmIsChecked(page.radiobutton3)).toBeFalsy();
-    expect(page.confirmIsChecked(page.radiobutton4)).toBeFalsy();
-    expect<any>(page.text1.getText()).toBe('100');
+    it('should have correct initial states', () => {
 
-    // All enabled.
-    expect(page.confirmIsDisabled(page.radiobutton1)).toBeFalsy();
-    expect(page.confirmIsDisabled(page.radiobutton2)).toBeFalsy();
-    expect(page.confirmIsDisabled(page.radiobutton3)).toBeFalsy();
-    expect(page.confirmIsDisabled(page.radiobutton4)).toBeFalsy();
+        // Initial values.
+        expect(page.confirmIsChecked(page.radiobutton1)).toBeTruthy();
+        expect(page.confirmIsChecked(page.radiobutton2)).toBeFalsy();
+        expect(page.confirmIsChecked(page.radiobutton3)).toBeFalsy();
+        expect(page.confirmIsChecked(page.radiobutton4)).toBeFalsy();
+        expect<any>(page.text1.getText()).toBe('100');
 
-    // None with simplified style.
-    expect(page.confirmIsSimplified(page.radiobutton1)).toBeFalsy();
-    expect(page.confirmIsSimplified(page.radiobutton2)).toBeFalsy();
-    expect(page.confirmIsSimplified(page.radiobutton3)).toBeFalsy();
-    expect(page.confirmIsSimplified(page.radiobutton4)).toBeFalsy();
-    
-  });
+        // All enabled.
+        expect(page.confirmIsDisabled(page.radiobutton1)).toBeFalsy();
+        expect(page.confirmIsDisabled(page.radiobutton2)).toBeFalsy();
+        expect(page.confirmIsDisabled(page.radiobutton3)).toBeFalsy();
+        expect(page.confirmIsDisabled(page.radiobutton4)).toBeFalsy();
 
-  it('should react to clicks', () => {
-  
-    page.radiobutton2.click();
+        // None with simplified style.
+        expect(page.confirmIsSimplified(page.radiobutton1)).toBeFalsy();
+        expect(page.confirmIsSimplified(page.radiobutton2)).toBeFalsy();
+        expect(page.confirmIsSimplified(page.radiobutton3)).toBeFalsy();
+        expect(page.confirmIsSimplified(page.radiobutton4)).toBeFalsy();
 
-    expect(page.confirmIsChecked(page.radiobutton1)).toBeFalsy();
-    expect(page.confirmIsChecked(page.radiobutton2)).toBeTruthy();
-    expect(page.confirmIsChecked(page.radiobutton3)).toBeFalsy();
-    expect(page.confirmIsChecked(page.radiobutton4)).toBeFalsy();
-    expect<any>(page.text1.getText()).toBe('string');
+    });
 
-    page.radiobutton3.click();
+    it('should react to clicks', () => {
 
-    expect(page.confirmIsChecked(page.radiobutton1)).toBeFalsy();
-    expect(page.confirmIsChecked(page.radiobutton2)).toBeFalsy();
-    expect(page.confirmIsChecked(page.radiobutton3)).toBeTruthy();
-    expect(page.confirmIsChecked(page.radiobutton4)).toBeFalsy();
-    expect<any>(page.text1.getText()).toBe('[object Object]');
+        page.radiobutton2.click();
 
-    page.radiobutton4.click();
+        expect(page.confirmIsChecked(page.radiobutton1)).toBeFalsy();
+        expect(page.confirmIsChecked(page.radiobutton2)).toBeTruthy();
+        expect(page.confirmIsChecked(page.radiobutton3)).toBeFalsy();
+        expect(page.confirmIsChecked(page.radiobutton4)).toBeFalsy();
+        expect<any>(page.text1.getText()).toBe('string');
 
-    expect(page.confirmIsChecked(page.radiobutton1)).toBeFalsy();
-    expect(page.confirmIsChecked(page.radiobutton2)).toBeFalsy();
-    expect(page.confirmIsChecked(page.radiobutton3)).toBeFalsy();
-    expect(page.confirmIsChecked(page.radiobutton4)).toBeTruthy();
-    expect<any>(page.text1.getText()).toBe('Wrap-Text');
+        page.radiobutton3.click();
 
-    page.radiobutton1.click();
+        expect(page.confirmIsChecked(page.radiobutton1)).toBeFalsy();
+        expect(page.confirmIsChecked(page.radiobutton2)).toBeFalsy();
+        expect(page.confirmIsChecked(page.radiobutton3)).toBeTruthy();
+        expect(page.confirmIsChecked(page.radiobutton4)).toBeFalsy();
+        expect<any>(page.text1.getText()).toBe('[object Object]');
 
-    expect(page.confirmIsChecked(page.radiobutton1)).toBeTruthy();
-    expect(page.confirmIsChecked(page.radiobutton2)).toBeFalsy();
-    expect(page.confirmIsChecked(page.radiobutton3)).toBeFalsy();
-    expect(page.confirmIsChecked(page.radiobutton4)).toBeFalsy();
-    expect<any>(page.text1.getText()).toBe('100');
-    
-  });
+        page.radiobutton4.click();
 
-  it('should react to disabling', () => {
-  
-    page.disableFirstButton.click();
+        expect(page.confirmIsChecked(page.radiobutton1)).toBeFalsy();
+        expect(page.confirmIsChecked(page.radiobutton2)).toBeFalsy();
+        expect(page.confirmIsChecked(page.radiobutton3)).toBeFalsy();
+        expect(page.confirmIsChecked(page.radiobutton4)).toBeTruthy();
+        expect<any>(page.text1.getText()).toBe('Wrap-Text');
 
-    expect(page.confirmIsDisabled(page.radiobutton1)).toBeTruthy();
-    expect(page.confirmIsDisabled(page.radiobutton2)).toBeFalsy();
-    expect(page.confirmIsDisabled(page.radiobutton3)).toBeFalsy();
-    expect(page.confirmIsDisabled(page.radiobutton4)).toBeFalsy();
-    expect<any>(page.text1.getText()).toBe('100');
+        page.radiobutton1.click();
 
-    page.radiobutton1.click();
+        expect(page.confirmIsChecked(page.radiobutton1)).toBeTruthy();
+        expect(page.confirmIsChecked(page.radiobutton2)).toBeFalsy();
+        expect(page.confirmIsChecked(page.radiobutton3)).toBeFalsy();
+        expect(page.confirmIsChecked(page.radiobutton4)).toBeFalsy();
+        expect<any>(page.text1.getText()).toBe('100');
 
-    expect(page.confirmIsChecked(page.radiobutton1)).toBeTruthy();
-    expect(page.confirmIsChecked(page.radiobutton2)).toBeFalsy();
-    expect(page.confirmIsChecked(page.radiobutton3)).toBeFalsy();
-    expect(page.confirmIsChecked(page.radiobutton4)).toBeFalsy();
-    expect<any>(page.text1.getText()).toBe('100');
+    });
 
-    page.radiobutton4.click();
+    it('should react to disabling', () => {
 
-    expect(page.confirmIsChecked(page.radiobutton1)).toBeFalsy();
-    expect(page.confirmIsChecked(page.radiobutton2)).toBeFalsy();
-    expect(page.confirmIsChecked(page.radiobutton3)).toBeFalsy();
-    expect(page.confirmIsChecked(page.radiobutton4)).toBeTruthy();
-    expect<any>(page.text1.getText()).toBe('Wrap-Text');
-    
-  });
+        page.disableFirstButton.click();
 
-  it('should react to setting to simplified style', () => {
-  
-    page.changeToSimplified.click();
+        expect(page.confirmIsDisabled(page.radiobutton1)).toBeTruthy();
+        expect(page.confirmIsDisabled(page.radiobutton2)).toBeFalsy();
+        expect(page.confirmIsDisabled(page.radiobutton3)).toBeFalsy();
+        expect(page.confirmIsDisabled(page.radiobutton4)).toBeFalsy();
+        expect<any>(page.text1.getText()).toBe('100');
 
-    expect(page.confirmIsSimplified(page.radiobutton1)).toBeTruthy();
-    expect(page.confirmIsSimplified(page.radiobutton2)).toBeTruthy();
-    expect(page.confirmIsSimplified(page.radiobutton3)).toBeTruthy();
-    expect(page.confirmIsSimplified(page.radiobutton4)).toBeTruthy();
-    
-  });
+        page.radiobutton1.click();
 
-  it('should toggle the radio button when pressing space', () => {
-  
-    page.toggleByKey(page.radiobutton2, Key.SPACE);
+        expect(page.confirmIsChecked(page.radiobutton1)).toBeTruthy();
+        expect(page.confirmIsChecked(page.radiobutton2)).toBeFalsy();
+        expect(page.confirmIsChecked(page.radiobutton3)).toBeFalsy();
+        expect(page.confirmIsChecked(page.radiobutton4)).toBeFalsy();
+        expect<any>(page.text1.getText()).toBe('100');
 
-    expect(page.confirmIsChecked(page.radiobutton1)).toBeFalsy();
-    expect(page.confirmIsChecked(page.radiobutton2)).toBeTruthy();
-    expect(page.confirmIsChecked(page.radiobutton3)).toBeFalsy();
-    expect(page.confirmIsChecked(page.radiobutton4)).toBeFalsy();
-    expect<any>(page.text1.getText()).toBe('string');
-    
-  });
+        page.radiobutton4.click();
+
+        expect(page.confirmIsChecked(page.radiobutton1)).toBeFalsy();
+        expect(page.confirmIsChecked(page.radiobutton2)).toBeFalsy();
+        expect(page.confirmIsChecked(page.radiobutton3)).toBeFalsy();
+        expect(page.confirmIsChecked(page.radiobutton4)).toBeTruthy();
+        expect<any>(page.text1.getText()).toBe('Wrap-Text');
+
+    });
+
+    it('should react to setting to simplified style', () => {
+
+        page.changeToSimplified.click();
+
+        expect(page.confirmIsSimplified(page.radiobutton1)).toBeTruthy();
+        expect(page.confirmIsSimplified(page.radiobutton2)).toBeTruthy();
+        expect(page.confirmIsSimplified(page.radiobutton3)).toBeTruthy();
+        expect(page.confirmIsSimplified(page.radiobutton4)).toBeTruthy();
+
+    });
+
+    it('should toggle the radio button when pressing space', () => {
+
+        page.toggleByKey(page.radiobutton2, Key.SPACE);
+
+        expect(page.confirmIsChecked(page.radiobutton1)).toBeFalsy();
+        expect(page.confirmIsChecked(page.radiobutton2)).toBeTruthy();
+        expect(page.confirmIsChecked(page.radiobutton3)).toBeFalsy();
+        expect(page.confirmIsChecked(page.radiobutton4)).toBeFalsy();
+        expect<any>(page.text1.getText()).toBe('string');
+
+    });
 });

--- a/e2e/tests/components/select-list/select-list.e2e-spec.ts
+++ b/e2e/tests/components/select-list/select-list.e2e-spec.ts
@@ -3,12 +3,8 @@ import { SelectListPage } from './select-list.po.spec';
 
 describe('Select List Tests', () => {
 
-    let page: SelectListPage;
-
-    beforeEach(() => {
-        page = new SelectListPage();
-        page.getPage();
-    });
+    let page: SelectListPage = new SelectListPage();
+    page.getPage();
 
     it('should have correct initial state', async () => {
         expect(await page.getItemCount()).toBe(20);
@@ -21,6 +17,8 @@ describe('Select List Tests', () => {
 
         // the selected items should update
         expect(await page.getSelection()).toBe('Margaret Douglas');
+
+        await page.reset();
     });
 
     it('should select one item at a time', async () => {
@@ -35,6 +33,8 @@ describe('Select List Tests', () => {
 
         // the selected items should update
         expect(await page.getSelection()).toBe('Sara Valdez');
+
+        await page.reset();
     });
 
     it('should retain selection after search', async () => {
@@ -52,14 +52,20 @@ describe('Select List Tests', () => {
 
         // the selection should remain the same
         expect(await page.getSelection()).toBe('Margaret Douglas');
+
+        await page.reset();
     });
 
     it('should only have one tabbable item', async () => {
         expect(await page.getTabbableItemCount()).toBe(1);
+
+        await page.reset();
     });
 
     it('should make the first item intially tabbable', async () => {
         expect(await page.getTabbableItem()).toBe('Linnie Dixon');
+
+        await page.reset();
     });
 
     it('should change the tabbable item on selection', async () => {
@@ -75,9 +81,15 @@ describe('Select List Tests', () => {
         // selected item should be tabbable
         expect(await page.getTabbableItem()).toBe('Margaret Douglas');
 
+        await page.reset();
+
     });
 
     it('should change the tabbable item when arrow keys are pressed', async () => {
+
+        // we need to reload the page for this test
+        await page.getPage();
+
         // first item should initially be tabbable
         expect(await page.getTabbableItem()).toBe('Linnie Dixon');
 
@@ -102,6 +114,8 @@ describe('Select List Tests', () => {
         // selected item should be tabbable again
         expect(await page.getTabbableItem()).toBe('Margaret Douglas');
 
+        await page.reset();
+
 
     });
 
@@ -115,6 +129,8 @@ describe('Select List Tests', () => {
 
         // the selected items should update
         expect(await page.getSelection()).toBe('Margaret Douglas');
+
+        await page.reset();
     });
 
     it('should select multiple items at a time when multiple select is enabled', async () => {
@@ -133,6 +149,8 @@ describe('Select List Tests', () => {
 
         // the selected items should update
         expect(await page.getSelection()).toBe('Margaret Douglas, Sara Valdez');
+
+        await page.reset();
     });
 
     it('should retain selection after search when multiple select is enabled', async () => {
@@ -154,6 +172,8 @@ describe('Select List Tests', () => {
 
         // the selection should remain the same
         expect(await page.getSelection()).toBe('Margaret Douglas');
+
+        await page.reset();
     });
 
     it('should only have one tabbable item when multiple select is enabled', async () => {
@@ -162,6 +182,8 @@ describe('Select List Tests', () => {
         await page.toggleButton.click();
 
         expect(await page.getTabbableItemCount()).toBe(1);
+
+        await page.reset();
     });
 
     it('should make the first item intially tabbable when multiple select is enabled', async () => {
@@ -170,6 +192,8 @@ describe('Select List Tests', () => {
         await page.toggleButton.click();
 
         expect(await page.getTabbableItem()).toBe('Linnie Dixon');
+
+        await page.reset();
     });
 
     it('should change the tabbable item on selection when multiple select is enabled', async () => {
@@ -188,6 +212,8 @@ describe('Select List Tests', () => {
 
         // selected item should be tabbable
         expect(await page.getTabbableItem()).toBe('Margaret Douglas');
+
+        await page.reset();
 
     });
 });

--- a/e2e/tests/components/select-list/select-list.po.spec.ts
+++ b/e2e/tests/components/select-list/select-list.po.spec.ts
@@ -7,9 +7,10 @@ export class SelectListPage {
     items = $$('ux-select-list-item');
     output = $('#select-output');
     toggleButton = $('#toggle-btn');
+    resetButton = $('#reset-btn');
 
-    getPage(): void {
-        browser.get('#/select-list');
+    getPage() {
+        return browser.get('#/select-list');
     }
 
     async getItemCount(): Promise<number> {
@@ -37,5 +38,9 @@ export class SelectListPage {
     async getTabbableItem(): Promise<string> {
         const items = await this.items.filter(element => element.getAttribute('tabindex').then(tabindex => tabindex === '0'));
         return await items[0].getText();
+    }
+
+    async reset(): Promise<void> {
+        return this.resetButton.click();
     }
 }

--- a/e2e/tests/components/timeline/timeline.e2e-spec.ts
+++ b/e2e/tests/components/timeline/timeline.e2e-spec.ts
@@ -1,75 +1,71 @@
-import { Constants, Functions } from '../common/common.spec';
 import { TimelinePage } from './timeline.po.spec';
 
 describe('TimelinePage Tests', () => {
 
-  let page: TimelinePage;
-  let constants: Constants;
-  let functions: Functions;
-
-  beforeEach(() => {
-    page = new TimelinePage();
+    let page: TimelinePage = new TimelinePage();
     page.getPage();
 
-    constants = new Constants();
-    functions = new Functions();
-  });
+    it('should start with 4 events', async () => {
 
-  it('should start with 4 events', () => {
-    
-    // Four events should be visible.
-    expect(page.timeline.isPresent()).toBeTruthy();
-    expect<any>(page.getNumberOfEvents()).toEqual(4);
-    expect(page.addEvent.isPresent()).toBeTruthy();
-    
-  });
-  
-  it('should allow the addition of events', () => {
-    
-    // Create events, checking the number displayed.
-    page.addEvent.click();
-    page.addEvent.click();
-    expect<any>(page.getNumberOfEvents()).toEqual(6);
-    
-  });
+        // Four events should be visible.
+        expect(page.timeline.isPresent()).toBeTruthy();
+        expect<any>(page.getNumberOfEvents()).toEqual(4);
+        expect(page.addEvent.isPresent()).toBeTruthy();
 
-  it('should display the correct information for events', () => {    
 
-    // Check elements of various events.
+        await page.reset();
+    });
 
-    const now = Date.now();
+    it('should allow the addition of events', async () => {
 
-    const weekdays: string[] = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
-    const months: string[] = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
-    const dayInMilliSeconds = 24 * 60 * 60 * 1000;
-    
-    // Third event.
-    let thirdEvent = new Date(now + (dayInMilliSeconds * 2));
-    let dayOfWeek = weekdays[thirdEvent.getDay()];
-    let month = months[thirdEvent.getMonth()];
-    let day = thirdEvent.getDate();
-    let badgeTitle = dayOfWeek + ' ' + month + ' ' + day;
-    expect<any>(page.getEventBadgeTitle(1)).toEqual(badgeTitle);
+        // Create events, checking the number displayed.
+        page.addEvent.click();
+        page.addEvent.click();
+        expect<any>(page.getNumberOfEvents()).toEqual(6);
 
-    expect<any>(page.getEventBadge(1).getAttribute('class')).toContain('alternate2');
 
-    // First event.
-    expect<any>(page.getEventBadge(3).getAttribute('class')).toContain('primary');
+        await page.reset();
+    });
 
-    expect<any>(page.getEventPanelText(3)).toContain('was recorded by');
+    it('should display the correct information for events', async () => {
 
-    // Add a fifth event and check it.
-    page.addEvent.click();
+        // Check elements of various events.
 
-    let newEvent = new Date(now + (dayInMilliSeconds * 4));    
-    dayOfWeek = weekdays[newEvent.getDay()];
-    month = months[newEvent.getMonth()];
-    day = newEvent.getDate();
-    badgeTitle = dayOfWeek + ' ' + month + ' ' + day;
-    expect<any>(page.getEventBadgeTitle(0)).toEqual(badgeTitle);
+        const now = Date.now();
 
-    expect<any>(page.getEventBadge(0).getAttribute('class')).toContain('grey4');
+        const weekdays: string[] = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+        const months: string[] = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+        const dayInMilliSeconds = 24 * 60 * 60 * 1000;
 
-    expect<any>(page.getEventPanelText(0)).toContain('was updated by');
-  });
+        // Third event.
+        let thirdEvent = new Date(now + (dayInMilliSeconds * 2));
+        let dayOfWeek = weekdays[thirdEvent.getDay()];
+        let month = months[thirdEvent.getMonth()];
+        let day = thirdEvent.getDate();
+        let badgeTitle = dayOfWeek + ' ' + month + ' ' + day;
+        expect<any>(page.getEventBadgeTitle(1)).toEqual(badgeTitle);
+
+        expect<any>(page.getEventBadge(1).getAttribute('class')).toContain('alternate2');
+
+        // First event.
+        expect<any>(page.getEventBadge(3).getAttribute('class')).toContain('primary');
+
+        expect<any>(page.getEventPanelText(3)).toContain('was recorded by');
+
+        // Add a fifth event and check it.
+        page.addEvent.click();
+
+        let newEvent = new Date(now + (dayInMilliSeconds * 4));
+        dayOfWeek = weekdays[newEvent.getDay()];
+        month = months[newEvent.getMonth()];
+        day = newEvent.getDate();
+        badgeTitle = dayOfWeek + ' ' + month + ' ' + day;
+        expect<any>(page.getEventBadgeTitle(0)).toEqual(badgeTitle);
+
+        expect<any>(page.getEventBadge(0).getAttribute('class')).toContain('grey4');
+
+        expect<any>(page.getEventPanelText(0)).toContain('was updated by');
+
+        await page.reset();
+    });
 });

--- a/e2e/tests/components/timeline/timeline.po.spec.ts
+++ b/e2e/tests/components/timeline/timeline.po.spec.ts
@@ -1,4 +1,4 @@
-import { browser, element, by } from 'protractor';
+import { browser, by, element } from 'protractor';
 
 export class TimelinePage {
 
@@ -8,14 +8,15 @@ export class TimelinePage {
 
     addEvent = element(by.id('button'));
     timeline = element(by.id('timeline'));
-    
+    resetBtn = element(by.id('reset-btn'));
+
     getNumberOfEvents() {
         return this.timeline.$('div.timeline').$$('ux-timeline-event').count();
     }
-    
+
     getEvent(index: number) {
         return this.timeline.$('div.timeline').$$('ux-timeline-event').get(index);
-    }    
+    }
 
     getEventBadge(index: number) {
         return this.getEvent(index).$('.timeline-badge');
@@ -31,5 +32,9 @@ export class TimelinePage {
 
     getEventPanelText(index: number) {
         return this.getEventPanel(index).$('p').getText();
+    }
+
+    reset() {
+        return this.resetBtn.click();
     }
 }

--- a/e2e/tests/components/toggleswitches/toggleswitches.e2e-spec.ts
+++ b/e2e/tests/components/toggleswitches/toggleswitches.e2e-spec.ts
@@ -3,112 +3,116 @@ import { ToggleSwitchesPage } from './toggleswitches.po.spec';
 
 describe('ToggleSwitchesPage Tests', () => {
 
-  let page: ToggleSwitchesPage;
-
-  beforeEach(() => {
-    page = new ToggleSwitchesPage();
+    let page: ToggleSwitchesPage = new ToggleSwitchesPage();
     page.getPage();
-  });
 
-  it('should have correct initial states', () => {
-    // Initial values
-    expect(page.confirmIsChecked(page.toggleswitch1)).toBeTruthy();
-    expect(page.confirmIsChecked(page.toggleswitch2)).toBeFalsy();
-    expect(page.confirmIsChecked(page.toggleswitch3)).toBeFalsy();
-    expect(page.confirmIsChecked(page.toggleswitch4)).toBeFalsy();
-    expect<any>(page.text1.getText()).toBe('true');
-    expect<any>(page.text2.getText()).toBe('false');
-    expect<any>(page.text3.getText()).toBe('false');
-    expect<any>(page.text4.getText()).toBe('false');
+    it('should have correct initial states', async () => {
+        // Initial values
+        expect(page.confirmIsChecked(page.toggleswitch1)).toBeTruthy();
+        expect(page.confirmIsChecked(page.toggleswitch2)).toBeFalsy();
+        expect(page.confirmIsChecked(page.toggleswitch3)).toBeFalsy();
+        expect(page.confirmIsChecked(page.toggleswitch4)).toBeFalsy();
+        expect<any>(page.text1.getText()).toBe('true');
+        expect<any>(page.text2.getText()).toBe('false');
+        expect<any>(page.text3.getText()).toBe('false');
+        expect<any>(page.text4.getText()).toBe('false');
 
-    // All enabled
-    expect(page.confirmIsDisabled(page.toggleswitch1)).toBeFalsy();
-    expect(page.confirmIsDisabled(page.toggleswitch2)).toBeFalsy();
-    expect(page.confirmIsDisabled(page.toggleswitch3)).toBeFalsy();
-    expect(page.confirmIsDisabled(page.toggleswitch4)).toBeFalsy();
-  });
+        // All enabled
+        expect(page.confirmIsDisabled(page.toggleswitch1)).toBeFalsy();
+        expect(page.confirmIsDisabled(page.toggleswitch2)).toBeFalsy();
+        expect(page.confirmIsDisabled(page.toggleswitch3)).toBeFalsy();
+        expect(page.confirmIsDisabled(page.toggleswitch4)).toBeFalsy();
 
-  it('should react to clicks', () => {
-    page.toggleswitch2.click();
+        await page.reset();
+    });
 
-    expect(page.confirmIsChecked(page.toggleswitch1)).toBeTruthy();
-    expect(page.confirmIsChecked(page.toggleswitch2)).toBeTruthy();
-    expect(page.confirmIsChecked(page.toggleswitch3)).toBeFalsy();
-    expect(page.confirmIsChecked(page.toggleswitch4)).toBeFalsy();
-    expect<any>(page.text1.getText()).toBe('true');
-    expect<any>(page.text2.getText()).toBe('true');
-    expect<any>(page.text3.getText()).toBe('false');
-    expect<any>(page.text4.getText()).toBe('false');
+    it('should react to clicks', async () => {
+        page.toggleswitch2.click();
 
-    page.toggleswitch3.click();
+        expect(page.confirmIsChecked(page.toggleswitch1)).toBeTruthy();
+        expect(page.confirmIsChecked(page.toggleswitch2)).toBeTruthy();
+        expect(page.confirmIsChecked(page.toggleswitch3)).toBeFalsy();
+        expect(page.confirmIsChecked(page.toggleswitch4)).toBeFalsy();
+        expect<any>(page.text1.getText()).toBe('true');
+        expect<any>(page.text2.getText()).toBe('true');
+        expect<any>(page.text3.getText()).toBe('false');
+        expect<any>(page.text4.getText()).toBe('false');
 
-    expect(page.confirmIsChecked(page.toggleswitch1)).toBeTruthy();
-    expect(page.confirmIsChecked(page.toggleswitch2)).toBeTruthy();
-    expect(page.confirmIsChecked(page.toggleswitch3)).toBeTruthy();
-    expect(page.confirmIsChecked(page.toggleswitch4)).toBeFalsy();
-    expect<any>(page.text1.getText()).toBe('true');
-    expect<any>(page.text2.getText()).toBe('true');
-    expect<any>(page.text3.getText()).toBe('true');
-    expect<any>(page.text4.getText()).toBe('false');
+        page.toggleswitch3.click();
 
-    page.toggleswitch4.click();
+        expect(page.confirmIsChecked(page.toggleswitch1)).toBeTruthy();
+        expect(page.confirmIsChecked(page.toggleswitch2)).toBeTruthy();
+        expect(page.confirmIsChecked(page.toggleswitch3)).toBeTruthy();
+        expect(page.confirmIsChecked(page.toggleswitch4)).toBeFalsy();
+        expect<any>(page.text1.getText()).toBe('true');
+        expect<any>(page.text2.getText()).toBe('true');
+        expect<any>(page.text3.getText()).toBe('true');
+        expect<any>(page.text4.getText()).toBe('false');
 
-    expect(page.confirmIsChecked(page.toggleswitch1)).toBeTruthy();
-    expect(page.confirmIsChecked(page.toggleswitch2)).toBeTruthy();
-    expect(page.confirmIsChecked(page.toggleswitch3)).toBeTruthy();
-    expect(page.confirmIsChecked(page.toggleswitch4)).toBeTruthy();
-    expect<any>(page.text1.getText()).toBe('true');
-    expect<any>(page.text2.getText()).toBe('true');
-    expect<any>(page.text3.getText()).toBe('true');
-    expect<any>(page.text4.getText()).toBe('true');
-  });
+        page.toggleswitch4.click();
 
-  it('should react to disabling', () => {
-    page.disableButton.click();
+        expect(page.confirmIsChecked(page.toggleswitch1)).toBeTruthy();
+        expect(page.confirmIsChecked(page.toggleswitch2)).toBeTruthy();
+        expect(page.confirmIsChecked(page.toggleswitch3)).toBeTruthy();
+        expect(page.confirmIsChecked(page.toggleswitch4)).toBeTruthy();
+        expect<any>(page.text1.getText()).toBe('true');
+        expect<any>(page.text2.getText()).toBe('true');
+        expect<any>(page.text3.getText()).toBe('true');
+        expect<any>(page.text4.getText()).toBe('true');
 
-    expect(page.confirmIsDisabled(page.toggleswitch1)).toBeTruthy();
-    expect(page.confirmIsDisabled(page.toggleswitch2)).toBeFalsy();
-    expect(page.confirmIsDisabled(page.toggleswitch3)).toBeFalsy();
-    expect(page.confirmIsDisabled(page.toggleswitch4)).toBeFalsy();
-    expect<any>(page.text1.getText()).toBe('true');
-    expect<any>(page.text2.getText()).toBe('false');
-    expect<any>(page.text3.getText()).toBe('false');
-    expect<any>(page.text4.getText()).toBe('false');
+        await page.reset();
+    });
 
-    page.toggleswitch1.click();
+    it('should react to disabling', async () => {
+        page.disableButton.click();
 
-    expect(page.confirmIsChecked(page.toggleswitch1)).toBeTruthy();
-    expect(page.confirmIsChecked(page.toggleswitch2)).toBeFalsy();
-    expect(page.confirmIsChecked(page.toggleswitch3)).toBeFalsy();
-    expect(page.confirmIsChecked(page.toggleswitch4)).toBeFalsy();
-    expect<any>(page.text1.getText()).toBe('true');
-    expect<any>(page.text2.getText()).toBe('false');
-    expect<any>(page.text3.getText()).toBe('false');
-    expect<any>(page.text4.getText()).toBe('false');
+        expect(page.confirmIsDisabled(page.toggleswitch1)).toBeTruthy();
+        expect(page.confirmIsDisabled(page.toggleswitch2)).toBeFalsy();
+        expect(page.confirmIsDisabled(page.toggleswitch3)).toBeFalsy();
+        expect(page.confirmIsDisabled(page.toggleswitch4)).toBeFalsy();
+        expect<any>(page.text1.getText()).toBe('true');
+        expect<any>(page.text2.getText()).toBe('false');
+        expect<any>(page.text3.getText()).toBe('false');
+        expect<any>(page.text4.getText()).toBe('false');
 
-    page.toggleswitch4.click();
+        page.toggleswitch1.click();
 
-    expect(page.confirmIsChecked(page.toggleswitch1)).toBeTruthy();
-    expect(page.confirmIsChecked(page.toggleswitch2)).toBeFalsy();
-    expect(page.confirmIsChecked(page.toggleswitch3)).toBeFalsy();
-    expect(page.confirmIsChecked(page.toggleswitch4)).toBeTruthy();
-    expect<any>(page.text1.getText()).toBe('true');
-    expect<any>(page.text2.getText()).toBe('false');
-    expect<any>(page.text3.getText()).toBe('false');
-    expect<any>(page.text4.getText()).toBe('true');
-  });
+        expect(page.confirmIsChecked(page.toggleswitch1)).toBeTruthy();
+        expect(page.confirmIsChecked(page.toggleswitch2)).toBeFalsy();
+        expect(page.confirmIsChecked(page.toggleswitch3)).toBeFalsy();
+        expect(page.confirmIsChecked(page.toggleswitch4)).toBeFalsy();
+        expect<any>(page.text1.getText()).toBe('true');
+        expect<any>(page.text2.getText()).toBe('false');
+        expect<any>(page.text3.getText()).toBe('false');
+        expect<any>(page.text4.getText()).toBe('false');
 
-  it('should toggle the toggle switch when pressing space', () => {
-    page.toggleByKey(page.toggleswitch1, Key.SPACE);
-    page.toggleByKey(page.toggleswitch2, Key.SPACE);
+        page.toggleswitch4.click();
 
-    expect(page.confirmIsChecked(page.toggleswitch1)).toBeFalsy();
-    expect(page.confirmIsChecked(page.toggleswitch2)).toBeTruthy();
-    expect(page.confirmIsChecked(page.toggleswitch3)).toBeFalsy();
-    expect(page.confirmIsChecked(page.toggleswitch4)).toBeFalsy();
-    expect<any>(page.text1.getText()).toBe('false');
-    expect<any>(page.text2.getText()).toBe('true');
-    expect<any>(page.text3.getText()).toBe('false');
-    expect<any>(page.text4.getText()).toBe('false');
-  });
+        expect(page.confirmIsChecked(page.toggleswitch1)).toBeTruthy();
+        expect(page.confirmIsChecked(page.toggleswitch2)).toBeFalsy();
+        expect(page.confirmIsChecked(page.toggleswitch3)).toBeFalsy();
+        expect(page.confirmIsChecked(page.toggleswitch4)).toBeTruthy();
+        expect<any>(page.text1.getText()).toBe('true');
+        expect<any>(page.text2.getText()).toBe('false');
+        expect<any>(page.text3.getText()).toBe('false');
+        expect<any>(page.text4.getText()).toBe('true');
+
+        await page.reset();
+    });
+
+    it('should toggle the toggle switch when pressing space', async () => {
+        page.toggleByKey(page.toggleswitch1, Key.SPACE);
+        page.toggleByKey(page.toggleswitch2, Key.SPACE);
+
+        expect(page.confirmIsChecked(page.toggleswitch1)).toBeFalsy();
+        expect(page.confirmIsChecked(page.toggleswitch2)).toBeTruthy();
+        expect(page.confirmIsChecked(page.toggleswitch3)).toBeFalsy();
+        expect(page.confirmIsChecked(page.toggleswitch4)).toBeFalsy();
+        expect<any>(page.text1.getText()).toBe('false');
+        expect<any>(page.text2.getText()).toBe('true');
+        expect<any>(page.text3.getText()).toBe('false');
+        expect<any>(page.text4.getText()).toBe('false');
+
+        await page.reset();
+    });
 });

--- a/e2e/tests/components/toggleswitches/toggleswitches.po.spec.ts
+++ b/e2e/tests/components/toggleswitches/toggleswitches.po.spec.ts
@@ -1,11 +1,11 @@
-import { ElementFinder, browser, by, element } from 'protractor';
+import { browser, by, element, ElementFinder } from 'protractor';
 
 export class ToggleSwitchesPage {
-        
+
     getPage(): void {
         browser.get('#/toggleswitches');
     }
-    
+
     toggleswitch1 = element(by.id('switch1'));
     toggleswitch2 = element(by.id('switch2'));
     toggleswitch3 = element(by.id('switch3'));
@@ -15,16 +15,21 @@ export class ToggleSwitchesPage {
     text3 = element(by.id('text3'));
     text4 = element(by.id('text4'));
     disableButton = element(by.id('button1'));
-    
+    resetButton = element(by.id('reset-button'));
+
     confirmIsChecked(toggleswitch: ElementFinder) {
         return toggleswitch.$('.ux-toggleswitch-checked').isPresent();
     }
-    
+
     confirmIsDisabled(toggleswitch: ElementFinder) {
         return toggleswitch.$('.ux-toggleswitch-disabled').isPresent();
     }
-    
+
     toggleByKey(toggleswitch: ElementFinder, key: string) {
         toggleswitch.$('.ux-toggleswitch').sendKeys(key);
+    }
+
+    reset() {
+        return this.resetButton.click();
     }
 }

--- a/e2e/tests/components/tooltips/tooltips.e2e-spec.ts
+++ b/e2e/tests/components/tooltips/tooltips.e2e-spec.ts
@@ -1,18 +1,16 @@
-import { Key, browser } from 'protractor';
+import { browser, Key } from 'protractor';
 import { TooltipsPage } from './tooltips.po.spec';
 
 describe('Tooltips', () => {
 
-    let page: TooltipsPage;
-
-    beforeEach(() => {
-        page = new TooltipsPage();
-        page.getPage();
-    });
+    let page: TooltipsPage = new TooltipsPage();
+    page.getPage();
 
     it('should have correct initial states', async () => {
         expect(await page.cdkOverlayContainer.isPresent()).toBe(false);
         expect(await page.tooltip.isPresent()).toBe(false);
+
+        await page.reset();
     });
 
     it('should show tooltip on mouse enter', async () => {
@@ -23,6 +21,8 @@ describe('Tooltips', () => {
         // the tooltip should now be visible
         expect(await page.cdkOverlayContainer.isPresent()).toBe(true);
         expect(await page.tooltip.isPresent()).toBe(true);
+
+        await page.reset();
     });
 
     it('should hide tooltip on mouse leave', async () => {
@@ -40,22 +40,28 @@ describe('Tooltips', () => {
         // the tooltip should now be hidden but the overlay container should remain
         expect(await page.cdkOverlayContainer.isPresent()).toBe(true);
         expect(await page.tooltip.isPresent()).toBe(false);
+
+        await page.reset();
     });
 
-    it ('should be able to programmatically show the tooltip', async () => {
+    it('should be able to programmatically show the tooltip', async () => {
         await page.showTooltip();
         expect(await page.tooltip.isPresent()).toBe(true);
+
+        await page.reset();
     });
 
-    it ('should be able to programmatically hide the tooltip', async () => {
+    it('should be able to programmatically hide the tooltip', async () => {
         await page.showTooltip();
         expect(await page.tooltip.isPresent()).toBe(true);
 
         await page.hideTooltip();
         expect(await page.tooltip.isPresent()).toBe(false);
+
+        await page.reset();
     });
 
-    it ('should be able to programmatically toggle the tooltip', async () => {
+    it('should be able to programmatically toggle the tooltip', async () => {
         await page.toggleTooltip();
         expect(await page.tooltip.isPresent()).toBe(true);
 
@@ -64,9 +70,11 @@ describe('Tooltips', () => {
 
         await page.toggleTooltip();
         expect(await page.tooltip.isPresent()).toBe(true);
+
+        await page.reset();
     });
 
-    it ('should be able to position the tooltip', async () => {
+    it('should be able to position the tooltip', async () => {
         // by default the tooltip should be displayed on top
         expect(await page.getTooltipPlacement()).toBe('top');
 
@@ -86,13 +94,17 @@ describe('Tooltips', () => {
         await page.placementTopBtn.click();
         expect(await page.getTooltipPlacement()).toBe('top');
 
+        await page.reset();
+
     });
 
-    it ('should show the correct content', async () => {
+    it('should show the correct content', async () => {
         expect(await page.getTooltipContent()).toBe('Some content here');
+
+        await page.reset();
     });
 
-    it ('should allow a custom class', async () => {
+    it('should allow a custom class', async () => {
 
         // should not initially have the class
         expect(await page.tooltipHasClass('my-custom-class')).toBe(false);
@@ -102,9 +114,11 @@ describe('Tooltips', () => {
 
         // should now have the class
         expect(await page.tooltipHasClass('my-custom-class')).toBe(true);
+
+        await page.reset();
     });
 
-    it ('should allow a TemplateRef to be used', async () => {
+    it('should allow a TemplateRef to be used', async () => {
         // the original content should initially be shown
         expect(await page.getTooltipContent()).toBe('Some content here');
 
@@ -113,9 +127,14 @@ describe('Tooltips', () => {
 
         // the content should now have changed
         expect(await page.getTooltipContent()).toBe('My Template Here');
+
+        await page.reset();
     });
 
-    it ('should show the tooltip on button focus', async () => {
+    it('should show the tooltip on button focus', async () => {
+
+        // we need to reload this page
+        await page.getPage();
 
         // the tooltip should initially be hidden
         expect(await page.tooltip.isPresent()).toBe(false);
@@ -125,9 +144,14 @@ describe('Tooltips', () => {
 
         // the tooltip should be visible
         expect(await page.tooltip.isPresent()).toBe(true);
+
+        await page.reset();
     });
 
-    it ('should hide the tooltip on button blur', async () => {
+    it('should hide the tooltip on button blur', async () => {
+
+        // we need to reload this page
+        await page.getPage();
 
         // the tooltip should initially be hidden
         expect(await page.tooltip.isPresent()).toBe(false);
@@ -143,5 +167,7 @@ describe('Tooltips', () => {
 
         // the tooltip should be hidden again
         expect(await page.tooltip.isPresent()).toBe(false);
+
+        await page.reset();
     });
 });

--- a/e2e/tests/components/tooltips/tooltips.po.spec.ts
+++ b/e2e/tests/components/tooltips/tooltips.po.spec.ts
@@ -12,12 +12,13 @@ export class TooltipsPage {
     programmaticallyShowBtn = $('#programmatically-show-btn');
     programmaticallyHideBtn = $('#programmatically-hide-btn');
     programmaticallyToggleBtn = $('#programmatically-toggle-btn');
+    resetBtn = $('#reset-btn');
 
     cdkOverlayContainer = $('.cdk-overlay-container');
     tooltip = $('.tooltip');
 
-    getPage(): void {
-        browser.get('#/tooltips');
+    getPage() {
+        return browser.get('#/tooltips');
     }
 
     async showTooltip(): Promise<void> {
@@ -70,6 +71,10 @@ export class TooltipsPage {
         const classes = await this.getTooltipClasses();
 
         return classes.indexOf(className) !== -1;
+    }
+
+    reset() {
+        return this.resetBtn.click();
     }
 
 }


### PR DESCRIPTION
#### Summary
Preventing page reload in e2e tests where it did not require a lot of rework. Seems to reduce test time to around 9m 45s so an improvement of between 1-2 mins.

Also updated pagination tests to test our pagination component rather than ngx-bootstrap pagination

Tests that avoid reloading:
- Checkbox
- Pagination
- Select List
- Timeline
- Toggle Switch
- Tooltips
- Custom Facet
- Facet Container
- Expanding Text Area
- Flippable Cards
- Floating Action Buttons
- Number picker
- Radio Buttons

#### Ticket
https://autjira.microfocus.com/browse/EL-3327

#### Documentation CI URL
Not Applicable
