### PR TITLE
EL-3430 - Timeline Chart Build Issue

### DIFF
--- a/docs/app/data/charts-page.json
+++ b/docs/app/data/charts-page.json
@@ -376,8 +376,12 @@
                         "content": "ng2-charts"
                     },
                     {
-                        "title": "Dependencies",
-                        "content": "TimelineChartPlugin"
+                        "title": "Module name",
+                        "content": "TimelineChartModule"
+                    },
+                    {
+                        "title": "Library",
+                        "content": "@ux-aspects/ux-aspects"
                     }]
                 },
                 {

--- a/docs/app/pages/charts/charts-sections/timeline-chart/timeline-chart.module.ts
+++ b/docs/app/pages/charts/charts-sections/timeline-chart/timeline-chart.module.ts
@@ -1,6 +1,6 @@
 import { ComponentFactoryResolver, NgModule } from '@angular/core';
 import { RouterModule } from '@angular/router';
-import { ColorServiceModule, HybridModule, TabsetModule } from '@ux-aspects/ux-aspects';
+import { ColorServiceModule, HybridModule, TabsetModule, TimelineChartModule } from '@ux-aspects/ux-aspects';
 import { ChartsModule } from 'ng2-charts';
 import { DocumentationComponentsModule } from '../../../../components/components.module';
 import { DocumentationCategoryComponent } from '../../../../components/documentation-category/documentation-category.component';
@@ -32,6 +32,7 @@ const ROUTES = [
         HybridModule,
         RouterModule.forChild(ROUTES),
         TabsetModule,
+        TimelineChartModule,
         WrappersModule,
     ],
     exports: SECTIONS,

--- a/docs/app/pages/charts/charts-sections/timeline-chart/timeline-chart/snippets/app.ts
+++ b/docs/app/pages/charts/charts-sections/timeline-chart/timeline-chart/snippets/app.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { ColorService, TimelineChartOptions, TimelineChartPlugin } from '@ux-aspects/ux-aspects';
+import { ColorService, TimelineChartOptions } from '@ux-aspects/ux-aspects';
 import { TimelineChartService } from './timeline-chart.service';
 
 @Component({
@@ -113,7 +113,5 @@ export class AppComponent {
         }
     };
 
-    constructor(private _dataService: TimelineChartService, private _colorService: ColorService) {
-        TimelineChartPlugin.register();
-    }
+    constructor(private _dataService: TimelineChartService, private _colorService: ColorService) { }
 }

--- a/docs/app/pages/charts/charts-sections/timeline-chart/timeline-chart/timeline-chart.component.html
+++ b/docs/app/pages/charts/charts-sections/timeline-chart/timeline-chart/timeline-chart.component.html
@@ -27,10 +27,7 @@
     needs to be added to the appropriate <code>NgModule</code>.
 </p>
 <p>
-    To add Timeline functionality the <code>TimelineChartPlugin</code> should be imported from
-    the <code>@ux-aspects/ux-aspects</code> library and the <code>TimelineChartPlugin.register()</code> function should be called.
-    This function registers the plugin globally and must be called before the chart initializes. It can be called in the consuming
-    component constructor, or if used by multiple components it may also be called within a module.
+    To add Timeline functionality the <code>TimelineChartModule</code> should be imported from the <code>@ux-aspects/ux-aspects</code> library.
 </p>
 
 <p>The a <code>timeline</code> object should be added to the chart options to configure the chart:</p>

--- a/docs/app/pages/charts/charts-sections/timeline-chart/timeline-chart/timeline-chart.component.ts
+++ b/docs/app/pages/charts/charts-sections/timeline-chart/timeline-chart/timeline-chart.component.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { ColorService, TimelineChartOptions, TimelineChartPlugin } from '@ux-aspects/ux-aspects';
+import { ColorService, TimelineChartOptions } from '@ux-aspects/ux-aspects';
 import { BaseDocumentationSection } from '../../../../../components/base-documentation-section/base-documentation-section';
 import { DocumentationSectionComponent } from '../../../../../decorators/documentation-section-component';
 import { IPlunk } from '../../../../../interfaces/IPlunk';
@@ -131,13 +131,12 @@ export class ChartsTimelineChartComponent extends BaseDocumentationSection imple
             imports: ['ChartsModule'],
             library: 'ng2-charts'
         }, {
-            imports: ['ColorServiceModule'],
+            imports: ['ColorServiceModule', 'TimelineChartModule'],
             library: '@ux-aspects/ux-aspects'
         }]
     };
 
     constructor(private _dataService: TimelineChartService, private _colorService: ColorService) {
         super(require.context('./snippets/', false, /(html|css|js|ts)$/));
-        TimelineChartPlugin.register();
     }
 }

