### PR TITLE
EL-3466 - Sortable Header Icon Alignment

### DIFF
--- a/docs/app/pages/components/components-sections/tables/multiple-column-sorting-ng1/multiple-column-sorting-ng1.component.html
+++ b/docs/app/pages/components/components-sections/tables/multiple-column-sorting-ng1/multiple-column-sorting-ng1.component.html
@@ -46,6 +46,9 @@
     <tr uxd-api-property name="default-order" type="boolean" binding="variable" required="true">
         Boolean option indicating the sort order of the default column when the page loads, setting this to a variable will allow the sort to be remembered between visits.
     </tr>
+    <tr uxd-api-property name="inline-icon" type="boolean" binding="variable" defaultValue="false">
+        Boolean option indicating if the sort icon should appear immediately after the text instead of being positioned at the end of the column.
+    </tr>
 </uxd-api-properties>
 
 <p>The controller implements the select function and will accept the following attributes within the headers object:</p>

--- a/docs/app/pages/components/components-sections/tables/single-column-sorting-ng1/single-column-sorting-ng1.component.html
+++ b/docs/app/pages/components/components-sections/tables/single-column-sorting-ng1/single-column-sorting-ng1.component.html
@@ -44,6 +44,9 @@
     <tr uxd-api-property name="default-order" type="boolean" binding="variable" required="true">
         Boolean option indicating the sort order of the default column when the page loads, setting this to a variable will allow the sort to be remembered between visits.
     </tr>
+    <tr uxd-api-property name="inline-icon" type="boolean" binding="variable" defaultValue="false">
+        Boolean option indicating if the sort icon should appear immediately after the text instead of being positioned at the end of the column.
+    </tr>
 </uxd-api-properties>
 
 <p>The controller implements the select function and will accept the following attributes within the headers object:</p>

