### PR TITLE
EL-3463-Number-Picker-Precision

### DIFF
--- a/docs/app/pages/components/components-sections/input-controls/number-picker/number-picker.component.html
+++ b/docs/app/pages/components/components-sections/input-controls/number-picker/number-picker.component.html
@@ -44,6 +44,9 @@
         Can be used to show a red outline around the input to indicate an invalid value. By default the
         error state will appear if the user enters a number below the minimum value or above the maximum value.
     </tr>
+    <tr uxd-api-property name="precision" type="number" defaultValue="6">
+        Define the precision of floating point values.
+    </tr>
 </uxd-api-properties>
 
 <uxd-api-properties tableTitle="Outputs">

--- a/e2e/pages/app/number-picker/number-picker.testpage.component.html
+++ b/e2e/pages/app/number-picker/number-picker.testpage.component.html
@@ -10,7 +10,7 @@
 
 <p class="m-t-md">Selecting a decimal:</p>
 
-<ux-number-picker id="numberPicker2" class="number-picker-component-demo" step="0.5" min="0" max="10" [valid]="form.controls['decimal'].valid" [formControl]="form.controls['decimal']"></ux-number-picker>
+<ux-number-picker id="numberPicker2" class="number-picker-component-demo" step="0.1" min="0" max="10" [valid]="form.controls['decimal'].valid" [formControl]="form.controls['decimal']"></ux-number-picker>
 
 <p id="errorMessage2" class="text-error" *ngIf="form.controls['decimal'].invalid">
     <span class="hpe-icon hpe-alert"></span> Enter a number between 0 and 10.