--- a/src/plugins/chartjs/timeline/timeline-chart.interface.ts
+++ b/src/plugins/chartjs/timeline/timeline-chart.interface.ts
@@ -1,0 +1,58 @@
+export enum TimelineHandle {
+    Lower = 'lower',
+    Upper = 'upper',
+    Range = 'range'
+}
+
+export interface TimelineChartOptions {
+    timeline?: {
+        backgroundColor?: Chart.ChartColor;
+        selectionColor?: Chart.ChartColor;
+        onChange?: (lower: Date, upper: Date) => void;
+        keyboard?: {
+            step?: number;
+        },
+        handles?: {
+            backgroundColor?: Chart.ChartColor;
+            foregroundColor?: Chart.ChartColor;
+            focusIndicatorColor?: Chart.ChartColor;
+        }
+        range: {
+            lower: Date,
+            upper: Date,
+            minimum?: number,
+            maximum?: number
+        }
+    };
+}
+
+/**
+ * Store internal state of the chart but don't expose it
+ * in the public options interface
+ */
+export interface TimelineChartStateOptions {
+    timeline?: {
+        state: TimelineChartState
+    };
+}
+
+export interface TimelineChartState {
+    handle?: TimelineHandle | null;
+    mouseX?: number;
+    onMouseDown?: (event: MouseEvent) => void;
+    onMouseUp?: (event: MouseEvent) => void;
+    onKeydown?: (event: KeyboardEvent) => void;
+    lowerHandleFocus?: boolean;
+    upperHandleFocus?: boolean;
+    lowerHandleElement?: HTMLDivElement;
+    upperHandleElement?: HTMLDivElement;
+}
+
+export interface TimelineChartConfig {
+    config: {
+        options: TimelineChartOptions & TimelineChartStateOptions;
+    };
+    chart: Chart;
+}
+
+export type TimelineChart = Chart & TimelineChartConfig;

--- a/src/plugins/chartjs/timeline/timeline-chart.module.ts
+++ b/src/plugins/chartjs/timeline/timeline-chart.module.ts
@@ -1,0 +1,14 @@
+import { NgModule } from '@angular/core';
+import { TimelineChartPlugin } from './timeline-chart';
+
+/**
+ * Directly exporting a file that is not an Angular component, module, etc..
+ * can cause build issues. We can use a module that instantiates the plugin
+ * instead of directly exporting the Chart.js plugin.
+ */
+@NgModule({})
+export class TimelineChartModule {
+    constructor() {
+        TimelineChartPlugin.register();
+    }
+}

--- a/src/plugins/chartjs/timeline/timeline-chart.ts
+++ b/src/plugins/chartjs/timeline/timeline-chart.ts
@@ -1,5 +1,6 @@
 import { END, HOME, LEFT_ARROW, RIGHT_ARROW } from '@angular/cdk/keycodes';
 import * as Chart from 'chart.js';
+import { TimelineChart, TimelineChartOptions, TimelineChartState, TimelineHandle } from './timeline-chart.interface';
 
 const timelineDefaultOptions: TimelineChartOptions & TimelineChartState = {
     timeline: {
@@ -645,62 +646,3 @@ export class TimelineChartPlugin {
     }
 
 }
-
-enum TimelineHandle {
-    Lower = 'lower',
-    Upper = 'upper',
-    Range = 'range'
-}
-
-export interface TimelineChartOptions {
-    timeline?: {
-        backgroundColor?: Chart.ChartColor;
-        selectionColor?: Chart.ChartColor;
-        onChange?: (lower: Date, upper: Date) => void;
-        keyboard?: {
-            step?: number;
-        },
-        handles?: {
-            backgroundColor?: Chart.ChartColor;
-            foregroundColor?: Chart.ChartColor;
-            focusIndicatorColor?: Chart.ChartColor;
-        }
-        range: {
-            lower: Date,
-            upper: Date,
-            minimum?: number,
-            maximum?: number
-        }
-    };
-}
-
-/**
- * Store internal state of the chart but don't expose it
- * in the public options interface
- */
-interface TimelineChartStateOptions {
-    timeline?: {
-        state: TimelineChartState
-    };
-}
-
-interface TimelineChartState {
-    handle?: TimelineHandle | null;
-    mouseX?: number;
-    onMouseDown?: (event: MouseEvent) => void;
-    onMouseUp?: (event: MouseEvent) => void;
-    onKeydown?: (event: KeyboardEvent) => void;
-    lowerHandleFocus?: boolean;
-    upperHandleFocus?: boolean;
-    lowerHandleElement?: HTMLDivElement;
-    upperHandleElement?: HTMLDivElement;
-}
-
-interface TimelineChartConfig {
-    config: {
-        options: TimelineChartOptions & TimelineChartStateOptions;
-    };
-    chart: Chart;
-}
-
-type TimelineChart = Chart & TimelineChartConfig;

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -1,2 +1,3 @@
-export * from './chartjs/timeline-chart';
+export * from './chartjs/timeline/timeline-chart.interface';
+export * from './chartjs/timeline/timeline-chart.module';
 


### PR DESCRIPTION
I remember getting this issue before when we added the tick operator (which we removed the public export to fix). There seems to be an issue sometimes when directly exporting a file that doesn't contain and Angular component/service/pipe etc.. To fix this I have introduced a `TimelineChartModule` ngModule which registers the plugin for them. This way we can avoid directly exporting the file, and it also is probably easier for the consumer than before as this is the way we include all other components.

I haven't been able to test whether or not this fixes the build issue as I am not able to reproduce the issue on my machine.

#### Ticket
https://autjira.microfocus.com/browse/EL-3430

#### Documentation CI URL
https://pages.github.houston.softwaregrp.net/sepg-docs-qa/UXAspects_CI_UXAspects_EL-3430-Timeline-Chart-2
