### PR TITLE
EL-3344 - Virtual Scroll Improvements

### DIFF
--- a/docs/app/pages/components/components-sections/scrollbar/virtual-scroll/snippets/app.html
+++ b/docs/app/pages/components/components-sections/scrollbar/virtual-scroll/snippets/app.html
@@ -7,10 +7,10 @@
     [loadOnScroll]="loadOnScroll"
     (loading)="loadPage($event)">
 
-    <div *uxVirtualScrollCell="let cell = cell"
+    <div *uxVirtualScrollCell="let cell = cell; let index = index"
         role="listitem"
         [attr.aria-setsize]="totalItems"
-        [attr.aria-posinset]="cell.position"
+        [attr.aria-posinset]="index"
         class="virtual-cell">
 
         <div class="employee-details">

--- a/docs/app/pages/components/components-sections/scrollbar/virtual-scroll/snippets/app.ts
+++ b/docs/app/pages/components/components-sections/scrollbar/virtual-scroll/snippets/app.ts
@@ -15,7 +15,6 @@ export class AppComponent {
     loadOnScroll: boolean = true;
     employees: Subject<Employee[]> = new Subject<Employee[]>();
     loading = false;
-
     pageSize = 2000;
     totalPages = 10;
     totalItems: number;
@@ -42,8 +41,7 @@ export class AppComponent {
                 id: idx,
                 name: name,
                 email: name.toLowerCase().replace(' ', '.') + '@business.com',
-                department: chance.pickone(DEPARTMENTS),
-                position: idx
+                department: chance.pickone(DEPARTMENTS)
             });
         }
 
@@ -67,5 +65,4 @@ interface Employee {
     name: string;
     email: string;
     department: string;
-    position: number;
 }

--- a/docs/app/pages/components/components-sections/scrollbar/virtual-scroll/virtual-scroll.component.html
+++ b/docs/app/pages/components/components-sections/scrollbar/virtual-scroll/virtual-scroll.component.html
@@ -7,10 +7,10 @@
     [loadOnScroll]="loadOnScroll"
     (loading)="loadPage($event)">
 
-    <div *uxVirtualScrollCell="let cell = cell"
+    <div *uxVirtualScrollCell="let cell = cell; let index = index"
         role="listitem"
         [attr.aria-setsize]="totalItems"
-        [attr.aria-posinset]="cell.position"
+        [attr.aria-posinset]="index"
         class="virtual-cell">
 
         <div class="employee-details">

--- a/docs/app/pages/components/components-sections/scrollbar/virtual-scroll/virtual-scroll.component.ts
+++ b/docs/app/pages/components/components-sections/scrollbar/virtual-scroll/virtual-scroll.component.ts
@@ -66,8 +66,7 @@ export class ComponentsVirtualScrollComponent extends BaseDocumentationSection i
                 id: idx,
                 name: name,
                 email: name.toLowerCase().replace(' ', '.') + '@business.com',
-                department: chance.pickone(DEPARTMENTS),
-                position: idx
+                department: chance.pickone(DEPARTMENTS)
             });
         }
 
@@ -91,5 +90,4 @@ interface Employee {
     name: string;
     email: string;
     department: string;
-    position: number;
 }

--- a/docs/app/pages/components/components-sections/utilities/tabbable-list/tabbable-list.component.html
+++ b/docs/app/pages/components/components-sections/utilities/tabbable-list/tabbable-list.component.html
@@ -62,6 +62,10 @@
     <tr uxd-api-property name="expanded" type="boolean" defaultValue="false">
         Indicate if the item is expanded if used as a hierarchical item.
     </tr>
+    <tr uxd-api-property name="key" type="any">
+        Specify a unique identifier for the tabbable item.
+        This should be used if using a tabbable list in a virtual scroll component.
+    </tr>
 </uxd-api-properties>
 
 

--- a/src/components/virtual-scroll/virtual-scroll.component.html
+++ b/src/components/virtual-scroll/virtual-scroll.component.html
@@ -13,5 +13,5 @@
     <div class="virtual-scroll-load-button" *ngIf="loadButtonTemplate && !loadOnScroll && !loadingComplete && !isLoading" (click)="loadNextPage()">
         <ng-container *ngTemplateOutlet="loadButtonTemplate"></ng-container>
     </div>
-    
+
 </div>

--- a/src/components/virtual-scroll/virtual-scroll.component.html
+++ b/src/components/virtual-scroll/virtual-scroll.component.html
@@ -3,7 +3,7 @@
 
     <!-- Virtually Render Cells -->
     <ng-container *ngFor="let cell of cells | async">
-        <ng-container *ngTemplateOutlet="cellTemplate; context: { cell: cell }"></ng-container>
+        <ng-container *ngTemplateOutlet="cellTemplate; context: { cell: cell.data, index: cell.index }"></ng-container>
     </ng-container>
 
     <!-- Loading Indicator -->

