### PR TITLE
EL-3366 - Masthead Expression Changed

### DIFF
--- a/src/components/tabset/tab/tab.component.ts
+++ b/src/components/tabset/tab/tab.component.ts
@@ -1,7 +1,8 @@
 import { ChangeDetectionStrategy, Component, EventEmitter, Input, OnDestroy, Output, TemplateRef } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
-import { Subscription } from 'rxjs/Subscription';
 import { map } from 'rxjs/operators';
+import { Subscription } from 'rxjs/Subscription';
+import { tick } from '../../../common/index';
 import { TabsetService } from '../tabset.service';
 
 let uniqueTabId = 0;
@@ -28,7 +29,7 @@ export class TabComponent implements OnDestroy {
     }
 
     headingRef: TemplateRef<any>;
-    active$: Observable<boolean> = this._tabset.active$.pipe(map(active => active === this));
+    active$: Observable<boolean> = this._tabset.active$.pipe(map(active => active === this), tick());
 
     private _subscription: Subscription;
 


### PR DESCRIPTION
The Tab Component is causing the error when the active property is set on initialisation. It can be easily be reproduced, eg: https://plnkr.co/edit/NWlz3Z8C2J4LfDXIzHaV?p=preview

Just added the tick operator to the `active$` observable in the tab component.

#### Ticket
https://autjira.microfocus.com/browse/EL-3366

#### Documentation CI URL
https://pages.github.houston.softwaregrp.net/sepg-docs-qa/UXAspects_CI_UXAspects_EL-3366-Masthead-Expression-Changed
