### PR TITLE
EL-3343 - Select Focus Issue Fix

### DIFF
--- a/src/components/select/select.component.html
+++ b/src/components/select/select.component.html
@@ -51,8 +51,8 @@
         [(ngModel)]="input"
         [placeholder]="placeholder"
         [disabled]="disabled"
-        (click)="inputClickHandler($event)"
-        (blur)="inputBlurHandler($event)"
+        (click)="inputClickHandler()"
+        (blur)="inputBlurHandler()"
         (keydown)="inputKeyHandler($event)">
 
     <ux-typeahead #singleTypeahead

--- a/src/components/select/select.component.ts
+++ b/src/components/select/select.component.ts
@@ -1,3 +1,4 @@
+import { ENTER } from '@angular/cdk/keycodes';
 import { DOCUMENT } from '@angular/common';
 import { Component, ElementRef, EventEmitter, forwardRef, HostBinding, HostListener, Inject, Input, OnChanges, OnDestroy, OnInit, Output, SimpleChanges, StaticProvider, TemplateRef, ViewChild } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
@@ -21,16 +22,13 @@ export const SELECT_VALUE_ACCESSOR: StaticProvider = {
     selector: 'ux-select, ux-combobox, ux-dropdown',
     templateUrl: 'select.component.html',
     providers: [SELECT_VALUE_ACCESSOR],
-    host: {
-        'tabindex': '0'
-    }
 })
