### PR TITLE
EL-3378 - Toolbar Search - Always Expanded

### DIFF
--- a/docs/app/pages/components/components-sections/search/toolbar-search/toolbar-search.component.html
+++ b/docs/app/pages/components/components-sections/search/toolbar-search/toolbar-search.component.html
@@ -38,7 +38,7 @@
             </button>
         </ux-toolbar-search>
     </div>
-    
+
 </div>
 
 <p class="m-t-md">Searched for: <strong>{{searchedFor}}</strong></p>
@@ -81,6 +81,9 @@
     <tr uxd-api-property name="direction" type="'left' | 'right'" defaultValue="right">
         The direction in which the search box will expand. If the search button is aligned to the right edge of the
         container, specify <code>left</code>.
+    </tr>
+    <tr uxd-api-property name="alwaysExpanded" type="boolean" defaultValue="false">
+        Whether the input field should always appear in the expanded state.
     </tr>
 </uxd-api-properties>
 

--- a/e2e/pages/app/toolbar-search/toolbar-search.module.ts
+++ b/e2e/pages/app/toolbar-search/toolbar-search.module.ts
@@ -1,14 +1,15 @@
-import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { FormsModule } from '@angular/forms';
+import { NgModule } from '@angular/core';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { RouterModule } from '@angular/router';
-import { ToolbarSearchModule, ColorServiceModule } from '@ux-aspects/ux-aspects';
-
+import { ColorServiceModule, ToolbarSearchModule } from '@ux-aspects/ux-aspects';
 import { ToolbarSearchTestPageComponent } from './toolbar-search.testpage.component';
