### PR TITLE
EL-3373 - Resize Directive Destroy Improvement

### DIFF
--- a/src/directives/resize/resize.directive.ts
+++ b/src/directives/resize/resize.directive.ts
@@ -1,6 +1,6 @@
 import { Directive, ElementRef, EventEmitter, Input, NgZone, OnDestroy, OnInit, Output } from '@angular/core';
-import { debounceTime } from 'rxjs/operators';
-import { Subscription } from 'rxjs/Subscription';
+import { debounceTime, takeUntil } from 'rxjs/operators';
+import { Subject } from 'rxjs/Subject';
 import { ResizeDimensions, ResizeService } from './resize.service';
 
 @Directive({
@@ -9,21 +9,26 @@ import { ResizeDimensions, ResizeService } from './resize.service';
 })
 export class ResizeDirective implements OnInit, OnDestroy {
 
+    /** Debounce the resize event emitter */
     @Input() throttle: number = 0;
+
+    /** Emits whenever a resize event occurs */
     @Output() uxResize: EventEmitter<ResizeDimensions> = new EventEmitter<ResizeDimensions>();
 
-    private _subscription: Subscription;
+    /** Remove all subscriptions on component destroy */
+    private _onDestroy = new Subject<void>();
 
     constructor(private _elementRef: ElementRef, private _resizeService: ResizeService, private _ngZone: NgZone) { }
 
     ngOnInit(): void {
-        this._subscription = this._resizeService.addResizeListener(this._elementRef.nativeElement)
-            .pipe(debounceTime(this.throttle))
+        this._resizeService.addResizeListener(this._elementRef.nativeElement)
+            .pipe(takeUntil(this._onDestroy), debounceTime(this.throttle))
             .subscribe((event: ResizeDimensions) => this._ngZone.run(() => this.uxResize.emit(event)));
     }
 
     ngOnDestroy(): void {
         this._resizeService.removeResizeListener(this._elementRef.nativeElement);
-        this._subscription.unsubscribe();
+        this._onDestroy.next();
+        this._onDestroy.complete();
     }
 }


### PR DESCRIPTION
- Changing the resize directive to use the `_onDestroy` unsubscription method.

#### Ticket
https://autjira.microfocus.com/browse/EL-3373

#### Documentation CI URL
(see the project attached to the jira for repro environment, also CI build is giving out of space errors)