--- a/src/components/virtual-scroll/virtual-scroll.component.ts
+++ b/src/components/virtual-scroll/virtual-scroll.component.ts
@@ -15,10 +15,16 @@ import { VirtualScrollLoadingDirective } from './directives/virtual-scroll-loadi
 })
 export class VirtualScrollComponent<T> implements OnInit, AfterContentInit, OnDestroy {
 
+    /** Provide the collection of items to display */
     @Input() collection: Observable<T[]> = Observable.create();
+
+    /** Specify the height of each cell */
     @Input() cellHeight: number;
+
+    /** Indicate whether pages should be loaded on scroll or button click */
     @Input() loadOnScroll: boolean = true;
 
+    /** Emit when we need to load another page */
     @Output() loading: EventEmitter<number> = new EventEmitter<number>();
 
     @ContentChild(VirtualScrollCellDirective, { read: TemplateRef }) cellTemplate: TemplateRef<any>;

--- a/src/components/virtual-scroll/virtual-scroll.component.ts
+++ b/src/components/virtual-scroll/virtual-scroll.component.ts
@@ -1,8 +1,8 @@
 import { AfterContentInit, Component, ContentChild, ElementRef, EventEmitter, HostListener, Input, OnDestroy, OnInit, Output, SimpleChanges, TemplateRef } from '@angular/core';
-import { Subject } from 'rxjs';
 import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 import { Observable } from 'rxjs/Observable';
 import { takeUntil } from 'rxjs/operators';
+import { Subject } from 'rxjs/Subject';
 import { Subscription } from 'rxjs/Subscription';
 import { ResizeService } from '../../directives/resize/index';
 import { VirtualScrollCellDirective } from './directives/virtual-scroll-cell.directive';
@@ -25,7 +25,7 @@ export class VirtualScrollComponent<T> implements OnInit, AfterContentInit, OnDe
     @ContentChild(VirtualScrollLoadingDirective, { read: TemplateRef }) loadingIndicatorTemplate: TemplateRef<any>;
     @ContentChild(VirtualScrollLoadButtonDirective, { read: TemplateRef }) loadButtonTemplate: TemplateRef<any>;
 
-    cells: BehaviorSubject<T[]> = new BehaviorSubject([]);
+    cells: BehaviorSubject<VirtualCell<T>[]> = new BehaviorSubject([]);
     scrollTop: number = 0;
     isLoading: boolean = false;
     pageNumber: number = 0;
@@ -104,7 +104,7 @@ export class VirtualScrollComponent<T> implements OnInit, AfterContentInit, OnDe
         }
     }
 
