### PR TITLE
EL-3368 - Tree View HTML tooltip support

### DIFF
--- a/src/ng1/directives/treeView/treeView.partial.html
+++ b/src/ng1/directives/treeView/treeView.partial.html
@@ -28,7 +28,7 @@
   </span>
 
   <span class="title-readonly"
-        tooltip="{{ tv.getTooltip(node) }}"
+        tooltip-html="tv.getTooltip(node)"
         ng-click="node.disabled ? null : tv.edit(this); $event.preventDefault(); $event.stopPropagation()"
         ng-show="!tv.isBeingEdited(this)"
         tabindex="{{ node.disabled ? -1 : 0 }}"


### PR DESCRIPTION
Adding support for HTML tooltips on tree view. Switched to use the ui-bootstrap `tooltip-html` directive instead of `tooltip` as it supports both plain text and html so existing uses will remain as is while also allow html content.

#### Ticket
https://autjira.microfocus.com/browse/EL-3368

#### Documentation CI URL
Will make build when ticket is in active sprint
