### PR TITLE
EL-3116 - Organization Chart Improvements

### DIFF
--- a/docs/app/pages/charts/charts-sections/organization-chart/organization-chart.module.ts
+++ b/docs/app/pages/charts/charts-sections/organization-chart/organization-chart.module.ts
@@ -1,3 +1,4 @@
+import { CommonModule } from '@angular/common';
 import { ComponentFactoryResolver, NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { RouterModule } from '@angular/router';
@@ -28,6 +29,7 @@ const ROUTES = [
 @NgModule({
     imports: [
         AccordionModule,
+        CommonModule,
         TabsetModule,
         FormsModule,
         RadioButtonModule,

--- a/docs/app/pages/charts/charts-sections/organization-chart/organization-chart/organization-chart.component.html
+++ b/docs/app/pages/charts/charts-sections/organization-chart/organization-chart/organization-chart.component.html
@@ -24,12 +24,12 @@
                 <p class="employee-job-title">{{ data.position }}</p>
                 <p class="employee-email">{{ data.email }}</p>
 
-                <div class="employee-icon">
+                <div class="employee-icon" *ngIf="node.children && node.children?.length > 0">
                     <i class="hpe-icon hpe-user-manager"></i>
-                    <span class="employee-icon-count">{{ node.children?.length }}</span>
+                    <span class="employee-icon-count">{{ node.children.length }}</span>
                 </div>
 
-                <div class="employee-icon employee-icon-expanded">
+                <div class="employee-icon employee-icon-expanded" *ngIf="node.children && node.children?.length > 0">
                     <i class="hpe-icon hpe-tab-up"></i>
                 </div>
             </div>

--- a/docs/app/pages/charts/charts-sections/organization-chart/organization-chart/snippets/app.html
+++ b/docs/app/pages/charts/charts-sections/organization-chart/organization-chart/snippets/app.html
@@ -24,12 +24,14 @@
                 <p class="employee-job-title">{{ data.position }}</p>
                 <p class="employee-email">{{ data.email }}</p>
 
-                <div class="employee-icon">
+                <div class="employee-icon"
+                     *ngIf="node.children && node.children?.length > 0">
                     <i class="hpe-icon hpe-user-manager"></i>
-                    <span class="employee-icon-count">{{ node.children?.length }}</span>
+                    <span class="employee-icon-count">{{ node.children.length }}</span>
                 </div>
 
-                <div class="employee-icon employee-icon-expanded">
+                <div class="employee-icon employee-icon-expanded"
+                     *ngIf="node.children && node.children?.length > 0">
                     <i class="hpe-icon hpe-tab-up"></i>
                 </div>
             </div>

--- a/src/components/hierarchy-bar/hierarchy-bar-node/hierarchy-bar-node.component.html
+++ b/src/components/hierarchy-bar/hierarchy-bar-node/hierarchy-bar-node.component.html
@@ -17,6 +17,7 @@
     <!-- Show a dropdown arrow if there are children -->
     <button type="button"
             uxFocusIndicator
+            uxFocusIndicatorOrigin
             *ngIf="node.children"
             #popover="ux-popover"
             aria-label="Show children"


### PR DESCRIPTION
Fixing the issues mentioned by Roland:

- Items with no children should not show the icon and child count or up arrow on hover
- Fixed issue in hierarchy bar where focus indicator doesnt show on first menu item when it is triggered by the keyboard

(note there was another issue mentioned in the ticket about showing the hover state when an item is focused, this was completed as part of the original PR so no changes are required for it)

#### Ticket
https://portal.digitalsafe.net/browse/EL-3116

#### Documentation CI URL
https://pages.github.houston.softwaregrp.net/sepg-docs-qa/UXAspects_CI_UXAspects_EL-3116-Organization-Chart-QA
