### PR TITLE
EL-3269 - Side Menu Route Options

### DIFF
--- a/e2e/pages/app/app.module.ts
+++ b/e2e/pages/app/app.module.ts
@@ -94,6 +94,10 @@ const routes: Routes = [
         loadChildren: './marquee-wizard/marquee-wizard.module#MarqueeWizardTestPageModule'
     },
     {
+        path: 'navigation',
+        loadChildren: './navigation/navigation.module#NavigationTestPageModule'
+    },
+    {
         path: 'number-picker',
         loadChildren: './number-picker/number-picker.module#NumberPickerTestPageModule'
     },

--- a/e2e/pages/app/navigation/navigation.module.ts
+++ b/e2e/pages/app/navigation/navigation.module.ts
@@ -1,0 +1,56 @@
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { RouterModule } from '@angular/router';
+import { NavigationModule } from '@ux-aspects/ux-aspects';
+import { NavigationTestPageComponent } from './navigation.testpage.component';
+import { NavigationPageComponent } from './page.component';
+
+@NgModule({
+    imports: [
+        CommonModule,
+        NavigationModule,
+        RouterModule.forChild([
+            {
+                path: '',
+                component: NavigationTestPageComponent,
+                children: [
+                    {
+                        path: 'dashboard',
+                        component: NavigationPageComponent,
+                        data: { title: 'Dashboard' }
+                    },
+                    {
+                        path: 'products/add',
+                        component: NavigationPageComponent,
+                        data: { title: 'Product Add' }
+                    },
+                    {
+                        path: 'products/remove',
+                        component: NavigationPageComponent,
+                        data: { title: 'Product Remove' }
+                    },
+                    {
+                        path: 'accounts',
+                        component: NavigationPageComponent,
+                        data: { title: 'Accounts' }
+                    },
+                    {
+                        path: 'accounts/add',
+                        component: NavigationPageComponent,
+                        data: { title: 'Accounts Add' }
+                    },
+                    {
+                        path: 'accounts/remove',
+                        component: NavigationPageComponent,
+                        data: { title: 'Accounts Remove' }
+                    }
+                ]
+            }
+        ])
+    ],
+    declarations: [
+        NavigationTestPageComponent,
+        NavigationPageComponent
+    ]
+})
+export class NavigationTestPageModule { }

--- a/e2e/pages/app/navigation/navigation.testpage.component.html
+++ b/e2e/pages/app/navigation/navigation.testpage.component.html
@@ -1,0 +1,20 @@
+<div class="container">
+    <div class="row">
+        <div class="col-sm-6 col-md-3">
+            <ux-navigation
+                [items]="items"
+                [tree]="tree"
+                [autoCollapse]="autoCollapse">
+            </ux-navigation>
+        </div>
+        <div class="col-sm-6 col-md-9">
+            <router-outlet></router-outlet>
+        </div>
+    </div>
+
+    <div class="btn-container">
+        <button id="enable-tree-btn" class="btn button-secondary" (click)="tree = true">Enable Tree Mode</button>
+        <button id="enable-auto-collapse-btn" class="btn button-secondary" (click)="autoCollapse = true">Enable Auto Collapse</button>
+        <button id="disable-exact" class="btn button-secondary" (click)="disableExact()">Disable Exact</button>
+    </div>
+</div>

--- a/e2e/pages/app/navigation/navigation.testpage.component.ts
+++ b/e2e/pages/app/navigation/navigation.testpage.component.ts
@@ -1,0 +1,63 @@
+import { Component } from '@angular/core';
+import { NavigationItem } from '@ux-aspects/ux-aspects';
+
+@Component({
+    selector: 'app-navigation',
+    templateUrl: './navigation.testpage.component.html',
+    styleUrls: ['./navigation.testpage.component.css']
+})
+export class NavigationTestPageComponent {
+
+    items: NavigationItem[] = [
+        {
+            title: 'Dashboard',
+            icon: 'hpe-dashboard',
+            routerLink: '/navigation/dashboard'
+        },
+        {
+            title: 'Products',
+            icon: 'hpe-service-business',
+            children: [
+                {
+                    title: 'Add Product',
+                    routerLink: '/navigation/products/add'
+                },
+                {
+                    title: 'Remove Product',
+                    routerLink: '/navigation/products/remove',
+                    routerOptions: {
+                        ignoreQueryParams: true
+                    }
+                }
+            ]
+        },
+        {
+            title: 'Accounts',
+            icon: 'hpe-user',
+            routerLink: '/navigation/accounts',
+            children: [
+                {
+                    title: 'Add Account',
+                    routerLink: '/navigation/accounts/add'
+                },
+                {
+                    title: 'Remove Account',
+                    routerLink: '/navigation/accounts/remove'
+                }
+            ]
+        },
+    ];
+
+    tree: boolean = false;
+    autoCollapse: boolean = false;
+
+    disableExact(): void {
+        this.items.forEach((item: NavigationItem) => {
+            item.routerOptions = { ...item.routerOptions, exact: false };
+
+            if (item.children) {
+                item.children.forEach((child: NavigationItem) => child.routerOptions = { ...child.routerOptions, exact: false });
+            }
+        });
+    }
+}

