### PR TITLE
EL-3460 - Column Resizing QA

### DIFF
--- a/src/directives/fixed-header-table/fixed-header-table.module.ts
+++ b/src/directives/fixed-header-table/fixed-header-table.module.ts
@@ -1,9 +1,16 @@
 import { NgModule } from '@angular/core';
-
+import { ResizeModule } from '../resize/index';
 import { FixedHeaderTableDirective } from './fixed-header-table.directive';
 
 @NgModule({
-    exports: [FixedHeaderTableDirective],
-    declarations: [FixedHeaderTableDirective]
+    imports: [
+        ResizeModule
+    ],
+    exports: [
+        FixedHeaderTableDirective
+    ],
+    declarations: [
+        FixedHeaderTableDirective
+    ]
 })
 export class FixedHeaderTableModule { }


### PR DESCRIPTION
Turns out the fixed header table directive had the same issue as column resizing, it sets the layout when the modal appears but it obviously has no width. Changed it to automatically update the layout when the modal resizes (or appears for the first time)

#### Ticket
https://autjira.microfocus.com/browse/EL-3460

#### Documentation CI URL
https://pages.github.houston.softwaregrp.net/sepg-docs-qa/UXAspects_CI_UXAspects_EL-3460-Column-Resizing-QA
