### PR TITLE
EL-3406 - Focus Indicator Rework QA Fixes

### DIFF
--- a/docs/app/pages/components/components-sections/date-time-picker/date-time-picker/date-time-picker.component.html
+++ b/docs/app/pages/components/components-sections/date-time-picker/date-time-picker/date-time-picker.component.html
@@ -6,7 +6,10 @@
                     <i class="hpe-icon hpe-calendar" aria-hidden="true"></i>
                 </button>
             </span>
-            <input type="text" #input #popover="ux-popover"
+            <input type="text"
+                   #input
+                   #popover="ux-popover"
+                   uxFocusIndicatorOrigin
                    [ngModel]="date | date:'dd MMMM yyyy HH:mm'"
                    [uxPopover]="popoverTemplate"
                    placement="bottom"

--- a/docs/app/pages/components/components-sections/date-time-picker/date-time-picker/snippets/app.html
+++ b/docs/app/pages/components/components-sections/date-time-picker/date-time-picker/snippets/app.html
@@ -6,7 +6,10 @@
                     <i class="hpe-icon hpe-calendar" aria-hidden="true"></i>
                 </button>
             </span>
-            <input type="text" #input #popover="ux-popover"
+            <input type="text"
+                #input
+                #popover="ux-popover"
+                uxFocusIndicatorOrigin
                 [ngModel]="date | date:'dd MMMM yyyy HH:mm'"
                 [uxPopover]="popoverTemplate"
                 placement="bottom"
@@ -23,7 +26,7 @@
 </div>
 
 <ng-template #popoverTemplate>
-    <ux-date-time-picker 
+    <ux-date-time-picker
         [(date)]="date"
         [(timezone)]="timezone"
         [showTime]="showTime"

--- a/docs/app/pages/components/components-sections/utilities/focus-indicator/focus-indicator.component.html
+++ b/docs/app/pages/components/components-sections/utilities/focus-indicator/focus-indicator.component.html
@@ -95,6 +95,15 @@
 
 <uxd-snippet [content]="snippets.compiled.serviceTs"></uxd-snippet>
 
+<h4>Focus Origin</h4>
+
+<p>
+    There are occasions where an element is focused when it is first shown, for example when a modal is launched the primary
+    button might receive focus. Ideally the button would only show a focus indicator when the modal was opened using
+    the keyboard and not when trigged using a click. To achieve this behavior you can add the <code>uxFocusIndicatorOrigin</code>
+    directive to the element that indirectly causes the focus, e.g. the button that launches the modal.
+</p>
+
 <h4>Global Defaults</h4>
 
 <p>

--- a/docs/app/pages/components/components-sections/utilities/focus-indicator/focus-indicator.component.html
+++ b/docs/app/pages/components/components-sections/utilities/focus-indicator/focus-indicator.component.html
@@ -105,11 +105,12 @@
 
 <uxd-snippet [content]="snippets.compiled.configTs"></uxd-snippet>
 
-<h4>Component Defaults</h4>
+<h4>Local Defaults</h4>
 
 <p>
-    The global configuration can be overriden on a component level by supplying options in the <code>providers</code>
-    array of the component decorator. These options will be applied to any child elements of this component using the focus indicator.
+    The global configuration can be overriden on a element level by adding a <code>uxFocusIndicatorOptions</code>
+    to an element. This will provide all the inputs available to the <code>uxFocusIndicator</code>.
+    These options will be applied to any child elements using the focus indicator.
 </p>
 
-<uxd-snippet [content]="snippets.compiled.componentConfigTs"></uxd-snippet>
+<uxd-snippet [content]="snippets.compiled.localOptionsHtml"></uxd-snippet>

--- a/docs/app/pages/components/components-sections/utilities/focus-indicator/snippets/component-config.ts
+++ b/docs/app/pages/components/components-sections/utilities/focus-indicator/snippets/component-config.ts
@@ -1,9 +1,0 @@
-@Component({
-    providers: [
-        {
-            provide: ACCESSIBILITY_OPTIONS_TOKEN,
-            useValue: { programmaticFocusIndicator: true }
-        }
-    ]
-})
-export class CustomComponent { }

--- a/docs/app/pages/components/components-sections/utilities/focus-indicator/snippets/local-options.html
+++ b/docs/app/pages/components/components-sections/utilities/focus-indicator/snippets/local-options.html
@@ -1,0 +1,3 @@
+<div uxFocusIndicatorOptions [mouseFocusIndicator]="true">
+    <!-- Child elements with uxFocusIndicator will show indicator on click by default -->
+</div>

