### PR TITLE
EL-3456 - Hierarchy Bar Inline

### DIFF
--- a/docs/app/pages/components/components-sections/hierarchy-bar/hierarchy-bar/hierarchy-bar.component.html
+++ b/docs/app/pages/components/components-sections/hierarchy-bar/hierarchy-bar/hierarchy-bar.component.html
@@ -108,9 +108,15 @@
 </uxd-api-properties>
 
 <p>
-    Custom items can be added to the left and right of the hierarchy bar nodes by adding the elements as content of the <code>ux-hierarchy-bar</code> component and
-    adding a <code>uxHierarchyBarLeftAddon</code> or <code>uxHierarchyBarRightAddon</code> attribute to the element.
+    Custom items can be added to the hierarchy bar by adding an element as content of the <code>ux-hierarchy-bar</code> component and
+    adding one of the following attributes to the element:
 </p>
+
+<ul>
+    <li><code>uxHierarchyBarLeftAddon</code> - This will add the element to the left side of the hierarchy bar.</li>
+    <li><code>uxHierarchyBarTrailingAddon</code> - This will add the element immediately after the last visible node.</li>
+    <li><code>uxHierarchyBarRightAddon</code> - This will add the element to the right side of the hierarchy bar.</li>
+</ul>
 
 <p>
     The following code can be used to create the example above:

--- a/e2e/pages/app/hierarchy-bar/hierarchy-bar.module.ts
+++ b/e2e/pages/app/hierarchy-bar/hierarchy-bar.module.ts
@@ -1,11 +1,12 @@
+import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { RouterModule } from '@angular/router';
 import { HierarchyBarModule } from '@ux-aspects/ux-aspects';
 import { HierarchyBarTestPageComponent } from './hierarchy-bar.testpage.component';
 
