### PR TITLE
EL-3496 - Tree Grid Keyboard Fix

### DIFF
--- a/src/ng1/directives/treegrid/accessibility/treegrid-navigation-item.controller.js
+++ b/src/ng1/directives/treegrid/accessibility/treegrid-navigation-item.controller.js
@@ -96,7 +96,7 @@ export class TreeGridNavigationItemController {
                 break;
 
             case RIGHT_ARROW:
-                this.expand();
+                this.expand(event);
                 break;
 
             case LEFT_ARROW:
@@ -127,13 +127,20 @@ export class TreeGridNavigationItemController {
         event.preventDefault();
     }
 
-    expand() {
-        if (this.$attrs.treegridExpand) {
-            // make the expansion and update the UI
-            this.$scope.$apply(() => this.$scope.$eval(this.$attrs.treegridExpand));
+    /**
+     * @param {KeyboardEvent} event
+     */
+    expand(event) {
+        if (this.$attrs.treegridExpand && this.data.canExpand && !this.data.expanded) {
+            // stop the list hover actions from focusing the first item
+            event.stopImmediatePropagation();
 
-            // we must focus the index rather than the actual element as ng-repeat will create a new DOM node
-            this.navigationCtrl.focus(null, this.index);
+            // make the expansion and update the UI
+            this.$scope.$apply(() => this.$scope.$eval(this.$attrs.treegridExpand).then(() => {
+                // we must focus the index rather than the actual element as ng-repeat will create a new DOM node
+                // a delay is required to allow ng-repeat to update before we focus
+                requestAnimationFrame(() => this.navigationCtrl.focus(null, this.index));
+            }));
         }
     }
 

--- a/src/ng1/directives/treegrid/treegrid.controller.js
+++ b/src/ng1/directives/treegrid/treegrid.controller.js
@@ -150,9 +150,11 @@ export function TreeGridController($scope, $q, multipleSelectProvider, $timeout)
         }
 
         row.expanding = true;
-        // run async to allow loading indicator to appear
-        return $q(resolve => $timeout(() => expand(row).then(result => resolve(result))));
 
+        // run async to allow loading indicator to appear
+        // adding in 17ms delay (1 frame at 60fps - 16.6667ms)
+        // to ensure firefox shows the loading indicator before blocking the main UI thread
+        return $q(resolve => $timeout(() => expand(row).then(result => resolve(result)), 17));
     };
 
     // Contract the specified row if possible. Returns true if the row is contractable.
@@ -351,9 +353,7 @@ export function TreeGridController($scope, $q, multipleSelectProvider, $timeout)
         if (row.expanded) {
             return contract(row);
         } else {
-            row.expanding = true;
-            // run async to allow loading indicator to appear
-            return $q(resolve => $timeout(() => expand(row).then(result => resolve(result))));
+            return vm.expandAsync(row);
         }
     }
 

--- a/src/ng1/directives/treegrid/treegrid.controller.js
+++ b/src/ng1/directives/treegrid/treegrid.controller.js
@@ -139,7 +139,7 @@ export function TreeGridController($scope, $q, multipleSelectProvider, $timeout)
         if (!row.canExpand || row.expanded) {
             return false;
         }
-        expand(row);
+        $timeout(() => expand(row));
         return true;
     };
 
@@ -148,7 +148,11 @@ export function TreeGridController($scope, $q, multipleSelectProvider, $timeout)
         if (!row.canExpand || row.expanded) {
             return $q.when(false);
         }
-        return expand(row);
+
+        row.expanding = true;
+        // run async to allow loading indicator to appear
+        return $q(resolve => $timeout(() => expand(row).then(result => resolve(result))));
+
     };
 
     // Contract the specified row if possible. Returns true if the row is contractable.

--- a/src/ng1/directives/treegrid/treegrid.html
+++ b/src/ng1/directives/treegrid/treegrid.html
@@ -32,7 +32,7 @@
                 treegrid-multiple-select-item="row"
                 treegrid-multiple-select-item-disabled="vm.isDisabled(row)"
                 treegrid-multiple-select-options="vm.allOptions"
-                treegrid-expand="vm.expand(row)"
+                treegrid-expand="vm.expandAsync(row)"
                 treegrid-contract="vm.contract(row)"
                 treegrid-navigation-item="row"
                 treegrid-navigation-item-index="$index"

--- a/src/ng1/directives/treegrid/treegrid.spec.js
+++ b/src/ng1/directives/treegrid/treegrid.spec.js
@@ -234,33 +234,34 @@ describe('treegrid', function () {
                 expect(rows.length).toBe(1);
                 expect(rows[0].level).toBe(0);
                 expect(rows[0].canExpand).toBe(true);
-                // Expand "Row 1"
-                ctrl.expanderClick(rows[0], DummyEvent)
-                    .then(function () {
-                        rows = ctrl.getGridRows();
-                        expect(rows.length).toBe(2);
-                        expect(rows[1].level).toBe(1);
-                        expect(rows[1].canExpand).toBe(true);
-                    })
-                    // Expand "Row 1.1"
-                    .then(function () { return ctrl.expanderClick(rows[1], DummyEvent); })
-                    .then(function () {
-                        rows = ctrl.getGridRows();
-                        expect(rows.length).toBe(3);
-                        expect(rows[2].level).toBe(2);
-                        expect(rows[2].canExpand).toBe(false);
-                    })
-                    // Expand "Row 1.1.1" (should do nothing)
-                    .then(function () { return ctrl.expanderClick(rows[2], DummyEvent); })
-                    .then(function () {
-                        rows = ctrl.getGridRows();
-                        expect(rows.length).toBe(3);
-                    })
-                    .catch(failTest)
-                    .finally(done);
 
-                $timeout.flush();
+                // Expand "Row 1"
+                ctrl.expanderClick(rows[0], DummyEvent).then(() => {
+                    rows = ctrl.getGridRows();
+                    expect(rows.length).toBe(2);
+                    expect(rows[1].level).toBe(1);
+                    expect(rows[1].canExpand).toBe(true);
+
+                    setTimeout(() => {
+                        ctrl.expanderClick(rows[1], DummyEvent).then(() => {
+                            rows = ctrl.getGridRows();
+                            expect(rows.length).toBe(3);
+                            expect(rows[2].level).toBe(2);
+                            expect(rows[2].canExpand).toBe(false);
+
+                            ctrl.expanderClick(rows[2], DummyEvent);
+                            rows = ctrl.getGridRows();
+                            expect(rows.length).toBe(3);
+
+                            done();
+                        });
+
+                        $timeout.flush();
+                    });
+                });
+
                 $rootScope.$apply();
+                setTimeout(() => $timeout.flush());
             });
         });
 


### PR DESCRIPTION
- Showing indicator whenever keyboard is used to expand/contract nodes

#### Ticket
https://portal.digitalsafe.net/browse/EL-3496

#### Documentation CI URL
https://pages.github.houston.softwaregrp.net/sepg-docs-qa/UXAspects_CI_UXAspects_EL-3496-Tree-Grid-Fix
