### PR TITLE
EL-3336 - Date Time Picker

### DIFF
--- a/docs/app/pages/components/components-sections/date-time-picker/date-time-picker/date-time-picker.component.html
+++ b/docs/app/pages/components/components-sections/date-time-picker/date-time-picker/date-time-picker.component.html
@@ -114,7 +114,7 @@
         Defines the text to be displayed in the button used to set the selected time to the current time.
     </tr>
     <tr uxd-api-property name="startOfWeek" type="WeekDay" defaultValue="WeekDay.Sunday">
-        Defines the day of the week that should appear in the first column.
+        Defines the day of the week that should appear in the first column. <code>WeekDay</code> is an enumeration available in <code>@angular/common</code>.
     </tr>
 </uxd-api-properties>
 

--- a/docs/app/pages/components/components-sections/date-time-picker/date-time-picker/date-time-picker.component.html
+++ b/docs/app/pages/components/components-sections/date-time-picker/date-time-picker/date-time-picker.component.html
@@ -76,8 +76,8 @@
         Will set the selected timezone.
     </tr>
     <tr uxd-api-property name="timezones" type="DateTimePickerTimezone[]">
-        Defines the list of available timezones. The <b>DateTimePickerTimezone</b> interface specifies that 
-        each timezone should be an object with a <b>name</b> property that represents the timezone, eg. <code>GMT+2</code>, 
+        Defines the list of available timezones. The <b>DateTimePickerTimezone</b> interface specifies that
+        each timezone should be an object with a <b>name</b> property that represents the timezone, eg. <code>GMT+2</code>,
         and an <b>offset</b> property that represents the number of minutes relative to GMT the timezone is.
     </tr>
     <tr uxd-api-property name="showDate" type="boolean">
@@ -112,6 +112,9 @@
     </tr>
     <tr uxd-api-property name="nowBtnText" type="string">
         Defines the text to be displayed in the button used to set the selected time to the current time.
+    </tr>
+    <tr uxd-api-property name="startOfWeek" type="WeekDay" defaultValue="WeekDay.Sunday">
+        Defines the day of the week that should appear in the first column.
     </tr>
 </uxd-api-properties>
 

--- a/e2e/pages/app/app.module.ts
+++ b/e2e/pages/app/app.module.ts
@@ -26,6 +26,10 @@ const routes: Routes = [
         loadChildren: './dashboard/dashboard.module#DashboardTestPageModule'
     },
     {
+        path: 'date-time-picker',
+        loadChildren: './date-time-picker/date-time-picker.module#DateTimePickerTestPageModule'
+    },
+    {
         path: 'expanding-text-area',
         loadChildren: './expanding-text-area/expanding-text-area.module#ExpandingTextAreaModule'
     },

--- a/e2e/pages/app/date-time-picker/date-time-picker.module.ts
+++ b/e2e/pages/app/date-time-picker/date-time-picker.module.ts
@@ -1,0 +1,20 @@
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { RouterModule } from '@angular/router';
+import { DateTimePickerModule } from '@ux-aspects/ux-aspects';
+import { DateTimePickerTestPageComponent } from './date-time-picker.testpage.component';
+
+@NgModule({
+    imports: [
+        CommonModule,
+        DateTimePickerModule,
+        RouterModule.forChild([
+            {
+                path: '',
+                component: DateTimePickerTestPageComponent
+            }
+        ])
+    ],
+    declarations: [DateTimePickerTestPageComponent]
+})
+export class DateTimePickerTestPageModule { }

--- a/e2e/pages/app/date-time-picker/date-time-picker.testpage.component.html
+++ b/e2e/pages/app/date-time-picker/date-time-picker.testpage.component.html
@@ -1,0 +1,14 @@
+<ux-date-time-picker
+    class="date-time-picker"
+    [(date)]="date"
+    [(timezone)]="timezone"
+    [showTime]="showTime"
+    [showMeridian]="showMeridians"
+    [showSpinners]="showSpinners"
+    [showTimezone]="showTimezones"
+    [startOfWeek]="startOfWeek">
+</ux-date-time-picker>
+
+<br>
+
+<button id="change-start-of-week" class="btn button-primary" (click)="startOfWeek = startOfWeek + 1">Change StartOfWeek</button>

--- a/e2e/pages/app/date-time-picker/date-time-picker.testpage.component.less
+++ b/e2e/pages/app/date-time-picker/date-time-picker.testpage.component.less
@@ -1,0 +1,3 @@
+.date-time-picker {
+    width: 400px;
+}