-
 @NgModule({
     imports: [
+        CommonModule,
         HierarchyBarModule,
         RouterModule.forChild([
             {

--- a/e2e/pages/app/hierarchy-bar/hierarchy-bar.testpage.component.html
+++ b/e2e/pages/app/hierarchy-bar/hierarchy-bar.testpage.component.html
@@ -1,4 +1,8 @@
-<ux-hierarchy-bar [root]="node" [(selected)]="selected"></ux-hierarchy-bar>
+<ux-hierarchy-bar [root]="node" [(selected)]="selected">
+    <button *ngIf="showLeftAddon" class="btn button-secondary" uxHierarchyBarLeftAddon>Left Addon</button>
+    <button *ngIf="showTrailingAddon" class="btn button-secondary" uxHierarchyBarTrailingAddon>Trailing Addon</button>
+    <button *ngIf="showRightAddon" class="btn button-secondary" uxHierarchyBarRightAddon>Right Addon</button>
+</ux-hierarchy-bar>
 
 <br>
 
@@ -6,4 +10,10 @@
 
 <br>
 
-<button id="set-selected-btn" class="btn btn-primary" (click)="setSelected()">Set Selected</button>
+<button id="set-selected-btn" class="btn btn-primary m-b" (click)="setSelected()">Set Selected</button>
+
+<br>
+
+<button id="show-left-addon-btn" class="btn button-secondary m-r" (click)="showLeftAddon = true">Show Left Addon</button>
+<button id="show-trailing-addon-btn" class="btn button-secondary m-r" (click)="showTrailingAddon = true">Show Trailing Addon</button>
+<button id="show-right-addon-btn" class="btn button-secondary" (click)="showRightAddon = true">Show Right Addon</button>

--- a/e2e/pages/app/hierarchy-bar/hierarchy-bar.testpage.component.ts
+++ b/e2e/pages/app/hierarchy-bar/hierarchy-bar.testpage.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
+import { HierarchyBarNode } from '@ux-aspects/ux-aspects';
 import { Observable } from 'rxjs/Observable';
 import { Observer } from 'rxjs/Observer';
-import { HierarchyBarNode } from '@ux-aspects/ux-aspects';
 
 @Component({
     selector: 'app-hierarchy-bar',
@@ -9,6 +9,10 @@ import { HierarchyBarNode } from '@ux-aspects/ux-aspects';
     styleUrls: ['./hierarchy-bar.testpage.component.css']
 })
 export class HierarchyBarTestPageComponent {
+
+    showLeftAddon: boolean = false;
+    showTrailingAddon: boolean = false;
+    showRightAddon: boolean = false;
 
     managerIcon = 'https://uxaspects.github.io/UXAspects/assets/IconManagerColorized.png';
     userIcon = 'https://uxaspects.github.io/UXAspects/assets/IconUser.png';
@@ -82,7 +86,7 @@ export class HierarchyBarTestPageComponent {
                                 children: [
                                     {
                                         title: 'Bob Collins',
-                                        icon: this.userIcon,                                        
+                                        icon: this.userIcon,
                                     }
                                 ]
                             }

--- a/e2e/tests/components/hierarchy-bar/hierarchy-bar.e2e-spec.ts
+++ b/e2e/tests/components/hierarchy-bar/hierarchy-bar.e2e-spec.ts
@@ -80,6 +80,49 @@ describe('Hierarchy Bar Tests', () => {
         expect(await page.getSelectedNodeTitle()).toBe('Theresa Chandler');
     });
 
+    it('should not have any addons initially', async () => {
+        expect((await page.getAddons()).length).toBe(0);
+    });
+
+    it('should show left addon', async () => {
+        // show the left addon
+        await page.showLeftAddonBtn.click();
+
+        // there should now be one addon
+        expect((await page.getAddons()).length).toBe(1);
+
+        // check the text of the addon
+        const addon = (await page.getAddons())[0];
+
+        expect(await addon.getAttribute('innerText')).toBe('LEFT ADDON');
+    });
+
+    it('should show trailing addon', async () => {
+        // show the trailing addon
+        await page.showTrailingAddonBtn.click();
+
+        // there should now be one addon
+        expect((await page.getAddons()).length).toBe(1);
+
+        // check the text of the addon
+        const addon = (await page.getAddons())[0];
+
+        expect(await addon.getAttribute('innerText')).toBe('TRAILING ADDON');
+    });
+
+    it('should show right addon', async () => {
+        // show the right addon
+        await page.showRightAddonBtn.click();
+
+        // there should now be one addon
+        expect((await page.getAddons()).length).toBe(1);
+
+        // check the text of the addon
+        const addon = (await page.getAddons())[0];
+
+        expect(await addon.getAttribute('innerText')).toBe('RIGHT ADDON');
+    });
+
     /**
      * This test is being a bit flaky across machines so commenting this out for now
      */

--- a/e2e/tests/components/hierarchy-bar/hierarchy-bar.po.spec.ts
+++ b/e2e/tests/components/hierarchy-bar/hierarchy-bar.po.spec.ts
@@ -2,9 +2,14 @@ import { $, $$, browser, ElementFinder } from 'protractor';
 
 export class HierarchyBarPage {
 
+    hierarchyBar = $('ux-hierarchy-bar');
     nodes = $$('.hierarchy-bar-node');
     selectedLabel = $('#selected');
     selectButton = $('#set-selected-btn');
+
+    showLeftAddonBtn = $('#show-left-addon-btn');
+    showRightAddonBtn = $('#show-right-addon-btn');
+    showTrailingAddonBtn = $('#show-trailing-addon-btn');
 
     getPage(): void {
         browser.get('#/hierarchy-bar');
@@ -109,6 +114,10 @@ export class HierarchyBarPage {
         }
 
         return titles;
+    }
+
+    async getAddons(): Promise<ElementFinder[]> {
+        return await this.hierarchyBar.$$('.button-secondary');
     }
 
 }

--- a/src/components/hierarchy-bar/hierarchy-bar-collapsed/hierarchy-bar-collapsed.component.html
+++ b/src/components/hierarchy-bar/hierarchy-bar-collapsed/hierarchy-bar-collapsed.component.html
@@ -43,6 +43,11 @@
         (select)="hierarchyBar.selectNode($event)">
     </ux-hierarchy-bar-node>
 
+    <!-- Allow content to be placed after the last node -->
+    <div class="hierarchy-bar-addons">
+        <ng-content select="trailing-addons"></ng-content>
+    </div>
+
 </div>
 
 <!-- Allow content to be placed on the right of the items -->

--- a/src/components/hierarchy-bar/hierarchy-bar-standard/hierarchy-bar-standard.component.html
+++ b/src/components/hierarchy-bar/hierarchy-bar-standard/hierarchy-bar-standard.component.html
@@ -27,6 +27,11 @@
         (select)="hierarchyBar.selectNode(node)">
     </ux-hierarchy-bar-node>
 
+    <!-- Allow content to be placed after the last node -->
+    <div class="hierarchy-bar-addons">
+        <ng-content select="trailing-addons"></ng-content>
+    </div>
+
 </div>
 
 <!-- Allow content to be placed on the right of the items -->

--- a/src/components/hierarchy-bar/hierarchy-bar.component.html
+++ b/src/components/hierarchy-bar/hierarchy-bar.component.html
@@ -3,6 +3,7 @@
 
     <!-- Forward the content to the correct layout -->
     <ng-container ngProjectAs="left-addons" [ngTemplateOutlet]="leftAddons"></ng-container>
+    <ng-container ngProjectAs="trailing-addons" [ngTemplateOutlet]="trailingAddons"></ng-container>
     <ng-container ngProjectAs="right-addons" [ngTemplateOutlet]="rightAddons"></ng-container>
 
 </ux-hierarchy-bar-standard>
@@ -12,6 +13,7 @@
 
     <!-- Forward the content to the correct layout -->
     <ng-container ngProjectAs="left-addons" [ngTemplateOutlet]="leftAddons"></ng-container>
+    <ng-container ngProjectAs="trailing-addons" [ngTemplateOutlet]="trailingAddons"></ng-container>
     <ng-container ngProjectAs="right-addons" [ngTemplateOutlet]="rightAddons"></ng-container>
 
 </ux-hierarchy-bar-collapsed>
@@ -19,6 +21,10 @@
 <!-- We can only have one ng-content so this allows us to use it more than once -->
 <ng-template #leftAddons>
     <ng-content select="[uxHierarchyBarLeftAddon]"></ng-content>
+</ng-template>
+
+<ng-template #trailingAddons>
+    <ng-content select="[uxHierarchyBarTrailingAddon]"></ng-content>
 </ng-template>
 
 <ng-template #rightAddons>


### PR DESCRIPTION
- Added option to have a custom element trailing the last visible node.

An example of this can be seen here:

https://plnkr.co/edit/DjlEIMF5BjKmBylOY8Ov?p=preview

#### Ticket
https://autjira.microfocus.com/browse/EL-3456

#### Documentation CI URL
https://pages.github.houston.softwaregrp.net/sepg-docs-qa/UXAspects_CI_UXAspects_EL-3456-Hierarchy-Bar-Inline-Addon
