### PR TITLE
EL-3404 - Focus Visual Rework

### DIFF
--- a/docs/app/pages/components/components-sections/wizard/marquee-wizard/marquee-wizard.component.html
+++ b/docs/app/pages/components/components-sections/wizard/marquee-wizard/marquee-wizard.component.html
@@ -22,7 +22,7 @@
 
             <!-- Add Dismiss Button to Modal -->
             <div class="dismiss">
-                <button class="modal-close" (click)="close()" type="button" aria-label="Close Modal" tabindex="0">
+                <button class="modal-close" uxFocusIndicator (click)="close()" type="button" aria-label="Close Modal" tabindex="0">
                     <i class="hpe-icon hpe-close"></i>
                 </button>
             </div>

--- a/docs/app/pages/components/components-sections/wizard/marquee-wizard/snippets/app.html
+++ b/docs/app/pages/components/components-sections/wizard/marquee-wizard/snippets/app.html
@@ -16,6 +16,7 @@
             <!-- Add Dismiss Button to Modal -->
             <div class="dismiss">
                 <button class="modal-close"
+                    uxFocusIndicator
                     (click)="close()"
                     type="button"
                     aria-label="Close Modal"

--- a/docs/app/pages/components/components-sections/wizard/wizard.module.ts
+++ b/docs/app/pages/components/components-sections/wizard/wizard.module.ts
@@ -3,7 +3,7 @@ import { CommonModule } from '@angular/common';
 import { ComponentFactoryResolver, NgModule } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
 import { RouterModule } from '@angular/router';
-import { AccordionModule, CheckboxModule, FocusIfModule, MarqueeWizardModule, RadioButtonModule, TabsetModule, WizardModule } from '@ux-aspects/ux-aspects';
+import { AccessibilityModule, AccordionModule, CheckboxModule, FocusIfModule, MarqueeWizardModule, RadioButtonModule, TabsetModule, WizardModule } from '@ux-aspects/ux-aspects';
 import { ModalModule } from 'ngx-bootstrap/modal';
 import { DocumentationComponentsModule } from '../../../../components/components.module';
 import { DocumentationCategoryComponent } from '../../../../components/documentation-category/documentation-category.component';
