### PR TITLE
EL-3468 - Side Panel focus

### DIFF
--- a/docs/app/pages/components/components-sections/panels/item-display-panel/item-display-panel.component.html
+++ b/docs/app/pages/components/components-sections/panels/item-display-panel/item-display-panel.component.html
@@ -132,6 +132,10 @@
 
 <p>To add a footer to the item display panel the <code>uxItemDisplayPanelFooter</code> directive can be added as an attribute allowing you to add any required content to the bottom of the item display panel</p>
 
+<blockquote>
+    <p><strong>Note</strong>: The root module must import <code>BrowserAnimationsModule</code> from <code>'@angular/platform-browser/animations'</code>.</p>
+</blockquote>
+
 <p>The following code will produce the example shown above:</p>
 
 <ux-tabset [minimal]="false">

--- a/docs/app/pages/components/components-sections/panels/side-panel/side-panel.component.html
+++ b/docs/app/pages/components/components-sections/panels/side-panel/side-panel.component.html
@@ -202,6 +202,10 @@
     </tr>
 </uxd-api-properties>
 
+<blockquote>
+    <p><strong>Note</strong>: The root module must import <code>BrowserAnimationsModule</code> from <code>'@angular/platform-browser/animations'</code>.</p>
+</blockquote>
+
 <ux-tabset [minimal]="false">
     <ux-tab heading="HTML">
         <uxd-snippet [content]="snippets.compiled.appHtml"></uxd-snippet>

--- a/e2e/pages/app/item-display-panel/item-display-panel.testpage.component.ts
+++ b/e2e/pages/app/item-display-panel/item-display-panel.testpage.component.ts
@@ -16,31 +16,31 @@ export class ItemDisplayPanelTestPageComponent {
     selectedItem: Item;
     previousEnabled: boolean = true;
     nextEnabled: boolean = true;
-    animate: boolean = true;
+    animate: boolean = false;
     shadow: boolean = true;
-    
+
     sparkBarColor: string;
     sparkTrackColor: string;
 
     // templates
     pdf = `<div class="p-r-md p-l-md p-t-sm">
   <h1>Preview PDF</h1>
-  <p>Praesent venenatis eros vel felis vehicula dictum. Phasellus augue libero, vulputate euismod purus 
-  sed, dictum porta mauris. Nunc vitae purus vel velit dapibus porttitor et sagittis mauris. Etiam non 
+  <p>Praesent venenatis eros vel felis vehicula dictum. Phasellus augue libero, vulputate euismod purus
+  sed, dictum porta mauris. Nunc vitae purus vel velit dapibus porttitor et sagittis mauris. Etiam non
   semper odio, at ultricies velit. Duis non suscipit lectus, vitae fringilla turpis.</p>
 </div>`;
 
     doc = `<div class="p-r-md p-l-md p-t-sm">
   <h1>Preview DOC</h1>
-  <p>Donec sagittis augue et pellentesque ultrices. Nulla quis orci sit amet sem ornare auctor. Ut in 
-  lobortis turpis. Vivamus ante felis, viverra sed ornare ut, ultricies eget ipsum. 
+  <p>Donec sagittis augue et pellentesque ultrices. Nulla quis orci sit amet sem ornare auctor. Ut in
+  lobortis turpis. Vivamus ante felis, viverra sed ornare ut, ultricies eget ipsum.
   Vivamus commodo convallis tortor.</p>
 </div>`;
 
     ppt = `<div class="p-r-md p-l-md p-t-sm">
   <h1>Preview PPT</h1>
-  <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris fringilla, nunc sit amet faucibus 
-  dapibus, est purus luctus magna, ut tempus orci quam vitae diam. Proin dapibus elit et rhoncus 
+  <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris fringilla, nunc sit amet faucibus
+  dapibus, est purus luctus magna, ut tempus orci quam vitae diam. Proin dapibus elit et rhoncus
   interdum. Pellentesque ornare nibh ac nulla sodales commodo. Sed vestibulum hendrerit ultrices.</p>
 </div>`;
 

--- a/e2e/pages/app/side-panel/side-panel.testpage.component.html
+++ b/e2e/pages/app/side-panel/side-panel.testpage.component.html
@@ -21,7 +21,8 @@
         [top]="top"
         [width]="width"
         [modal]="modal"
-        [closeOnExternalClick]="closeOnExternalClick">
+        [closeOnExternalClick]="closeOnExternalClick"
+        [animate]="false">
 
         <div class="ux-side-panel-header">
             <h3>Side Panel</h3>

--- a/src/components/item-display-panel/item-display-panel.component.html
+++ b/src/components/item-display-panel/item-display-panel.component.html
@@ -3,6 +3,7 @@
     [style.position]="position"
     [style.width]="hostWidth"
     [style.top]="cssTop"
+    [@panelState]="animationPanelState"
     [tabindex]="open ? 0 : -1"
     [focusIf]="open && focusOnShow">
 

--- a/src/components/item-display-panel/item-display-panel.component.ts
+++ b/src/components/item-display-panel/item-display-panel.component.ts
@@ -79,6 +79,7 @@ export class ItemDisplayPanelComponent extends SidePanelComponent implements OnI
     }
 
     ngOnInit() {
+        super.ngOnInit();
         this.service.open$.pipe(distinctUntilChanged(), takeUntil(this._onDestroy)).subscribe(isVisible => this.visibleChange.emit(isVisible));
     }
 

--- a/src/components/item-display-panel/item-display-panel.component.ts
+++ b/src/components/item-display-panel/item-display-panel.component.ts
@@ -1,5 +1,6 @@
 import { Component, ContentChild, Directive, ElementRef, EventEmitter, Input, OnInit, Output, ViewChild } from '@angular/core';
 import { distinctUntilChanged, takeUntil } from 'rxjs/operators';
