### PR TITLE
EL-3470 - Number Picker - "underline" style for the compact variant

### DIFF
--- a/src/components/number-picker/number-picker.component.less
+++ b/src/components/number-picker/number-picker.component.less
@@ -1,4 +1,5 @@
-ux-number-picker {
+ux-number-picker,
+ux-number-picker-inline {
     display: flex;
     flex-direction: row;
     height: 34px;

--- a/src/components/number-picker/number-picker.component.ts
+++ b/src/components/number-picker/number-picker.component.ts
@@ -11,7 +11,7 @@ export const NUMBER_PICKER_VALUE_ACCESSOR: any = {
 };
 
 @Component({
-    selector: 'ux-number-picker',
+    selector: 'ux-number-picker, ux-number-picker-inline',
     templateUrl: './number-picker.component.html',
     providers: [NUMBER_PICKER_VALUE_ACCESSOR],
     host: {


### PR DESCRIPTION
Since the "compact" variant of the number picker will be the most used style, I'm adding a new selector for it. This should aid with code completion instead of having to remember the class name when implementing the number picker.

#### Ticket
https://portal.digitalsafe.net/browse/EL-3470

#### Documentation CI URL
https://pages.github.houston.softwaregrp.net/sepg-docs-qa/UXAspects_CI_UXAspects_EL-3470-number-picker