+
 @NgModule({
     imports: [
         CommonModule,
         FormsModule,
+        ReactiveFormsModule,
         ToolbarSearchModule,
         ColorServiceModule,
         RouterModule.forChild([{

--- a/e2e/pages/app/toolbar-search/toolbar-search.testpage.component.html
+++ b/e2e/pages/app/toolbar-search/toolbar-search.testpage.component.html
@@ -1,33 +1,71 @@
 <div class="demo-toolbar">
 
     <div class="demo-toolbar-left">
-        <ux-toolbar-search id="searchLeft" [(expanded)]="expanded" direction="right" (search)="onSearch($event)">
-            <input uxToolbarSearchField #searchField type="text" class="form-control" placeholder="Search" aria-label="Search" [(ngModel)]="searchText">
-            <button uxToolbarSearchButton type="button" class="btn btn-link btn-icon button-secondary" aria-label="Toggle Search">
+        <ux-toolbar-search id="searchLeft"
+            [alwaysExpanded]="alwaysExpanded"
+            [(expanded)]="expanded"
+            direction="right"
+            (search)="onSearch($event)">
+
+            <input uxToolbarSearchField
+                #searchField
+                type="text"
+                class="form-control"
+                placeholder="Search"
+                aria-label="Search"
+                [(ngModel)]="searchText">
+
+            <button uxToolbarSearchButton
+                type="button"
+                class="btn btn-link btn-icon button-secondary"
+                aria-label="Toggle Search">
                 <span class="hpe-icon hpe-search"></span>
             </button>
-            <button *ngIf="searchText" type="button" class="btn btn-link btn-icon button-secondary ux-toolbar-search-clear" (click)="searchText = ''; searchField.focus()">
+
+            <button *ngIf="searchText"
+                type="button"
+                class="btn btn-link btn-icon button-secondary ux-toolbar-search-clear"
+                (click)="searchText = ''; searchField.focus()">
                 <span class="hpe-icon hpe-close"></span>
             </button>
+
         </ux-toolbar-search>
+
         <button type="button" class="btn btn-link btn-icon button-secondary">
             <span class="hpe-icon hpe-add"></span>
         </button>
+
         <button type="button" class="btn btn-link btn-icon button-secondary">
             <span class="hpe-icon hpe-edit"></span>
         </button>
     </div>
 
-    <div class="demo-toolbar-right">
+    <div class="demo-toolbar-right" [formGroup]="form">
         <button type="button" class="btn btn-link btn-icon button-secondary">
             <span class="hpe-icon hpe-grid"></span>
         </button>
+
         <button type="button" class="btn btn-link btn-icon button-secondary">
             <span class="hpe-icon hpe-list"></span>
         </button>
-        <ux-toolbar-search id="searchRight" direction="left" (search)="onSearchRight($event)">
-            <input uxToolbarSearchField #searchFieldRight type="text" class="form-control" placeholder="Search" aria-label="Search">
-            <button uxToolbarSearchButton type="button" class="btn btn-link btn-icon button-secondary" aria-label="Toggle Search">
+
+        <ux-toolbar-search
+            id="searchRight"
+            [alwaysExpanded]="alwaysExpanded"
+            direction="left"
+            (search)="onSearchRight()">
+
+            <input uxToolbarSearchField
+                formControlName="search"
+                type="text"
+                class="form-control"
+                placeholder="Search"
+                aria-label="Search">
+
+            <button uxToolbarSearchButton
+                    type="button"
+                    class="btn btn-link btn-icon button-secondary"
+                    aria-label="Toggle Search">
                 <span class="hpe-icon hpe-search"></span>
             </button>
         </ux-toolbar-search>
@@ -38,3 +76,5 @@
 <p class="m-t-md">Searched for:
     <strong id="searchedFor">{{searchedFor}}</strong>
 </p>
+
+<button id="always-expanded-btn" class="btn button-primary" (click)="alwaysExpanded = true">Set Always Expanded</button>

--- a/e2e/pages/app/toolbar-search/toolbar-search.testpage.component.ts
+++ b/e2e/pages/app/toolbar-search/toolbar-search.testpage.component.ts
@@ -1,4 +1,5 @@
-import { Component, ElementRef, ViewChild } from '@angular/core';
+import { Component } from '@angular/core';
+import { FormControl, FormGroup } from '@angular/forms';
 
 @Component({
     selector: 'uxd-toolbar-search',
@@ -10,9 +11,11 @@ export class ToolbarSearchTestPageComponent {
     expanded: boolean;
     searchText: string;
     searchedFor: string = '';
+    alwaysExpanded: boolean = false;
 
-    @ViewChild('searchFieldRight')
-    searchFieldRight: ElementRef;
+    form = new FormGroup({
+        search: new FormControl('')
+    });
 
     onSearch(searchText: string) {
         // Execute search here
@@ -22,9 +25,8 @@ export class ToolbarSearchTestPageComponent {
         this.expanded = false;
     }
 
-    onSearchRight(searchText: string) {
+    onSearchRight() {
         // Execute search here
-        this.searchedFor = searchText;
-        this.searchFieldRight.nativeElement.blur();
+        this.searchedFor = this.form.controls.search.value;
     }
 }

--- a/e2e/tests/components/toolbar-search/toolbar-search.e2e-spec.ts
+++ b/e2e/tests/components/toolbar-search/toolbar-search.e2e-spec.ts
@@ -1,247 +1,342 @@
 import { browser, protractor } from 'protractor';
-import { Constants, Functions } from '../common/common.spec';
 import { ToolbarSearchPage } from './toolbar-search.po.spec';
 
 const ec = protractor.ExpectedConditions;
 
 describe('Toolbar Search', () => {
 
-  const ANIMATION_TIMEOUT = 500;
+    const ANIMATION_TIMEOUT = 500;
 
-  let page: ToolbarSearchPage;
-  const constants = new Constants();
-  const functions = new Functions();
+    let page: ToolbarSearchPage;
 
-  beforeEach(() => {
-
-    page = new ToolbarSearchPage();
-    page.getPage();
-  });
-
-  it('should have correct initial states', () => {
-
-    expect(page.leftInput.isDisplayed()).toBeFalsy();
-    expect(page.leftButton.isDisplayed()).toBeTruthy();
-    expect(page.leftClear.isPresent()).toBeFalsy();
-
-    expect(page.rightInput.isDisplayed()).toBeFalsy();
-    expect(page.rightButton.isDisplayed()).toBeTruthy();
-    expect(page.rightClear.isPresent()).toBeFalsy();
-
-    expect<any>(page.searchedFor.getText()).toBe('');
-
-  });
-
-  it('should display search input when the button is clicked', () => {
-
-    page.leftButton.click();
-    browser.wait(ec.visibilityOf(page.leftInput), ANIMATION_TIMEOUT);
-
-    // Verify states (left)
-    expect(page.leftInput.isDisplayed()).toBeTruthy();
-    expect(page.leftButton.isDisplayed()).toBeTruthy();
-    expect(page.leftClear.isPresent()).toBeFalsy();
-
-    // Verify input focus
-    expect(browser.driver.switchTo().activeElement().getId()).toEqual(page.leftInput.getId());
-
-    // Verify input value
-    expect<any>(page.leftInput.getAttribute('value')).toBe('');
-
-    // Verify states (right) - should be unaffected
-    expect(page.rightInput.isDisplayed()).toBeFalsy();
-    expect(page.rightButton.isDisplayed()).toBeTruthy();
-    expect(page.rightClear.isPresent()).toBeFalsy();
-
-  });
-
-  it('should hide search input when the button is clicked and the input is empty', () => {
-
-    page.leftButton.click();
-    browser.wait(ec.visibilityOf(page.leftInput), ANIMATION_TIMEOUT);
-
-    // Verify states (left)
-    expect(page.leftInput.isDisplayed()).toBeTruthy();
-    expect(page.leftButton.isDisplayed()).toBeTruthy();
-    expect(page.leftClear.isPresent()).toBeFalsy();
-    expect<any>(page.searchedFor.getText()).toBe('');
-
-    page.leftButton.click();
-    browser.wait(ec.invisibilityOf(page.leftInput), ANIMATION_TIMEOUT);
-
-    expect(page.leftInput.isDisplayed()).toBeFalsy();
-    expect(page.leftButton.isDisplayed()).toBeTruthy();
-    expect(page.leftClear.isPresent()).toBeFalsy();
-    expect<any>(page.searchedFor.getText()).toBe('');
-
-  });
-
-  it('should execute search handler when the button is clicked and the input has text', () => {
-
-    page.leftButton.click();
-    browser.wait(ec.visibilityOf(page.leftInput), ANIMATION_TIMEOUT);
-
-    // Verify states (left)
-    expect(page.leftInput.isDisplayed()).toBeTruthy();
-    expect(page.leftButton.isDisplayed()).toBeTruthy();
-    expect(page.leftClear.isPresent()).toBeFalsy();
-    expect<any>(page.searchedFor.getText()).toBe('');
-
-    // Enter search text
-    page.leftInput.sendKeys('orange');
-
-    // Click the search button
-    page.leftButton.click();
-
-    // Verify that the states are unchanged
-    expect(page.leftInput.isDisplayed()).toBeTruthy();
-    expect(page.leftButton.isDisplayed()).toBeTruthy();
-    expect(page.leftClear.isPresent()).toBeFalsy();
-
-    // Verify that the search handler updated the page
-    expect<any>(page.searchedFor.getText()).toBe('orange');
-
-  });
-
-  it('should hide search input when the button is clicked and the input was deleted', () => {
-
-    page.leftButton.click();
-    browser.wait(ec.visibilityOf(page.leftInput), ANIMATION_TIMEOUT);
-
-    // Verify states (left)
-    expect(page.leftInput.isDisplayed()).toBeTruthy();
-    expect(page.leftButton.isDisplayed()).toBeTruthy();
-    expect(page.leftClear.isPresent()).toBeFalsy();
-    expect<any>(page.searchedFor.getText()).toBe('');
-
-    // Enter search text
-    page.leftInput.sendKeys('orange');
-    expect(page.leftClear.isPresent()).toBeTruthy();
-
-    // Clear the text
-    page.leftClear.click();
-
-    // Verify that the input was cleared
-    expect<any>(page.leftInput.getAttribute('value')).toBe('');
-
-    // Click the search button
-    page.leftButton.click();
-
-    // Verify collapsed state
-    expect(page.leftInput.isDisplayed()).toBeTruthy();
-    expect(page.leftButton.isDisplayed()).toBeTruthy();
-    expect(page.leftClear.isPresent()).toBeFalsy();
-
-    // Verify that the search was unchanged
-    expect<any>(page.searchedFor.getText()).toBe('');
-
-  });
-
-  describe('key handling', () => {
-
-    it('should hide search input when the escape key is pressed', () => {
-
-      page.leftButton.click();
-      browser.wait(ec.visibilityOf(page.leftInput), ANIMATION_TIMEOUT);
-
-      // Verify states (left)
-      expect(page.leftInput.isDisplayed()).toBeTruthy();
-      expect(page.leftButton.isDisplayed()).toBeTruthy();
-      expect(page.leftClear.isPresent()).toBeFalsy();
-      expect<any>(page.searchedFor.getText()).toBe('');
-
-      browser.actions().sendKeys(protractor.Key.ESCAPE).perform();
-      browser.wait(ec.invisibilityOf(page.leftInput), ANIMATION_TIMEOUT);
-
-      expect(page.leftInput.isDisplayed()).toBeFalsy();
-      expect(page.leftButton.isDisplayed()).toBeTruthy();
-      expect(page.leftClear.isPresent()).toBeFalsy();
-      expect<any>(page.searchedFor.getText()).toBe('');
-
+    beforeEach(() => {
+        page = new ToolbarSearchPage();
+        page.getPage();
     });
 
-    it('should clear search input when the escape key is pressed', () => {
+    it('should have correct initial states', () => {
 
-      page.leftButton.click();
-      browser.wait(ec.visibilityOf(page.leftInput), ANIMATION_TIMEOUT);
+        expect(page.leftInput.isDisplayed()).toBeFalsy();
+        expect(page.leftButton.isDisplayed()).toBeTruthy();
+        expect(page.leftClear.isPresent()).toBeFalsy();
 
-      // Verify states (left)
-      expect(page.leftInput.isDisplayed()).toBeTruthy();
-      expect(page.leftButton.isDisplayed()).toBeTruthy();
-      expect(page.leftClear.isPresent()).toBeFalsy();
-      expect<any>(page.searchedFor.getText()).toBe('');
+        expect(page.rightInput.isDisplayed()).toBeFalsy();
+        expect(page.rightButton.isDisplayed()).toBeTruthy();
+        expect(page.rightClear.isPresent()).toBeFalsy();
 
-      // Input search query
-      page.leftInput.sendKeys('orange');
-      expect<any>(page.leftInput.getAttribute('value')).toBe('orange');
-
-      // Press escape
-      browser.actions().sendKeys(protractor.Key.ESCAPE).perform();
-      browser.wait(ec.invisibilityOf(page.leftInput), ANIMATION_TIMEOUT);
-
-      expect(page.leftInput.isDisplayed()).toBeFalsy();
-      expect(page.leftButton.isDisplayed()).toBeTruthy();
-      expect(page.leftClear.isPresent()).toBeFalsy();
-      expect<any>(page.searchedFor.getText()).toBe('');
-
-      // Reopen search input
-      page.leftButton.click();
-      browser.wait(ec.visibilityOf(page.leftInput), ANIMATION_TIMEOUT);
-
-      // Verify input value
-      expect<any>(page.leftInput.getAttribute('value')).toBe('');
+        expect<any>(page.searchedFor.getText()).toBe('');
 
     });
-
-    it('should execute search handler when the enter key is pressed', () => {
-  
-      page.leftButton.click();
-      browser.wait(ec.visibilityOf(page.leftInput), ANIMATION_TIMEOUT);
-  
-      // Verify states (left)
-      expect(page.leftInput.isDisplayed()).toBeTruthy();
-      expect(page.leftButton.isDisplayed()).toBeTruthy();
-      expect(page.leftClear.isPresent()).toBeFalsy();
-      expect<any>(page.searchedFor.getText()).toBe('');
-  
-      // Enter search text
-      page.leftInput.sendKeys('orange');
-
-      // Press enter
-      browser.actions().sendKeys(protractor.Key.ENTER).perform();
-      browser.wait(ec.invisibilityOf(page.leftInput), ANIMATION_TIMEOUT);
-
-      expect(page.leftInput.isDisplayed()).toBeFalsy();
-      expect(page.leftButton.isDisplayed()).toBeTruthy();
-      expect(page.leftClear.isPresent()).toBeFalsy();
-  
-      // Verify that the search handler updated the page
-      expect<any>(page.searchedFor.getText()).toBe('orange');
-  
-    });
-
-  });
-
-  describe('right alignment', () => {
 
     it('should display search input when the button is clicked', () => {
 
-      page.rightButton.click();
-      browser.wait(ec.visibilityOf(page.rightInput), ANIMATION_TIMEOUT);
-  
-      // Verify states (right)
-      expect(page.rightInput.isDisplayed()).toBeTruthy();
-      expect(page.rightButton.isDisplayed()).toBeTruthy();
-      expect(page.rightClear.isPresent()).toBeFalsy();
-  
-      // Verify input focus
-      expect(browser.driver.switchTo().activeElement().getId()).toEqual(page.rightInput.getId());
-  
-      // Verify input value
-      expect<any>(page.rightInput.getAttribute('value')).toBe('');
-  
+        page.leftButton.click();
+        browser.wait(ec.visibilityOf(page.leftInput), ANIMATION_TIMEOUT);
+
+        // Verify states (left)
+        expect(page.leftInput.isDisplayed()).toBeTruthy();
+        expect(page.leftButton.isDisplayed()).toBeTruthy();
+        expect(page.leftClear.isPresent()).toBeFalsy();
+
+        // Verify input focus
+        expect(browser.driver.switchTo().activeElement().getId()).toEqual(page.leftInput.getId());
+
+        // Verify input value
+        expect<any>(page.leftInput.getAttribute('value')).toBe('');
+
+        // Verify states (right) - should be unaffected
+        expect(page.rightInput.isDisplayed()).toBeFalsy();
+        expect(page.rightButton.isDisplayed()).toBeTruthy();
+        expect(page.rightClear.isPresent()).toBeFalsy();
+
     });
 
-  });
+    it('should hide search input when the button is clicked and the input is empty', () => {
+
+        page.leftButton.click();
+        browser.wait(ec.visibilityOf(page.leftInput), ANIMATION_TIMEOUT);
+
+        // Verify states (left)
+        expect(page.leftInput.isDisplayed()).toBeTruthy();
+        expect(page.leftButton.isDisplayed()).toBeTruthy();
+        expect(page.leftClear.isPresent()).toBeFalsy();
+        expect<any>(page.searchedFor.getText()).toBe('');
+
+        page.leftButton.click();
+        browser.wait(ec.invisibilityOf(page.leftInput), ANIMATION_TIMEOUT);
+
+        expect(page.leftInput.isDisplayed()).toBeFalsy();
+        expect(page.leftButton.isDisplayed()).toBeTruthy();
+        expect(page.leftClear.isPresent()).toBeFalsy();
+        expect<any>(page.searchedFor.getText()).toBe('');
+
+    });
+
+    it('should execute search handler when the button is clicked and the input has text', () => {
+
+        page.leftButton.click();
+        browser.wait(ec.visibilityOf(page.leftInput), ANIMATION_TIMEOUT);
+
+        // Verify states (left)
+        expect(page.leftInput.isDisplayed()).toBeTruthy();
+        expect(page.leftButton.isDisplayed()).toBeTruthy();
+        expect(page.leftClear.isPresent()).toBeFalsy();
+        expect<any>(page.searchedFor.getText()).toBe('');
+
+        // Enter search text
+        page.leftInput.sendKeys('orange');
+
+        // Click the search button
+        page.leftButton.click();
+
+        // Verify that the states are unchanged
+        expect(page.leftInput.isDisplayed()).toBeTruthy();
+        expect(page.leftButton.isDisplayed()).toBeTruthy();
+        expect(page.leftClear.isPresent()).toBeFalsy();
+
+        // Verify that the search handler updated the page
+        expect<any>(page.searchedFor.getText()).toBe('orange');
+
+    });
+
+    it('should hide search input when the button is clicked and the input was deleted', () => {
+
+        page.leftButton.click();
+        browser.wait(ec.visibilityOf(page.leftInput), ANIMATION_TIMEOUT);
+
+        // Verify states (left)
+        expect(page.leftInput.isDisplayed()).toBeTruthy();
+        expect(page.leftButton.isDisplayed()).toBeTruthy();
+        expect(page.leftClear.isPresent()).toBeFalsy();
+        expect<any>(page.searchedFor.getText()).toBe('');
+
+        // Enter search text
+        page.leftInput.sendKeys('orange');
+        expect(page.leftClear.isPresent()).toBeTruthy();
+
+        // Clear the text
+        page.leftClear.click();
+
+        // Verify that the input was cleared
+        expect<any>(page.leftInput.getAttribute('value')).toBe('');
+
+        // Click the search button
+        page.leftButton.click();
+
+        // Verify collapsed state
+        expect(page.leftInput.isDisplayed()).toBeTruthy();
+        expect(page.leftButton.isDisplayed()).toBeTruthy();
+        expect(page.leftClear.isPresent()).toBeFalsy();
+
+        // Verify that the search was unchanged
+        expect<any>(page.searchedFor.getText()).toBe('');
+
+    });
+
+    describe('key handling', () => {
+
+        it('should hide search input when the escape key is pressed', () => {
+
+            page.leftButton.click();
+            browser.wait(ec.visibilityOf(page.leftInput), ANIMATION_TIMEOUT);
+
+            // Verify states (left)
+            expect(page.leftInput.isDisplayed()).toBeTruthy();
+            expect(page.leftButton.isDisplayed()).toBeTruthy();
+            expect(page.leftClear.isPresent()).toBeFalsy();
+            expect<any>(page.searchedFor.getText()).toBe('');
+
+            browser.actions().sendKeys(protractor.Key.ESCAPE).perform();
+            browser.wait(ec.invisibilityOf(page.leftInput), ANIMATION_TIMEOUT);
+
+            expect(page.leftInput.isDisplayed()).toBeFalsy();
+            expect(page.leftButton.isDisplayed()).toBeTruthy();
+            expect(page.leftClear.isPresent()).toBeFalsy();
+            expect<any>(page.searchedFor.getText()).toBe('');
+
+        });
+
+        it('should clear search input when the escape key is pressed', () => {
+
+            page.leftButton.click();
+            browser.wait(ec.visibilityOf(page.leftInput), ANIMATION_TIMEOUT);
+
+            // Verify states (left)
+            expect(page.leftInput.isDisplayed()).toBeTruthy();
+            expect(page.leftButton.isDisplayed()).toBeTruthy();
+            expect(page.leftClear.isPresent()).toBeFalsy();
+            expect<any>(page.searchedFor.getText()).toBe('');
+
+            // Input search query
+            page.leftInput.sendKeys('orange');
+            expect<any>(page.leftInput.getAttribute('value')).toBe('orange');
+
+            // Press escape
+            browser.actions().sendKeys(protractor.Key.ESCAPE).perform();
+            browser.wait(ec.invisibilityOf(page.leftInput), ANIMATION_TIMEOUT);
+
+            expect(page.leftInput.isDisplayed()).toBeFalsy();
+            expect(page.leftButton.isDisplayed()).toBeTruthy();
+            expect(page.leftClear.isPresent()).toBeFalsy();
+            expect<any>(page.searchedFor.getText()).toBe('');
+
+            // Reopen search input
+            page.leftButton.click();
+            browser.wait(ec.visibilityOf(page.leftInput), ANIMATION_TIMEOUT);
+
+            // Verify input value
+            expect<any>(page.leftInput.getAttribute('value')).toBe('');
+
+        });
+
+        it('should execute search handler when the enter key is pressed', () => {
+
+            page.leftButton.click();
+            browser.wait(ec.visibilityOf(page.leftInput), ANIMATION_TIMEOUT);
+
+            // Verify states (left)
+            expect(page.leftInput.isDisplayed()).toBeTruthy();
+            expect(page.leftButton.isDisplayed()).toBeTruthy();
+            expect(page.leftClear.isPresent()).toBeFalsy();
+            expect<any>(page.searchedFor.getText()).toBe('');
+
+            // Enter search text
+            page.leftInput.sendKeys('orange');
+
+            // Press enter
+            browser.actions().sendKeys(protractor.Key.ENTER).perform();
+            browser.wait(ec.invisibilityOf(page.leftInput), ANIMATION_TIMEOUT);
+
+            expect(page.leftInput.isDisplayed()).toBeFalsy();
+            expect(page.leftButton.isDisplayed()).toBeTruthy();
+            expect(page.leftClear.isPresent()).toBeFalsy();
+
+            // Verify that the search handler updated the page
+            expect<any>(page.searchedFor.getText()).toBe('orange');
+
+        });
+
+    });
+
+    describe('right alignment', () => {
+
+        it('should display search input when the button is clicked', () => {
+
+            page.rightButton.click();
+            browser.wait(ec.visibilityOf(page.rightInput), ANIMATION_TIMEOUT);
+
+            // Verify states (right)
+            expect(page.rightInput.isDisplayed()).toBeTruthy();
+            expect(page.rightButton.isDisplayed()).toBeTruthy();
+            expect(page.rightClear.isPresent()).toBeFalsy();
+
+            // Verify input focus
+            expect(browser.driver.switchTo().activeElement().getId()).toEqual(page.rightInput.getId());
+
+            // Verify input value
+            expect<any>(page.rightInput.getAttribute('value')).toBe('');
+
+        });
+
+    });
+
+    describe('always expanded', () => {
+
+        it('should be initially expanded', async () => {
+            // set the always expanded state
+            await page.alwaysExpandedBtn.click();
+
+            // wait for any animation to finish
+            await browser.wait(ec.visibilityOf(page.leftInput), ANIMATION_TIMEOUT);
+
+            // Verify states (left)
+            expect(await page.leftInput.isDisplayed()).toBeTruthy();
+            expect(await page.leftButton.isDisplayed()).toBeTruthy();
+            expect(await page.leftClear.isPresent()).toBeFalsy();
+
+            // Verify states (left)
+            expect(await page.rightInput.isDisplayed()).toBeTruthy();
+            expect(await page.rightButton.isDisplayed()).toBeTruthy();
+            expect(await page.rightClear.isPresent()).toBeFalsy();
+        });
+
+        it('should not hide search input when the button is clicked and the input is empty', async () => {
+
+            // set the always expanded state
+            await page.alwaysExpandedBtn.click();
+
+            // wait for any animation to finish
+            await browser.wait(ec.visibilityOf(page.leftInput), ANIMATION_TIMEOUT);
+
+            // Verify states (left)
+            expect(await page.searchedFor.getText()).toBe('');
+
+            await page.leftButton.click();
+
+            expect(await page.leftInput.isDisplayed()).toBeTruthy();
+            expect(await page.leftButton.isDisplayed()).toBeTruthy();
+            expect(await page.leftClear.isPresent()).toBeFalsy();
+
+            expect(await page.rightInput.isDisplayed()).toBeTruthy();
+            expect(await page.rightButton.isDisplayed()).toBeTruthy();
+            expect(await page.rightClear.isPresent()).toBeFalsy();
+
+            expect(await page.searchedFor.getText()).toBe('');
+        });
+
+        it('should not clear search input and not close when the escape key is pressed', async () => {
+
+            await page.alwaysExpandedBtn.click();
+
+            await browser.wait(ec.visibilityOf(page.leftInput), ANIMATION_TIMEOUT);
+
+            // Verify states (left)
+            expect(await page.leftInput.isDisplayed()).toBeTruthy();
+            expect(await page.leftButton.isDisplayed()).toBeTruthy();
+            expect(await page.leftClear.isPresent()).toBeFalsy();
+            expect<any>(await page.searchedFor.getText()).toBe('');
+
+            // Input search query
+            await page.leftInput.sendKeys('orange');
+            expect(await page.leftInput.getAttribute('value')).toBe('orange');
+
+            // Press escape
+            await browser.actions().sendKeys(protractor.Key.ESCAPE).perform();
+
+            expect(await page.leftInput.isDisplayed()).toBeTruthy();
+            expect(await page.leftButton.isDisplayed()).toBeTruthy();
+            expect(await page.leftClear.isPresent()).toBeTruthy();
+            expect(await page.searchedFor.getText()).toBe('');
+
+        });
+
+        it('should execute search handler when the enter key is pressed', async () => {
+
+            await page.alwaysExpandedBtn.click();
+
+            await browser.wait(ec.visibilityOf(page.leftInput), ANIMATION_TIMEOUT);
+
+            // Verify states (left)
+            expect(await page.leftInput.isDisplayed()).toBeTruthy();
+            expect(await page.leftButton.isDisplayed()).toBeTruthy();
+            expect(await page.leftClear.isPresent()).toBeFalsy();
+            expect(await page.searchedFor.getText()).toBe('');
+
+            // Enter search text
+            await page.leftInput.sendKeys('orange');
+
+            // Press enter
+            await browser.actions().sendKeys(protractor.Key.ENTER).perform();
+
+            expect(await page.leftInput.isDisplayed()).toBeTruthy();
+            expect(await page.leftButton.isDisplayed()).toBeTruthy();
+            expect(await page.leftClear.isPresent()).toBeTruthy();
+
+            // Verify that the search handler updated the page
+            expect(await page.searchedFor.getText()).toBe('orange');
+
+        });
+
+    });
 
 });

--- a/e2e/tests/components/toolbar-search/toolbar-search.po.spec.ts
+++ b/e2e/tests/components/toolbar-search/toolbar-search.po.spec.ts
@@ -1,4 +1,4 @@
-import { browser, element, by, ElementFinder } from 'protractor';
+import { browser, by, element } from 'protractor';
 
 export class ToolbarSearchPage {
 
@@ -20,4 +20,7 @@ export class ToolbarSearchPage {
 
     // Most recently submitted search query
     searchedFor = element(by.id('searchedFor'));
+
+    // button to set always expanded state
+    alwaysExpandedBtn = element(by.id('always-expanded-btn'));
 }

--- a/src/components/toolbar-search/toolbar-search-button.directive.ts
+++ b/src/components/toolbar-search/toolbar-search-button.directive.ts
@@ -1,12 +1,12 @@
-import { Directive, HostListener, Output, EventEmitter, ElementRef } from '@angular/core';
+import { Directive, ElementRef, EventEmitter, HostListener, Output } from '@angular/core';
 
 @Directive({
     selector: '[uxToolbarSearchButton]'
 })
 export class ToolbarSearchButtonDirective {
 
-    @Output()
-    clicked = new EventEmitter<void>();
+    /** Emit whenever the button is clicked */
+    @Output() clicked = new EventEmitter<void>();
 
     get width(): number {
         return this._elementRef.nativeElement.offsetWidth;
@@ -15,7 +15,7 @@ export class ToolbarSearchButtonDirective {
     constructor(private _elementRef: ElementRef) { }
 
     @HostListener('click')
-    clickHandler() {
+    clickHandler(): void {
         this.clicked.emit();
     }
 }

--- a/src/components/toolbar-search/toolbar-search-button.directive.ts
+++ b/src/components/toolbar-search/toolbar-search-button.directive.ts
@@ -8,6 +8,7 @@ export class ToolbarSearchButtonDirective {
     /** Emit whenever the button is clicked */
     @Output() clicked = new EventEmitter<void>();
 
+    /** Get the width of the button element */
     get width(): number {
         return this._elementRef.nativeElement.offsetWidth;
     }

--- a/src/components/toolbar-search/toolbar-search.component.ts
+++ b/src/components/toolbar-search/toolbar-search.component.ts
@@ -25,7 +25,7 @@ import { ToolbarSearchFieldDirective } from './toolbar-search-field.directive';
         '[class.expanded]': 'expanded',
         '[class.left]': 'direction === "left"',
         '[class.right]': 'direction === "right"',
-        '[class.inverse]': 'invserse',
+        '[class.inverse]': 'inverse',
         '[style.position]': '_position',
         '[style.background-color]': '_backgroundColor',
         '[@expanded]': '_expandedAnimation'
@@ -39,14 +39,17 @@ export class ToolbarSearchComponent implements AfterContentInit, OnDestroy {
     /** Whether the color scheme is inverted. For use when the component is hosted on a dark background, e.g. the masthead. */
     @Input() inverse = false;
 
+    /** Indicate whether or not the search field should always be expanded */
+    @Input() alwaysExpanded: boolean = false;
+
     /** Whether the input field is visible. Use this to collapse or expand the control in response to other events. */
     @Input()
     set expanded(value: boolean) {
         this._expanded = value;
 
-        this.expandedChange.emit(value);
+        this.expandedChange.emit(this.expanded);
 
-        if (value) {
+        if (this.expanded) {
             // Set focus on the input when expanded
             this.field.focus();
         } else {
@@ -59,7 +62,7 @@ export class ToolbarSearchComponent implements AfterContentInit, OnDestroy {
     }
 
     get expanded(): boolean {
-        return this._expanded;
+        return this.alwaysExpanded || this._expanded;
     }
 
     /*
@@ -80,6 +83,7 @@ export class ToolbarSearchComponent implements AfterContentInit, OnDestroy {
      */
     @Output() search = new EventEmitter<string>();
 
+    /** Return the correct animation based on the expanded state */
     get _expandedAnimation(): any {
         return {
             value: this.expanded ? 'expanded' : 'collapsed',


### PR DESCRIPTION
Related PR: https://github.houston.softwaregrp.net/caf/ux-aspects-micro-focus/pull/338

- Added `alwaysExpanded` option to make sure the input never closes
- Updated documentation to include the new property
- The placeholder element was being created using `document.createElement`, now switched to use renderer and correctly dispose of the element. Also added a safety check so we don't try to use `getComputedStyle` in a Server Side Rendered environment.
- Changed toolbar search component to use `OnPush` change detection
- There were quite a few subscriptions that were never disposed of so I have added in the teardown code
- We supported ngModel however we did not support ReactiveForms so I have changed this to use the `ControlValueAccessor` allowing us to target both
- Added new tests to cover the `alwaysExpanded` option
- Updated tests to use reactive forms as well as ngModel

#### Ticket
https://autjira.microfocus.com/browse/EL-3378

#### Documentation CI URL
https://pages.github.houston.softwaregrp.net/sepg-docs-qa/UXAspects_CI_UXAspects_EL-3378-Toolbar-Search