--- a/e2e/tests/components/number-picker/number-picker.e2e-spec.ts
+++ b/e2e/tests/components/number-picker/number-picker.e2e-spec.ts
@@ -2,146 +2,150 @@ import { NumberPickerPage } from './number-picker.po.spec';
 
 describe('Number Picker Tests', () => {
 
-    let page: NumberPickerPage = new NumberPickerPage();
+    const page: NumberPickerPage = new NumberPickerPage();
     page.getPage();
 
-    it('should have correct initial states', () => {
+    it('should have correct initial states', async () => {
 
         // Initial values.
-        expect(page.numberPicker1.isPresent()).toBeTruthy();
-        expect(page.numberPicker1.$('input').isPresent()).toBeTruthy();
-        expect<any>(page.getNumberPickerMinimum(page.numberPicker1)).toEqual('-10');
-        expect<any>(page.getNumberPickerMaximum(page.numberPicker1)).toEqual('10');
-        expect<any>(page.getNumberPickerStep(page.numberPicker1)).toEqual('1');
-        expect<any>(page.getNumberPickerValue(page.numberPicker1)).toEqual('0');
-        expect(page.confirmUpDownControlIsDisabled(page.numberPicker1, 'up')).toBeFalsy();
-        expect(page.confirmUpDownControlIsDisabled(page.numberPicker1, 'down')).toBeFalsy();
-        expect(page.confirmErrorMessage1IsVisible()).toBeFalsy();
+        expect(await page.numberPicker1.isPresent()).toBeTruthy();
+        expect(await page.numberPicker1.$('input').isPresent()).toBeTruthy();
+        expect(await page.getNumberPickerMinimum(page.numberPicker1)).toEqual('-10');
+        expect(await page.getNumberPickerMaximum(page.numberPicker1)).toEqual('10');
+        expect(await page.getNumberPickerStep(page.numberPicker1)).toEqual('1');
+        expect(await page.getNumberPickerValue(page.numberPicker1)).toEqual('0');
+        expect(await page.confirmUpDownControlIsDisabled(page.numberPicker1, 'up')).toBeFalsy();
+        expect(await page.confirmUpDownControlIsDisabled(page.numberPicker1, 'down')).toBeFalsy();
+        expect(await page.confirmErrorMessage1IsVisible()).toBeFalsy();
 
-        expect(page.numberPicker2.isPresent()).toBeTruthy();
-        expect(page.numberPicker2.$('input').isPresent()).toBeTruthy();
-        expect<any>(page.getNumberPickerMinimum(page.numberPicker2)).toEqual('0');
-        expect<any>(page.getNumberPickerMaximum(page.numberPicker2)).toEqual('10');
-        expect<any>(page.getNumberPickerStep(page.numberPicker2)).toEqual('0.5');
-        expect<any>(page.getNumberPickerValue(page.numberPicker2)).toEqual('0');
-        expect(page.confirmUpDownControlIsDisabled(page.numberPicker2, 'up')).toBeFalsy();
-        expect(page.confirmUpDownControlIsDisabled(page.numberPicker2, 'down')).toBeTruthy();
-        expect(page.confirmErrorMessage2IsVisible()).toBeFalsy();
-
-    });
-
-    it('should allow changes to the value by clicking', () => {
-
-        // Number Picker 1
-        page.incrementNumberPickerValue(page.numberPicker1);
-        expect<any>(page.getNumberPickerValue(page.numberPicker1)).toEqual('1');
-        page.incrementNumberPickerValue(page.numberPicker1);
-        page.incrementNumberPickerValue(page.numberPicker1);
-        page.incrementNumberPickerValue(page.numberPicker1);
-        expect<any>(page.getNumberPickerValue(page.numberPicker1)).toEqual('4');
-        page.decrementNumberPickerValue(page.numberPicker1);
-        page.decrementNumberPickerValue(page.numberPicker1);
-        page.decrementNumberPickerValue(page.numberPicker1);
-        page.decrementNumberPickerValue(page.numberPicker1);
-        page.decrementNumberPickerValue(page.numberPicker1);
-        page.decrementNumberPickerValue(page.numberPicker1);
-        expect<any>(page.getNumberPickerValue(page.numberPicker1)).toEqual('-2');
-        page.incrementNumberPickerValue(page.numberPicker1);
-        page.incrementNumberPickerValue(page.numberPicker1);
-        page.incrementNumberPickerValue(page.numberPicker1);
-        expect<any>(page.getNumberPickerValue(page.numberPicker1)).toEqual('1');
-
-        // Number Picker 2
-        page.incrementNumberPickerValue(page.numberPicker2);
-        expect<any>(page.getNumberPickerValue(page.numberPicker2)).toEqual('0.5');
-        page.incrementNumberPickerValue(page.numberPicker2);
-        page.incrementNumberPickerValue(page.numberPicker2);
-        page.incrementNumberPickerValue(page.numberPicker2);
-        expect<any>(page.getNumberPickerValue(page.numberPicker2)).toEqual('2');
-        page.decrementNumberPickerValue(page.numberPicker2);
-        page.decrementNumberPickerValue(page.numberPicker2);
-        page.decrementNumberPickerValue(page.numberPicker2);
-        expect<any>(page.getNumberPickerValue(page.numberPicker2)).toEqual('0.5');
-        page.decrementNumberPickerValue(page.numberPicker2);
-        expect<any>(page.getNumberPickerValue(page.numberPicker2)).toEqual('0');
+        expect(await page.numberPicker2.isPresent()).toBeTruthy();
+        expect(await page.numberPicker2.$('input').isPresent()).toBeTruthy();
+        expect(await page.getNumberPickerMinimum(page.numberPicker2)).toEqual('0');
+        expect(await page.getNumberPickerMaximum(page.numberPicker2)).toEqual('10');
+        expect(await page.getNumberPickerStep(page.numberPicker2)).toEqual('0.1');
+        expect(await page.getNumberPickerValue(page.numberPicker2)).toEqual('0');
+        expect(await page.confirmUpDownControlIsDisabled(page.numberPicker2, 'up')).toBeFalsy();
+        expect(await page.confirmUpDownControlIsDisabled(page.numberPicker2, 'down')).toBeTruthy();
+        expect(await page.confirmErrorMessage2IsVisible()).toBeFalsy();
 
     });
 
-    it('should allow changes to the value by text entry', () => {
+    it('should allow changes to the value by clicking', async () => {
 
         // Number Picker 1
-        page.setNumberPickerValue(page.numberPicker1, '5');
-        expect<any>(page.getNumberPickerValue(page.numberPicker1)).toEqual('5');
-        page.setNumberPickerValue(page.numberPicker1, '10');
-        expect<any>(page.getNumberPickerValue(page.numberPicker1)).toEqual('10');
-        page.setNumberPickerValue(page.numberPicker1, '-10');
-        expect<any>(page.getNumberPickerValue(page.numberPicker1)).toEqual('-10');
-        page.setNumberPickerValue(page.numberPicker1, '15');
-        expect<any>(page.getNumberPickerValue(page.numberPicker1)).toEqual('15');
+        await page.incrementNumberPickerValue(page.numberPicker1);
+        expect(await page.getNumberPickerValue(page.numberPicker1)).toEqual('1');
+        await page.incrementNumberPickerValue(page.numberPicker1);
+        await page.incrementNumberPickerValue(page.numberPicker1);
+        await page.incrementNumberPickerValue(page.numberPicker1);
+        expect(await page.getNumberPickerValue(page.numberPicker1)).toEqual('4');
+        await page.decrementNumberPickerValue(page.numberPicker1);
+        await page.decrementNumberPickerValue(page.numberPicker1);
+        await page.decrementNumberPickerValue(page.numberPicker1);
+        await page.decrementNumberPickerValue(page.numberPicker1);
+        await page.decrementNumberPickerValue(page.numberPicker1);
+        await page.decrementNumberPickerValue(page.numberPicker1);
+        expect(await page.getNumberPickerValue(page.numberPicker1)).toEqual('-2');
+        await page.incrementNumberPickerValue(page.numberPicker1);
+        await page.incrementNumberPickerValue(page.numberPicker1);
+        await page.incrementNumberPickerValue(page.numberPicker1);
+        expect(await page.getNumberPickerValue(page.numberPicker1)).toEqual('1');
 
         // Number Picker 2
-        page.setNumberPickerValue(page.numberPicker1, '5');
-        expect<any>(page.getNumberPickerValue(page.numberPicker1)).toEqual('5');
-        page.setNumberPickerValue(page.numberPicker1, '15');
-        expect<any>(page.getNumberPickerValue(page.numberPicker1)).toEqual('15');
-        page.setNumberPickerValue(page.numberPicker1, '-10');
-        expect<any>(page.getNumberPickerValue(page.numberPicker1)).toEqual('-10');
+        await page.incrementNumberPickerValue(page.numberPicker2);
+        expect(await page.getNumberPickerValue(page.numberPicker2)).toEqual('0.1');
+        await page.incrementNumberPickerValue(page.numberPicker2);
+        expect(await page.getNumberPickerValue(page.numberPicker2)).toEqual('0.2');
+        await page.incrementNumberPickerValue(page.numberPicker2);
+        expect(await page.getNumberPickerValue(page.numberPicker2)).toEqual('0.3');
+        await page.incrementNumberPickerValue(page.numberPicker2);
+        expect(await page.getNumberPickerValue(page.numberPicker2)).toEqual('0.4');
+        await page.decrementNumberPickerValue(page.numberPicker2);
+        expect(await page.getNumberPickerValue(page.numberPicker2)).toEqual('0.3');
+        await page.decrementNumberPickerValue(page.numberPicker2);
+        expect(await page.getNumberPickerValue(page.numberPicker2)).toEqual('0.2');
+        await page.decrementNumberPickerValue(page.numberPicker2);
+        expect(await page.getNumberPickerValue(page.numberPicker2)).toEqual('0.1');
+        await page.decrementNumberPickerValue(page.numberPicker2);
+        expect(await page.getNumberPickerValue(page.numberPicker2)).toEqual('0');
 
     });
 
-    it('should display an error is the minimum limit is breached', () => {
+    it('should allow changes to the value by text entry', async () => {
 
         // Number Picker 1
-        page.setNumberPickerValue(page.numberPicker1, '-11');
-        expect(page.confirmErrorMessage1IsVisible()).toBeTruthy();
+        await page.setNumberPickerValue(page.numberPicker1, '5');
+        expect(await page.getNumberPickerValue(page.numberPicker1)).toEqual('5');
+        await page.setNumberPickerValue(page.numberPicker1, '10');
+        expect(await page.getNumberPickerValue(page.numberPicker1)).toEqual('10');
+        await page.setNumberPickerValue(page.numberPicker1, '-10');
+        expect(await page.getNumberPickerValue(page.numberPicker1)).toEqual('-10');
+        await page.setNumberPickerValue(page.numberPicker1, '15');
+        expect(await page.getNumberPickerValue(page.numberPicker1)).toEqual('15');
 
         // Number Picker 2
-        page.setNumberPickerValue(page.numberPicker2, '-0.5');
-        expect(page.confirmErrorMessage2IsVisible()).toBeTruthy();
+        await page.setNumberPickerValue(page.numberPicker1, '5');
+        expect(await page.getNumberPickerValue(page.numberPicker1)).toEqual('5');
+        await page.setNumberPickerValue(page.numberPicker1, '15');
+        expect(await page.getNumberPickerValue(page.numberPicker1)).toEqual('15');
+        await page.setNumberPickerValue(page.numberPicker1, '-10');
+        expect(await page.getNumberPickerValue(page.numberPicker1)).toEqual('-10');
 
     });
 
-    it('should display an error is the maximum limit is breached', () => {
+    it('should display an error is the minimum limit is breached', async () => {
 
         // Number Picker 1
-        page.setNumberPickerValue(page.numberPicker1, '11');
-        expect(page.confirmErrorMessage1IsVisible()).toBeTruthy();
+        await page.setNumberPickerValue(page.numberPicker1, '-11');
+        expect(await page.confirmErrorMessage1IsVisible()).toBeTruthy();
 
         // Number Picker 2
-        page.setNumberPickerValue(page.numberPicker2, '10.5');
-        expect(page.confirmErrorMessage2IsVisible()).toBeTruthy();
+        await page.setNumberPickerValue(page.numberPicker2, '-0.5');
+        expect(await page.confirmErrorMessage2IsVisible()).toBeTruthy();
 
     });
 
-    it('should prevent changes by clicking if the minimum limit has been reached', () => {
+    it('should display an error is the maximum limit is breached', async () => {
 
         // Number Picker 1
-        page.setNumberPickerValue(page.numberPicker1, '-9');
-        page.decrementNumberPickerValue(page.numberPicker1);
-        expect(page.confirmUpDownControlIsDisabled(page.numberPicker1, 'up')).toBeFalsy();
-        expect(page.confirmUpDownControlIsDisabled(page.numberPicker1, 'down')).toBeTruthy();
+        await page.setNumberPickerValue(page.numberPicker1, '11');
+        expect(await page.confirmErrorMessage1IsVisible()).toBeTruthy();
 
         // Number Picker 2
-        page.setNumberPickerValue(page.numberPicker2, '0.5');
-        page.decrementNumberPickerValue(page.numberPicker2);
-        expect(page.confirmUpDownControlIsDisabled(page.numberPicker2, 'up')).toBeFalsy();
-        expect(page.confirmUpDownControlIsDisabled(page.numberPicker2, 'down')).toBeTruthy();
+        await page.setNumberPickerValue(page.numberPicker2, '10.5');
+        expect(await page.confirmErrorMessage2IsVisible()).toBeTruthy();
 
     });
 
-    it('should prevent changes by clicking if the maximum limit has been reached', () => {
+    it('should prevent changes by clicking if the minimum limit has been reached', async () => {
 
         // Number Picker 1
-        page.setNumberPickerValue(page.numberPicker1, '9');
-        page.incrementNumberPickerValue(page.numberPicker1);
-        expect(page.confirmUpDownControlIsDisabled(page.numberPicker1, 'up')).toBeTruthy();
-        expect(page.confirmUpDownControlIsDisabled(page.numberPicker1, 'down')).toBeFalsy();
+        await page.setNumberPickerValue(page.numberPicker1, '-9');
+        await page.decrementNumberPickerValue(page.numberPicker1);
+        expect(await page.confirmUpDownControlIsDisabled(page.numberPicker1, 'up')).toBeFalsy();
+        expect(await page.confirmUpDownControlIsDisabled(page.numberPicker1, 'down')).toBeTruthy();
 
         // Number Picker 2
-        page.setNumberPickerValue(page.numberPicker2, '9.5');
-        page.incrementNumberPickerValue(page.numberPicker2);
-        expect(page.confirmUpDownControlIsDisabled(page.numberPicker2, 'up')).toBeTruthy();
-        expect(page.confirmUpDownControlIsDisabled(page.numberPicker2, 'down')).toBeFalsy();
+        await page.setNumberPickerValue(page.numberPicker2, '0.1');
+        await page.decrementNumberPickerValue(page.numberPicker2);
+        expect(await page.confirmUpDownControlIsDisabled(page.numberPicker2, 'up')).toBeFalsy();
+        expect(await page.confirmUpDownControlIsDisabled(page.numberPicker2, 'down')).toBeTruthy();
+
+    });
+
+    it('should prevent changes by clicking if the maximum limit has been reached', async () => {
+
+        // Number Picker 1
+        await page.setNumberPickerValue(page.numberPicker1, '9');
+        await page.incrementNumberPickerValue(page.numberPicker1);
+        expect(await page.confirmUpDownControlIsDisabled(page.numberPicker1, 'up')).toBeTruthy();
+        expect(await page.confirmUpDownControlIsDisabled(page.numberPicker1, 'down')).toBeFalsy();
+
+        // Number Picker 2
+        await page.setNumberPickerValue(page.numberPicker2, '9.9');
+        await page.incrementNumberPickerValue(page.numberPicker2);
+        expect(await page.confirmUpDownControlIsDisabled(page.numberPicker2, 'up')).toBeTruthy();
+        expect(await page.confirmUpDownControlIsDisabled(page.numberPicker2, 'down')).toBeFalsy();
 
     });
 });

--- a/e2e/tests/components/number-picker/number-picker.po.spec.ts
+++ b/e2e/tests/components/number-picker/number-picker.po.spec.ts
@@ -1,83 +1,67 @@
-import { browser, element, by, ElementFinder } from 'protractor';
+import { browser, by, element, ElementFinder } from 'protractor';
 
 export class NumberPickerPage {
-        
-    getPage(): void {
-        browser.get('#/number-picker');
-    }
-    
+
     root = element(by.id('root'));
     numberPicker1 = element(by.id('numberPicker1'));
     numberPicker2 = element(by.id('numberPicker2'));
 
-    getNumberPickerMinimum(numberPicker: ElementFinder) {
-        return numberPicker.getAttribute('min').then(function(min: string) {
-            return min;
-        });
+    getPage(): void {
+        browser.get('#/number-picker');
     }
-    
-    getNumberPickerMaximum(numberPicker: ElementFinder) {
-        return numberPicker.getAttribute('max').then(function(max: string) {
-            return max;
-        });
+
+    async getNumberPickerMinimum(numberPicker: ElementFinder): Promise<string> {
+        return await numberPicker.getAttribute('min');
     }
-    
-    getNumberPickerStep(numberPicker: ElementFinder) {
-        return numberPicker.getAttribute('step').then(function(step: string) {
-            if (step) {
-                return step;
-            } else {
-                return '1';
-            }
-        });
+
+    async getNumberPickerMaximum(numberPicker: ElementFinder): Promise<string> {
+        return await numberPicker.getAttribute('max');
     }
-    
-    getNumberPickerValue(numberPicker: ElementFinder) {
-        return numberPicker.$('input').getAttribute('value').then(function(value: string) {
-            return value;
-        });
+
+    async getNumberPickerStep(numberPicker: ElementFinder): Promise<string> {
+        return await numberPicker.getAttribute('step') || '1';
     }
-    
-    confirmNumberPickerClassExists(item: ElementFinder, soughtClass: string) {
-        return item.getAttribute('class').then(function(classes: string) {
-            var allClasses = classes.split(' ');
-            if (allClasses.indexOf(soughtClass) > -1) {
-                return true;
-            } else {
-                return false;
-            }
-        });
+
+    async getNumberPickerValue(numberPicker: ElementFinder): Promise<any> {
+        return await numberPicker.$('input').getAttribute('value');
     }
-    
-    confirmUpDownControlIsDisabled(numberPicker: ElementFinder, direction: string) {
-        var arrow;
+
+    async confirmNumberPickerClassExists(item: ElementFinder, soughtClass: string): Promise<boolean> {
+        const classes = await item.getAttribute('class');
+        return classes.split(' ').indexOf(soughtClass) > -1;
+    }
+
+    async confirmUpDownControlIsDisabled(numberPicker: ElementFinder, direction: string): Promise<boolean> {
+        let arrow;
+
         if (direction === 'up') {
             arrow = numberPicker.$('div.number-picker-controls').$('div.number-picker-control-up');
         } else {
             arrow = numberPicker.$('div.number-picker-controls').$('div.number-picker-control-down');
         }
-        return this.confirmNumberPickerClassExists(arrow, 'disabled');
+
+        return await this.confirmNumberPickerClassExists(arrow, 'disabled');
     }
-    
-    setNumberPickerValue(numberPicker: ElementFinder, value: string) {
-        numberPicker.$('input').clear();
-        numberPicker.$('input').sendKeys(value);
+
+    async setNumberPickerValue(numberPicker: ElementFinder, value: string): Promise<void> {
+        await numberPicker.$('input').clear();
+        await numberPicker.$('input').sendKeys(value);
     }
-    
-    incrementNumberPickerValue(numberPicker: ElementFinder) {
-        numberPicker.$('div.number-picker-controls').$('div.number-picker-control-up').$('span').click();
+
+    async incrementNumberPickerValue(numberPicker: ElementFinder): Promise<void> {
+        await numberPicker.$('div.number-picker-controls').$('div.number-picker-control-up').$('span').click();
     }
-    
-    decrementNumberPickerValue(numberPicker: ElementFinder) {
-        numberPicker.$('div.number-picker-controls').$('div.number-picker-control-down').$('span').click();
+
+    async decrementNumberPickerValue(numberPicker: ElementFinder): Promise<void> {
+        await numberPicker.$('div.number-picker-controls').$('div.number-picker-control-down').$('span').click();
     }
-    
-    confirmErrorMessage1IsVisible() {
-        return this.root.$('p#errorMessage1').isPresent();
+
+    async confirmErrorMessage1IsVisible(): Promise<boolean> {
+        return await this.root.$('p#errorMessage1').isPresent();
     }
-    
-    confirmErrorMessage2IsVisible() {
-        return this.root.$('p#errorMessage2').isPresent();
+
+    async confirmErrorMessage2IsVisible(): Promise<boolean> {
+        return await this.root.$('p#errorMessage2').isPresent();
     }
 }
 

--- a/src/components/number-picker/number-picker.component.ts
+++ b/src/components/number-picker/number-picker.component.ts
@@ -107,7 +107,7 @@ export class NumberPickerComponent implements ControlValueAccessor {
             this.value = Math.max(Math.min(this.value + this.step, this.max), this.min);
 
             // account for javascripts terrible handling of floating point numbers
-            this.value = parseFloat(this.value.toPrecision(6));
+            this.value = parseFloat(this.value.toPrecision(this.precision));
         }
     }
 
@@ -120,7 +120,7 @@ export class NumberPickerComponent implements ControlValueAccessor {
             this.value = Math.min(Math.max(this.value - this.step, this.min), this.max);
 
             // account for javascripts terrible handling of floating point numbers
-            this.value = parseFloat(this.value.toPrecision(6));
+            this.value = parseFloat(this.value.toPrecision(this.precision));
         }
     }
 

--- a/src/components/number-picker/number-picker.component.ts
+++ b/src/components/number-picker/number-picker.component.ts
@@ -27,11 +27,22 @@ export class NumberPickerComponent implements ControlValueAccessor {
     private _value: number = 0;
     private _propagateChange = (_: any) => { };
 
+    /** Sets the id of the number picker. The child input will have this value with a -input suffix as its id. */
     @Input() id: string = `ux-number-picker-${uniqueId++}`;
+
+    /** Can be used to show a red outline around the input to indicate an invalid value. By default the error state will appear if the user enters a number below the minimum value or above the maximum value. */
     @Input() valid: boolean = true;
+
+    /** Provice an aria labelledby attribute */
     @Input('aria-labelledby') labelledBy: string;
+
+    /** Define the precision of floating point values */
+    @Input() precision: number = 6;
+
+    /** If two way binding is used this value will be updated any time the number picker value changes. */
     @Output() valueChange = new EventEmitter<number>();
 
+    /** Sets the value displayed in the number picker component. */
     @Input()
     get value(): number {
         return this._value;
@@ -43,6 +54,7 @@ export class NumberPickerComponent implements ControlValueAccessor {
         this._propagateChange(value);
     }
 
+    /** Defines the minimum value the number picker can set. */
     @Input()
     get min(): number {
         return this._min;
@@ -52,6 +64,7 @@ export class NumberPickerComponent implements ControlValueAccessor {
         this._min = coerceNumberProperty(value);
     }
 
+    /** Defines the maximum value the number picker can set. */
     @Input()
     get max(): number {
         return this._max;
@@ -61,6 +74,7 @@ export class NumberPickerComponent implements ControlValueAccessor {
         this._max = coerceNumberProperty(value);
     }
 
+    /** Defines the amount the number picker should increase or decrease when the buttons or arrow keys are used. */
     @Input()
     get step(): number {
         return this._step;
@@ -70,6 +84,7 @@ export class NumberPickerComponent implements ControlValueAccessor {
         this._step = coerceNumberProperty(value);
     }
 
+    /** Indicate if the number picker is disabled or not. */
     @Input()
     get disabled(): boolean {
         return this._disabled;
@@ -83,19 +98,29 @@ export class NumberPickerComponent implements ControlValueAccessor {
         return this.id + '-input';
     }
 
-    increment(event: MouseEvent | KeyboardEvent): void {
-        event.preventDefault();
+    increment(event?: MouseEvent | KeyboardEvent): void {
+        if (event) {
+            event.preventDefault();
+        }
 
         if (!this.disabled) {
             this.value = Math.max(Math.min(this.value + this.step, this.max), this.min);
+
+            // account for javascripts terrible handling of floating point numbers
+            this.value = parseFloat(this.value.toPrecision(6));
         }
     }
 
-    decrement(event: MouseEvent | KeyboardEvent): void {
-        event.preventDefault();
+    decrement(event?: MouseEvent | KeyboardEvent): void {
+        if (event) {
+            event.preventDefault();
+        }
 
         if (!this.disabled) {
             this.value = Math.min(Math.max(this.value - this.step, this.min), this.max);
+
+            // account for javascripts terrible handling of floating point numbers
+            this.value = parseFloat(this.value.toPrecision(6));
         }
     }
 


### PR DESCRIPTION
- Ensuring that we limit number picker precision otherwise incrementing/decrementing in steps of 0.1 can result in strange numbers like `0.30000000000000004` due to Javascripts weird handling of floating point numbers. Eg: https://plnkr.co/edit/kPyFlZ7PL8XasCRq6Sjk?p=preview

- Updated tests to use async/await and changed to cover this precision issue

#### Ticket
https://autjira.microfocus.com/browse/EL-3462

#### Documentation CI URL
https://pages.github.houston.softwaregrp.net/sepg-docs-qa/UXAspects_CI_UXAspects_EL-3463-Number-Picker-Precision