--- a/e2e/pages/app/date-time-picker/date-time-picker.testpage.component.ts
+++ b/e2e/pages/app/date-time-picker/date-time-picker.testpage.component.ts
@@ -1,0 +1,18 @@
+import { Component } from '@angular/core';
+import { DateTimePickerTimezone } from '@ux-aspects/ux-aspects';
+
+@Component({
+    selector: 'app-date-time-picker',
+    templateUrl: './date-time-picker.testpage.component.html',
+    styleUrls: ['./date-time-picker.testpage.component.less'],
+})
+export class DateTimePickerTestPageComponent {
+
+    date: Date = new Date(2019, 0, 3, 12, 0, 0);
+    timezone: DateTimePickerTimezone = { name: 'GMT', offset: 0 };
+    showTime: boolean = true;
+    showTimezones: boolean = true;
+    showMeridians: boolean = true;
+    showSpinners: boolean = true;
+    startOfWeek: number = 0;
+}

--- a/e2e/tests/components/date-time-picker/date-time-picker.e2e-spec.ts
+++ b/e2e/tests/components/date-time-picker/date-time-picker.e2e-spec.ts
@@ -1,0 +1,76 @@
+import { DateTimePickerPage } from './date-time-picker.po.spec';
+
+describe('Date Time Picker Tests', () => {
+
+    let page: DateTimePickerPage;
+
+    beforeEach(() => {
+        page = new DateTimePickerPage();
+        page.getPage();
+    });
+
+    it('should have correct initial states', async () => {
+        // expect the correct header
+        expect(await page.header.getText()).toBe('January 2019');
+
+        // expect the correct date to be selected
+        expect(await page.selectedDate.getText()).toBe('3');
+
+        // expect there to be the correct number of days in the month
+        expect(await page.dates.count()).toBe(35);
+        expect(await page.previewDates.count()).toBe(4);
+
+        // expect the headers to be Sun -> Sat
+        expect(await page.getWeekdayOrder()).toEqual(['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']);
+    });
+
+    it('should allow changing the startOfWeek', async () => {
+
+        // expect the headers to be Sun -> Sat
+        expect(await page.getWeekdayOrder()).toEqual(['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']);
+        expect(await page.getPositionOfSelectedDate()).toBe(4);
+
+        // change the start of the week
+        await page.changeWeekStartBtn.click();
+
+        // expect the headers to be Mon -> Sun
+        expect(await page.getWeekdayOrder()).toEqual(['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']);
+        expect(await page.getPositionOfSelectedDate()).toBe(3);
+
+        // change the start of the week
+        await page.changeWeekStartBtn.click();
+
+        // expect the headers to be Tue -> Mon
+        expect(await page.getWeekdayOrder()).toEqual(['Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun', 'Mon']);
+        expect(await page.getPositionOfSelectedDate()).toBe(2);
+
+        // change the start of the week
+        await page.changeWeekStartBtn.click();
+
+        // expect the headers to be Wed -> Tue
+        expect(await page.getWeekdayOrder()).toEqual(['Wed', 'Thu', 'Fri', 'Sat', 'Sun', 'Mon', 'Tue']);
+        expect(await page.getPositionOfSelectedDate()).toBe(8);
+
+        // change the start of the week
+        await page.changeWeekStartBtn.click();
+
+        // expect the headers to be Thu -> Wed
+        expect(await page.getWeekdayOrder()).toEqual(['Thu', 'Fri', 'Sat', 'Sun', 'Mon', 'Tue', 'Wed']);
+        expect(await page.getPositionOfSelectedDate()).toBe(7);
+
+        // change the start of the week
+        await page.changeWeekStartBtn.click();
+
+        // expect the headers to be Fri -> Thu
+        expect(await page.getWeekdayOrder()).toEqual(['Fri', 'Sat', 'Sun', 'Mon', 'Tue', 'Wed', 'Thu']);
+        expect(await page.getPositionOfSelectedDate()).toBe(6);
+
+        // change the start of the week
+        await page.changeWeekStartBtn.click();
+
+        // expect the headers to be Sat -> Fri
+        expect(await page.getWeekdayOrder()).toEqual(['Sat', 'Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri']);
+        expect(await page.getPositionOfSelectedDate()).toBe(5);
+
+    });
+});

