### PR TITLE
EL-2869 - Input Addon Styles

### DIFF
--- a/src/styles/buttons.less
+++ b/src/styles/buttons.less
@@ -884,6 +884,7 @@ fieldset[disabled] .btn-toggle.active {
 
         &:active,
         &:focus {
+            outline: none;
             z-index: @button-group-front-z-index;
             box-shadow: 0 0 1px 1px @accent;
         }

--- a/src/styles/controls.less
+++ b/src/styles/controls.less
@@ -221,7 +221,7 @@ label {
 }
 
 //removing the curve from addons
-.input-group .form-control:last-child, .input-group-addon:last-child, .input-group-btn:last-child > .btn, .input-group-btn:last-child > .btn-group > .btn, .input-group-btn:last-child > .dropdown-toggle, .input-group-btn:first-child > .btn:not(:first-child),.input-group-btn:first-child > .btn-group:not(:first-child) > .btn {
+.input-group .form-control:last-child, .input-group-addon:last-child, .input-group-btn:last-child > .btn, .input-group-btn:last-child > .btn-group > .btn, .input-group-btn:last-child > .dropdown-toggle, .input-group-btn:first-child > .btn:not(:first-child), .input-group-btn:first-child > .btn-group:not(:first-child) > .btn {
     border-top-right-radius: @form-control-border-radius;
     border-bottom-right-radius: @form-control-border-radius;
 }
@@ -239,6 +239,15 @@ label {
     .input-group-btn {
         button {
             height: 34px;
+
+            &.button-secondary {
+                border-color: @form-control-border;
+            }
+        }
+
+        &:first-child > .btn,
+        &:first-child > .btn-group {
+            margin-right: -2px;
         }
     }
 }
@@ -1951,7 +1960,7 @@ tree-view > div:first-child > ol:nth-of-type(1) {
 
         > .chevron .hpe-icon,
         > .chevron .hpe-icon:hover,
-        > .chevron .hpe-icon:focus, {
+        > .chevron .hpe-icon:focus {
             opacity: 1;
         }
     }


### PR DESCRIPTION
- Changing secondary button border colour when used as an input addon to match the textbox border color

#### Ticket
https://autjira.microfocus.com/browse/EL-2869

#### Documentation CI URL
https://pages.github.houston.softwaregrp.net/sepg-docs-qa/UXAspects_CI_UXAspects_EL-2869-Addon-Styles
