### PR TITLE
EL-3361 - Tree Node Accessibility

### DIFF
--- a/docs/app/pages/components/components-sections/tree-view/tree-view/snippets/app.snippet.html
+++ b/docs/app/pages/components/components-sections/tree-view/tree-view/snippets/app.snippet.html
@@ -7,14 +7,15 @@
                 [attr.aria-expanded]="node.isExpanded"
                 [tabindex]="node === focused || !focused && node.isRoot && node.index === 0 ? 0 : -1"
                 (focus)="focus(node)"
+                (blur)="blur(node)"
                 [focusIf]="node === focused">
 
-                <div class="node-content-wrapper" 
+                <div class="node-content-wrapper"
                     [class.node-content-wrapper-active]="node.isActive"
                     [class.node-content-wrapper-focused]="node.isFocused">
 
                     <tree-node-expander class="m-r-xs" [node]="node"></tree-node-expander>
-                    
+
                     <span class="hpe-icon m-r-xxs"
                         [class.hpe-folder]="node.hasChildren && !node.isExpanded"
                         [class.hpe-folder-open]="node.hasChildren && node.isExpanded"

--- a/docs/app/pages/components/components-sections/tree-view/tree-view/snippets/app.snippet.ts
+++ b/docs/app/pages/components/components-sections/tree-view/tree-view/snippets/app.snippet.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { TreeModel, TreeNode, TreeComponent } from 'angular-tree-component';
+import { TreeNode } from 'angular-tree-component';
 
 @Component({
     selector: 'app',
@@ -66,7 +66,7 @@ export class AppComponent {
         ]
     }];
 
-    focused: TreeNode;    
+    focused: TreeNode;
 
     /**
      * If tree view is tabbed to, focus the node
@@ -74,6 +74,14 @@ export class AppComponent {
     focus(node: TreeNode): void {
         node.focus();
         node.treeModel.setFocus(true);
+    }
+
+    /** Ensure the blur state is updated consistently */
+    blur(node: TreeNode): void {
+        if (this.focused === node) {
+            node.blur();
+            node.treeModel.setFocus(false);
+        }
     }
 }
 

--- a/docs/app/pages/components/components-sections/tree-view/tree-view/tree-view.component.html
+++ b/docs/app/pages/components/components-sections/tree-view/tree-view/tree-view.component.html
@@ -7,14 +7,15 @@
                  [attr.aria-expanded]="node.hasChildren ? node.isExpanded || false : null"
                  [tabindex]="node === focused || !focused && node.isRoot && node.index === 0 ? 0 : -1"
                  (focus)="focus(node)"
+                 (blur)="blur(node)"
                  [focusIf]="node === focused">
 
-                <div class="node-content-wrapper" 
+                <div class="node-content-wrapper"
                      [class.node-content-wrapper-active]="node.isActive"
                      [class.node-content-wrapper-focused]="node.isFocused">
 
                     <tree-node-expander class="m-r-xs" [node]="node"></tree-node-expander>
-                    
+
                     <span class="hpe-icon m-r-xxs"
                         [class.hpe-folder]="node.hasChildren && !node.isExpanded"
                         [class.hpe-folder-open]="node.hasChildren && node.isExpanded"

--- a/docs/app/pages/components/components-sections/tree-view/tree-view/tree-view.component.ts
+++ b/docs/app/pages/components/components-sections/tree-view/tree-view/tree-view.component.ts
@@ -1,5 +1,5 @@
-import { Component, ViewChild } from '@angular/core';
-import { TreeComponent, TreeNode } from 'angular-tree-component';
+import { Component } from '@angular/core';
+import { TreeNode } from 'angular-tree-component';
 import { BaseDocumentationSection } from '../../../../../components/base-documentation-section/base-documentation-section';
 import { DocumentationSectionComponent } from '../../../../../decorators/documentation-section-component';
 
@@ -79,9 +79,17 @@ export class ComponentsTreeViewComponent extends BaseDocumentationSection {
     /**
      * If tree view is tabbed to, focus the node
      */
-    focus(node: TreeNode, element: HTMLElement): void {
+    focus(node: TreeNode): void {
         node.focus();
         node.treeModel.setFocus(true);
+    }
+
+    /** Ensure the blur state is updated consistently */
+    blur(node: TreeNode): void {
+        if (this.focused === node) {
+            node.blur();
+            node.treeModel.setFocus(false);
+        }
     }
 }
 


### PR DESCRIPTION
Bug where focus on a tree view node then press tab. The node is no longer focused by left and right arrow keys would still expand/collapse the node.

Updated documentation to fix this example.

#### Ticket
https://autjira.microfocus.com/browse/EL-3361

#### Documentation CI URL
https://pages.github.houston.softwaregrp.net/sepg-docs-qa/UXAspects_CI_UXAspects_EL-3361-Tree-Accessibility-Documentation