### PR TITLE
EL-3426 - Button Dropdown Fix

### DIFF
--- a/src/styles/buttons.less
+++ b/src/styles/buttons.less
@@ -818,10 +818,10 @@ button {
 
 .dropdown-menu {
     margin-top: 5px;
-}
 
-.dropdown-open {
-    display: block;
+    &.dropdown-open {
+        display: block;
+    }
 }
 
 .dropdown-icon-inline {


### PR DESCRIPTION
Making selector more specific as the default quantum style for `.dropdown-menu` where overriding it.

#### Ticket
https://portal.digitalsafe.net/browse/EL-3426

#### Documentation CI URL
https://pages.github.houston.softwaregrp.net/sepg-docs-qa/UXAspects_CI_UXAspects_EL-3426-Button-Dropdown-Fix
