### PR TITLE
Tabbable List Fix

### DIFF
--- a/e2e/tests/components/tabbable-list/tabbable-list.e2e-spec.ts
+++ b/e2e/tests/components/tabbable-list/tabbable-list.e2e-spec.ts
@@ -301,6 +301,21 @@ describe('Tabbable List Tests', () => {
         expect(await page.getFocused(4)).toBe(false);
     });
 
+    it('should ensure there is always one tabbable item when the list changes', async () => {
+
+        // expect the third document to not be tabbable
+        expect(await page.getTabIndex(2)).toBe('-1');
+
+        // perform a search that will leave only the third item in the list visible
+        await page.search('Document 3');
+
+        // expect this remaining item to now be tabbable
+        expect(await page.getTabIndex(0)).toBe('0');
+
+        // however it should not receive focus
+        expect(await page.getFocused(0)).toBe(false);
+    });
+
     it('should initially focus the first item when [focusOnShow]="true"', async () => {
         // toggle focus on show
         await page.toggleFocusOnShow();

--- a/src/directives/accessibility/tabbable-list/tabbable-list.service.ts
+++ b/src/directives/accessibility/tabbable-list/tabbable-list.service.ts
@@ -82,6 +82,9 @@ export class TabbableListService implements OnDestroy {
             // call the on init function on any new items
             this._items.filter(item => !item.initialized).forEach(item => item.onInit());
 
+            // ensure we update the tab indexes
+            this.onTabIndexChange.next();
+
             // ensure there is at least one item tabbable at all times
             this.ensureTabbableItem();
         });


### PR DESCRIPTION
I have just discovered a bug in the tabbable list that I would like to get fixed before release. 

It is hard to reproduce, but i can get it to happen consistently when hiding a wizard step. Essentially, previously any time the tab indexes in a tabbable list changed we updated the tabindex attributes by running change detection, which seems to cause an issue in this case as change detection was already running. Switching to setting the tabindex using the renderer instead of relying on CD seems to resolve this issue.

https://plnkr.co/edit/uit7Wgd4wTdUDXdjLwGs?p=preview

#### Ticket
https://portal.digitalsafe.net/browse/EL-3479

#### Documentation CI URL
https://pages.github.houston.softwaregrp.net/sepg-docs-qa/UXAspects_CI_UXAspects_Tabbable-List-Issue-Fix