-export class SelectComponent implements OnInit, OnChanges, OnDestroy, ControlValueAccessor {
+export class SelectComponent<T> implements OnInit, OnChanges, OnDestroy, ControlValueAccessor {
 
     @Input() @HostBinding('attr.id') id: string = `ux-select-${++uniqueId}`;
 
     @Input()
-    set value(value: any) {
+    set value(value: T) {
         this._value$.next(value);
     }
     get value() {
@@ -54,9 +52,9 @@ export class SelectComponent implements OnInit, OnChanges, OnDestroy, ControlVal
         return this._dropdownOpen;
     }
 
-    @Input() options: any[] | InfiniteScrollLoadFunction;
-    @Input() display: (option: any) => string | string;
-    @Input() key: (option: any) => string | string;
+    @Input() options: T[] | InfiniteScrollLoadFunction;
+    @Input() display: (option: T) => string | string;
+    @Input() key: (option: T) => string | string;
     @Input() allowNull: boolean = false;
     @Input() disabled: boolean = false;
     @Input() dropDirection: 'up' | 'down' = 'down';
@@ -70,7 +68,7 @@ export class SelectComponent implements OnInit, OnChanges, OnDestroy, ControlVal
     @Input() noOptionsTemplate: TemplateRef<any>;
     @Input() optionTemplate: TemplateRef<any>;
 
-    @Output() valueChange = new EventEmitter<any>();
+    @Output() valueChange = new EventEmitter<T>();
     @Output() inputChange = new EventEmitter<string>();
     @Output() dropdownOpenChange = new EventEmitter<boolean>();
 
@@ -83,7 +81,7 @@ export class SelectComponent implements OnInit, OnChanges, OnDestroy, ControlVal
     filter$: Observable<string>;
     propagateChange = (_: any) => { };
 
-    private _value$ = new BehaviorSubject<any>(null);
+    private _value$ = new BehaviorSubject<T>(null);
     private _input$ = new BehaviorSubject<string>('');
     private _dropdownOpen: boolean = false;
     private _onDestroy = new Subject<void>();
@@ -93,7 +91,7 @@ export class SelectComponent implements OnInit, OnChanges, OnDestroy, ControlVal
         @Inject(DOCUMENT) private _document: any,
         private _typeaheadKeyService: TypeaheadKeyService) { }
 
-    ngOnInit() {
+    ngOnInit(): void {
 
         // Emit change events
         this._value$.pipe(takeUntil(this._onDestroy), distinctUntilChanged()).subscribe(value => {
@@ -135,7 +133,7 @@ export class SelectComponent implements OnInit, OnChanges, OnDestroy, ControlVal
         });
     }
 
-    ngOnChanges(changes: SimpleChanges) {
+    ngOnChanges(changes: SimpleChanges): void {
         if (changes.multiple && !changes.multiple.firstChange && changes.multiple.currentValue !== changes.multiple.previousValue) {
             this.input = '';
         }
@@ -146,8 +144,8 @@ export class SelectComponent implements OnInit, OnChanges, OnDestroy, ControlVal
         this._onDestroy.complete();
     }
 
-    @HostListener('focus')
-    onfocus(): void {
+    @HostListener('click')
+    onClick(): void {
         if (this.singleInput) {
             this.singleInput.nativeElement.focus();
         } else if (this.tagInput) {
@@ -155,7 +153,7 @@ export class SelectComponent implements OnInit, OnChanges, OnDestroy, ControlVal
         }
     }
 
-    writeValue(obj: any): void {
+    writeValue(obj: T): void {
         if (obj !== undefined && obj !== this.value) {
             this.value = obj;
         }
@@ -165,18 +163,18 @@ export class SelectComponent implements OnInit, OnChanges, OnDestroy, ControlVal
         this.propagateChange = fn;
     }
 
-    registerOnTouched(fn: any): void { }
+    registerOnTouched(fn: T): void { }
 
     setDisabledState(isDisabled: boolean): void {
         this.disabled = isDisabled;
     }
 
-    inputClickHandler(event: MouseEvent) {
+    inputClickHandler(): void {
         this.selectInputText();
         this.dropdownOpen = true;
     }
 
-    inputBlurHandler(event: Event) {
+    inputBlurHandler(): void {
 
         // If a click on the typeahead is in progress, just refocus the input.
         // This works around an issue in IE where clicking a scrollbar drops focus.
@@ -199,13 +197,13 @@ export class SelectComponent implements OnInit, OnChanges, OnDestroy, ControlVal
     /**
      * Key handler for single select only. Multiple select key handling is in TagInputComponent.
      */
-    inputKeyHandler(event: KeyboardEvent) {
+    inputKeyHandler(event: KeyboardEvent): void {
 
         // Standard keys for typeahead (up/down/esc)
         this._typeaheadKeyService.handleKey(event, this.singleTypeahead);
 
-        switch (event.key) {
-            case 'Enter':
+        switch (event.keyCode) {
+            case ENTER:
                 if (this._dropdownOpen) {
                     // Set the highlighted option as the value and close
                     this.value = this.singleTypeahead.highlighted;
@@ -219,7 +217,7 @@ export class SelectComponent implements OnInit, OnChanges, OnDestroy, ControlVal
         }
     }
 
-    singleOptionSelected(event: TypeaheadOptionEvent) {
+    singleOptionSelected(event: TypeaheadOptionEvent): void {
         if (event.option) {
             this.value = event.option;
             this.dropdownOpen = false;
@@ -229,7 +227,7 @@ export class SelectComponent implements OnInit, OnChanges, OnDestroy, ControlVal
     /**
      * Returns the display value of the given option.
      */
-    getDisplay(option: any): string {
+    getDisplay(option: T): string {
         if (option === null || option === undefined) {
             return '';
         }
@@ -239,10 +237,10 @@ export class SelectComponent implements OnInit, OnChanges, OnDestroy, ControlVal
         if (typeof this.display === 'string' && option.hasOwnProperty(this.display)) {
             return option[<string>this.display];
         }
-        return option;
+        return option as any;
     }
 
-    private selectInputText() {
+    private selectInputText(): void {
         this.singleInput.nativeElement.select();
     }
 }

--- a/src/components/select/select.component.ts
+++ b/src/components/select/select.component.ts
@@ -1,6 +1,6 @@
 import { ENTER } from '@angular/cdk/keycodes';
 import { DOCUMENT } from '@angular/common';
-import { Component, ElementRef, EventEmitter, forwardRef, HostBinding, HostListener, Inject, Input, OnChanges, OnDestroy, OnInit, Output, SimpleChanges, StaticProvider, TemplateRef, ViewChild } from '@angular/core';
+import { Component, ElementRef, EventEmitter, forwardRef, HostBinding, Inject, Input, OnChanges, OnDestroy, OnInit, Output, SimpleChanges, StaticProvider, TemplateRef, ViewChild } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 import { Observable } from 'rxjs/Observable';
@@ -142,15 +142,6 @@ export class SelectComponent<T> implements OnInit, OnChanges, OnDestroy, Control
     ngOnDestroy(): void {
         this._onDestroy.next();
         this._onDestroy.complete();
-    }
-
-    @HostListener('click')
-    onClick(): void {
-        if (this.singleInput) {
-            this.singleInput.nativeElement.focus();
-        } else if (this.tagInput) {
-            this.tagInput.focus();
-        }
     }
 
     writeValue(obj: T): void {

--- a/src/components/tag-input/tag-input.component.html
+++ b/src/components/tag-input/tag-input.component.html
@@ -4,7 +4,7 @@
         [ngClass]="tagClass(tag, i, isSelected(i))"
         [attr.tabindex]="disabled ? null : 0"
         [focusIf]="isSelected(i)"
-        (click)="tagClickHandler($event, tag, i)"
+        (click)="tagClickHandler($event, tag, i); $event.stopPropagation()"
         (focus)="selectTagAt(i)">
 
         <ng-container [ngTemplateOutlet]="tagTemplate"

--- a/src/components/tag-input/tag-input.component.ts
+++ b/src/components/tag-input/tag-input.component.ts
@@ -38,7 +38,7 @@ export class TagInputComponent implements OnInit, AfterContentInit, OnChanges, C
 
     @Input() @HostBinding('attr.id') id: string = `ux-tag-input-${++uniqueId}`;
 
-    @Input('tags')
+    @Input()
     get tags() {
         if (!this._tags) {
             this._tags = [];
@@ -53,7 +53,7 @@ export class TagInputComponent implements OnInit, AfterContentInit, OnChanges, C
 
     @Output() tagsChange = new EventEmitter<any[]>();
 
-    @Input('input')
+    @Input()
     get input() {
         return this._input;
     }
@@ -300,6 +300,16 @@ export class TagInputComponent implements OnInit, AfterContentInit, OnChanges, C
                 }
             }
         }, 200);
+    }
+
+    @HostListener('click')
+    onClick(): void {
+
+        // focus the input element
+        this.tagInput.nativeElement.focus();
+
+        // show the typeahead if we need to
+        this.inputClickHandler();
     }
 
     tagClickHandler(event: MouseEvent, tag: any, index: number): void {

--- a/src/components/typeahead/typeahead-key.service.ts
+++ b/src/components/typeahead/typeahead-key.service.ts
@@ -1,3 +1,4 @@
+import { DOWN_ARROW, ENTER, ESCAPE, UP_ARROW } from '@angular/cdk/keycodes';
 import { Injectable } from '@angular/core';
 import { TypeaheadComponent } from './typeahead.component';
 
@@ -5,36 +6,39 @@ import { TypeaheadComponent } from './typeahead.component';
 export class TypeaheadKeyService {
 
     handleKey(event: KeyboardEvent, typeahead: TypeaheadComponent) {
-        if (typeahead) {
-            switch (event.key) {
-                case 'ArrowUp':
-                case 'Up':
-                    if (!typeahead.open) {
-                        typeahead.open = true;
-                    } else {
-                        typeahead.moveHighlight(-1);
-                    }
-                    event.preventDefault();
-                    break;
-                case 'ArrowDown':
-                case 'Down':
-                    if (!typeahead.open) {
-                        typeahead.open = true;
-                    } else {
-                        typeahead.moveHighlight(1);
-                    }
-                    event.preventDefault();
-                    break;
-                case 'Escape':
-                case 'Esc':
-                    typeahead.open = false;
-                    break;
 
-                case 'Enter':
-                    if (typeahead.selectOnEnter) {
-                        typeahead.selectHighlighted();
-                    }
-            }
+        if (!typeahead) {
+            return;
+        }
+
+        switch (event.keyCode) {
+
+            case UP_ARROW:
+                if (!typeahead.open) {
+                    typeahead.open = true;
+                } else {
+                    typeahead.moveHighlight(-1);
+                }
+                event.preventDefault();
+                break;
+
+            case DOWN_ARROW:
+                if (!typeahead.open) {
+                    typeahead.open = true;
+                } else {
+                    typeahead.moveHighlight(1);
+                }
+                event.preventDefault();
+                break;
+
+            case ESCAPE:
+                typeahead.open = false;
+                break;
+
+            case ENTER:
+                if (typeahead.selectOnEnter) {
+                    typeahead.selectHighlighted();
+                }
         }
     }
 }


### PR DESCRIPTION
Pressing shift+tab when select is focused was not moving to the previous tabbable element.

The issue was we had a focus hostlistener on the `ux-select` element which focused the child input. The purpose of this was if the user clicked here:
![image](https://user-images.githubusercontent.com/20795331/50968254-631c5680-14d2-11e9-8232-be3550b9d963.png)
This is inside the component but not inside the input, so we programmatically focused the child input for them.

However this meant if we are focused on the input, then shift+tab this now focuses the `ux-select` which triggers the host listener and refocuses the input, preventing us from ever leaving focus that way. I have changed it to a click listener so we get the same behaviour without the error.

Additionally I have updated the component to use generics instead of any for better type inference and changed to use CDK keycodes for key presses. I also removed some used event variables.

#### Ticket
https://autjira.microfocus.com/browse/EL-3343

#### Documentation CI URL
https://pages.github.houston.softwaregrp.net/sepg-docs-qa/UXAspects_CI_UXAspects_EL-3343-Select-Focus-Issue
