### PR TITLE
EL-3367 - Hierarchy Bar QA Fixes

### DIFF
--- a/docs/app/pages/components/components-sections/hierarchy-bar/hierarchy-bar/hierarchy-bar.component.html
+++ b/docs/app/pages/components/components-sections/hierarchy-bar/hierarchy-bar/hierarchy-bar.component.html
@@ -59,7 +59,7 @@
     </tr>
 
     <tr uxd-api-property name="overflowTemplate" type="TemplateRef">
-        If specified, this will allow customization of the overflow region.
+        If specified, this will allow customization of the overflow region. The hidden nodes are available in the implicit template context.
     </tr>
 
     <tr uxd-api-property name="popoverShowTriggers" type="string[]" defaultValue="['click']">

--- a/docs/app/pages/components/components-sections/hierarchy-bar/hierarchy-bar/hierarchy-bar.component.ts
+++ b/docs/app/pages/components/components-sections/hierarchy-bar/hierarchy-bar/hierarchy-bar.component.ts
@@ -107,7 +107,7 @@ export class ComponentsHierarchyBarComponent extends BaseDocumentationSection im
         },
         modules: [
             {
-                imports: ['HierarchyBarModule', 'AccordionModule', 'RadioButtonModule'],
+                imports: ['HierarchyBarModule', 'RadioButtonModule'],
                 library: '@ux-aspects/ux-aspects'
             }
         ]

--- a/docs/app/pages/components/components-sections/hierarchy-bar/hierarchy-bar/snippets/app.html
+++ b/docs/app/pages/components/components-sections/hierarchy-bar/hierarchy-bar/snippets/app.html
@@ -4,19 +4,7 @@
     </button>
 </ux-hierarchy-bar>
 
-<div class="row uxd-customize-example">
-    <div class="col-md-12">
-        <ux-accordion>
-            <ux-accordion-panel class="accordion-chevron" heading="Customize Example...">
-                <div class="row">
-                    <div class="col-sm-6 col-md-3">
-                        <ux-radio-button option="standard" [(ngModel)]="mode">Standard</ux-radio-button>
-                    </div>
-                    <div class="col-sm-6 col-md-3">
-                        <ux-radio-button option="collapsed" [(ngModel)]="mode">Collapsed</ux-radio-button>
-                    </div>
-                </div>
-            </ux-accordion-panel>
-        </ux-accordion>
-    </div>
+<div class="p-t">
+    <ux-radio-button class="m-r" option="standard" [(ngModel)]="mode">Standard</ux-radio-button>
+    <ux-radio-button option="collapsed" [(ngModel)]="mode">Collapsed</ux-radio-button>
 </div>

--- a/src/components/hierarchy-bar/hierarchy-bar-collapsed/hierarchy-bar-collapsed.component.html
+++ b/src/components/hierarchy-bar/hierarchy-bar-collapsed/hierarchy-bar-collapsed.component.html
@@ -13,7 +13,9 @@
 
     <div class="hierarchy-bar-overflow" *ngIf="_parents.length > 0">
         <div class="hierarchy-bar-overflow-container">
-            <ng-container [ngTemplateOutlet]="hierarchyBar.overflowTemplate || defaultOverflowTemplate"></ng-container>
+            <ng-container [ngTemplateOutlet]="hierarchyBar.overflowTemplate || defaultOverflowTemplate"
+                          [ngTemplateOutletContext]="{ $implicit: _parents }">
+            </ng-container>
         </div>
 
         <button [attr.aria-label]="hierarchyBar.showSiblingsAriaLabel"

--- a/src/components/hierarchy-bar/hierarchy-bar-standard/hierarchy-bar-standard.component.html
+++ b/src/components/hierarchy-bar/hierarchy-bar-standard/hierarchy-bar-standard.component.html
@@ -15,7 +15,9 @@
          [popoverContext]="{ popover: popover }"
          placement="bottom"
          popoverClass="hierarchy-bar-popover">
-        <ng-container [ngTemplateOutlet]="hierarchyBar.overflowTemplate || defaultOverflowTemplate"></ng-container>
+        <ng-container [ngTemplateOutlet]="hierarchyBar.overflowTemplate || defaultOverflowTemplate"
+                      [ngTemplateOutletContext]="{ $implicit: overflow$ | async }">
+        </ng-container>
     </div>
 
     <ux-hierarchy-bar-node


### PR DESCRIPTION
- Making overflow nodes available in the implicit template context so they can be accessed
- Removing the customize example accordion from the example code

#### Ticket
https://autjira.microfocus.com/browse/EL-3367

#### Documentation CI URL
https://pages.github.houston.softwaregrp.net/sepg-docs-qa/UXAspects_CI_UXAspects_EL-3367-Hierarchy-Bar-Qa