--- a/e2e/tests/components/date-time-picker/date-time-picker.po.spec.ts
+++ b/e2e/tests/components/date-time-picker/date-time-picker.po.spec.ts
@@ -1,0 +1,27 @@
+import { $, $$, browser } from 'protractor';
+
+export class DateTimePickerPage {
+
+    header = $('.header-title');
+    weekdayColumns = $$('th.weekday');
+    dates = $$('.date-button');
+    previewDates = $$('.date-button.preview');
+    selectedDate = $('.date-button.active');
+
+    changeWeekStartBtn = $('#change-start-of-week');
+
+    getPage(): void {
+        browser.get('#/date-time-picker');
+    }
+
+    async getWeekdayOrder(): Promise<string[]> {
+        return await this.weekdayColumns.map<string>(element => element.getText());
+    }
+
+    async getPositionOfSelectedDate(): Promise<number> {
+        const dates: string[] = await this.dates.map<string>(element => element.getText());
+        const selected: string = await this.selectedDate.getText();
+
+        return dates.indexOf(selected);
+    }
+}

--- a/src/components/date-time-picker/date-time-picker.component.ts
+++ b/src/components/date-time-picker/date-time-picker.component.ts
@@ -1,3 +1,4 @@
+import { WeekDay } from '@angular/common';
 import { ChangeDetectionStrategy, Component, EventEmitter, Input, OnDestroy, Output } from '@angular/core';
 import { distinctUntilChanged, takeUntil } from 'rxjs/operators';
 import { Subject } from 'rxjs/Subject';