+import { sidePanelStateAnimation } from '../side-panel/side-panel-animations';
 import { SidePanelComponent } from '../side-panel/side-panel.component';
 import { SidePanelService } from '../side-panel/side-panel.service';
 
@@ -17,6 +18,7 @@ export class ItemDisplayPanelFooterDirective { }
     selector: 'ux-item-display-panel',
     templateUrl: './item-display-panel.component.html',
     providers: [SidePanelService],
+    animations: [sidePanelStateAnimation],
     host: {
         'class': 'ux-side-panel ux-item-display-panel'
     }

--- a/src/components/side-panel/side-panel-animations.ts
+++ b/src/components/side-panel/side-panel-animations.ts
@@ -1,0 +1,31 @@
+import { trigger, state, style, transition, animate } from '@angular/animations';
+
+export enum SidePanelAnimationState {
+    Closed = 'closed',
+    Open = 'open',
+    OpenImmediate = 'openImmediate'
+}
+
+export const sidePanelStateAnimation = trigger('panelState', [
+    state(
+        SidePanelAnimationState.Closed,
+        style({
+            visibility: 'hidden'
+        })
+    ),
+    state(
+        `${SidePanelAnimationState.Open}, ${SidePanelAnimationState.OpenImmediate}`,
+        style({
+            visibility: 'visible',
+            transform: 'none'
+        })
+    ),
+    transition(
+        `${SidePanelAnimationState.Closed} <=> ${SidePanelAnimationState.Open}`,
+        animate('0.2s cubic-bezier(0.49, 1, 0.38, 0.98)')
+    ),
+    transition(
+        `${SidePanelAnimationState.Closed} <=> ${SidePanelAnimationState.OpenImmediate}`,
+        animate('0s')
+    )
+]);

--- a/src/components/side-panel/side-panel.component.html
+++ b/src/components/side-panel/side-panel.component.html
@@ -8,6 +8,7 @@
     [style.width]="hostWidth"
     [style.top]="cssTop"
     [tabindex]="open ? 0 : -1"
+    [@panelState]="animationPanelState"
     [focusIf]="open && focusOnShow"
     [focusIfScroll]="false"
     [cdkTrapFocus]="open && modal">

--- a/src/components/side-panel/side-panel.component.less
+++ b/src/components/side-panel/side-panel.component.less
@@ -3,7 +3,6 @@
         > .ux-side-panel-host {
             box-shadow: 1px 0 20px 0 @display-panel-shadow;
             border-left: 1px solid @display-panel-border;
-            transform: translateX(0);
         }
     }
 
@@ -11,7 +10,7 @@
         flex: none;
 
         &.animate {
-            transition: width 0.4s;
+            transition: width 0.2s cubic-bezier(0.49, 1, 0.38, 0.98);
         }
 
         > .ux-side-panel-host {
@@ -24,18 +23,6 @@
     &:not(.inline) {
         > .ux-side-panel-host {
             transform: translateX(100%);
-        }
-
-        &.open {
-            > .ux-side-panel-host {
-                transform: translateX(0);
-            }
-        }
-
-        &.animate {
-            > .ux-side-panel-host {
-                transition: transform 0.4s;
-            }
         }
     }
 

--- a/src/components/side-panel/side-panel.component.ts
+++ b/src/components/side-panel/side-panel.component.ts
@@ -1,55 +1,15 @@
-import { animate, state, style, transition, trigger } from '@angular/animations';
-import {
-    Component,
-    ElementRef,
-    EventEmitter,
-    HostBinding,
-    HostListener,
-    Input,
-    OnDestroy,
-    OnInit,
-    Output
-} from '@angular/core';
+import { Component, ElementRef, EventEmitter, HostBinding, HostListener, Input, OnDestroy, OnInit, Output } from '@angular/core';
 import { takeUntil } from 'rxjs/operators';
 import { Subject } from 'rxjs/Subject';
+import { sidePanelStateAnimation, SidePanelAnimationState } from './side-panel-animations';
 import { SidePanelService } from './side-panel.service';
-
-enum SidePanelAnimationState {
-    Closed = 'closed',
-    Open = 'open',
-    OpenImmediate = 'openImmediate'
-}
 
 @Component({
     selector: 'ux-side-panel',
     exportAs: 'ux-side-panel',
     templateUrl: 'side-panel.component.html',
     providers: [SidePanelService],
-    animations: [
-        trigger('panelState', [
-            state(
-                SidePanelAnimationState.Closed,
-                style({
-                    visibility: 'hidden'
-                })
-            ),
-            state(
-                `${SidePanelAnimationState.Open}, ${SidePanelAnimationState.OpenImmediate}`,
-                style({
-                    visibility: 'visible',
-                    transform: 'none'
-                })
-            ),
-            transition(
-                `${SidePanelAnimationState.Closed} <=> ${SidePanelAnimationState.Open}`,
-                animate('0.2s cubic-bezier(0.49, 1, 0.38, 0.98)')
-            ),
-            transition(
-                `${SidePanelAnimationState.Closed} <=> ${SidePanelAnimationState.OpenImmediate}`,
-                animate('0s')
-            )
-        ])
-    ],
+    animations: [sidePanelStateAnimation],
     host: {
         class: 'ux-side-panel'
     }


### PR DESCRIPTION
* Using Angular animations in order to set `visibility` with the proper timing. `visibility: hidden` prevents focus landing on panel content when it is closed.
* Converted the duration and timing function to match quantum.

#### Ticket
https://portal.digitalsafe.net/browse/EL-3468

#### Documentation CI URL
https://pages.github.houston.softwaregrp.net/sepg-docs-qa/UXAspects_CI_UXAspects_EL-3468-side-panel