-    getVisibleCells(): T[] {
+    getVisibleCells(): VirtualCell<T>[] {
 
         // store the initial element height
         if (!this._height) {
@@ -124,7 +124,10 @@ export class VirtualScrollComponent<T> implements OnInit, AfterContentInit, OnDe
         this.scrollTop = (scrollTop - (scrollTop % this.cellHeight)) - ((startCell - startBuffer) * this.cellHeight);
 
         // return a sublist of items visible on the screen
-        return this.data.slice(startBuffer, endBuffer);
+        const cells = this.data.slice(startBuffer, endBuffer);
+
+        // now map these cells to a virtual cell interface
+        return cells.map((cell, index) => ({ data: cell, index: startBuffer + index }));
     }
 
     getTotalHeight(): number {
@@ -155,4 +158,9 @@ export class VirtualScrollComponent<T> implements OnInit, AfterContentInit, OnDe
         // reload first page
         this.loadNextPage();
     }
+}
+
+export interface VirtualCell<T> {
+    data: T;
+    index: number;
 }

--- a/src/directives/accessibility/tabbable-list/tabbable-list-item.directive.ts
+++ b/src/directives/accessibility/tabbable-list/tabbable-list-item.directive.ts
@@ -6,6 +6,7 @@ import { tick } from '../../../common/index';
 import { TabbableListService } from './tabbable-list.service';
 
 let nextId = 0;
+let uniqueKey = 0;
 
 @Directive({
     selector: '[uxTabbableListItem]',
@@ -22,6 +23,9 @@ export class TabbableListItemDirective implements FocusableOption, OnDestroy {
     @Input() expanded: boolean = false;
 
     @Input() order: number = 0;
+
+    /** Provide a unique key to help identify items when used in a virtual list */
+    @Input() key: any = `tabbable-list-key-${uniqueKey++}`;
 
     @Output() expandedChange = new EventEmitter<boolean>();
 
@@ -81,7 +85,7 @@ export class TabbableListItemDirective implements FocusableOption, OnDestroy {
     focus(): void {
 
         // apply focus to the element
-        this._elementRef.nativeElement.focus();
+        (this._elementRef.nativeElement as HTMLElement).focus({ preventScroll: !this._tabbableList.shouldScrollInView });
 
         // ensure the focus key manager updates the active item correctly
         this._tabbableList.activate(this);

--- a/src/directives/accessibility/tabbable-list/tabbable-list-item.directive.ts
+++ b/src/directives/accessibility/tabbable-list/tabbable-list-item.directive.ts
@@ -21,6 +21,8 @@ export class TabbableListItemDirective implements FocusableOption, OnDestroy {
 
     @Input() expanded: boolean = false;
 
+    @Input() order: number = 0;
+
     @Output() expandedChange = new EventEmitter<boolean>();
 
     @HostBinding() tabindex: number = -1;

--- a/src/directives/accessibility/tabbable-list/tabbable-list-item.directive.ts
+++ b/src/directives/accessibility/tabbable-list/tabbable-list-item.directive.ts
@@ -22,8 +22,6 @@ export class TabbableListItemDirective implements FocusableOption, OnDestroy {
 
     @Input() expanded: boolean = false;
 
-    @Input() order: number = 0;
-
     /** Provide a unique key to help identify items when used in a virtual list */
     @Input() key: any = `tabbable-list-key-${uniqueKey++}`;
 

--- a/src/directives/accessibility/tabbable-list/tabbable-list-item.directive.ts
+++ b/src/directives/accessibility/tabbable-list/tabbable-list-item.directive.ts
@@ -89,4 +89,8 @@ export class TabbableListItemDirective implements FocusableOption, OnDestroy {
     onKeydown(event: KeyboardEvent): void {
         this._tabbableList.onKeydown(this, event);
     }
+
+    getFocused(): boolean {
+        return this._elementRef.nativeElement === document.activeElement;
+    }
 }

--- a/src/directives/accessibility/tabbable-list/tabbable-list.directive.ts
+++ b/src/directives/accessibility/tabbable-list/tabbable-list.directive.ts
@@ -53,11 +53,11 @@ export class TabbableListDirective implements AfterContentInit, OnDestroy {
 
         // store the currently focused element
         this._focusedElement = document.activeElement as HTMLElement;
+        this._orderedItems = new QueryList<TabbableListItemDirective>();
 
         if (this._tabbableList.hierarchy) {
 
             // Sort items in a hierarchy
-            this._orderedItems = new QueryList<TabbableListItemDirective>();
             this._orderedItems.reset(this._tabbableList.sortItemsByHierarchy(this.items));
 
             // Ensure that the child items remain sorted
@@ -68,8 +68,17 @@ export class TabbableListDirective implements AfterContentInit, OnDestroy {
 
         } else {
 
-            // Items are already in order
-            this._orderedItems = this.items;
+            // Sort items by the specified order
+            this._orderedItems.reset(this.items.toArray().sort((itemOne, itemTwo) => itemOne.order - itemTwo.order));
+
+            // Ensure that the child items remain sorted
+            this.items.changes.pipe(takeUntil(this._onDestroy)).subscribe(() => {
+                this._orderedItems.reset(this.items.toArray().sort((itemOne, itemTwo) => {
+                    debugger;
+                    return itemOne.order - itemTwo.order;
+                }));
+                this._orderedItems.notifyOnChanges();
+            });
         }
 
         // Set up the focus monitoring

--- a/src/directives/accessibility/tabbable-list/tabbable-list.directive.ts
+++ b/src/directives/accessibility/tabbable-list/tabbable-list.directive.ts
@@ -68,28 +68,20 @@ export class TabbableListDirective implements AfterContentInit, OnDestroy {
 
         } else {
 
-            // Sort items by the specified order
-            this._orderedItems.reset(this.items.toArray().sort((itemOne, itemTwo) => itemOne.order - itemTwo.order));
+            // Items are already in order
+            this._orderedItems = this.items;
 
-            // Ensure that the items remain sorted
-            this.items.changes.pipe(takeUntil(this._onDestroy)).subscribe(() => {
+            // Ensure we reselect a selected item after the querylist has changed
+            this.items.changes.pipe(takeUntil(this._onDestroy)).subscribe((items: QueryList<TabbableListItemDirective>) => {
+
                 // check if an item is currently focused
                 const activeItem = this._tabbableList.focusKeyManager.activeItem;
-
-                // get the new array of items sorted
-                const items = this.items.toArray().sort((itemOne, itemTwo) => itemOne.order - itemTwo.order);
-
-                // reset the list of items
-                this._orderedItems.reset(items);
-
-                // emit the change event
-                this._orderedItems.notifyOnChanges();
 
                 // restore the selected item if there was one and it is still visible
                 if (activeItem) {
 
                     // find the matching index
-                    const index = items.findIndex(item => item.key === activeItem.key);
+                    const index = items.toArray().findIndex(item => item.key === activeItem.key);
 
                     // if the item is still in the list we want to focus it
                     if (index > -1) {

--- a/src/directives/accessibility/tabbable-list/tabbable-list.service.ts
+++ b/src/directives/accessibility/tabbable-list/tabbable-list.service.ts
@@ -54,6 +54,21 @@ export class TabbableListService implements OnDestroy {
 
             // ensure there is at least one item tabbable at all times
             this.ensureTabbableItem();
+
+            // check if an item is currently focused
+            const focusedElement = this._items.find(item => item.getFocused());
+
+            // if there is an item focused we need to ensure we update it's index within the list (required for virtual scrolling)
+            if (focusedElement) {
+
+                debugger;
+                // CDK version 5 specific - Deprecated and removed in CDK v8.0
+                if (this.focusKeyManager.updateActiveItemIndex) {
+                    this.focusKeyManager.updateActiveItemIndex(this._items.toArray().indexOf(focusedElement));
+                } else if ((this.focusKeyManager as any).updateActiveItem) {
+                    (this.focusKeyManager as any).updateActiveItem(focusedElement);
+                }
+            }
         });
     }
 
@@ -112,6 +127,7 @@ export class TabbableListService implements OnDestroy {
         }
     }
 
+    counter: number = 0;
 
     onKeydown(source: TabbableListItemDirective, event: KeyboardEvent): any {
 
@@ -120,6 +136,11 @@ export class TabbableListService implements OnDestroy {
             return;
         }
 
+        this.counter++;
+
+        if (this.counter === 6) {
+            debugger;
+        }
         this.focusKeyManager.onKeydown(event);
 
         // if the key is a boundary key and boundary keys are enabled

--- a/src/directives/accessibility/tabbable-list/tabbable-list.service.ts
+++ b/src/directives/accessibility/tabbable-list/tabbable-list.service.ts
@@ -54,21 +54,6 @@ export class TabbableListService implements OnDestroy {
 
             // ensure there is at least one item tabbable at all times
             this.ensureTabbableItem();
-
-            // check if an item is currently focused
-            const focusedElement = this._items.find(item => item.getFocused());
-
-            // if there is an item focused we need to ensure we update it's index within the list (required for virtual scrolling)
-            if (focusedElement) {
-
-                debugger;
-                // CDK version 5 specific - Deprecated and removed in CDK v8.0
-                if (this.focusKeyManager.updateActiveItemIndex) {
-                    this.focusKeyManager.updateActiveItemIndex(this._items.toArray().indexOf(focusedElement));
-                } else if ((this.focusKeyManager as any).updateActiveItem) {
-                    (this.focusKeyManager as any).updateActiveItem(focusedElement);
-                }
-            }
         });
     }
 
@@ -127,8 +112,6 @@ export class TabbableListService implements OnDestroy {
         }
     }
 
-    counter: number = 0;
-
     onKeydown(source: TabbableListItemDirective, event: KeyboardEvent): any {
 
         // prevent anything happening when modifier keys are pressed if they have been disabled
@@ -136,11 +119,6 @@ export class TabbableListService implements OnDestroy {
             return;
         }
 
-        this.counter++;
-
-        if (this.counter === 6) {
-            debugger;
-        }
         this.focusKeyManager.onKeydown(event);
 
         // if the key is a boundary key and boundary keys are enabled

--- a/src/directives/accessibility/tabbable-list/tabbable-list.service.ts
+++ b/src/directives/accessibility/tabbable-list/tabbable-list.service.ts
@@ -12,6 +12,7 @@ export class TabbableListService implements OnDestroy {
     allowAltModifier: boolean = true;
     allowCtrlModifier: boolean = true;
     allowBoundaryKeys: boolean = false;
+    shouldScrollInView: boolean = true;
     focusKeyManager: FocusKeyManager<TabbableListItemDirective>;
 
     private _items: QueryList<TabbableListItemDirective>;


### PR DESCRIPTION
Virtual Scrolling did not work well with tabbable list. This was for a number of reasons:

- The number of cells in the dom above and below the visible range were sometimes 0 which meant pressing arrow led to no dom node. I have increased the number of DOM cells on each side of the virtual list.
- The ListKeyManager, when the QueryList of TabbableListItem changes tries to see if the previously focused item is still in the list and refocuses it. However, the way the virtual scroll works meant a new tabbable list item instance is created each time a cell is redrawn meaning it never got reselected when the virtual scroll visible range changed. So I have updated this to allow for a `key` input on tabbable list items so we can identify when an item is the same even if it is a different instance.

Also exposed an `index` property in the virtual scroll context and updated the example

#### Ticket
https://autjira.microfocus.com/browse/EL-3344

#### Documentation CI URL
https://pages.github.houston.softwaregrp.net/sepg-docs-qa/UXAspects_CI_UXAspects_EL-3344-Virtual-Scroll-Improvements
