### PR TITLE
EL-3460 - Column Resizing in a Modal

### DIFF
--- a/src/components/table/table-column-resize/resizable-table.directive.ts
+++ b/src/components/table/table-column-resize/resizable-table.directive.ts
@@ -18,35 +18,63 @@ export class ResizableTableDirective implements AfterViewInit, OnDestroy {
     /** Get all the column headers */
     @ContentChildren(ResizableTableColumnComponent, { descendants: true }) columns: QueryList<ResizableTableColumnComponent>;
 
+    /** Store the initialised state of the table */
+    private _initialised: boolean = false;
+
     /** Unsubscribe from the observables */
     private _onDestroy = new Subject<void>();
 
     constructor(private _elementRef: ElementRef, private _table: ResizableTableService, resize: ResizeService) {
         // watch for the table being resized
-        resize.addResizeListener(this._elementRef.nativeElement)
-            .pipe(takeUntil(this._onDestroy))
-            .subscribe(() => _table.tableWidth = this.getScrollWidth());
+        resize.addResizeListener(this._elementRef.nativeElement).pipe(takeUntil(this._onDestroy)).subscribe(() => {
+            // store the latest table size
+            _table.tableWidth = this.getScrollWidth();
+
+            // run the initial logic if the table is fully visible
+            this.onTableReady();
+        });
     }
 
     /** Once we have the columns make them resizable and watch for changes to columns */
     ngAfterViewInit(): void {
-
-        // ensure we initially set the table width
-        this._table.tableWidth = this.getScrollWidth();
-
-        // set the columns - prevent expression changed error
-        requestAnimationFrame(() => this._table.setColumns(this.columns));
-
-        // watch for any future changes to the columns
-        this.columns.changes.pipe(takeUntil(this._onDestroy)).subscribe(() =>
-            requestAnimationFrame(() => this._table.setColumns(this.columns))
-        );
+        this.onTableReady();
     }
 
     /** Cleanup after the component is destroyed */
     ngOnDestroy(): void {
         this._onDestroy.next();
         this._onDestroy.complete();
+    }
+
+    /**
+     * If this is being used within a modal the table width may initially be zero. This can cause some issues when it does actually appear
+     * visibily on screen. We should only setup the table once we actually have a width/
+     */
+    onTableReady(): void {
+
+        // if we have already initialised or the table width is currently 0 then do nothing
+        if (this._initialised || this.getScrollWidth() === 0) {
+            return;
+        }
+
+        // ensure we initially set the table width
+        this._table.tableWidth = this.getScrollWidth();
+
+        // set the columns - prevent expression changed error
+        requestAnimationFrame(() => {
+            // initially set the columns
+            this._table.setColumns(this.columns);
+
+            // force relayout to occur to ensure the UI is consistent with the internal state
+            this.updateLayout();
+        });
+
+        // watch for any future changes to the columns
+        this.columns.changes.pipe(takeUntil(this._onDestroy)).subscribe(() =>
+            requestAnimationFrame(() => this._table.setColumns(this.columns))
+        );
+
+        this._initialised = true;
     }
 
     /** Force the layout to recalculate */


### PR DESCRIPTION
Issue was that column resizing does not work within a modal.

The issue was caused because the contents of a modal are initialized before they are visible on the screen. This caused the table width to be `0` and all columns widths to be `0`. We do percentage calculations so `column width`/`table width` -> `0/0` = `NaN` causing some problems.

I have changed this to now delay initialization of the column resizing until the table has a width greater than 0.

Here is a plunker with referencing the library with the fix:
https://next.plnkr.co/edit/Hm3F6BK5Ncw69X0H

#### Ticket
https://autjira.microfocus.com/browse/EL-3460

#### Documentation CI URL
https://pages.github.houston.softwaregrp.net/sepg-docs-qa/UXAspects_CI_UXAspects_EL-3460-Column-Resizing-Modal
