### PR TITLE
EL-3117 - Partition Map Collapse Height

### DIFF
--- a/docs/app/pages/charts/charts-sections/partition-map/partition-map/partition-map.component.html
+++ b/docs/app/pages/charts/charts-sections/partition-map/partition-map/partition-map.component.html
@@ -38,8 +38,8 @@
     <tr uxd-api-property name="selected" type="Readonly<PartitionMapSegment>">
         Define the currently selected item.
     </tr>
-    <tr uxd-api-property name="collapsedHeight" type="number" defaultValue="5">
-        Determine the percentage height of collapsed segments.
+    <tr uxd-api-property name="collapsedHeight" type="number" defaultValue="40">
+        Determine the pixel height of collapsed segments.
     </tr>
     <tr uxd-api-property name="minSegmentWidth" type="number" defaultValue="5">
         Define the minimum desired pixel width for a segment. Segments will appear at least this

--- a/docs/app/pages/charts/charts-sections/partition-map/partition-map/partition-map.component.html
+++ b/docs/app/pages/charts/charts-sections/partition-map/partition-map/partition-map.component.html
@@ -1,4 +1,4 @@
-<ux-partition-map [dataset]="dataset" [colors]="colors">
+<ux-partition-map class="partition-map" [dataset]="dataset" [colors]="colors">
     <ng-template #partitionMapSegment let-segment="segment" let-value="value">
 
         <div class="partition-map-custom-segment"

--- a/docs/app/pages/charts/charts-sections/partition-map/partition-map/partition-map.component.less
+++ b/docs/app/pages/charts/charts-sections/partition-map/partition-map/partition-map.component.less
@@ -1,3 +1,7 @@
+.partition-map {
+    height: 600px;
+}
+
 .partition-map-custom-segment {
     display: flex;
     width: 100%;

--- a/docs/app/pages/charts/charts-sections/partition-map/partition-map/snippets/app.css
+++ b/docs/app/pages/charts/charts-sections/partition-map/partition-map/snippets/app.css
@@ -1,3 +1,7 @@
+.partition-map {
+    height: 600px;
+}
+
 .partition-map-custom-segment {
     display: flex;
     width: 100%;

--- a/docs/app/pages/charts/charts-sections/partition-map/partition-map/snippets/app.html
+++ b/docs/app/pages/charts/charts-sections/partition-map/partition-map/snippets/app.html
@@ -1,4 +1,4 @@
-<ux-partition-map [dataset]="dataset" [colors]="colors">
+<ux-partition-map class="partition-map" [dataset]="dataset" [colors]="colors">
     <ng-template #partitionMapSegment let-segment="segment" let-value="value">
 
         <div class="partition-map-custom-segment"

--- a/src/components/partition-map/partition-map.component.less
+++ b/src/components/partition-map/partition-map.component.less
@@ -2,7 +2,8 @@ ux-partition-map {
     display: block;
     position: relative;
     overflow: hidden;
-    height: 600px;
+    width: 100%;
+    height: 100%;
     background-color: #000;
 
     .partition-map-segment {

--- a/src/components/partition-map/partition-map.component.ts
+++ b/src/components/partition-map/partition-map.component.ts
@@ -126,6 +126,12 @@ export class PartitionMapComponent implements OnInit, OnDestroy {
             this._height = dimensions.height;
             this._changeDetector.detectChanges();
 
+            // set our new ranges
+            if (this._selected) {
+                this._x.domain([this.getSegmentX(this._selected), this.getSegmentX(this._selected) + this.getSegmentWidth(this._selected)]);
+                this._y.domain([this._selected.y0, 1]).range([this.getTotalCollapsedHeight(), 100]);
+            }
+
             // render the chart to ensure positions and sizes are correct
             this.updateSegments();
         });


### PR DESCRIPTION
As discussed yesterday during storytime, I have updated the partition map to use pixel values for the collapsed height rather than a percentage.

#### Ticket
https://portal.digitalsafe.net/browse/EL-3117

#### Documentation CI URL
https://pages.github.houston.softwaregrp.net/sepg-docs-qa/UXAspects_CI_UXAspects_EL-3117-Partition-Map-Collapse-Height
