### PR TITLE
Fixing Build - Focus Option Interface

### DIFF
--- a/src/directives/accessibility/focus-indicator/focus-indicator.ts
+++ b/src/directives/accessibility/focus-indicator/focus-indicator.ts
@@ -55,7 +55,7 @@ export class FocusIndicator {
     }
 
     /** Focus the element with a specific origin */
-    focus(origin?: FocusOrigin, options?: FocusOptions): void {
+    focus(origin?: FocusOrigin, options?: { preventScroll?: boolean }): void {
         this._focusIndicatorOrigin.setOrigin(origin);
         this._element.focus(options);
     }


### PR DESCRIPTION
The `FocusOptions` interface that is part of the standard `lib.d.ts` is not present in older versions of TypeScript that were used in Angular CLI v5 & v6 causing a compiler error. I have updated the code to avoid using the interface.

#### Ticket
N/A

#### Documentation CI URL
https://pages.github.houston.softwaregrp.net/sepg-docs-qa/UXAspects_CI_UXAspects_Fixing-Build-Focus-Options