--- a/e2e/pages/app/navigation/page.component.ts
+++ b/e2e/pages/app/navigation/page.component.ts
@@ -1,0 +1,25 @@
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import { Subscription } from 'rxjs/Subscription';
+
+@Component({
+    selector: 'app-navigation-page',
+    template: `<p id="page-content">{{ title }}</p>`,
+    styles: [``]
+})
+export class NavigationPageComponent implements OnInit, OnDestroy {
+
+    title: string;
+
+    private _subscription: Subscription;
+
+    constructor(public route: ActivatedRoute) { }
+
+    ngOnInit(): void {
+        this._subscription = this.route.data.subscribe(data => this.title = data['title']);
+    }
+
+    ngOnDestroy(): void {
+        this._subscription.unsubscribe();
+    }
+}

--- a/e2e/tests/components/navigation/navigation.e2e-spec.ts
+++ b/e2e/tests/components/navigation/navigation.e2e-spec.ts
@@ -1,0 +1,248 @@
+import { browser } from 'protractor';
+import { NavigationPage } from './navigation.po.spec';
+
+describe('Number Picker Tests', () => {
+
+    let page: NavigationPage;
+
+    beforeEach(() => {
+        page = new NavigationPage();
+        page.getPage();
+    });
+
+    it('should intially be collapsed with no items selected', async () => {
+
+        // there should be 3 top level items
+        const items = await page.getTopLevelItems();
+        expect(items.length).toBe(3);
+
+        // none of these items should be selected
+        expect(await page.isItemActive(items[0])).toBeFalsy();
+        expect(await page.isItemActive(items[1])).toBeFalsy();
+        expect(await page.isItemActive(items[2])).toBeFalsy();
+
+        // all items should be collapsed
+        expect((await page.getItemChildren(items[0])).length).toBe(0);
+        expect((await page.getItemChildren(items[1])).length).toBe(0);
+        expect((await page.getItemChildren(items[2])).length).toBe(0);
+    });
+
+    it('should navigate to the routerLink when clicked', async () => {
+        const items = await page.getTopLevelItems();
+
+        await page.selectItem(items[0]);
+
+        expect(await page.isItemActive(items[0])).toBeTruthy();
+        expect(await page.isItemActive(items[1])).toBeFalsy();
+        expect(await page.isItemActive(items[2])).toBeFalsy();
+    });
+
+    it('should expand but not change route when item has children but no routerLink', async () => {
+        const items = await page.getTopLevelItems();
+
+        await page.selectItem(items[1]);
+
+        expect(await page.isItemActive(items[0])).toBeFalsy();
+        expect(await page.isItemActive(items[1])).toBeFalsy();
+        expect(await page.isItemActive(items[2])).toBeFalsy();
+
+        // get the visible children
+        expect((await page.getItemChildren(items[0])).length).toBe(0);
+        expect((await page.getItemChildren(items[1])).length).toBe(2);
+        expect((await page.getItemChildren(items[2])).length).toBe(0);
+    });
+
+    it('should expand and change route when item has children and routerLink', async () => {
+        const items = await page.getTopLevelItems();
+
+        await page.selectItem(items[2]);
+
+        expect(await page.isItemActive(items[0])).toBeFalsy();
+        expect(await page.isItemActive(items[1])).toBeFalsy();
+        expect(await page.isItemActive(items[2])).toBeTruthy();
+
+        // get the visible children
+        expect((await page.getItemChildren(items[0])).length).toBe(0);
+        expect((await page.getItemChildren(items[1])).length).toBe(0);
+        expect((await page.getItemChildren(items[2])).length).toBe(2);
+
+        // expect the page content to be correct
+        expect(await page.getPageContent()).toBe('Accounts');
+    });
+
+    it('should allow selection of child nodes', async () => {
+        const items = await page.getTopLevelItems();
+
+        await page.selectItem(items[1]);
+
+        // get the child nodes
+        const children = await page.getItemChildren(items[1]);
+
+        // select the first child
+        await page.selectItem(children[0]);
+
+        // the selected state should be updated correctly
+        expect(await page.isItemActive(children[0])).toBeTruthy();
+        expect(await page.isItemActive(children[1])).toBeFalsy();
+
+        // expect the page content to be correct
+        expect(await page.getPageContent()).toBe('Product Add');
+    });
+
+    it('should initially select a root node if the router link matches', async () => {
+        await browser.get('#/navigation/dashboard');
+
+        const items = await page.getTopLevelItems();
+
+        // expect the first item to be selected
+        expect(await page.isItemActive(items[0])).toBeTruthy();
+        expect(await page.isItemActive(items[1])).toBeFalsy();
+        expect(await page.isItemActive(items[2])).toBeFalsy();
+
+        // expect the page content to be correct
+        expect(await page.getPageContent()).toBe('Dashboard');
+    });
+
+    it('should initially select a child node if the router link matches', async () => {
+        await browser.get('#/navigation/products/add');
+
+        const items = await page.getTopLevelItems();
+
+        // expect the first item to be selected
+        expect(await page.isItemActive(items[0])).toBeFalsy();
+        expect(await page.isItemActive(items[1])).toBeFalsy();
+        expect(await page.isItemActive(items[2])).toBeFalsy();
+
+        // get the visible children
+        expect((await page.getItemChildren(items[0])).length).toBe(0);
+        expect((await page.getItemChildren(items[1])).length).toBe(2);
+        expect((await page.getItemChildren(items[2])).length).toBe(0);
+
+        const children = await page.getItemChildren(items[1]);
+
+        // the selected state should be updated correctly
+        expect(await page.isItemActive(children[0])).toBeTruthy();
+        expect(await page.isItemActive(children[1])).toBeFalsy();
+
+        // expect the page content to be correct
+        expect(await page.getPageContent()).toBe('Product Add');
+    });
+
+    it('should collapse an expanded node on click', async () => {
+        const items = await page.getTopLevelItems();
+
+        await page.selectItem(items[1]);
+
+        // get the visible children
+        expect((await page.getItemChildren(items[0])).length).toBe(0);
+        expect((await page.getItemChildren(items[1])).length).toBe(2);
+        expect((await page.getItemChildren(items[2])).length).toBe(0);
+
+        await page.selectItem(items[1]);
+
+        // get the visible children
+        expect((await page.getItemChildren(items[0])).length).toBe(0);
+        expect((await page.getItemChildren(items[1])).length).toBe(0);
+        expect((await page.getItemChildren(items[2])).length).toBe(0);
+    });
+
+    it('should not collapse other items when autoCollapse is false', async () => {
+        const items = await page.getTopLevelItems();
+        await page.selectItem(items[1]);
+
+        // get the visible children
+        expect((await page.getItemChildren(items[0])).length).toBe(0);
+        expect((await page.getItemChildren(items[1])).length).toBe(2);
+        expect((await page.getItemChildren(items[2])).length).toBe(0);
+
+        await page.selectItem(items[2]);
+
+        // get the visible children
+        expect((await page.getItemChildren(items[0])).length).toBe(0);
+        expect((await page.getItemChildren(items[1])).length).toBe(2);
+        expect((await page.getItemChildren(items[2])).length).toBe(2);
+    });
+
+    it('should collapse other items when autoCollapse is true', async () => {
+        const items = await page.getTopLevelItems();
+        await page.selectItem(items[1]);
+
+        // get the visible children
+        expect((await page.getItemChildren(items[0])).length).toBe(0);
+        expect((await page.getItemChildren(items[1])).length).toBe(2);
+        expect((await page.getItemChildren(items[2])).length).toBe(0);
+
+        // enable auto collapse
+        await page.enableAutoCollapse.click();
+
+        await page.selectItem(items[2]);
+
+        // get the visible children
+        expect((await page.getItemChildren(items[0])).length).toBe(0);
+        expect((await page.getItemChildren(items[1])).length).toBe(0);
+        expect((await page.getItemChildren(items[2])).length).toBe(2);
+    });
+
+    it('should select parent and child when exact is false', async () => {
+        await page.disableExact.click();
+        const items = await page.getTopLevelItems();
+        await page.selectItem(items[2]);
+
+        const children = await page.getItemChildren(items[2]);
+        await page.selectItem(children[0]);
+
+        expect(await page.isItemActive(items[0])).toBeFalsy();
+        expect(await page.isItemActive(items[1])).toBeFalsy();
+        expect(await page.isItemActive(items[2])).toBeTruthy();
+
+        expect(await page.isItemActive(children[0])).toBeTruthy();
+        expect(await page.isItemActive(children[1])).toBeFalsy();
+
+        // expect the page content to be correct
+        expect(await page.getPageContent()).toBe('Accounts Add');
+    });
+
+    it('should update the UI when tree mode is enabled', async () => {
+        expect(await page.isTreeModeActive()).toBeFalsy();
+        await page.enableTreeBtn.click();
+        expect(await page.isTreeModeActive()).toBeTruthy();
+    });
+
+    it('should not activate item when queryParams are set', async () => {
+        await browser.get('#/navigation/products/add?search=phone');
+
+        const items = await page.getTopLevelItems();
+
+        // none of these items should be selected
+        expect(await page.isItemActive(items[0])).toBeFalsy();
+        expect(await page.isItemActive(items[1])).toBeFalsy();
+        expect(await page.isItemActive(items[2])).toBeFalsy();
+
+        // all items should be collapsed
+        expect((await page.getItemChildren(items[0])).length).toBe(0);
+        expect((await page.getItemChildren(items[1])).length).toBe(0);
+        expect((await page.getItemChildren(items[2])).length).toBe(0);
+    });
+
+    it('should activate item when queryParams are set and ignoreQueryParams is set', async () => {
+        await browser.get('#/navigation/products/remove?search=phone');
+
+        const items = await page.getTopLevelItems();
+
+        // none of these items should be selected
+        expect(await page.isItemActive(items[0])).toBeFalsy();
+        expect(await page.isItemActive(items[1])).toBeTruthy();
+        expect(await page.isItemActive(items[2])).toBeFalsy();
+
+        // all items should be collapsed
+        expect((await page.getItemChildren(items[0])).length).toBe(0);
+        expect((await page.getItemChildren(items[1])).length).toBe(2);
+        expect((await page.getItemChildren(items[2])).length).toBe(0);
+
+        const children = await page.getItemChildren(items[1]);
+
+        // none of these items should be selected
+        expect(await page.isItemActive(children[0])).toBeFalsy();
+        expect(await page.isItemActive(children[1])).toBeTruthy();
+    });
+});