--- a/src/components/date-time-picker/month-view/month-view.component.html
+++ b/src/components/date-time-picker/month-view/month-view.component.html
@@ -3,6 +3,7 @@
 
     <button type="button"
          uxFocusIndicator
+         uxFocusIndicatorOrigin
          [programmaticFocusIndicator]="true"
          role="gridcell"
          class="calendar-item"

--- a/src/components/date-time-picker/year-view/year-view.component.html
+++ b/src/components/date-time-picker/year-view/year-view.component.html
@@ -3,6 +3,7 @@
 
     <button *ngFor="let item of row; trackBy: trackYearByFn"
          uxFocusIndicator
+         uxFocusIndicatorOrigin
          [programmaticFocusIndicator]="true"
          type="button"
          role="gridcell"

--- a/src/components/floating-action-buttons/floating-action-button.component.html
+++ b/src/components/floating-action-buttons/floating-action-button.component.html
@@ -1,4 +1,6 @@
 <button #button
+        uxFocusIndicator
+        [programmaticFocusIndicator]="true"
         type="button"
         class="btn floating-action-button"
         [class.button-primary]="primary"

--- a/src/components/floating-action-buttons/floating-action-button.component.ts
+++ b/src/components/floating-action-buttons/floating-action-button.component.ts
@@ -14,8 +14,16 @@ import { FloatingActionButtonsService } from './floating-action-buttons.service'
 })
 export class FloatingActionButtonComponent implements AfterViewInit, OnDestroy {
 
+    /**
+     * If specified, defines which icon from the icon set to display in the button.
+     * If you wish to display custom content you can simply add children to the
+     * component and they will be displayed within the button. */
     @Input() icon: string;
+
+    /** Define the aria label for the button */
     @Input('aria-label') ariaLabel: string;
+
+    /** Access the element ref of the button element */
     @ViewChild('button') button: ElementRef;
 
     primary: boolean = false;

--- a/src/components/hierarchy-bar/hierarchy-bar-collapsed/hierarchy-bar-collapsed.component.html
+++ b/src/components/hierarchy-bar/hierarchy-bar-collapsed/hierarchy-bar-collapsed.component.html
@@ -19,6 +19,7 @@
         </div>
 
         <button [attr.aria-label]="hierarchyBar.showSiblingsAriaLabel"
+            uxFocusIndicator
             class="hierarchy-bar-node-arrow"
             placement="bottom"
             [uxPopover]="siblingsTemplate"

--- a/src/components/hierarchy-bar/hierarchy-bar-popover-item/hierarchy-bar-popover-item.component.html
+++ b/src/components/hierarchy-bar/hierarchy-bar-popover-item/hierarchy-bar-popover-item.component.html
@@ -1,5 +1,5 @@
 <!-- Show an icon if specified -->
-<img class="hierarchy-bar-node-icon" *ngIf="node.icon" [src]="node.icon" alt="Hierarchy Bar Icon">
+<img class="hierarchy-bar-node-icon" *ngIf="node?.icon" [src]="node.icon" alt="Hierarchy Bar Icon">
 
 <!-- Show the name of the current node -->
-<span class="hierarchy-bar-node-title">{{ node.title }}</span>
+<span class="hierarchy-bar-node-title">{{ node?.title }}</span>

--- a/src/directives/accessibility/accessibility.module.ts
+++ b/src/directives/accessibility/accessibility.module.ts
@@ -1,6 +1,7 @@
 import { A11yModule } from '@angular/cdk/a11y';
 import { ModuleWithProviders, NgModule } from '@angular/core';
 import { DefaultFocusIndicatorDirective } from './focus-indicator/default-focus-indicator.directive';
+import { FocusIndicatorOptionsDirective } from './focus-indicator/focus-indicator-options/focus-indicator-options.directive';
 import { FocusIndicatorDirective } from './focus-indicator/focus-indicator.directive';
 import { FocusIndicatorService } from './focus-indicator/focus-indicator.service';
 import { FocusWithinDirective } from './focus-within/focus-within.directive';
@@ -15,10 +16,11 @@ import { TabbableListDirective } from './tabbable-list/tabbable-list.directive';
     declarations: [
         DefaultFocusIndicatorDirective,
         FocusIndicatorDirective,
+        FocusIndicatorOptionsDirective,
         FocusWithinDirective,
+        SplitterAccessibilityDirective,
         TabbableListDirective,
         TabbableListItemDirective,
-        SplitterAccessibilityDirective
     ],
     imports: [
         A11yModule
@@ -26,10 +28,11 @@ import { TabbableListDirective } from './tabbable-list/tabbable-list.directive';
     exports: [
         DefaultFocusIndicatorDirective,
         FocusIndicatorDirective,
+        FocusIndicatorOptionsDirective,
         FocusWithinDirective,
+        SplitterAccessibilityDirective,
         TabbableListDirective,
         TabbableListItemDirective,
-        SplitterAccessibilityDirective,
     ],
     providers: [
         AccessibilityOptionsService,

--- a/src/directives/accessibility/accessibility.module.ts
+++ b/src/directives/accessibility/accessibility.module.ts
@@ -1,7 +1,9 @@
 import { A11yModule } from '@angular/cdk/a11y';
-import { ModuleWithProviders, NgModule } from '@angular/core';
+import { ModuleWithProviders, NgModule, Optional, SkipSelf } from '@angular/core';
 import { DefaultFocusIndicatorDirective } from './focus-indicator/default-focus-indicator.directive';
 import { FocusIndicatorOptionsDirective } from './focus-indicator/focus-indicator-options/focus-indicator-options.directive';
+import { FocusIndicatorOriginDirective } from './focus-indicator/focus-indicator-origin/focus-indicator-origin.directive';
+import { FocusIndicatorOriginService } from './focus-indicator/focus-indicator-origin/focus-indicator-origin.service';
 import { FocusIndicatorDirective } from './focus-indicator/focus-indicator.directive';
 import { FocusIndicatorService } from './focus-indicator/focus-indicator.service';
 import { FocusWithinDirective } from './focus-within/focus-within.directive';
@@ -12,6 +14,25 @@ import { SplitterAccessibilityDirective } from './splitter/splitter-accessibilit
 import { TabbableListItemDirective } from './tabbable-list/tabbable-list-item.directive';
 import { TabbableListDirective } from './tabbable-list/tabbable-list.directive';
 
+
+/**
+ * We want this service to be a singleton service (even across lazy modules).
+ * This allows us to ensure that it is a singleton without having to have
+ * the consumer call the `forRoot()` method on the module.
+ *
+ * This can be removed once Angular 5 support is dropped as it can be changed
+ * to be `providedIn: 'root'` instead.
+ */
+export function FOCUS_INDICATOR_ORIGIN_SERVICE_PROVIDER_FACTORY(parentFocusIndicatorOriginService: FocusIndicatorOriginService) {
+    return parentFocusIndicatorOriginService || new FocusIndicatorOriginService();
+}
+
+export const FOCUS_INDICATOR_ORIGIN_SERVICE_PROVIDER = {
+    provide: FocusIndicatorOriginService,
+    deps: [[new Optional(), new SkipSelf(), FocusIndicatorOriginService]],
+    useFactory: FOCUS_INDICATOR_ORIGIN_SERVICE_PROVIDER_FACTORY
+};
+
 @NgModule({
     declarations: [
         DefaultFocusIndicatorDirective,
@@ -21,6 +42,7 @@ import { TabbableListDirective } from './tabbable-list/tabbable-list.directive';
         SplitterAccessibilityDirective,
         TabbableListDirective,
         TabbableListItemDirective,
+        FocusIndicatorOriginDirective
     ],
     imports: [
         A11yModule
@@ -33,10 +55,12 @@ import { TabbableListDirective } from './tabbable-list/tabbable-list.directive';
         SplitterAccessibilityDirective,
         TabbableListDirective,
         TabbableListItemDirective,
+        FocusIndicatorOriginDirective
     ],
     providers: [
         AccessibilityOptionsService,
-        FocusIndicatorService
+        FocusIndicatorService,
+        FOCUS_INDICATOR_ORIGIN_SERVICE_PROVIDER
     ]
 })
 export class AccessibilityModule {
@@ -45,7 +69,8 @@ export class AccessibilityModule {
         return {
             ngModule: AccessibilityModule,
             providers: [
-                { provide: ACCESSIBILITY_OPTIONS_TOKEN, useValue: options }
+                { provide: ACCESSIBILITY_OPTIONS_TOKEN, useValue: options },
+                FOCUS_INDICATOR_ORIGIN_SERVICE_PROVIDER
             ]
         };
     }

--- a/src/directives/accessibility/focus-indicator/default-focus-indicator.directive.ts
+++ b/src/directives/accessibility/focus-indicator/default-focus-indicator.directive.ts
@@ -1,5 +1,6 @@
-import { ChangeDetectorRef, Directive, ElementRef } from '@angular/core';
+import { ChangeDetectorRef, Directive, ElementRef, Optional } from '@angular/core';
 import { AccessibilityOptionsService } from '../options/accessibility-options.service';
+import { LocalFocusIndicatorOptions } from './focus-indicator-options/focus-indicator-options';
 import { FocusIndicatorDirective } from './focus-indicator.directive';
 import { FocusIndicatorService } from './focus-indicator.service';
 
@@ -19,9 +20,10 @@ export class DefaultFocusIndicatorDirective extends FocusIndicatorDirective {
         elementRef: ElementRef,
         focusIndicatorService: FocusIndicatorService,
         optionsService: AccessibilityOptionsService,
-        changeDetectorRef: ChangeDetectorRef
+        changeDetectorRef: ChangeDetectorRef,
+        @Optional() localOptions: LocalFocusIndicatorOptions
     ) {
-        super(elementRef, focusIndicatorService, changeDetectorRef, optionsService);
+        super(elementRef, focusIndicatorService, changeDetectorRef, optionsService, localOptions);
 
         // Enable programmatic focus by default
         this.programmaticFocusIndicator = true;

--- a/src/directives/accessibility/focus-indicator/focus-indicator-options/focus-indicator-options.directive.ts
+++ b/src/directives/accessibility/focus-indicator/focus-indicator-options/focus-indicator-options.directive.ts
@@ -1,0 +1,34 @@
+import { Directive, Input, Self } from '@angular/core';
+import { AccessibilityOptions } from '../../options/accessibility-options.interface';
+import { LocalFocusIndicatorOptions } from './focus-indicator-options';
+
+@Directive({
+    selector: '[uxFocusIndicatorOptions]',
+    providers: [LocalFocusIndicatorOptions]
+})
+export class FocusIndicatorOptionsDirective implements AccessibilityOptions {
+
+    /** If `true`, this element will receive a focus indicator when the element is clicked on. */
+    @Input() set mouseFocusIndicator(mouseFocusIndicator: boolean) {
+        this._options.mouseFocusIndicator = mouseFocusIndicator;
+    }
+
+    /** If `true`, this element will receive a focus indicator when the element is touched. */
+    @Input() set touchFocusIndicator(touchFocusIndicator: boolean) {
+        this._options.touchFocusIndicator = touchFocusIndicator;
+    }
+
+    /** If `true`, this element will receive a focus indicator when the element is focused using the keyboard. */
+    @Input() set keyboardFocusIndicator(keyboardFocusIndicator: boolean) {
+        this._options.keyboardFocusIndicator = keyboardFocusIndicator;
+    }
+
+    /** If `true`, this element will receive a focus indicator when the element is programmatically focused. */
+    @Input() set programmaticFocusIndicator(programmaticFocusIndicator: boolean) {
+        this._options.programmaticFocusIndicator = programmaticFocusIndicator;
+    }
+
+
+    constructor(@Self() private _options: LocalFocusIndicatorOptions) { }
+
+}

--- a/src/directives/accessibility/focus-indicator/focus-indicator-options/focus-indicator-options.ts
+++ b/src/directives/accessibility/focus-indicator/focus-indicator-options/focus-indicator-options.ts
@@ -1,0 +1,8 @@
+import { AccessibilityOptions } from '../../options/accessibility-options.interface';
+
+export class LocalFocusIndicatorOptions implements AccessibilityOptions {
+    mouseFocusIndicator: boolean;
+    touchFocusIndicator: boolean;
+    keyboardFocusIndicator: boolean;
+    programmaticFocusIndicator: boolean;
+}

--- a/src/directives/accessibility/focus-indicator/focus-indicator-origin/focus-indicator-origin.directive.ts
+++ b/src/directives/accessibility/focus-indicator/focus-indicator-origin/focus-indicator-origin.directive.ts
@@ -1,0 +1,33 @@
+import { Directive, HostListener } from '@angular/core';
+import { FocusIndicatorOriginService } from './focus-indicator-origin.service';
+
+@Directive({
+    selector: '[uxFocusIndicatorOrigin]',
+})
+export class FocusIndicatorOriginDirective {
+
+    /** Click events can be trigged by both mouse and keyboard so we want to ensure we emit the correct origin */
+    private _isMouseEvent: boolean;
+
+    constructor(private _focusIndicatorEvent: FocusIndicatorOriginService) { }
+
+    @HostListener('mousedown')
+    onMouseDown(): void {
+        this._isMouseEvent = true;
+    }
+
+    @HostListener('click')
+    onClick(): void {
+        // if the click was triggered after a mousedown event then it is a keyboard event
+        this._focusIndicatorEvent.setOrigin(this._isMouseEvent ? 'mouse' : 'keyboard');
+
+        // reset the mouse event flag
+        this._isMouseEvent = false;
+    }
+
+    @HostListener('keydown')
+    onKeydown(): void {
+        this._isMouseEvent = false;
+        this._focusIndicatorEvent.setOrigin('keyboard');
+    }
+}

--- a/src/directives/accessibility/focus-indicator/focus-indicator-origin/focus-indicator-origin.service.ts
+++ b/src/directives/accessibility/focus-indicator/focus-indicator-origin/focus-indicator-origin.service.ts
@@ -1,0 +1,27 @@
+import { FocusOrigin } from '@angular/cdk/a11y';
+import { Injectable } from '@angular/core';
+
+@Injectable()
+export class FocusIndicatorOriginService {
+
+    /** Store the most recent origin event */
+    private _origin: FocusOrigin;
+
+    /** Store the event source origin */
+    setOrigin(origin: FocusOrigin): void {
+        this._origin = origin;
+    }
+
+    /** Get the most recent event origin */
+    getOrigin(): FocusOrigin | null {
+
+        // get the most recent origin if there is one
+        const origin = this._origin;
+
+        // we should clear the origin so this value doesn't cause issues with future focus events
+        this._origin = null;
+
+        return origin;
+    }
+
+}

--- a/src/directives/accessibility/focus-indicator/focus-indicator.directive.ts
+++ b/src/directives/accessibility/focus-indicator/focus-indicator.directive.ts
@@ -1,10 +1,9 @@
-import { ChangeDetectorRef, Directive, ElementRef, EventEmitter, Inject, Input, OnDestroy, OnInit, Optional, Output } from '@angular/core';
+import { ChangeDetectorRef, Directive, ElementRef, EventEmitter, Input, OnDestroy, OnInit, Optional, Output } from '@angular/core';
 import { takeUntil } from 'rxjs/operators';
 import { Subject } from 'rxjs/Subject';
-import { AccessibilityOptions } from '../options/accessibility-options.interface';
 import { AccessibilityOptionsService } from '../options/accessibility-options.service';
-import { ACCESSIBILITY_OPTIONS_TOKEN } from '../options/accessibility-options.token';
 import { FocusIndicator } from './focus-indicator';
+import { LocalFocusIndicatorOptions } from './focus-indicator-options/focus-indicator-options';
 import { FocusIndicatorService } from './focus-indicator.service';
 
 @Directive({
@@ -73,7 +72,7 @@ export class FocusIndicatorDirective implements OnInit, OnDestroy {
         private readonly _focusIndicatorService: FocusIndicatorService,
         private readonly _changeDetectorRef: ChangeDetectorRef,
         readonly optionsService: AccessibilityOptionsService,
-        @Optional() @Inject(ACCESSIBILITY_OPTIONS_TOKEN) readonly localOptions?: AccessibilityOptions
+        @Optional() readonly localOptions?: LocalFocusIndicatorOptions
     ) {
 
         // set the inital option values based on global options

--- a/src/directives/accessibility/focus-indicator/focus-indicator.service.ts
+++ b/src/directives/accessibility/focus-indicator/focus-indicator.service.ts
@@ -5,6 +5,7 @@ import { AccessibilityOptionsService } from '../options/accessibility-options.se
 import { ACCESSIBILITY_OPTIONS_TOKEN } from '../options/accessibility-options.token';
 import { FocusIndicator } from './focus-indicator';
 import { FocusIndicatorOptions } from './focus-indicator-options.interface';
+import { FocusIndicatorOriginService } from './focus-indicator-origin/focus-indicator-origin.service';
 
 @Injectable()
 export class FocusIndicatorService {
@@ -15,6 +16,7 @@ export class FocusIndicatorService {
     constructor(
         private _focusMonitor: FocusMonitor,
         private _globalOptions: AccessibilityOptionsService,
+        private _focusIndicatorOrigin: FocusIndicatorOriginService,
         @Optional() @Inject(ACCESSIBILITY_OPTIONS_TOKEN) private _localOptions: AccessibilityOptions,
         rendererFactory: RendererFactory2) {
 
@@ -24,7 +26,7 @@ export class FocusIndicatorService {
 
     /** This is essentially just a factory method to prevent the user having to pass in focus monitor, renderer and global options each time */
     monitor(element: HTMLElement, options: FocusIndicatorOptions = { ...this._globalOptions.options, ...this._localOptions, checkChildren: false }): FocusIndicator {
-        return new FocusIndicator(element, this._focusMonitor, this._renderer, { ...this._globalOptions.options, ...this._localOptions, ...options });
+        return new FocusIndicator(element, this._focusMonitor, this._renderer, { ...this._globalOptions.options, ...this._localOptions, ...options }, this._focusIndicatorOrigin);
     }
 
 }

--- a/src/directives/accessibility/focus-indicator/focus-indicator.ts
+++ b/src/directives/accessibility/focus-indicator/focus-indicator.ts
@@ -67,6 +67,12 @@ export class FocusIndicator {
     /** Monitor changes to an elements focus state */
     private onFocusChange(origin: FocusOrigin): void {
 
+        // if the origin is null then we blurred
+        if (origin === null) {
+            this.isFocused = false;
+            return;
+        }
+
         // get the origin if there is one
         const syntheticOrigin = this._focusIndicatorOrigin.getOrigin();
 

--- a/src/directives/accessibility/focus-indicator/focus-indicator.ts
+++ b/src/directives/accessibility/focus-indicator/focus-indicator.ts
@@ -4,6 +4,7 @@ import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 import { takeUntil } from 'rxjs/operators';
 import { Subject } from 'rxjs/Subject';
 import { FocusIndicatorOptions } from './focus-indicator-options.interface';
+import { FocusIndicatorOriginService } from './focus-indicator-origin/focus-indicator-origin.service';
 
 export class FocusIndicator {
 
@@ -33,7 +34,8 @@ export class FocusIndicator {
         private readonly _element: HTMLElement,
         private readonly _focusMonitor: FocusMonitor,
         private readonly _renderer: Renderer2,
-        private _options: FocusIndicatorOptions) {
+        private _options: FocusIndicatorOptions,
+        private _focusIndicatorOrigin: FocusIndicatorOriginService) {
         this.initialise();
     }
 
@@ -65,7 +67,10 @@ export class FocusIndicator {
     /** Monitor changes to an elements focus state */
     private onFocusChange(origin: FocusOrigin): void {
 
-        switch (origin) {
+        // get the origin if there is one
+        const syntheticOrigin = this._focusIndicatorOrigin.getOrigin();
+
+        switch (syntheticOrigin || origin) {
 
             case 'mouse':
                 this.isFocused = this._options.mouseFocusIndicator;


### PR DESCRIPTION
Related PR: https://github.houston.softwaregrp.net/caf/ux-aspects-micro-focus/pull/354

- Fixing Hierarchy Bar focus ring showing in collapsed mode
- Adding `uxFocusIndicatorOptions` directive (instead of the previous inject the ACCESSIBILITY_OPTIONS_TOKEN). You can now just add this directive to any element and you can override all the options that are available to the uxFocusIndicator (note `checkChildren` is not an option as this is something that the component itself would need to decide). This gives us much more fine grained control than with the injection token.

Your date picker plunker showing the issue can be updated like this:

```html
<ux-date-time-picker
        uxFocusIndicatorOptions
        [mouseFocusIndicator]="true"
        [(date)]="date"
        [(timezone)]="timezone"
        [showTime]="showTime"
        [showMeridian]="showMeridians"
        [showSpinners]="showSpinners"
        [showTimezone]="showTimezones"
        (keydown.escape)="popover.hide(); input.focus()">
</ux-date-time-picker>
```

Also updated documentation for this.

- Adding a `uxFocusIndicatorOrigin` directive to allow events to be persisted in a non-linear way, for example when a modal opens the primary button is focused after a 200ms delay. This will allow the focus origin to be retained until that focus event occurs. Added documentation for this and updated the date picker and date picker example to use this.

#### Ticket
https://autjira.microfocus.com/browse/EL-3406

#### Documentation CI URL
https://pages.github.houston.softwaregrp.net/sepg-docs-qa/UXAspects_CI_UXAspects_EL-3406-Focus-Indicator-Rework
