### PR TITLE
EL-3385 - Selection Expression Has Changed Error

### DIFF
--- a/src/directives/selection/selection.directive.ts
+++ b/src/directives/selection/selection.directive.ts
@@ -1,93 +1,110 @@
 import { AfterContentInit, ChangeDetectorRef, ContentChildren, Directive, EventEmitter, HostBinding, Input, OnDestroy, Output, QueryList } from '@angular/core';
-import { takeUntil } from 'rxjs/operators';
+import { debounceTime, takeUntil } from 'rxjs/operators';
 import { Subject } from 'rxjs/Subject';
 import { SelectionItemDirective } from './selection-item.directive';
 import { SelectionMode, SelectionService } from './selection.service';
 import { SelectionStrategy } from './strategies/selection.strategy';
 
 @Directive({
-  selector: '[uxSelection]',
-  exportAs: 'ux-selection',
-  providers: [ SelectionService ]
+    selector: '[uxSelection]',
+    exportAs: 'ux-selection',
+    providers: [SelectionService]
 })
 export class SelectionDirective<T> implements AfterContentInit, OnDestroy {
 
-  @Input() set uxSelection(items: T[]) {
-    this._selectionService.select(...items);
-  }
-
-  @Input() set disabled(disabled: boolean) {
-    this._selectionService.setDisabled(disabled);
-  }
-
-  @Input() set mode(mode: SelectionMode | SelectionStrategy<T>) {
-    this._selectionService.setStrategy(mode);
-  }
-
-  @Input() set clickSelection(isClickEnabled: boolean) {
-    this._selectionService.isClickEnabled = isClickEnabled;
-  }
-
-  @Input() set keyboardSelection(isKeyboardEnabled: boolean) {
-    this._selectionService.isKeyboardEnabled = isKeyboardEnabled;
-  }
-
-  @Input() @HostBinding('attr.tabindex') tabindex: number = null;
-
-  @Output() uxSelectionChange = new EventEmitter<T[]>();
-
-  @ContentChildren(SelectionItemDirective) items: QueryList<SelectionItemDirective<T>>;
-
-  private _onDestroy = new Subject<void>();
-
-  constructor(private _selectionService: SelectionService<T>, private _cdRef: ChangeDetectorRef) {
-    _selectionService.selection$.pipe(takeUntil(this._onDestroy)).subscribe(items => this.uxSelectionChange.emit(items));
-  }
-
-  ngAfterContentInit(): void {
-    // provide the initial list of selection items
-    this.update();
-
-    // if the list changes then inform the service
-    this.items.changes.pipe(takeUntil(this._onDestroy)).subscribe(() => this.update());
-  }
-
-  ngOnDestroy(): void {
-    this._onDestroy.next();
-    this._onDestroy.complete();
-  }
-
-  /**
-   * Update the dataset to reflect the latest selection items
-   */
-  update(): void {
-
-    this._selectionService.dataset = this.items.map(item => item.uxSelectionItem);
-
-    // Make sure that a tab target has been defined so that the component can be tabbed to.
-    if (this._selectionService.focus$.getValue() === null && this._selectionService.dataset.length > 0) {
-      this._selectionService.focus$.next(this._selectionService.dataset[0]);
+    /** Defines the items that should be selected. */
+    @Input() set uxSelection(items: T[]) {
+        this._selectionService.select(...items);
     }
 
-    // The above could trigger a change in the computed tabindex for selection items
-    this._cdRef.detectChanges();
-  }
-
-  /**
-   * Select all the items in the list
-   */
-  selectAll(): void {
-    if (this._selectionService.isEnabled) {
-      this._selectionService.strategy.selectAll();
+    /** Can be used to enabled/disable selection behavior. */
+    @Input() set disabled(disabled: boolean) {
+        this._selectionService.setDisabled(disabled);
     }
-  }
 
-  /**
-   * Deselect all currently selected items
-   */
-  deselectAll(): void {
-    if (this._selectionService.isEnabled) {
-      this._selectionService.strategy.deselectAll();
+    /**
+     * Defines the selection behavior. Alternatively, custom selection behavior can be defined by defining a
+     * class which extends SelectionStrategy, and providing an instance of the custom class to this property.
+     * See below for details of the SelectionStrategy class.
+     */
+    @Input() set mode(mode: SelectionMode | SelectionStrategy<T>) {
+        this._selectionService.setStrategy(mode);
     }
-  }
+
+    /**
+     * Can be used to enable/disable click selection on items. This can be used to manually control the selection of an item,
+     * for example, binding the selection state to a checkbox.
+     */
+    @Input() set clickSelection(isClickEnabled: boolean) {
+        this._selectionService.isClickEnabled = isClickEnabled;
+    }
+
+    /** Can be used to enable/disable keyboard navigation on items. Use this if you wish to provide custom keyboard controls for selection. */
+    @Input() set keyboardSelection(isKeyboardEnabled: boolean) {
+        this._selectionService.isKeyboardEnabled = isKeyboardEnabled;
+    }
+
+    /** The tabstop of the selection outer element */
+    @Input() @HostBinding('attr.tabindex') tabindex: number = null;
+
+    /** This event will be triggered when there is a change to the selected items. It will contain an array of the currently selected items. */
+    @Output() uxSelectionChange = new EventEmitter<T[]>();
+
+    /** Access all items within the list */
+    @ContentChildren(SelectionItemDirective) items: QueryList<SelectionItemDirective<T>>;
+
+    /** Unsubscribe from all observables on component destroy */
+    private _onDestroy = new Subject<void>();
+
+    constructor(private _selectionService: SelectionService<T>, private _cdRef: ChangeDetectorRef) {
+        _selectionService.selection$.pipe(takeUntil(this._onDestroy), debounceTime(0))
+            .subscribe(items => this.uxSelectionChange.emit(items));
+    }
+
+    ngAfterContentInit(): void {
+        // provide the initial list of selection items
+        this.update();
+
+        // if the list changes then inform the service
+        this.items.changes.pipe(takeUntil(this._onDestroy)).subscribe(() => this.update());
+    }
+
+    ngOnDestroy(): void {
+        this._onDestroy.next();
+        this._onDestroy.complete();
+    }
+
+    /**
+     * Update the dataset to reflect the latest selection items
+     */
+    update(): void {
+
+        this._selectionService.dataset = this.items.map(item => item.uxSelectionItem);
+
+        // Make sure that a tab target has been defined so that the component can be tabbed to.
+        if (this._selectionService.focus$.getValue() === null && this._selectionService.dataset.length > 0) {
+            this._selectionService.focus$.next(this._selectionService.dataset[0]);
+        }
+
+        // The above could trigger a change in the computed tabindex for selection items
+        this._cdRef.detectChanges();
+    }
+
+    /**
+     * Select all the items in the list
+     */
+    selectAll(): void {
+        if (this._selectionService.isEnabled) {
+            this._selectionService.strategy.selectAll();
+        }
+    }
+
+    /**
+     * Deselect all currently selected items
+     */
+    deselectAll(): void {
+        if (this._selectionService.isEnabled) {
+            this._selectionService.strategy.deselectAll();
+        }
+    }
 }


### PR DESCRIPTION
Added `debounceTime(0)` to the subscription. This has to be used instead of `tick` as the selection array may change multiple times during the course of the selection/deselection and we only want to emit the final finished result rather than all the intermediate ones (which was actually the source of the expression changed error)

#### Ticket
https://autjira.microfocus.com/browse/EL-3385

#### Documentation CI URL
https://pages.github.houston.softwaregrp.net/sepg-docs-qa/UXAspects_CI_UXAspects_EL-3385-Selection-Expression-Changed