--- a/e2e/tests/components/navigation/navigation.e2e-spec.ts
+++ b/e2e/tests/components/navigation/navigation.e2e-spec.ts
@@ -231,10 +231,10 @@ describe('Number Picker Tests', () => {
 
         // none of these items should be selected
         expect(await page.isItemActive(items[0])).toBeFalsy();
-        expect(await page.isItemActive(items[1])).toBeTruthy();
+        expect(await page.isItemActive(items[1])).toBeFalsy();
         expect(await page.isItemActive(items[2])).toBeFalsy();
 
-        // all items should be collapsed
+        // the second item should be collapsed
         expect((await page.getItemChildren(items[0])).length).toBe(0);
         expect((await page.getItemChildren(items[1])).length).toBe(2);
         expect((await page.getItemChildren(items[2])).length).toBe(0);

--- a/e2e/tests/components/navigation/navigation.e2e-spec.ts
+++ b/e2e/tests/components/navigation/navigation.e2e-spec.ts
@@ -1,7 +1,7 @@
 import { browser } from 'protractor';
 import { NavigationPage } from './navigation.po.spec';
 
-describe('Number Picker Tests', () => {
+describe('Navigation Tests', () => {
 
     let page: NavigationPage;
 

--- a/e2e/tests/components/navigation/navigation.po.spec.ts
+++ b/e2e/tests/components/navigation/navigation.po.spec.ts
@@ -1,0 +1,42 @@
+import { $, browser, ElementFinder } from 'protractor';
+
+export class NavigationPage {
+
+    navigation = $('ux-navigation');
+    pageContent = $('#page-content');
+    enableTreeBtn = $('#enable-tree-btn');
+    enableAutoCollapse = $('#enable-auto-collapse-btn');
+    disableExact = $('#disable-exact');
+
+    getPage(): void {
+        browser.get('#/navigation');
+    }
+
+    async getTopLevelItems(): Promise<ElementFinder[]> {
+        return await this.navigation.$$('.ux-side-nav > .nav > li');
+    }
+
+    async isItemActive(item: ElementFinder): Promise<boolean> {
+        const classes = await item.getAttribute('class');
+
+        return classes.split(' ').indexOf('active') !== -1;
+    }
+
+    async getItemChildren(item: ElementFinder): Promise<ElementFinder[]> {
+        return item.$$('ol > li');
+    }
+
+    async getPageContent(): Promise<string> {
+        return await this.pageContent.getText();
+    }
+
+    async selectItem(item: ElementFinder): Promise<void> {
+        await item.$(item.locator().value + ' > a').click();
+    }
+
+    async isTreeModeActive(): Promise<boolean> {
+        const classes = await this.navigation.$('.ux-side-nav').getAttribute('class');
+        return classes.split(' ').indexOf('tree') !== -1;
+    }
+}
+

--- a/src/components/navigation/index.ts
+++ b/src/components/navigation/index.ts
@@ -1,7 +1,7 @@
 export * from './navigation-item.inferface';
 export * from './navigation-item/navigation-item.component';
 export * from './navigation-link/navigation-link.directive';
+export * from './navigation-options';
 export * from './navigation.component';
 export * from './navigation.module';
 export * from './navigation.service';
-

--- a/src/components/navigation/navigation-item.inferface.ts
+++ b/src/components/navigation/navigation-item.inferface.ts
@@ -7,7 +7,13 @@ export interface NavigationItem {
     iconLabel?: string;
     routerLink?: string | any[];
     routerExtras?: NavigationExtras;
+    routerOptions?: NavigationItemRouterOptions;
     click?: (event: Event, navigationItem: NavigationItem) => void;
     expanded?: boolean;
     children?: NavigationItem[];
+}
+
+export interface NavigationItemRouterOptions {
+    exact?: boolean;
+    ignoreQueryParams?: boolean;
 }

--- a/src/components/navigation/navigation-item/navigation-item.component.html
+++ b/src/components/navigation/navigation-item/navigation-item.component.html
@@ -1,7 +1,15 @@
-<a *ngIf="link" [class.has-arrow]="children.length > 0" [class.no-arrow]="indentWithoutArrow" [routerLink]="link">
-    <span>{{header}}</span>
+<a *ngIf="link"
+   [class.has-arrow]="children.length > 0"
+   [class.no-arrow]="_indentWithoutArrow"
+   [routerLink]="link">
+    <span>{{ header }}</span>
 </a>
-<a *ngIf="!link" (click)="expanded = !expanded" [class.has-arrow]="children.length > 0" [class.no-arrow]="indentWithoutArrow">
-    <span>{{header}}</span>
+
+<a *ngIf="!link"
+   (click)="expanded = !expanded"
+   [class.has-arrow]="children.length > 0"
+   [class.no-arrow]="_indentWithoutArrow">
+    <span>{{ header }}</span>
 </a>
+
 <ng-content></ng-content>

--- a/src/components/navigation/navigation-link/navigation-link.directive.ts
+++ b/src/components/navigation/navigation-link/navigation-link.directive.ts
@@ -1,10 +1,11 @@
 import { LocationStrategy } from '@angular/common';
-import { ChangeDetectorRef, Directive, HostBinding, HostListener, Input, OnChanges, OnDestroy, OnInit } from '@angular/core';
+import { ChangeDetectorRef, Directive, HostBinding, HostListener, Inject, Input, OnChanges, OnDestroy, OnInit, Optional } from '@angular/core';
 import { ActivatedRoute, NavigationEnd, Router } from '@angular/router';
 import { filter, takeUntil } from 'rxjs/operators';
 import { Subject } from 'rxjs/Subject';
 import { tick } from '../../../common/index';
 import { NavigationItem, NavigationItemRouterOptions } from '../navigation-item.inferface';
+import { NavigationModuleOptions, NAVIGATION_MODULE_OPTIONS } from '../navigation-options';
 import { NavigationService } from '../navigation.service';
 
 @Directive({
@@ -48,7 +49,12 @@ export class NavigationLinkDirective implements OnInit, OnChanges, OnDestroy {
 
     /** Get the router options with defaults for missing properties */
     private get _routerOptions(): NavigationItemRouterOptions {
-        return { ...{ exact: true, ignoreQueryParams: false }, ...this.navigationItem.routerOptions };
+
+        // get the default options based on the ones provided in `forRoot`
+        const defaultOptions = { exact: true, ignoreQueryParams: false, ...(this._options ? this._options.routerOptions : {}) };
+
+        // if there are item specific router options they should take precendence
+        return { ...defaultOptions, ...this.navigationItem.routerOptions };
     }
 
     constructor(
@@ -56,7 +62,8 @@ export class NavigationLinkDirective implements OnInit, OnChanges, OnDestroy {
         private _locationStrategy: LocationStrategy,
         private _navigationService: NavigationService,
         private _changeDetector: ChangeDetectorRef,
-        private _route: ActivatedRoute
+        private _route: ActivatedRoute,
+        @Optional() @Inject(NAVIGATION_MODULE_OPTIONS) private _options: NavigationModuleOptions
     ) { }
 
     ngOnInit(): void {

--- a/src/components/navigation/navigation-link/navigation-link.directive.ts
+++ b/src/components/navigation/navigation-link/navigation-link.directive.ts
@@ -1,10 +1,10 @@
 import { LocationStrategy } from '@angular/common';
-import { Directive, HostBinding, HostListener, Input, OnChanges, OnDestroy, OnInit } from '@angular/core';
-import { NavigationEnd, Router } from '@angular/router';
+import { ChangeDetectorRef, Directive, HostBinding, HostListener, Input, OnChanges, OnDestroy, OnInit } from '@angular/core';
+import { ActivatedRoute, NavigationEnd, Router } from '@angular/router';
 import { filter, takeUntil } from 'rxjs/operators';
 import { Subject } from 'rxjs/Subject';
 import { tick } from '../../../common/index';
-import { NavigationItem } from '../navigation-item.inferface';
+import { NavigationItem, NavigationItemRouterOptions } from '../navigation-item.inferface';
 import { NavigationService } from '../navigation.service';
 
 @Directive({
@@ -13,46 +13,59 @@ import { NavigationService } from '../navigation.service';
 })
 export class NavigationLinkDirective implements OnInit, OnChanges, OnDestroy {
 
-    @Input()
-    navigationItem: NavigationItem;
+    /** The NavigationItem this element represents */
+    @Input() navigationItem: NavigationItem;
 
-    @Input()
-    set expanded(value: boolean) {
-        this._expanded$.next(value);
-    }
+    /** The expaned state of this item */
+    @Input() set expanded(value: boolean) { this._expanded$.next(value); }
 
-    @Input()
-    canExpand: boolean;
+    /** Determine if this item can be expanded */
+    @Input() canExpand: boolean;
 
-    @Input()
-    @HostBinding('class.indent')
-    indent: boolean;
+    /** Determine if this item should be indented */
+    @Input() @HostBinding('class.indent') indent: boolean;
 
-    @HostBinding('attr.href')
-    href: string;
+    /** Determine the href of this element */
+    @HostBinding('attr.href') href: string;
 
-    @HostBinding('attr.role')
-    role: string;
+    /** Determine the role of this element */
+    @HostBinding('attr.role') role: string;
 
-    @HostBinding('attr.aria-expanded')
-    ariaExpanded: string = 'undefined';
+    /** Update the aria-expanded attribute of this element */
+    @HostBinding('attr.aria-expanded') ariaExpanded: string;
 
+    /** Store the active state of the item */
     isActive: boolean;
 
+    /** Store the indendation state of the children */
     indentChildren: boolean;
 
+    /** Emit with the current expaned state */
     private _expanded$ = new Subject<boolean>();
+
+    /** Unsubscribe from all observables when this directive is destroyed */
     private _onDestroy = new Subject<void>();
+
+    /** Get the router options with defaults for missing properties */
+    private get _routerOptions(): NavigationItemRouterOptions {
+        return { ...{ exact: true, ignoreQueryParams: false }, ...this.navigationItem.routerOptions };
+    }
 
     constructor(
         private _router: Router,
         private _locationStrategy: LocationStrategy,
-        private _navigationService: NavigationService
+        private _navigationService: NavigationService,
+        private _changeDetector: ChangeDetectorRef,
+        private _route: ActivatedRoute
     ) { }
 
     ngOnInit(): void {
 
-        this._expanded$.pipe(takeUntil(this._onDestroy), tick()).subscribe(expanded => {
+        // any time expanded state anywhere change we should run change detection in case we should collapse
+        this._navigationService.expanded$.pipe(takeUntil(this._onDestroy))
+            .subscribe(() => this._changeDetector.markForCheck());
+
+        this._expanded$.pipe(tick(), takeUntil(this._onDestroy)).subscribe(expanded => {
             if (this.navigationItem.children && this.navigationItem.children.length > 0) {
                 this.ariaExpanded = `${expanded}`;
                 this._navigationService.setExpanded(this.navigationItem, expanded);
@@ -106,6 +119,8 @@ export class NavigationLinkDirective implements OnInit, OnChanges, OnDestroy {
                 this.navigationItem.expanded = true;
             }
         }
+
+        this._changeDetector.markForCheck();
     }
 
     private updateAttributes(): void {
@@ -129,10 +144,25 @@ export class NavigationLinkDirective implements OnInit, OnChanges, OnDestroy {
 
     private isActiveItem(item: NavigationItem): boolean {
 
+        const { exact, ignoreQueryParams } = this._routerOptions;
+
         if (item.routerLink) {
+
+            let routerExtras = item.routerExtras;
+
+            // if we are to ignore the query params we must remove them
+            if (routerExtras && ignoreQueryParams) {
+                // get the current actual query params
+                const { queryParams } = this._route.snapshot;
+
+                // override the provided query params with the actual query params so they will alway match
+                routerExtras = { ...routerExtras, queryParams };
+            }
+
             const commands = Array.isArray(item.routerLink) ? item.routerLink : [item.routerLink];
-            const urlTree = this._router.createUrlTree(commands, item.routerExtras);
-            return this._router.isActive(urlTree, true);
+            const urlTree = this._router.createUrlTree(commands, routerExtras);
+
+            return this._router.isActive(urlTree, exact);
         }
 
         return false;

--- a/src/components/navigation/navigation-options.ts
+++ b/src/components/navigation/navigation-options.ts
@@ -1,0 +1,8 @@
+import { InjectionToken } from '@angular/core';
+import { NavigationItemRouterOptions } from './navigation-item.inferface';
+
+export interface NavigationModuleOptions {
+    routerOptions: NavigationItemRouterOptions;
+}
+
+export const NAVIGATION_MODULE_OPTIONS = new InjectionToken('NAVIGATION_MODULE_OPTIONS');

--- a/src/components/navigation/navigation.component.html
+++ b/src/components/navigation/navigation.component.html
@@ -19,14 +19,14 @@
                     #tli="ux-tabbable-list-item"
                     [navigationItem]="item"
                     [expanded]="item.expanded"
-                    [canExpand]="level < depthLimit"
+                    [canExpand]="level < _depthLimit"
                     [indent]="indent"
                     uxTabbableListItem
                     [parent]="parent"
                     [rank]="rank"
                     [(expanded)]="item.expanded">
 
-                    <span *ngIf="!navigationItemTemplate && item.children && item.children.length > 0 && level < depthLimit"
+                    <span *ngIf="!navigationItemTemplate && item.children && item.children.length > 0 && level < _depthLimit"
                           aria-hidden="true"
                           class="nav-expander"
                           (click)="item.expanded = !item.expanded; $event.stopPropagation(); $event.preventDefault()">
@@ -42,7 +42,7 @@
 
                 </a>
 
-                <ol *ngIf="item.children && item.expanded && level < depthLimit"
+                <ol *ngIf="item.children && item.expanded && level < _depthLimit"
                     role="group"
                     class="nav"
                     [ngClass]="_hierarchyClasses[level]">

--- a/src/components/navigation/navigation.component.html
+++ b/src/components/navigation/navigation.component.html
@@ -4,7 +4,7 @@
 
         <ng-container *ngFor="let item of items; let rank = index"
             [ngTemplateOutlet]="navigationNode"
-            [ngTemplateOutletContext]="{item: item, level: 1, rank: rank, indent: needsIndent(items)}">
+            [ngTemplateOutletContext]="{ item: item, level: 1, rank: rank, indent: _needsIndent(items) }">
         </ng-container>
 
         <ng-template #navigationNode let-item="item" let-parent="parent" let-level="level" let-rank="rank" let-indent="indent">
@@ -16,37 +16,40 @@
 
                 <a uxNavigationLink
                     #navigationLink="uxNavigationLink"
+                    #tli="ux-tabbable-list-item"
                     [navigationItem]="item"
                     [expanded]="item.expanded"
                     [canExpand]="level < depthLimit"
                     [indent]="indent"
                     uxTabbableListItem
-                    #tli="ux-tabbable-list-item"
                     [parent]="parent"
                     [rank]="rank"
                     [(expanded)]="item.expanded">
 
                     <span *ngIf="!navigationItemTemplate && item.children && item.children.length > 0 && level < depthLimit"
-                        aria-hidden="true"
-                        class="nav-expander"
-                        (click)="item.expanded = !item.expanded; $event.stopPropagation(); $event.preventDefault()">
+                          aria-hidden="true"
+                          class="nav-expander"
+                          (click)="item.expanded = !item.expanded; $event.stopPropagation(); $event.preventDefault()">
                     </span>
                     <span *ngIf="!navigationItemTemplate && item.icon && !tree" class="nav-icon hpe-icon" [ngClass]="item.icon"></span>
                     <img *ngIf="!navigationItemTemplate && item.iconUrl && !tree" class="nav-icon" [src]="item.iconUrl" alt="item.iconLabel">
-                    <span *ngIf="!navigationItemTemplate" class="nav-title">{{item.title}}</span>
+                    <span *ngIf="!navigationItemTemplate" class="nav-title">{{ item.title }}</span>
 
-                    <ng-container [ngTemplateOutlet]="navigationItemTemplate"
-                        [ngTemplateOutletContext]="{item: item, level: level}">
+                    <ng-container
+                        [ngTemplateOutlet]="navigationItemTemplate"
+                        [ngTemplateOutletContext]="{ item: item, level: level }">
                     </ng-container>
 
                 </a>
 
                 <ol *ngIf="item.children && item.expanded && level < depthLimit"
-                    role="group" class="nav" [ngClass]="hierarchyClasses[level]">
+                    role="group"
+                    class="nav"
+                    [ngClass]="_hierarchyClasses[level]">
 
                     <ng-container *ngFor="let child of item.children; let rank = index"
                         [ngTemplateOutlet]="navigationNode"
-                        [ngTemplateOutletContext]="{item: child, parent: tli, level: level + 1, rank: rank, indent: navigationLink.indentChildren}">
+                        [ngTemplateOutletContext]="{ item: child, parent: tli, level: level + 1, rank: rank, indent: navigationLink.indentChildren }">
                     </ng-container>
 
                 </ol>

--- a/src/components/navigation/navigation.component.ts
+++ b/src/components/navigation/navigation.component.ts
@@ -40,7 +40,7 @@ export class NavigationComponent {
         'nav-fifth-level',
     ];
 
-    get depthLimit(): number {
+    get _depthLimit(): number {
         return this.tree ? this._hierarchyClasses.length : 2;
     }
 

--- a/src/components/navigation/navigation.component.ts
+++ b/src/components/navigation/navigation.component.ts
@@ -1,11 +1,12 @@
-import { Component, ContentChild, Input, TemplateRef } from '@angular/core';
+import { ChangeDetectionStrategy, Component, ContentChild, Input, TemplateRef } from '@angular/core';
 import { NavigationItem } from './navigation-item.inferface';
 import { NavigationService } from './navigation.service';
 
 @Component({
     selector: 'ux-navigation',
     templateUrl: './navigation.component.html',
-    providers: [NavigationService]
+    providers: [NavigationService],
+    changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class NavigationComponent {
 
@@ -19,8 +20,7 @@ export class NavigationComponent {
     }
 
     /** Whether to present the menu as a hierarchical tree. */
-    @Input()
-    tree: boolean = true;
+    @Input() tree: boolean = true;
 
     /** Whether to collapse other menu items when expanding a menu item. */
     @Input()
@@ -28,10 +28,11 @@ export class NavigationComponent {
         this._navigationService.autoCollapse = autoCollapse;
     }
 
-    @ContentChild('uxNavigationItem')
-    navigationItemTemplate: TemplateRef<any>;
+    /** Access a custom navigation item template if provided */
+    @ContentChild('uxNavigationItem') navigationItemTemplate: TemplateRef<any>;
 
-    hierarchyClasses = [
+    /** The classes to be added to each different level */
+    _hierarchyClasses = [
         '',
         'nav-second-level',
         'nav-third-level',
@@ -40,26 +41,15 @@ export class NavigationComponent {
     ];
 
     get depthLimit(): number {
-        return this.tree ? this.hierarchyClasses.length : 2;
+        return this.tree ? this._hierarchyClasses.length : 2;
     }
 
     constructor(private _navigationService: NavigationService) { }
 
-    itemClick(item: NavigationItem, event: Event): void {
-
-        // Toggle expanded state (relevant only if it has children)
-        item.expanded = !item.expanded;
-
-        // Invoke the custom click handler if specified
-        if (item.click) {
-            item.click(event, item);
-        }
-    }
-
     /**
      * Returns true if the sets of items needs to be indented to make room for one or more expander.
      */
-    needsIndent(items: NavigationItem[]): boolean {
+    _needsIndent(items: NavigationItem[]): boolean {
         return items && items.some(item => item.children && item.children.length > 0);
     }
 }

--- a/src/components/navigation/navigation.module.ts
+++ b/src/components/navigation/navigation.module.ts
@@ -1,9 +1,10 @@
 import { CommonModule } from '@angular/common';
-import { NgModule } from '@angular/core';
+import { ModuleWithProviders, NgModule } from '@angular/core';
 import { RouterModule } from '@angular/router';
 import { AccessibilityModule } from '../../directives/accessibility/index';
 import { NavigationItemComponent } from './navigation-item/navigation-item.component';
 import { NavigationLinkDirective } from './navigation-link/navigation-link.directive';
+import { NavigationModuleOptions, NAVIGATION_MODULE_OPTIONS } from './navigation-options';
 import { NavigationComponent } from './navigation.component';
 
 @NgModule({
@@ -22,4 +23,15 @@ import { NavigationComponent } from './navigation.component';
         NavigationLinkDirective
     ]
 })
-export class NavigationModule { }
+export class NavigationModule {
+
+    // allow options to be specified globally
+    static forRoot(options: NavigationModuleOptions): ModuleWithProviders {
+        return {
+            ngModule: NavigationModule,
+            providers: [
+                { provide: NAVIGATION_MODULE_OPTIONS, useValue: options }
+            ]
+        };
+    }
+}

--- a/src/components/navigation/navigation.service.ts
+++ b/src/components/navigation/navigation.service.ts
@@ -1,21 +1,34 @@
-import { Injectable } from '@angular/core';
+import { Injectable, OnDestroy } from '@angular/core';
+import { Subject } from 'rxjs/Subject';
 import { NavigationItem } from './navigation-item.inferface';
 
 @Injectable()
-export class NavigationService {
+export class NavigationService implements OnDestroy {
 
+    /** The navigation items to populate the menu with */
     items: NavigationItem[];
 
+    /** Whether to collapse other menu items when expanding a menu item. */
     autoCollapse: boolean = true;
 
+    /** Emit when the expanded state has changed */
+    expanded$ = new Subject<void>();
+
+    ngOnDestroy(): void {
+        this.expanded$.complete();
+    }
+
+    /** Set the expanded state of an item */
     setExpanded(source: NavigationItem, expanded: boolean): void {
         if (expanded && this.autoCollapse) {
             this.collapseSiblings(source);
+            this.expanded$.next();
         }
     }
 
     private collapseSiblings(source: NavigationItem): void {
         let siblings = this.items;
+
         for (let item of this.items) {
             const parent = this.getParent(source, item);
             if (parent) {
@@ -24,31 +37,18 @@ export class NavigationService {
             }
         }
 
-        for (let item of siblings) {
-            if (item !== source) {
-                this.collapseAll(item);
-            }
-        }
+        // collapse every sibling
+        siblings.filter(item => item !== source).forEach(item => this.collapseAll(item));
     }
 
     private collapseAll(item: NavigationItem): void {
         item.expanded = false;
         if (item.children) {
-            for (let child of item.children) {
-                this.collapseAll(child);
-            }
+            item.children.forEach(child => this.collapseAll(child));
         }
     }
 
     private getParent(target: NavigationItem, item: NavigationItem): NavigationItem {
-        if (item.children) {
-            for (let child of item.children) {
-                if (child === target) {
-                    return item;
-                }
-            }
-        }
-
-        return null;
+        return (item.children || []).find(child => child === target) ? item : null;
     }
 }

--- a/src/components/navigation/navigation.service.ts
+++ b/src/components/navigation/navigation.service.ts
@@ -26,6 +26,7 @@ export class NavigationService implements OnDestroy {
         }
     }
 
+    /** Collapse all siblings nodes */
     private collapseSiblings(source: NavigationItem): void {
         let siblings = this.items;
 
@@ -41,6 +42,7 @@ export class NavigationService implements OnDestroy {
         siblings.filter(item => item !== source).forEach(item => this.collapseAll(item));
     }
 
+    /** Collapse an item and all its children */
     private collapseAll(item: NavigationItem): void {
         item.expanded = false;
         if (item.children) {
@@ -48,7 +50,8 @@ export class NavigationService implements OnDestroy {
         }
     }
 
-    private getParent(target: NavigationItem, item: NavigationItem): NavigationItem {
+    /** Get a nodes parent if it has one */
+    private getParent(target: NavigationItem, item: NavigationItem): NavigationItem | null {
         return (item.children || []).find(child => child === target) ? item : null;
     }
 }


### PR DESCRIPTION
**NavigationItem Interface**
- Added new `routerOptions` property to the interface to contain all router related configuration as we may want to add more options over time. I did not want to use the existing `routerExtras` property as this maps directly to the Angular `routerExtras` properties used by `routerLink`. It also allows use to share the interface with the global config as mentioned below.
- Added option to specify the `exact` property (defaults to true to retain existing functionality)
- Added option to `ignoreQueryParams` (defaults to false to retain existing functionality)

**Navigation Module**
- Added a `forRoot` option to the module. This will allow the `exact` and `ignoreQueryParams` (and any others that we may add in future) to be specified on a global level rather than having to add these properties to ever item in the menu. If a menu item has these properties they will take precedence over the global options.

**Navigation Components**
- Updated to use `OnPush` change detection for better performance
- Did some refactoring and general tidying up, eg. removing `itemClick` function as it is not used anymore.

**Tests**
- Added protractor tests

**Documentation**
- This component is only documented in the Micro Focus documentation site so no changes required

#### Ticket
https://portal.digitalsafe.net/browse/EL-3269

#### Documentation CI URL
https://pages.github.houston.softwaregrp.net/sepg-docs-qa/UXAspects_CI_UXAspects_EL-3269-Side-Menu-Route-Options
