### PR TITLE
EL-3322 - Firefox Focus Issue

### DIFF
--- a/src/directives/accessibility/accessibility.module.ts
+++ b/src/directives/accessibility/accessibility.module.ts
@@ -1,4 +1,5 @@
 import { A11yModule } from '@angular/cdk/a11y';
+import { PlatformModule } from '@angular/cdk/platform';
 import { ModuleWithProviders, NgModule } from '@angular/core';
 import { DefaultFocusIndicatorDirective } from './focus-indicator/default-focus-indicator.directive';
 import { FocusIndicatorDirective } from './focus-indicator/focus-indicator.directive';
@@ -21,7 +22,8 @@ import { TabbableListDirective } from './tabbable-list/tabbable-list.directive';
         SplitterAccessibilityDirective
     ],
     imports: [
-        A11yModule
+        A11yModule,
+        PlatformModule
     ],
     exports: [
         DefaultFocusIndicatorDirective,

--- a/src/directives/accessibility/accessibility.module.ts
+++ b/src/directives/accessibility/accessibility.module.ts
@@ -1,5 +1,4 @@
 import { A11yModule } from '@angular/cdk/a11y';
-import { PlatformModule } from '@angular/cdk/platform';
 import { ModuleWithProviders, NgModule } from '@angular/core';
 import { DefaultFocusIndicatorDirective } from './focus-indicator/default-focus-indicator.directive';
 import { FocusIndicatorDirective } from './focus-indicator/focus-indicator.directive';
@@ -22,8 +21,7 @@ import { TabbableListDirective } from './tabbable-list/tabbable-list.directive';
         SplitterAccessibilityDirective
     ],
     imports: [
-        A11yModule,
-        PlatformModule
+        A11yModule
     ],
     exports: [
         DefaultFocusIndicatorDirective,

--- a/src/directives/accessibility/focus-indicator/default-focus-indicator.directive.ts
+++ b/src/directives/accessibility/focus-indicator/default-focus-indicator.directive.ts
@@ -1,4 +1,3 @@
-import { Platform } from '@angular/cdk/platform';
 import { ChangeDetectorRef, Directive, ElementRef } from '@angular/core';
 import { AccessibilityOptionsService } from '../options/accessibility-options.service';
 import { FocusIndicatorDirective } from './focus-indicator.directive';
@@ -18,19 +17,11 @@ export class DefaultFocusIndicatorDirective extends FocusIndicatorDirective {
         elementRef: ElementRef,
         focusIndicatorService: FocusIndicatorService,
         optionsService: AccessibilityOptionsService,
-        changeDetectorRef: ChangeDetectorRef,
-        platform: Platform
+        changeDetectorRef: ChangeDetectorRef
     ) {
         super(elementRef, focusIndicatorService, optionsService, changeDetectorRef);
-
-        /**
-         * @workaround - Firefox Focus Issue
-         * Firefox can mistakenly detect a focus origin as programmatic focus rather than via keyboard
-         * which can cause the focus indicator not to show. This workaround will show the indicator when
-         * programmtic focus is detected and our browser is firefox.
-         */
-        if (platform.FIREFOX) {
-            this.programmaticFocusIndicator = true;
-        }
+        
+        // Enable programmatic focus by default
+        this.programmaticFocusIndicator = true;
     }
 }

--- a/src/directives/accessibility/focus-indicator/default-focus-indicator.directive.ts
+++ b/src/directives/accessibility/focus-indicator/default-focus-indicator.directive.ts
@@ -1,3 +1,4 @@
+import { Platform } from '@angular/cdk/platform';
 import { ChangeDetectorRef, Directive, ElementRef } from '@angular/core';
 import { AccessibilityOptionsService } from '../options/accessibility-options.service';
 import { FocusIndicatorDirective } from './focus-indicator.directive';
@@ -13,8 +14,23 @@ import { FocusIndicatorService } from './focus-indicator.service';
 })
 export class DefaultFocusIndicatorDirective extends FocusIndicatorDirective {
 
-    constructor(elementRef: ElementRef, focusIndicatorService: FocusIndicatorService,
-        optionsService: AccessibilityOptionsService, changeDetectorRef: ChangeDetectorRef) {
+    constructor(
+        elementRef: ElementRef,
+        focusIndicatorService: FocusIndicatorService,
+        optionsService: AccessibilityOptionsService,
+        changeDetectorRef: ChangeDetectorRef,
+        platform: Platform
+    ) {
         super(elementRef, focusIndicatorService, optionsService, changeDetectorRef);
+
+        /**
+         * @workaround - Firefox Focus Issue
+         * Firefox can mistakenly detect a focus origin as programmatic focus rather than via keyboard
+         * which can cause the focus indicator not to show. This workaround will show the indicator when
+         * programmtic focus is detected and our browser is firefox.
+         */
+        if (platform.FIREFOX) {
+            this.programmaticFocusIndicator = true;
+        }
     }
 }


### PR DESCRIPTION
I'm really not sure how to go about fixing this, essentially there is a check in the CDK to determine if the window has focus or not, (if it does not have focus then it detects any focus event as "programmatic" origin instead of keyboard). For some strange reason Firefox can sometime detect the window as not focused when it is - I can only assume its based on the order event are triggered.

As a workaround I have set it so buttons will show a focus ring when triggered programmatically in Firefox. It will still prevent the focus ring on click, but I suppose there may now be a few cases in Firefox where the focus ring shows up. My thinking was it is better to show a focus ring in a few extra cases than cause accessibility issues by potentially not showing it.

I'm open to any feedback or suggestions around this, a few other alternative solutions could be:
- Make programmatic focus on in all buttons in all browsers
- Remove the automatic button focus control until we do further investigation

#### Ticket
https://autjira.microfocus.com/browse/EL-3322

#### Documentation CI URL
https://pages.github.houston.softwaregrp.net/sepg-docs-qa/UXAspects_CI_UXAspects_EL-3322-Firefox-Focus-Issue