@@ -38,6 +38,7 @@ const ROUTES = [
 @NgModule({
     imports: [
         A11yModule,
+        AccessibilityModule,
         AccordionModule,
         CheckboxModule,
         CommonModule,

--- a/src/components/color-picker/color-picker.component.html
+++ b/src/components/color-picker/color-picker.component.html
@@ -15,7 +15,7 @@
                     i18n-aria-label
                     aria-selected="color === (selected$ | async)"
                     class="btn btn-icon"
-                    [style.color]="_getContrastColor(color)"
+                    [uxColorContrast]="color.hex"
                     [style.background-color]="color.rgba"
                     (click)="selected$.next(color)"
                     uxTabbableListItem

--- a/src/components/color-picker/color-picker.component.html
+++ b/src/components/color-picker/color-picker.component.html
@@ -15,11 +15,13 @@
                     i18n-aria-label
                     aria-selected="color === (selected$ | async)"
                     class="btn btn-icon"
+                    [style.color]="_getContrastColor(color)"
                     [style.background-color]="color.rgba"
                     (click)="selected$.next(color)"
                     uxTabbableListItem
                     [uxTooltip]="color.name"
                     [tooltipDisabled]="!showTooltips">
+                    <i class="hpe-icon hpe-checkmark"></i>
                 </button>
 
             </div>

--- a/src/components/color-picker/color-picker.component.less
+++ b/src/components/color-picker/color-picker.component.less
@@ -30,6 +30,10 @@ ux-color-picker {
             height: 32px;
             box-shadow: 0 0 6px 2px #ddd;
 
+            > .hpe-icon {
+                display: none;
+            }
+
             &.ux-focus-indicator-active {
                 outline: none !important; // required until we move all focus styling to box-shadows
                 box-shadow: 0 0 0 3px fade(@primary, 50%);
@@ -55,10 +59,8 @@ ux-color-picker {
         }
 
         &.ux-selected {
-            border: 5px solid fade(@primary, 50%);
-
-            > button {
-                box-shadow: none;
+            > button > .hpe-icon {
+                display: block;
             }
         }
     }

--- a/src/components/color-picker/color-picker.component.less
+++ b/src/components/color-picker/color-picker.component.less
@@ -61,6 +61,7 @@ ux-color-picker {
         &.ux-selected {
             > button > .hpe-icon {
                 display: block;
+                font-weight: 700;
             }
         }
     }

--- a/src/components/color-picker/color-picker.component.ts
+++ b/src/components/color-picker/color-picker.component.ts
@@ -3,6 +3,7 @@ import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 import { combineLatest } from 'rxjs/observable/combineLatest';
 import { pairwise, takeUntil } from 'rxjs/operators';
 import { Subject } from 'rxjs/Subject';
+import { ThemeColor } from '../../services/color/index';
 import { ColorPickerColor } from './color-picker-color';
 
 // Values corresponding to stylesheet
@@ -152,6 +153,44 @@ export class ColorPickerComponent implements OnInit, OnDestroy {
     toggleColorEntryType(): void {
         this.inputMode = (this.inputMode === 'hex') ? 'rgba' : 'hex';
     }
+
+    /**
+     * Calculate the contract ratio between two colors.
+     * This uses the official WCAG Color Contrast Ratio
+     * Algorithm: https://www.w3.org/TR/WCAG20-TECHS/G17.html
+     */
+    _getContrastColor(backgroundColor: ColorPickerColor): string {
+        // get a ThemeColor from the ColorPickerColor
+        const themeColor = ThemeColor.parse(backgroundColor.hex);
+
+        const background = this.getLuminance(themeColor);
+        const white = this.getLuminance(ThemeColor.parse('#fff'));
+        const black = this.getLuminance(ThemeColor.parse('#000'));
+
+        // determine the contrast for both black and white
+        const whiteContrast = (white + 0.05) / (background + 0.05);
+        const blackContrast = (background + 0.05) / (black + 0.05);
+
+        // return the color with the most contrast ratio
+        return blackContrast > whiteContrast ? '#000' : '#fff';
+    }
+
+    private getLuminance(color: ThemeColor): number {
+
+        // normalize the colors
+        let r = +color.getRed() / 255;
+        let g = +color.getGreen() / 255;
+        let b = +color.getBlue() / 255;
+
+        // calculate the value required for each color component
+        r = r <= 0.03928 ? r / 12.92 : Math.pow((r + 0.055) / 1.055, 2.4);
+        g = g <= 0.03928 ? g / 12.92 : Math.pow((g + 0.055) / 1.055, 2.4);
+        b = b <= 0.03928 ? b / 12.92 : Math.pow((b + 0.055) / 1.055, 2.4);
+
+        // return the luminance
+        return (0.2126 * r) + (0.7152 * g) + (0.0722 * b);
+    }
+
 }
 
 export type ColorPickerInputColors = ColorPickerColor | string;

--- a/src/components/color-picker/color-picker.component.ts
+++ b/src/components/color-picker/color-picker.component.ts
@@ -3,7 +3,6 @@ import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 import { combineLatest } from 'rxjs/observable/combineLatest';
 import { pairwise, takeUntil } from 'rxjs/operators';
 import { Subject } from 'rxjs/Subject';
-import { ThemeColor } from '../../services/color/index';
 import { ColorPickerColor } from './color-picker-color';
 
 // Values corresponding to stylesheet
@@ -153,44 +152,6 @@ export class ColorPickerComponent implements OnInit, OnDestroy {
     toggleColorEntryType(): void {
         this.inputMode = (this.inputMode === 'hex') ? 'rgba' : 'hex';
     }
-
-    /**
-     * Calculate the contract ratio between two colors.
-     * This uses the official WCAG Color Contrast Ratio
-     * Algorithm: https://www.w3.org/TR/WCAG20-TECHS/G17.html
-     */
-    _getContrastColor(backgroundColor: ColorPickerColor): string {
-        // get a ThemeColor from the ColorPickerColor
-        const themeColor = ThemeColor.parse(backgroundColor.hex);
-
-        const background = this.getLuminance(themeColor);
-        const white = this.getLuminance(ThemeColor.parse('#fff'));
-        const black = this.getLuminance(ThemeColor.parse('#000'));
-
-        // determine the contrast for both black and white
-        const whiteContrast = (white + 0.05) / (background + 0.05);
-        const blackContrast = (background + 0.05) / (black + 0.05);
-
-        // return the color with the most contrast ratio
-        return blackContrast > whiteContrast ? '#000' : '#fff';
-    }
-
-    private getLuminance(color: ThemeColor): number {
-
-        // normalize the colors
-        let r = +color.getRed() / 255;
-        let g = +color.getGreen() / 255;
-        let b = +color.getBlue() / 255;
-
-        // calculate the value required for each color component
-        r = r <= 0.03928 ? r / 12.92 : Math.pow((r + 0.055) / 1.055, 2.4);
-        g = g <= 0.03928 ? g / 12.92 : Math.pow((g + 0.055) / 1.055, 2.4);
-        b = b <= 0.03928 ? b / 12.92 : Math.pow((b + 0.055) / 1.055, 2.4);
-
-        // return the luminance
-        return (0.2126 * r) + (0.7152 * g) + (0.0722 * b);
-    }
-
 }
 
 export type ColorPickerInputColors = ColorPickerColor | string;

--- a/src/components/facets/base/facet-header/facet-header.component.ts
+++ b/src/components/facets/base/facet-header/facet-header.component.ts
@@ -1,4 +1,5 @@
-import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { Component, ElementRef, EventEmitter, Input, OnDestroy, Output } from '@angular/core';
+import { FocusIndicator, FocusIndicatorService } from '../../../../directives/accessibility/index';
 
 @Component({
     selector: 'ux-facet-header',
@@ -12,12 +13,30 @@ import { Component, EventEmitter, Input, Output } from '@angular/core';
         '[attr.aria-label]': 'header + \' Facet: Activate to \' + (expanded ? \'collapse\' : \'expand\')'
     }
 })
-export class FacetHeaderComponent {
+export class FacetHeaderComponent implements OnDestroy {
 
+    /** Defines the text to display in the header. */
     @Input() header: string;
+
+    /** Defines whether or not clicking on the header will toggle the expanded state. */
     @Input() canExpand: boolean = true;
+
+    /** Can be used to set the initial expanded. */
     @Input() expanded: boolean = true;
+
+    /** If two-way binding is used it will be updated when the expanded state changes. */
     @Output() expandedChange: EventEmitter<boolean> = new EventEmitter<boolean>();
+
+    /** Store Focus Indicator instance */
+    private _focusIndicator: FocusIndicator;
+
+    constructor(focusIndicatorService: FocusIndicatorService, elementRef: ElementRef) {
+        this._focusIndicator = focusIndicatorService.monitor(elementRef.nativeElement);
+    }
+
+    ngOnDestroy(): void {
+        this._focusIndicator.destroy();
+    }
 
     toggleExpand(): void {
 

--- a/src/components/pagination/pagination.component.html
+++ b/src/components/pagination/pagination.component.html
@@ -10,12 +10,13 @@
 
     <li class="pagination-prev page-item"
         *ngIf="directionButtons"
+        uxFocusIndicator
+        [programmaticFocusIndicator]="true"
+        [checkChildren]="true"
         [class.disabled]="page === 1 || disabled">
 
       <a class="page-link"
-         tabindex="0"
-         uxFocusIndicator
-         [programmaticFocusIndicator]="true"
+         [tabindex]="page === 1 || disabled ? -1 : 0"
          [attr.aria-label]="previousAriaLabel"
          [ngClass]="pageBtnClass"
          (click)="select(page - 1)"
@@ -26,14 +27,15 @@
 
     <ng-container *ngFor="let pg of pages; trackBy: trackByFn">
       <li *ngIf="pg.visible"
+          uxFocusIndicator
+          [programmaticFocusIndicator]="true"
+          [checkChildren]="true"
           [class.disabled]="disabled"
           [class.active]="page === pg.index"
           class="pagination-page page-item">
 
         <a class="page-link"
            tabindex="0"
-           uxFocusIndicator
-           [programmaticFocusIndicator]="true"
            [ngClass]="pageBtnClass"
            [focusIf]="isKeyboardEvent && page === pg.index"
            [attr.aria-current]="page === pg.index"
@@ -48,12 +50,13 @@
 
     <li class="pagination-next page-item"
         *ngIf="directionButtons"
+        uxFocusIndicator
+        [programmaticFocusIndicator]="true"
+        [checkChildren]="true"
         [class.disabled]="page === pageCount || disabled">
 
       <a class="page-link"
-         tabindex="0"
-         uxFocusIndicator
-         [programmaticFocusIndicator]="true"
+         [tabindex]="page === pageCount || disabled ? -1 : 0"
          [attr.aria-label]="nextAriaLabel"
          [ngClass]="pageBtnClass"
          (click)="select(page + 1)"

--- a/src/components/pagination/pagination.component.html
+++ b/src/components/pagination/pagination.component.html
@@ -12,9 +12,10 @@
         *ngIf="directionButtons"
         [class.disabled]="page === 1 || disabled">
 
-      <a class="page-link ux-keyboard-focus"
+      <a class="page-link"
          tabindex="0"
-         cdkMonitorElementFocus
+         uxFocusIndicator
+         [programmaticFocusIndicator]="true"
          [attr.aria-label]="previousAriaLabel"
          [ngClass]="pageBtnClass"
          (click)="select(page - 1)"
@@ -29,10 +30,11 @@
           [class.active]="page === pg.index"
           class="pagination-page page-item">
 
-        <a class="page-link ux-keyboard-focus"
+        <a class="page-link"
            tabindex="0"
+           uxFocusIndicator
+           [programmaticFocusIndicator]="true"
            [ngClass]="pageBtnClass"
-           cdkMonitorElementFocus
            [focusIf]="isKeyboardEvent && page === pg.index"
            [attr.aria-current]="page === pg.index"
            [attr.aria-setsize]="pageCount"
@@ -48,9 +50,10 @@
         *ngIf="directionButtons"
         [class.disabled]="page === pageCount || disabled">
 
-      <a class="page-link ux-keyboard-focus"
+      <a class="page-link"
          tabindex="0"
-         cdkMonitorElementFocus
+         uxFocusIndicator
+         [programmaticFocusIndicator]="true"
          [attr.aria-label]="nextAriaLabel"
          [ngClass]="pageBtnClass"
          (click)="select(page + 1)"

--- a/src/components/table/table-column-resize/resizable-table-column.component.html
+++ b/src/components/table/table-column-resize/resizable-table-column.component.html
@@ -2,7 +2,7 @@
 
 <div #handle
      uxDrag
-     cdkMonitorElementFocus
+     uxFocusIndicator
      tabindex="0"
      aria-label="Column resize handle. Use arrow keys to change the column width."
      class="ux-resizable-table-column-handle"

--- a/src/components/table/table.module.ts
+++ b/src/components/table/table.module.ts
@@ -1,6 +1,7 @@
 import { A11yModule } from '@angular/cdk/a11y';
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
+import { AccessibilityModule } from '../../directives/accessibility/index';
 import { DragModule } from '../../directives/drag/index';
 import { ResizeModule } from '../../directives/resize/index';
 import { ResizableTableCellDirective } from './table-column-resize/resizable-table-cell.directive';
@@ -9,10 +10,11 @@ import { ResizableTableDirective } from './table-column-resize/resizable-table.d
 
 @NgModule({
     imports: [
+        A11yModule,
+        AccessibilityModule,
         CommonModule,
         DragModule,
         ResizeModule,
-        A11yModule
     ],
     declarations: [
         ResizableTableDirective,
@@ -25,4 +27,4 @@ import { ResizableTableDirective } from './table-column-resize/resizable-table.d
         ResizableTableCellDirective
     ]
 })
-export class TableModule {}
+export class TableModule { }

--- a/src/components/wizard/wizard-step.component.ts
+++ b/src/components/wizard/wizard-step.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, EventEmitter, Host, HostBinding, Inject, forwardRef } from '@angular/core';
+import { Component, EventEmitter, HostBinding, Input } from '@angular/core';
 
 @Component({
     selector: 'ux-wizard-step',
@@ -10,13 +10,23 @@ import { Component, Input, EventEmitter, Host, HostBinding, Inject, forwardRef }
 })
 export class WizardStepComponent {
 
+    /** The text to be displayed in the wizard step tab. */
     @Input() header: string;
+
+    /** Allows you to define whether or not a step is valid. The user will not be able to proceed to the next step if this property has a value of false. */
     @Input() valid: boolean = true;
+
+    /** Emits when visited changes. */
     @Input() visitedChange = new EventEmitter<boolean>();
 
     private _active: boolean = false;
     private _visited: boolean = false;
 
+    /**
+     * Defines whether or not this step has previously been visited.
+     * A visited step can be clicked on and jumped to at any time.
+     * By default, steps will become 'visited' when the user navigates to a step for the first time.
+     */
     @Input()
     get visited(): boolean {
         return this._visited;

--- a/src/components/wizard/wizard.component.html
+++ b/src/components/wizard/wizard.component.html
@@ -8,8 +8,10 @@
 
         <div *ngFor="let stp of steps; let index = index"
             role="tab"
+            uxFocusIndicator
             uxTabbableListItem
-            [disabled]="!stp.visited"
+            [programmaticFocusIndicator]="true"
+            [disabled]="index !== 0 && !stp.visited"
             class="wizard-step"
             [class.active]="stp.active"
             [class.visited]="stp.visited"

--- a/src/components/wizard/wizard.component.ts
+++ b/src/components/wizard/wizard.component.ts
@@ -14,42 +14,97 @@ let uniqueId: number = 0;
 })
 export class WizardComponent implements AfterViewInit, OnDestroy {
 
+    /** Defines whether or not the wizard should be displayed in a `horizontal` or `vertical` layout. */
     @Input() orientation: 'horizontal' | 'vertical' = 'horizontal';
 
+    /** Defines the text displayed in the 'Next' button. */
     @Input() nextText: string = 'Next';
+
+    /** Defines the text displayed in the 'Previous' button. */
     @Input() previousText: string = 'Previous';
+
+    /** Defines the text displayed in the 'Cancel' button. */
     @Input() cancelText: string = 'Cancel';
+
+    /** Defines the text displayed in the 'Finish' button. */
     @Input() finishText: string = 'Finish';
 
+    /** Defines the text displayed in the tooltip when the 'Next' button is hovered. */
     @Input() nextTooltip: string = 'Go to the next step';
+
+    /** Defines the text displayed in the tooltip when the 'Previous' button is hovered. */
     @Input() previousTooltip: string = 'Go to the previous step';
+
+    /** Defines the text displayed in the tooltip when the 'Cancel' button is hovered. */
     @Input() cancelTooltip: string = 'Cancel the wizard';
+
+    /** Defines the text displayed in the tooltip when the 'Finish' button is hovered. */
     @Input() finishTooltip: string = 'Finish the wizard';
 
+    /** Defines the text for the aria label on the 'Next' button. */
     @Input() nextAriaLabel: string = 'Go to the next step';
+
+    /** Defines the text for the aria label on the 'Previous' button. */
     @Input() previousAriaLabel: string = 'Go to the previous step';
+
+    /** Defines the text for the aria label on the 'Cancel' button. */
     @Input() cancelAriaLabel: string = 'Cancel the wizard';
+
+    /** Defines the text for the aria label on the 'Finish' button. */
     @Input() finishAriaLabel: string = 'Finish the wizard';
 
+    /** If set to `true` the 'Next' button will appear disabled and will not respond to clicks. */
     @Input() nextDisabled: boolean = false;
+
+    /** If set to `true` the 'Previous' button will appear disabled and will not respond to clicks. */
     @Input() previousDisabled: boolean = false;
+
+    /** If set to `true` the 'Cancel' button will appear disabled and will not respond to clicks. */
     @Input() cancelDisabled: boolean = false;
+
+    /** If set to `true` the 'Finish' button will appear disabled and will not respond to clicks. */
     @Input() finishDisabled: boolean = false;
 
+    /** If set to `false` the 'Next' button will be hidden. */
     @Input() nextVisible: boolean = true;
+
+    /** If set to `false` the 'Previous' button will be hidden. */
     @Input() previousVisible: boolean = true;
+
+    /** If set to `false` the 'Cancel' button will be hidden. */
     @Input() cancelVisible: boolean = true;
+
+    /** If set to false the 'Finish' button will be hidden. */
     @Input() finishVisible: boolean = true;
+
+    /** If set to `true` the 'Cancel' button will be visible even on the last step. By default it will be hidden on the final step. */
     @Input() cancelAlwaysVisible: boolean = false;
+
+    /** If set to `true` the 'Finish' button will be visible on all steps of the wizard. By default this button will only be visible on the final step of the wizard. */
     @Input() finishAlwaysVisible: boolean = false;
 
+    /** Emits when the wizard has moved to the next step. It will receive the current step index as a parameter. */
     @Output() onNext = new EventEmitter<number>();
+
+    /** Emits when the wizard has moved to the previous step. It will receive the current step index as a parameter. */
     @Output() onPrevious = new EventEmitter<number>();
+
+    /** Emits when the 'Cancel' button has been pressed. */
     @Output() onCancel = new EventEmitter<void>();
+
+    /** Emits when the 'Finish' button is clicked, but before the finish event fires. This fires regardless of the validity of the final step. */
     @Output() onFinishing = new EventEmitter<void>();
+
+    /** Emits when the 'Finish' button has been pressed and the final step is valid. */
     @Output() onFinish = new EventEmitter<void>();
+
+    /** Emits before the current step changes. The event contains the current step index in the `from` property, and the requested step index in the `to` property. */
     @Output() stepChanging = new EventEmitter<StepChangingEvent>();
+
+    /** Emits when the current step has changed. */
     @Output() stepChange = new EventEmitter<number>();
+
+    /** Emits when the user tries to continue but the current step is invalid. */
     @Output() stepError = new EventEmitter<number>();
 
     @ContentChildren(WizardStepComponent) steps = new QueryList<WizardStepComponent>();
@@ -57,6 +112,10 @@ export class WizardComponent implements AfterViewInit, OnDestroy {
     id: string = `ux-wizard-${uniqueId++}`;
     invalidIndicator: boolean = false;
 
+    /**
+     * The current active step. When the step changes an event will be emitted containing the index of the newly active step.
+     * If this is not specifed the wizard will start on the first step.
+     */
     @Input()
     get step() {
         return this._step;

--- a/src/directives/accessibility/accessibility.module.ts
+++ b/src/directives/accessibility/accessibility.module.ts
@@ -1,5 +1,8 @@
 import { A11yModule } from '@angular/cdk/a11y';
 import { ModuleWithProviders, NgModule, Optional, SkipSelf } from '@angular/core';
+import { ColorServiceModule } from '../../services/color/index';
+import { ColorContrastDirective } from './contrast-ratio/color-contrast.directive';
+import { ContrastService } from './contrast-ratio/contrast.service';
 import { DefaultFocusIndicatorDirective } from './focus-indicator/default-focus-indicator.directive';
 import { FocusIndicatorOptionsDirective } from './focus-indicator/focus-indicator-options/focus-indicator-options.directive';
 import { FocusIndicatorOriginDirective } from './focus-indicator/focus-indicator-origin/focus-indicator-origin.directive';
@@ -42,10 +45,12 @@ export const FOCUS_INDICATOR_ORIGIN_SERVICE_PROVIDER = {
         SplitterAccessibilityDirective,
         TabbableListDirective,
         TabbableListItemDirective,
-        FocusIndicatorOriginDirective
+        FocusIndicatorOriginDirective,
+        ColorContrastDirective
     ],
     imports: [
-        A11yModule
+        A11yModule,
+        ColorServiceModule
     ],
     exports: [
         DefaultFocusIndicatorDirective,
@@ -55,10 +60,12 @@ export const FOCUS_INDICATOR_ORIGIN_SERVICE_PROVIDER = {
         SplitterAccessibilityDirective,
         TabbableListDirective,
         TabbableListItemDirective,
-        FocusIndicatorOriginDirective
+        FocusIndicatorOriginDirective,
+        ColorContrastDirective
     ],
     providers: [
         AccessibilityOptionsService,
+        ContrastService,
         FocusIndicatorService,
         FOCUS_INDICATOR_ORIGIN_SERVICE_PROVIDER
     ]

--- a/src/directives/accessibility/contrast-ratio/color-contrast.directive.ts
+++ b/src/directives/accessibility/contrast-ratio/color-contrast.directive.ts
@@ -1,0 +1,54 @@
+import { Directive, HostBinding, Input } from '@angular/core';
+import { ColorService, ThemeColor } from '../../../services/color/index';
+import { ContrastService } from './contrast.service';
+
+@Directive({
+    selector: '[uxColorContrast]'
+})
+export class ColorContrastDirective {
+
+    /**
+     * Define the background color for contrast comparison.
+     * This can be a CSS color value or the name of a
+     * color from the color palette.
+     */
+    @Input() set uxColorContrast(backgroundColor: string) {
+        this._backgroundColor = ThemeColor.parse(this._colorService.resolve(backgroundColor));
+    }
+
+    /**
+     * Define the light color for contrast comparison.
+     * This can be a CSS color value or the name of a
+     * color from the color palette.
+     */
+    @Input() set lightColor(lightColor: string) {
+        this._lightColor = ThemeColor.parse(this._colorService.resolve(lightColor));
+    }
+
+    /**
+     * Define the dark color for contrast comparison.
+     * This can be a CSS color value or the name of a
+     * color from the color palette.
+     */
+    @Input() set darkColor(darkColor: string) {
+        this._darkColor = ThemeColor.parse(this._colorService.resolve(darkColor));
+    }
+
+    /** Determine the color to set based on the supplied parameters */
+    @HostBinding('style.color')
+    get _color(): string | null {
+        return this._backgroundColor ? this._contrastService.getContrastColor(this._backgroundColor, this._lightColor, this._darkColor) : null;
+    }
+
+    /** Store the background color as a ThemeColor object */
+    private _backgroundColor: ThemeColor;
+
+    /** Store the light color as a ThemeColor object */
+    private _lightColor: ThemeColor = ThemeColor.parse('#fff');
+
+    /** Store the light color as a ThemeColor object */
+    private _darkColor: ThemeColor = ThemeColor.parse('#000');
+
+    constructor(private _colorService: ColorService, private _contrastService: ContrastService) { }
+
+}

--- a/src/directives/accessibility/contrast-ratio/contrast.service.ts
+++ b/src/directives/accessibility/contrast-ratio/contrast.service.ts
@@ -1,0 +1,42 @@
+import { Injectable } from '@angular/core';
+import { ThemeColor } from '../../../services/color/index';
+
+@Injectable()
+export class ContrastService {
+    /**
+     * Calculate the contract ratio between two colors.
+     * This uses the official WCAG Color Contrast Ratio
+     * Algorithm: https://www.w3.org/TR/WCAG20-TECHS/G17.html
+     */
+    getContrastColor(backgroundColor: ThemeColor, lightColor: ThemeColor, darkColor: ThemeColor): string {
+        // get a ThemeColor from the ColorPickerColor
+        const themeColor = ThemeColor.parse(backgroundColor.toHex());
+
+        const background = this.getLuminance(themeColor);
+        const light = this.getLuminance(lightColor);
+        const dark = this.getLuminance(darkColor);
+
+        // determine the contrast for both black and white
+        const whiteContrast = (light + 0.05) / (background + 0.05);
+        const blackContrast = (background + 0.05) / (dark + 0.05);
+
+        // return the color with the most contrast ratio
+        return blackContrast > whiteContrast ? '#000' : '#fff';
+    }
+
+    private getLuminance(color: ThemeColor): number {
+
+        // normalize the colors
+        let r = +color.getRed() / 255;
+        let g = +color.getGreen() / 255;
+        let b = +color.getBlue() / 255;
+
+        // calculate the value required for each color component
+        r = r <= 0.03928 ? r / 12.92 : Math.pow((r + 0.055) / 1.055, 2.4);
+        g = g <= 0.03928 ? g / 12.92 : Math.pow((g + 0.055) / 1.055, 2.4);
+        b = b <= 0.03928 ? b / 12.92 : Math.pow((b + 0.055) / 1.055, 2.4);
+
+        // return the luminance
+        return (0.2126 * r) + (0.7152 * g) + (0.0722 * b);
+    }
+}

--- a/src/directives/accessibility/index.ts
+++ b/src/directives/accessibility/index.ts
@@ -1,4 +1,6 @@
 export * from './accessibility.module';
+export * from './contrast-ratio/color-contrast.directive';
+export * from './contrast-ratio/contrast.service';
 export * from './focus-indicator/focus-indicator';
 export * from './focus-indicator/focus-indicator-options.interface';
 export * from './focus-indicator/focus-indicator.directive';


### PR DESCRIPTION
Related PR: https://github.houston.softwaregrp.net/caf/ux-aspects-micro-focus/pull/355 & https://github.houston.softwaregrp.net/caf/quantum/pull/625

- Created a `ContrastService` that can be used to get the best contrasting colours. I found the WCAG AA Contrast Ratio algorithm in the spec and have implemented it so the contrast will be accurate according to the spec.
- Also created a `uxColorContrast` directive to set the color based on the background color automatically.
- Improved facet header focus behavior
- Improved pagination focus behavior (previous using CDK focus directives, now using `uxFocusIndicator` for consistency)
- Wizard now using focus-indicator. Also found a bug where the first wizard step was not initially tabbable, as we were basing the tab index of whether or not the step had been visited before. Changed to take into account if the step is the first step and if the step is visited.
- Added `uxFocusIndicator` to marquee wizard close button (sample code)

#### Ticket
https://autjira.microfocus.com/browse/EL-3404

#### Documentation CI URL
https://pages.github.houston.softwaregrp.net/sepg-docs-qa/UXAspects_CI_UXAspects_EL-3404-Focus-Visual-Rework