--- a/src/ng1/directives/sorters/multiSortableHeader/multiSortableHeader.controller.js
+++ b/src/ng1/directives/sorters/multiSortableHeader/multiSortableHeader.controller.js
@@ -6,6 +6,7 @@ export default function MultiSortableHeaderCtrl($scope, $attrs) {
     vm.headers = $scope.$parent.$eval($attrs.headers);
     vm.activeSorters = $scope.$parent.$eval($attrs.defaultSorter);
     vm.activeOrders = $scope.$parent.$eval($attrs.defaultOrder);
+    vm.inlineIcon = $scope.$parent.$eval($attrs.inlineIcon) || false;
 
     vm.classes = $attrs.class;
 
@@ -40,6 +41,21 @@ export default function MultiSortableHeaderCtrl($scope, $attrs) {
 
     // update data initially
     updateData();
+
+    vm.getHeaderWidth = function(header) {
+        // if there is no icon then fill the whole header
+        if (!vm.columnData[header.sort]) {
+            return { width: '100%' };
+        }
+
+        // if the icon should appear just after the text
+        if (vm.inlineIcon === true) {
+            return { maxWidth: 'calc(100% - 41px)' };
+        }
+
+        // otherwise show icon right aligned
+        return { width: 'calc(100% - 36px)' };
+    };
 
     vm.select = function(header) {
 

--- a/src/ng1/directives/sorters/multiSortableHeader/multiSortableHeader.html
+++ b/src/ng1/directives/sorters/multiSortableHeader/multiSortableHeader.html
@@ -1,13 +1,21 @@
-<tr class="multiSortHeader" ng-class="vm.classes">
+<tr class="multiSortHeader"
+    ng-class="vm.classes">
 
-	<th ng-repeat="header in vm.headers" class="header {{ ::header.fixedClass }}"
-		ng-class="{ 'text-center': header.center, 'clickable': header.sortable }" 
+    <th ng-repeat="header in vm.headers"
+        class="header {{ ::header.fixedClass }}"
+		ng-class="{ 'text-center': header.center, 'clickable': header.sortable }"
     	ng-click="vm.select(header)">
-		
-		<p class="multiSortTitle" ng-bind="header.sorterHeader" ng-style="{ width: !vm.columnData[header.sort] ? '100%' : 'calc(100% - 36px)' }"></p>
 
-		<div class="multiSortContainer" ng-class="{ 'ng-hide': !vm.columnData[header.sort] }">
-    		<i class="hpe-icon text-muted sortableHeaderIcon" ng-class="vm.columnData[header.sort] ? vm.columnData[header.sort].icon : ''"></i>
+        <p class="multiSortTitle"
+           ng-bind="header.sorterHeader"
+           ng-style="vm.getHeaderWidth(header)">
+        </p>
+
+        <div class="multiSortContainer"
+             ng-class="{ 'ng-hide': !vm.columnData[header.sort], 'inline-sort-icon': vm.inlineIcon }">
+            <i class="hpe-icon text-muted sortableHeaderIcon {{ vm.columnData[header.sort] ? vm.columnData[header.sort].icon : '' }}"
+               ng-class="{ 'sortable-header-icon-inline': vm.inlineIcon }">
+            </i>
         	<p class="multiSortNumber text-muted" ng-bind="vm.columnData[header.sort] ? vm.columnData[header.sort].order : ''"></p>
 		</div>
 

--- a/src/ng1/directives/sorters/sorterHeader/sortableHeader.controller.js
+++ b/src/ng1/directives/sorters/sorterHeader/sortableHeader.controller.js
@@ -7,6 +7,7 @@ export default function SorterHeaderCtrl($scope, $attrs) {
     vm.defaultSorter = $scope.$parent.$eval($attrs.defaultSorter);
     vm.defaultOrder = $scope.$parent.$eval($attrs.defaultOrder);
     vm.fontSize = $scope.$parent.$eval($attrs.fontSize);
+    vm.inlineIcon = $scope.$parent.$eval($attrs.inlineIcon) || false;
 
     // watch for changes to the headers value and update it when it is changed
     $scope.$watch(function() {
@@ -18,6 +19,21 @@ export default function SorterHeaderCtrl($scope, $attrs) {
     var selectedColumn = {
         header: findHeader(vm.defaultSorter),
         descending: vm.defaultOrder
+    };
+
+    vm.getHeaderWidth = function(header) {
+        // if there is no icon then fill the whole header
+        if (vm.getIcon(header) === 'ng-hide') {
+            return '100%';
+        }
+
+        // if the icon should appear just after the text
+        if (vm.inlineIcon === true) {
+            return;
+        }
+
+        // otherwise show icon right aligned
+        return 'calc(100% - 18px)';
     };
 
     vm.select = function(header) {

--- a/src/ng1/directives/sorters/sorterHeader/sortableHeader.controller.js
+++ b/src/ng1/directives/sorters/sorterHeader/sortableHeader.controller.js
@@ -24,16 +24,16 @@ export default function SorterHeaderCtrl($scope, $attrs) {
     vm.getHeaderWidth = function(header) {
         // if there is no icon then fill the whole header
         if (vm.getIcon(header) === 'ng-hide') {
-            return '100%';
+            return { width: '100%' };
         }
 
         // if the icon should appear just after the text
         if (vm.inlineIcon === true) {
-            return;
+            return { maxWidth: 'calc(100% - 23px)' };
         }
 
         // otherwise show icon right aligned
-        return 'calc(100% - 18px)';
+        return { width: 'calc(100% - 18px)' };
     };
 
     vm.select = function(header) {

--- a/src/ng1/directives/sorters/sorterHeader/sortableHeader.html
+++ b/src/ng1/directives/sorters/sorterHeader/sortableHeader.html
@@ -5,7 +5,7 @@
 
     <p class="sortableHeader"
        ng-bind="header.sorterHeader"
-       ng-style="{ width: vm.getHeaderWidth(header) }">
+       ng-style="vm.getHeaderWidth(header)">
     </p>
 
     <i class="hpe-icon text-muted sortableHeaderIcon {{ vm.getIcon(header) }}" ng-class="{ 'sortable-header-icon-inline': vm.inlineIcon }"></i>

--- a/src/ng1/directives/sorters/sorterHeader/sortableHeader.html
+++ b/src/ng1/directives/sorters/sorterHeader/sortableHeader.html
@@ -1,7 +1,12 @@
-<th ng-repeat="header in vm.headers" class="{{ ::header.fixedClass }}" 
-    ng-class="{ 'text-center': header.center, 'clickable': header.sortable }" 
+<th ng-repeat="header in vm.headers"
+    class="{{ ::header.fixedClass }}"
+    ng-class="{ 'text-center': header.center, 'clickable': header.sortable }"
     ng-click="vm.select(header)">
 
-    <p class="sortableHeader" ng-bind="header.sorterHeader" ng-style="{ width: vm.getIcon(header) == 'ng-hide' ? '100%' : 'calc(100% - 18px)' }"></p>
-    <i class="hpe-icon text-muted sortableHeaderIcon" ng-class="vm.getIcon(header)"></i>
+    <p class="sortableHeader"
+       ng-bind="header.sorterHeader"
+       ng-style="{ width: vm.getHeaderWidth(header) }">
+    </p>
+
+    <i class="hpe-icon text-muted sortableHeaderIcon {{ vm.getIcon(header) }}" ng-class="{ 'sortable-header-icon-inline': vm.inlineIcon }"></i>
 </th>

--- a/src/styles/tables.less
+++ b/src/styles/tables.less
@@ -887,6 +887,10 @@ table {
     width: 36px;
     display: inline-block;
     height: 22px;
+
+    &.inline-sort-icon {
+        width: 41px;
+    }
 }
 
 .fixed-layout {

--- a/src/styles/tables.less
+++ b/src/styles/tables.less
@@ -843,6 +843,10 @@ table {
     display: inline-block;
     width: 18px;
     vertical-align: middle;
+
+    &.sortable-header-icon-inline {
+        margin-left: 5px;
+    }
 }
 
 .multiSortTitle {


### PR DESCRIPTION
- Adding option to inline the icon so it appears immediately after the text rather than right aligned

#### Ticket
https://portal.digitalsafe.net/browse/EL-3466

#### Documentation CI URL
https://pages.github.houston.softwaregrp.net/sepg-docs-qa/UXAspects_CI_UXAspects_EL-3466-Inline-Sort-Icon
