### PR TITLE
EL-3467 - Wizard - step modifications not updating UI

### DIFF
--- a/e2e/pages/app/wizard/wizard.module.ts
+++ b/e2e/pages/app/wizard/wizard.module.ts
@@ -1,11 +1,13 @@
+import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { RouterModule } from '@angular/router';
 import { WizardModule } from '@ux-aspects/ux-aspects';
-
 import { WizardTestPageComponent } from './wizard.testpage.component';
+
 
 @NgModule({
     imports: [
+        CommonModule,
         WizardModule,
         RouterModule.forChild([
             {

--- a/e2e/pages/app/wizard/wizard.testpage.component.html
+++ b/e2e/pages/app/wizard/wizard.testpage.component.html
@@ -16,4 +16,11 @@
         <p>Step 4 Content</p>
     </ux-wizard-step>
 
+    <ux-wizard-step *ngIf="step5" header="Step 5">
+        <p>Step 5 Content</p>
+    </ux-wizard-step>
+
 </ux-wizard>
+
+<button id="addStep5" class="btn button-secondary" (click)="step5 = true">Add Step 5</button>
+<button id="removeStep5" class="btn button-secondary" (click)="step5 = false">Remove Step 5</button>

--- a/e2e/pages/app/wizard/wizard.testpage.component.ts
+++ b/e2e/pages/app/wizard/wizard.testpage.component.ts
@@ -5,4 +5,5 @@ import { Component } from '@angular/core';
     templateUrl: './wizard.testpage.component.html'
 })
 export class WizardTestPageComponent {
+    step5 = false;
 }

--- a/e2e/tests/components/wizard/wizard.po.spec.ts
+++ b/e2e/tests/components/wizard/wizard.po.spec.ts
@@ -1,4 +1,4 @@
-import { browser, element, by, $, $$, ElementFinder } from 'protractor';
+import { $, $$, browser, ElementFinder } from 'protractor';
 
 export class WizardPage {
 
@@ -6,7 +6,9 @@ export class WizardPage {
     stepHeaders = $$('.wizard-step');
     stepContents = $$('ux-wizard-step');
 
-    buttons = $$('button');
+    buttons = $$('ux-wizard button');
+    addStep5Button = $('#addStep5');
+    removeStep5Button = $('#removeStep5');
 
     getPage(): void {
         browser.get('#/wizard');
@@ -32,17 +34,32 @@ export class WizardPage {
         return await this.getButtonByText('Cancel');
     }
 
-
     async getFinishButton(): Promise<ElementFinder> {
         return await this.getButtonByText('Finish');
     }
 
-    async goToNext() {
+    async goToNext(): Promise<void> {
         // find the next button
-        let next: ElementFinder = await this.getNextButton();
-        
+        const next = await this.getNextButton();
+
         // click on the next button
-        await next.click();
+        return await next.click();
+    }
+
+    async goToPrevious(): Promise<void> {
+        // find the next button
+        const prev = await this.getPreviousButton();
+
+        // click on the next button
+        return await prev.click();
+    }
+
+    async addStep5(): Promise<void> {
+        return await this.addStep5Button.click();
+    }
+
+    async removeStep5(): Promise<void> {
+        return await this.removeStep5Button.click();
     }
 
 }

--- a/src/components/wizard/wizard.component.ts
+++ b/src/components/wizard/wizard.component.ts
@@ -1,6 +1,7 @@
 import { AfterViewInit, Component, ContentChildren, EventEmitter, Input, OnDestroy, Output, QueryList } from '@angular/core';
 import { takeUntil } from 'rxjs/operators';
 import { Subject } from 'rxjs/Subject';
+import { tick } from '../../common/index';
 import { WizardStepComponent } from './wizard-step.component';
 
 let uniqueId: number = 0;
@@ -151,7 +152,10 @@ export class WizardComponent implements AfterViewInit, OnDestroy {
         this.setWizardStepIds();
 
         // if the steps change then update the ids
-        this.steps.changes.pipe(takeUntil(this._onDestroy)).subscribe(() => this.setWizardStepIds());
+        this.steps.changes.pipe(tick(), takeUntil(this._onDestroy)).subscribe(() => {
+            this.setWizardStepIds();
+            this.update();
+        });
     }
 
     ngOnDestroy(): void {


### PR DESCRIPTION
* Added `tick` operator to the steps change handler, to allow the view to update.
* Also added an `update` call to keep the step index accurate.
* Added a test case for adding and removing a final step.
* Consolidated a number of wizard tests into one test case for efficiency.

#### Ticket
https://portal.digitalsafe.net/browse/EL-3467

#### Documentation CI URL
https://pages.github.houston.softwaregrp.net/sepg-docs-qa/UXAspects_CI_UXAspects_EL-3467-wizard-step-modifications
