### PR TITLE
EL-3426 - Button Dropdown

### DIFF
--- a/docs/app/pages/components/components-sections/buttons/dropdowns/dropdowns.component.less
+++ b/docs/app/pages/components/components-sections/buttons/dropdowns/dropdowns.component.less
@@ -6,10 +6,6 @@
     top: -52px;
 }
 
-.dropdown-open {
-    display: block;
-}
-
 .case-filter {
     margin: 9px;
 }

--- a/docs/app/pages/components/components-sections/buttons/dropdowns/snippets/app.css
+++ b/docs/app/pages/components/components-sections/buttons/dropdowns/snippets/app.css
@@ -6,10 +6,6 @@
     top: -52px;
 }
 
-.dropdown-open {
-    display: block;
-}
-
 .case-filter {
     margin: 9px;
 }

--- a/src/styles/buttons.less
+++ b/src/styles/buttons.less
@@ -820,6 +820,10 @@ button {
     margin-top: 5px;
 }
 
+.dropdown-open {
+    display: block;
+}
+
 .dropdown-icon-inline {
     padding-left: 12px;
 }


### PR DESCRIPTION
Moving `.dropdown-open` class to our global stylesheet, addressing the comment here: https://github.houston.softwaregrp.net/caf/ux-aspects-micro-focus/pull/390#discussion_r146273

#### Ticket
https://portal.digitalsafe.net/browse/EL-3426

#### Documentation CI URL
https://pages.github.houston.softwaregrp.net/sepg-docs-qa/UXAspects_CI_UXAspects_EL-3426-Button-Dropdown-2
