### PR TITLE
EL-3416 - Auto Grow Improvements

### DIFF
--- a/docs/app/pages/components/components-sections/input-controls/expanding-text-area/expanding-text-area.component.html
+++ b/docs/app/pages/components/components-sections/input-controls/expanding-text-area/expanding-text-area.component.html
@@ -16,7 +16,8 @@
     If the content becomes larger than the max height a vertical scrollbar will appear.
 </p>
 
-<p>To create an expanding textarea use the <code>uxAutoGrow</code> directive.</p>
+<p>To create an expanding textarea use the <code>uxAutoGrow</code> directive. You can pass true or false into the
+directive to enable or disable expanding.</p>
 
 <ux-tabset [minimal]="false">
     <ux-tab heading="HTML">

--- a/src/directives/auto-grow/auto-grow.directive.ts
+++ b/src/directives/auto-grow/auto-grow.directive.ts
@@ -1,9 +1,12 @@
-import { AfterViewInit, Directive, ElementRef, HostListener, Renderer2 } from '@angular/core';
+import { AfterViewInit, Directive, ElementRef, HostListener, Input, Renderer2 } from '@angular/core';
 
 @Directive({
   selector: '[uxAutoGrow]'
 })
 export class AutoGrowDirective implements AfterViewInit {
+
+  /** Specify whether the AutoGrow functionality is enabled */
+  @Input() uxAutoGrow: boolean = true;
 
   constructor(private _elementRef: ElementRef, private _renderer: Renderer2) {
     // ensure this is a textarea or else throw error
@@ -18,6 +21,11 @@ export class AutoGrowDirective implements AfterViewInit {
 
   @HostListener('input')
   update(): void {
+
+    // check if the AutoGrow functionality is enabled
+    if (this.uxAutoGrow === false) {
+      return;
+    }
 
     // perform sizing
     this._renderer.setStyle(this._elementRef.nativeElement, 'overflowY', 'hidden');


### PR DESCRIPTION
- Updated AutoGrow directive
- Email discussing the multi-line textarea suggested:
```
Will we support the expanding text area capability as well? (in which case we could perhaps have an accordion box with a control for enabling that as well for the example).
```
- Currently there was no option to disable/enable autogrow functionality.

#### Ticket
https://autjira.microfocus.com/browse/EL-3416

#### Documentation CI URL
https://pages.github.houston.softwaregrp.net/sepg-docs-qa/UXAspects_CI_UXAspects_EL-3416-Auto-Grow-Improvements
