### PR TITLE
EL-3116 - Organization Chart Bug Fixes

### DIFF
--- a/docs/app/pages/charts/charts-sections/organization-chart/organization-chart/organization-chart.component.html
+++ b/docs/app/pages/charts/charts-sections/organization-chart/organization-chart/organization-chart.component.html
@@ -92,6 +92,9 @@
     <tr uxd-api-property name="selected" type="OrganizationChartNode<T>">
         Define the selected node. By default the root node will be selected.
     </tr>
+    <tr uxd-api-property name="verticalSpacing" type="number">
+        Define the amount of space there is between parent and child nodes. By default this will be equal to the node height.
+    </tr>
 </uxd-api-properties>
 
 <uxd-api-properties tableTitle="Outputs">

--- a/docs/app/pages/charts/charts-sections/organization-chart/organization-chart/organization-chart.component.html
+++ b/docs/app/pages/charts/charts-sections/organization-chart/organization-chart/organization-chart.component.html
@@ -93,7 +93,7 @@
         Define the selected node. By default the root node will be selected.
     </tr>
     <tr uxd-api-property name="verticalSpacing" type="number">
-        Define the amount of space there is between parent and child nodes. By default this will be equal to the node height.
+        Define the amount of space there is between parent and child nodes in pixels. By default this will be equal to the node height.
     </tr>
 </uxd-api-properties>
 


### PR DESCRIPTION
- Fixing selection using the input issue. Initial selection is now deferred until the initial render has started.
- Added a `verticalSpacing` option to allow the user to customize the amount of space between parent and child nodes.

#### Ticket
https://portal.digitalsafe.net/browse/EL-3116

#### Documentation CI URL
https://pages.github.houston.softwaregrp.net/sepg-docs-qa/UXAspects_CI_UXAspects_EL-3116-Organization-Chart-Fixes
