### PR TITLE
Added uxSelection test for the ManagedFocusContainer functionality

### DIFF
--- a/e2e/pages/app/selection/selection.testpage.component.html
+++ b/e2e/pages/app/selection/selection.testpage.component.html
@@ -19,6 +19,9 @@
             </td>
             <td>{{ item.name }}</td>
             <td>{{ item.author }}</td>
+            <td>
+                <button type="button" class="row-button" tabindex="5">Test</button>
+            </td>
         </tr>
     </tbody>
 </table>

--- a/e2e/tests/components/selection/selection.e2e-spec.ts
+++ b/e2e/tests/components/selection/selection.e2e-spec.ts
@@ -17,6 +17,12 @@ describe('Selection Tests', () => {
         expect<any>(page.row2.isPresent()).toBe(true);
         expect<any>(page.row3.isPresent()).toBe(true);
 
+        // tabindex should be disabled on the child buttons
+        expect<any>(page.getRowButtonTabIndex(page.row0)).toBe('-1');
+        expect<any>(page.getRowButtonTabIndex(page.row1)).toBe('-1');
+        expect<any>(page.getRowButtonTabIndex(page.row2)).toBe('-1');
+        expect<any>(page.getRowButtonTabIndex(page.row3)).toBe('-1');
+
         // no table rows are selected
         expect(await page.getSelection()).toBe('[]');
     });
@@ -341,6 +347,25 @@ describe('Selection Tests', () => {
         // the selection should be updated
         expect(await page.getSelection()).toBe('[ { "name": "Document 1", "author": "John Smith", "selected": true }, { "name": "Document 2", "author": "John Smith", "selected": true }, { "name": "Document 3", "author": "John Smith", "selected": true }, { "name": "Document 4", "author": "John Smith", "selected": true } ]');
 
+    });
+
+    it('should restore tabindex on focused rows', async () => {
+
+        // tabindex should initially be disabled
+        expect<any>(page.getRowButtonTabIndex(page.row0)).toBe('-1');
+
+        // click the first row
+        await page.clickSelectRow(page.row0);
+
+        // Focus should restore the tabindex to its original value
+        expect<any>(page.getRowButtonTabIndex(page.row0)).toBe('5');
+
+        // click the second row
+        await page.clickSelectRow(page.row1);
+
+        // tabindex should be disabled again on blur
+        expect<any>(page.getRowButtonTabIndex(page.row0)).toBe('-1');
+        expect<any>(page.getRowButtonTabIndex(page.row1)).toBe('5');
     });
 
 });

--- a/e2e/tests/components/selection/selection.po.spec.ts
+++ b/e2e/tests/components/selection/selection.po.spec.ts
@@ -76,4 +76,10 @@ export class SelectionPage {
         await browser.actions().sendKeys(Key.SPACE).perform();
     }
 
+    async getRowButtonTabIndex(row: ElementFinder): Promise<string> {
+        const btn = row.$('.row-button');
+
+        return btn.getAttribute('tabindex');
+    }
+
 }


### PR DESCRIPTION
I don't think there are tests for hover actions and tabbable list yet.

#### Ticket
https://autjira.microfocus.com/browse/EL-3342

#### Documentation CI URL
https://pages.github.houston.softwaregrp.net/sepg-docs-qa/UXAspects_CI_UXAspects_EL-3342-table-navigation-e2e