@@ -5,100 +6,104 @@ import { DatePickerMode, DateTimePickerService } from './date-time-picker.servic
 import { dateComparator, DateTimePickerTimezone, timezoneComparator } from './date-time-picker.utils';
 
 @Component({
-  selector: 'ux-date-time-picker',
-  templateUrl: './date-time-picker.component.html',
-  providers: [DateTimePickerService],
-  changeDetection: ChangeDetectionStrategy.OnPush
+    selector: 'ux-date-time-picker',
+    templateUrl: './date-time-picker.component.html',
+    providers: [DateTimePickerService],
+    changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class DateTimePickerComponent implements OnDestroy {
 
-  @Input() set showDate(value: boolean) {
-    this.datepicker.showDate$.next(value);
-  }
-
-  @Input() set showTime(value: boolean) {
-    this.datepicker.showTime$.next(value);
-  }
-
-  @Input() set showTimezone(value: boolean) {
-    this.datepicker.showTimezone$.next(value);
-  }
-
-  @Input() set showSeconds(value: boolean) {
-    this.datepicker.showSeconds$.next(value);
-  }
-
-  @Input() set showMeridian(value: boolean) {
-    this.datepicker.showMeridian$.next(value);
-  }
-
-  @Input() set showSpinners(value: boolean) {
-    this.datepicker.showSpinners$.next(value);
-  }
-
-  @Input() set weekdays(value: string[]) {
-    this.datepicker.weekdays$.next(value);
-  }
-
-  @Input() set months(months: string[]) {
-    this.datepicker.months = months;
-  }
-
-  @Input() set monthsShort(months: string[]) {
-    this.datepicker.monthsShort = months;
-  }
-
-  @Input() set meridians(meridians: string[]) {
-    this.datepicker.meridians = meridians;
-  }
-
-  @Input() set nowBtnText(value: string) {
-    this.datepicker.nowBtnText$.next(value);
-  }
-
-  @Input() set timezones(value: DateTimePickerTimezone[]) {
-    this.datepicker.timezones$.next(value);
-  }
-
-  @Output() dateChange: EventEmitter<Date> = new EventEmitter<Date>();
-  @Output() timezoneChange: EventEmitter<DateTimePickerTimezone> = new EventEmitter<DateTimePickerTimezone>();
-
-  @Input()
-  set date(value: Date) {
-    if (!dateComparator(value, this.datepicker.selected$.value)) {
-      this.datepicker.selected$.next(new Date(value));
+    @Input() set showDate(value: boolean) {
+        this.datepicker.showDate$.next(value);
     }
-  }
 
-  @Input()
-  set timezone(value: DateTimePickerTimezone) {
-    this.datepicker.timezone$.next(value);
-  }
+    @Input() set showTime(value: boolean) {
+        this.datepicker.showTime$.next(value);
+    }
 
-  // expose enum to view
-  DatePickerMode = DatePickerMode;
+    @Input() set showTimezone(value: boolean) {
+        this.datepicker.showTimezone$.next(value);
+    }
 
-  private _onDestroy = new Subject<void>();
+    @Input() set showSeconds(value: boolean) {
+        this.datepicker.showSeconds$.next(value);
+    }
 
-  constructor(public datepicker: DateTimePickerService) {
-    datepicker.selected$.pipe(takeUntil(this._onDestroy), distinctUntilChanged(dateComparator))
-      .subscribe(date => this.dateChange.emit(date));
+    @Input() set showMeridian(value: boolean) {
+        this.datepicker.showMeridian$.next(value);
+    }
 
-    datepicker.timezone$.pipe(takeUntil(this._onDestroy), distinctUntilChanged(timezoneComparator))
-      .subscribe((timezone: DateTimePickerTimezone) => this.timezoneChange.emit(timezone));
-  }
+    @Input() set showSpinners(value: boolean) {
+        this.datepicker.showSpinners$.next(value);
+    }
 
-  ngOnDestroy(): void {
-    this._onDestroy.next();
-    this._onDestroy.complete();
-  }
+    @Input() set weekdays(value: string[]) {
+        this.datepicker.weekdays$.next(value);
+    }
 
-  /**
-   * Change the date to the current date and time
-   */
-  setToNow(): void {
+    @Input() set months(months: string[]) {
+        this.datepicker.months = months;
+    }
 
-    // set the date to the current moment
-    this.datepicker.setDateToNow();
-  }
+    @Input() set monthsShort(months: string[]) {
+        this.datepicker.monthsShort = months;
+    }
+
+    @Input() set meridians(meridians: string[]) {
+        this.datepicker.meridians = meridians;
+    }
+
+    @Input() set nowBtnText(value: string) {
+        this.datepicker.nowBtnText$.next(value);
+    }
+
+    @Input() set timezones(value: DateTimePickerTimezone[]) {
+        this.datepicker.timezones$.next(value);
+    }
+
+    @Input() set startOfWeek(startOfWeek: WeekDay) {
+        this.datepicker.startOfWeek$.next(startOfWeek);
+    }
+
+    @Output() dateChange: EventEmitter<Date> = new EventEmitter<Date>();
+    @Output() timezoneChange: EventEmitter<DateTimePickerTimezone> = new EventEmitter<DateTimePickerTimezone>();
+
+    @Input()
+    set date(value: Date) {
+        if (!dateComparator(value, this.datepicker.selected$.value)) {
+            this.datepicker.selected$.next(new Date(value));
+        }
+    }
+
+    @Input()
+    set timezone(value: DateTimePickerTimezone) {
+        this.datepicker.timezone$.next(value);
+    }
+
+    // expose enum to view
+    DatePickerMode = DatePickerMode;
+
+    private _onDestroy = new Subject<void>();
+
+    constructor(public datepicker: DateTimePickerService) {
+        datepicker.selected$.pipe(takeUntil(this._onDestroy), distinctUntilChanged(dateComparator))
+            .subscribe(date => this.dateChange.emit(date));
+
+        datepicker.timezone$.pipe(takeUntil(this._onDestroy), distinctUntilChanged(timezoneComparator))
+            .subscribe((timezone: DateTimePickerTimezone) => this.timezoneChange.emit(timezone));
+    }
+
+    ngOnDestroy(): void {
+        this._onDestroy.next();
+        this._onDestroy.complete();
+    }
+
+    /**
+     * Change the date to the current date and time
+     */
+    setToNow(): void {
+
+        // set the date to the current moment
+        this.datepicker.setDateToNow();
+    }
 }

--- a/src/components/date-time-picker/date-time-picker.module.ts
+++ b/src/components/date-time-picker/date-time-picker.module.ts
@@ -1,6 +1,7 @@
 import { CommonModule } from '@angular/common';
-import { NgModule } from '@angular/core';
+import { ModuleWithProviders, NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
+import { FocusIfModule } from '../../directives/focus-if/index';
 import { SpinButtonModule } from '../spin-button/index';
 import { TimePickerModule } from '../time-picker/index';
 import { DateTimePickerComponent } from './date-time-picker.component';
@@ -8,10 +9,9 @@ import { DateTimePickerConfig } from './date-time-picker.config';
 import { DayViewComponent } from './day-view/day-view.component';
 import { HeaderComponent } from './header/header.component';
 import { MonthViewComponent } from './month-view/month-view.component';
+import { WeekDaySortPipe } from './pipes/weekday-sort.pipe';
 import { TimeViewComponent } from './time-view/time-view.component';
 import { YearViewComponent } from './year-view/year-view.component';
-import { FocusIfModule } from '../../directives/focus-if/index';
-import { ModuleWithProviders } from '@angular/core';
 
 @NgModule({
     imports: [
@@ -22,7 +22,15 @@ import { ModuleWithProviders } from '@angular/core';
         FocusIfModule
     ],
     exports: [DateTimePickerComponent],
-    declarations: [DateTimePickerComponent, HeaderComponent, DayViewComponent, MonthViewComponent, YearViewComponent, TimeViewComponent]
+    declarations: [
+        DateTimePickerComponent,
+        HeaderComponent,
+        DayViewComponent,
+        MonthViewComponent,
+        YearViewComponent,
+        TimeViewComponent,
+        WeekDaySortPipe
+    ]
 })
 export class DateTimePickerModule {
     static forRoot(): ModuleWithProviders {

--- a/src/components/date-time-picker/date-time-picker.service.ts
+++ b/src/components/date-time-picker/date-time-picker.service.ts
@@ -1,10 +1,11 @@
+import { WeekDay } from '@angular/common';
 import { Injectable, Optional } from '@angular/core';
 import { BehaviorSubject } from 'rxjs/BehaviorSubject';
+import { distinctUntilChanged } from 'rxjs/operators';
 import { Subject } from 'rxjs/Subject';
 import { Subscription } from 'rxjs/Subscription';
-import { distinctUntilChanged } from 'rxjs/operators';
 import { DateTimePickerConfig } from './date-time-picker.config';
-import { dateComparator, weekdaysShort, timezones, DateTimePickerTimezone, months, monthsShort, meridians } from './date-time-picker.utils';
+import { dateComparator, DateTimePickerTimezone, meridians, months, monthsShort, timezones, weekdaysShort } from './date-time-picker.utils';
 
 @Injectable()
 export class DateTimePickerService {
@@ -31,6 +32,7 @@ export class DateTimePickerService {
     header$ = new BehaviorSubject<string>(null);
     headerEvent$ = new Subject<DatePickerHeaderEvent>();
     modeDirection: ModeDirection = ModeDirection.None;
+    startOfWeek$ = new BehaviorSubject<WeekDay>(WeekDay.Sunday);
 
     months: string[] = this._config ? this._config.months : months;
     monthsShort: string[] = this._config ? this._config.monthsShort : monthsShort;

--- a/src/components/date-time-picker/day-view/day-view.component.html
+++ b/src/components/date-time-picker/day-view/day-view.component.html
@@ -1,7 +1,7 @@
 <table class="calendar">
     <thead>
         <tr>
-            <th *ngFor="let day of datePicker.weekdays$ | async" class="weekday" [attr.aria-label]="day">{{ day }}</th>
+            <th *ngFor="let day of datePicker.weekdays$ | async | weekDaySort: (datePicker.startOfWeek$ | async)" class="weekday" [attr.aria-label]="day">{{ day }}</th>
         </tr>
     </thead>
 

--- a/src/components/date-time-picker/day-view/day-view.service.ts
+++ b/src/components/date-time-picker/day-view/day-view.service.ts
@@ -17,8 +17,6 @@ export class DayViewService implements OnDestroy {
     constructor(private _datepicker: DateTimePickerService) {
         this._subscription = combineLatest(_datepicker.month$, _datepicker.year$, _datepicker.startOfWeek$)
             .subscribe(([month, year]) => this.createDayGrid(month, year));
-
-        _datepicker.startOfWeek$.subscribe(() => this.createDayGrid(_datepicker.month$.value, _datepicker.year$.value));
     }
 
     ngOnDestroy(): void {

--- a/src/components/date-time-picker/pipes/weekday-sort.pipe.ts
+++ b/src/components/date-time-picker/pipes/weekday-sort.pipe.ts
@@ -1,0 +1,23 @@
+import { WeekDay } from '@angular/common';
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({
+    name: 'weekDaySort'
+})
+export class WeekDaySortPipe implements PipeTransform {
+
+    transform(value: string[], startOfWeek: WeekDay): string[] {
+
+        // ensure start of week is in range
+        startOfWeek = Math.max(WeekDay.Sunday, Math.min(WeekDay.Saturday, startOfWeek));
+
+        // create a new array to avoid altering the original
+        const weekdays = [...value];
+
+        for (let idx = 0; idx < startOfWeek; idx++) {
+            weekdays.push(weekdays.shift());
+        }
+
+        return weekdays;
+    }
+}


### PR DESCRIPTION
- Adding support for `startOfWeek` input which allows the user to define which day of the week should be in the first column.
- Added test case to cover this new feature.

#### Ticket
https://autjira.microfocus.com/browse/EL-3336

#### Documentation CI URL
https://pages.github.houston.softwaregrp.net/sepg-docs-qa/UXAspects_CI_UXAspects_EL-3336-Date-Start-Of-Week
