### PR TITLE
EL-3500 - Select IE issue

### DIFF
--- a/src/ng1/directives/dynamicSelect/dynamicSelect.controller.js
+++ b/src/ng1/directives/dynamicSelect/dynamicSelect.controller.js
@@ -325,7 +325,16 @@ export default class DynamicSelectCtrl {
    * @param {string} key
    */
   getModelIndex(key) {
-    return Array.isArray(this.ngModel) ? this.ngModel.findIndex(item => this.getItemKey(item) === key) : -1;
+
+    if (Array.isArray(this.ngModel)) {
+        for (let idx = 0; idx < this.ngModel.length; idx++) {
+            if (this.getItemKey(this.ngModel[idx]) === key) {
+                return idx;
+            }
+        }
+    }
+
+    return -1;
   }
 
   select(item) {


### PR DESCRIPTION
Removing the use of `array.findIndex` as this is not available in IE without a polyfill. Replacing with ES5 equivalent code.

#### Ticket
https://portal.digitalsafe.net/browse/EL-3500

#### Documentation CI URL
https://pages.github.houston.softwaregrp.net/sepg-docs-qa/UXAspects_CI_UXAspects_EL-3500-Select-QA
