### PR TITLE
EL-3513 - Calendar Drag Enhancement

### DIFF
--- a/src/directives/drag/drag.service.ts
+++ b/src/directives/drag/drag.service.ts
@@ -2,16 +2,16 @@ import { Injectable, OnDestroy } from '@angular/core';
 import { Subject } from 'rxjs/Subject';
 
 @Injectable()
-export class DragService implements OnDestroy {
+export class DragService<T = any> implements OnDestroy {
 
     /** Emit when dragging begins */
-    onDragStart = new Subject<UxDragEvent>();
+    onDragStart = new Subject<UxDragEvent<T>>();
 
     /** Emit when dragging moves */
-    onDrag = new Subject<UxDragEvent>();
+    onDrag = new Subject<UxDragEvent<T>>();
 
     /** Emit when dragging ends */
-    onDragEnd = new Subject<UxDragEvent>();
+    onDragEnd = new Subject<UxDragEvent<T>>();
 
     /** Emit when the user is dragging over the drop area */
     onDropEnter = new Subject<void>();
@@ -20,7 +20,7 @@ export class DragService implements OnDestroy {
     onDropLeave = new Subject<void>();
 
     /** Emit when a drop occurs */
-    onDrop = new Subject<any>();
+    onDrop = new Subject<T>();
 
     /** Destroy all observables */
     ngOnDestroy(): void {
@@ -34,4 +34,4 @@ export class DragService implements OnDestroy {
 
 }
 
-export type UxDragEvent = { group?: string, event?: MouseEvent, data?: any };
+export type UxDragEvent<T = any> = { group?: string, event?: MouseEvent, data?: T };

--- a/src/directives/drag/drop.directive.ts
+++ b/src/directives/drag/drop.directive.ts
@@ -9,13 +9,13 @@ import { DragService, UxDragEvent } from './drag.service';
         '[class.ux-drop-hover]': 'isMouseOver && isDragging'
     }
 })
-export class DropDirective implements OnDestroy {
+export class DropDirective<T = any> implements OnDestroy {
 
     /** Define a specific group of dragged items to listen to */
     @Input() group: string | string[];
 
     /** Emit the model of the item dropped */
-    @Output() onDrop = new EventEmitter<any>();
+    @Output() onDrop = new EventEmitter<T>();
 
     /** Determine whether or not the mouse is within the drop region */
     isMouseOver: boolean = false;
@@ -29,10 +29,13 @@ export class DropDirective implements OnDestroy {
     /** Ensure we destroy all subscriptions */
     private _onDestroy = new Subject<void>();
 
-    constructor(private _dragService: DragService) {
+    constructor(private _dragService: DragService<T>) {
         // subscribe to drag events
-        _dragService.onDragStart.pipe(takeUntil(this._onDestroy), filter(event => this.isGroupAllowed(event.group))).subscribe(this.onDragStart.bind(this));
-        _dragService.onDragEnd.pipe(takeUntil(this._onDestroy), filter(event => this.isGroupAllowed(event.group))).subscribe(this.onDragEnd.bind(this));
+        _dragService.onDragStart.pipe(filter(event => this.isGroupAllowed(event.group)), takeUntil(this._onDestroy))
+            .subscribe(this.onDragStart.bind(this));
+
+        _dragService.onDragEnd.pipe(filter(event => this.isGroupAllowed(event.group)), takeUntil(this._onDestroy))
+            .subscribe(this.onDragEnd.bind(this));
     }
 
     ngOnDestroy(): void {
@@ -65,13 +68,13 @@ export class DropDirective implements OnDestroy {
     }
 
     /** Update the dragging state */
-    onDragStart(event: UxDragEvent): void {
+    onDragStart(event: UxDragEvent<T>): void {
         this.isDragging = true;
         this._group = event.group;
     }
 
     /** Update the dragging state */
-    onDragEnd(event: UxDragEvent): void {
+    onDragEnd(event: UxDragEvent<T>): void {
 
         // update the dragging state
         this.isDragging = false;


### PR DESCRIPTION
- Updated the drag directives and service to use a generic rather than `any` to provide better type inference.
- Moved the `takeUntil` operators to the end of the `pipe` (after watching ng-conf yesterday it this was mentioned that this way of unsubscribing should come at the end to prevent certain edge cases where order is important)
- Updated the `dragEnd` `filter` operator to check if the model is the same instead of solely relying on `_isDragging`. This is because in the calendar when calendar items are rendered using an `ngFor` it can create a new instance of the directive so `isDragging` may be false simply because a new instance was created. The model is persisted across instances so we can alternatively compare against that.
- The `dragEnd` event is now a separate subscription. Previously it was emitted in the `complete` callback of the `drag` observable. The issue is, in the `ngFor` case where a new instance is created, the `_onDestroy` observable emits which triggers the `complete` callback when dragging is still occurring.

#### Ticket
https://portal.digitalsafe.net/browse/EL-3513

#### Documentation CI URL
https://pages.github.houston.softwaregrp.net/sepg-docs-qa/UXAspects_CI_UXAspects_EL-3513-Calendar-Drag-Enhancement
