### PR TITLE
EL3429 - Tooltip Cancel Delay

### DIFF
--- a/src/components/tooltip/tooltip.directive.ts
+++ b/src/components/tooltip/tooltip.directive.ts
@@ -410,7 +410,14 @@ export class TooltipDirective implements OnInit, OnChanges, OnDestroy {
     /** Handle the mouse leave event - show or hide accordingly */
     protected onMouseLeave(_: MouseEvent): void {
 
-        // this is an hide only trigger - if not open or it isn't a trigger do nothing
+        // If the tooltip is pending then cancel showing it
+        if (!this.isVisible && this.includes(this.hideTriggers, 'mouseleave') && this._showTimeoutId !== null) {
+            clearTimeout(this._showTimeoutId);
+            this._showTimeoutId = null;
+            return;
+        }
+
+        // if the tooltip is not visible or mouseleave isn't a hide trigger then do nothing
         if (!this.isVisible || !this.includes(this.hideTriggers, 'mouseleave')) {
             return;
         }

--- a/src/components/tooltip/tooltip.directive.ts
+++ b/src/components/tooltip/tooltip.directive.ts
@@ -393,6 +393,11 @@ export class TooltipDirective implements OnInit, OnChanges, OnDestroy {
             return this.hide();
         }
 
+        // if its not visible and click is a hide trigger close it and there is a pending tooltip
+        if (!this.isVisible && this.includes(this.hideTriggers, 'click') && this._showTimeoutId !== null) {
+            return this.cancelTooltip();
+        }
+
     }
 
     /** Handle the mouse enter event - show or hide accordingly */
@@ -412,9 +417,7 @@ export class TooltipDirective implements OnInit, OnChanges, OnDestroy {
 
         // If the tooltip is pending then cancel showing it
         if (!this.isVisible && this.includes(this.hideTriggers, 'mouseleave') && this._showTimeoutId !== null) {
-            clearTimeout(this._showTimeoutId);
-            this._showTimeoutId = null;
-            return;
+            return this.cancelTooltip();
         }
 
         // if the tooltip is not visible or mouseleave isn't a hide trigger then do nothing
@@ -441,6 +444,11 @@ export class TooltipDirective implements OnInit, OnChanges, OnDestroy {
     /** Handle the blur event - show or hide accordingly */
     protected onBlur(_: Event): void {
 
+        // If the tooltip is pending then cancel showing it
+        if (!this.isVisible && this.includes(this.hideTriggers, 'blur') && this._showTimeoutId !== null) {
+            return this.cancelTooltip();
+        }
+
         // this is an hide only trigger - if not open or it isn't a trigger do nothing
         if (!this.isVisible || !this.includes(this.hideTriggers, 'blur')) {
             return;
@@ -456,6 +464,14 @@ export class TooltipDirective implements OnInit, OnChanges, OnDestroy {
             this._renderer.removeAttribute(this._elementRef.nativeElement, 'aria-describedby');
         } else {
             this._renderer.setAttribute(this._elementRef.nativeElement, 'aria-describedby', id);
+        }
+    }
+
+    /** Cancel any pending tooltip (waiting on delay ellapsing) */
+    private cancelTooltip(): void {
+        if (this._showTimeoutId !== null) {
+            clearTimeout(this._showTimeoutId);
+            this._showTimeoutId = null;
         }
     }
 


### PR DESCRIPTION
Fixing timeout logic in tooltip to ensure that it is correctly cleared when we "hide" a tooltip before it has been shown.

#### Ticket
https://autjira.microfocus.com/browse/EL-3429

#### Documentation CI URL
https://pages.github.houston.softwaregrp.net/sepg-docs-qa/UXAspects_CI_UXAspects_EL-3429-Tooltip-Cancel-Delay
