### PR TITLE
Extended focus indicator selector

### DIFF
--- a/docs/app/components/components.module.ts
+++ b/docs/app/components/components.module.ts
@@ -54,6 +54,7 @@ const DOCUMENTATION_COMPONENTS = [
 
 @NgModule({
     imports: [
+        AccessibilityModule,
         BsDropdownModule,
         ButtonsModule,
         CommonModule,

--- a/src/directives/accessibility/focus-indicator/default-focus-indicator.directive.ts
+++ b/src/directives/accessibility/focus-indicator/default-focus-indicator.directive.ts
@@ -12,7 +12,7 @@ import { FocusIndicatorService } from './focus-indicator.service';
  * If the button has a uxFocusIndicator or uxMenuNavigationToggle directive applied we should skip this
  */
 @Directive({
-    selector: '.btn:not([uxFocusIndicator]):not([uxMenuNavigationToggle])',
+    selector: '.btn:not([uxFocusIndicator]):not([uxMenuNavigationToggle]), a[href]:not([uxFocusIndicator]):not([uxMenuNavigationToggle]), a[tabindex]:not([tabindex="-1"]):not([uxFocusIndicator]):not([uxMenuNavigationToggle])',
 })
 export class DefaultFocusIndicatorDirective extends FocusIndicatorDirective {
 


### PR DESCRIPTION
* Added `a[href]` (links) and `a[tabindex]:not([tabindex="-1"])` (used for some popovers).
* Added AccessibilityModule to the site components.

Let me know if you can think of something that I've missed. 

#### Ticket
https://portal.digitalsafe.net/browse/EL-3407

#### Documentation CI URL
https://pages.github.houston.softwaregrp.net/sepg-docs-qa/UXAspects_CI_UXAspects_EL-3407-focus-indicator
