### PR TITLE
EL-3454 - Date Range Picker Fixes

### DIFF
--- a/docs/app/pages/components/components-sections/date-time-picker/date-range-picker/date-range-picker.component.html
+++ b/docs/app/pages/components/components-sections/date-time-picker/date-range-picker/date-range-picker.component.html
@@ -17,7 +17,7 @@
                     (ngModelChange)="onDateChange($event)"
                     [uxPopover]="popoverTemplate"
                     placement="bottom"
-                    popoverClass="date-range-picker-popover"
+                    [popoverClass]="showNowBtn ? 'date-range-picker-now-btn-popover' : 'date-range-picker-popover'"
                     class="form-control"
                     aria-label="Selected date"
                     (keydown.enter)="popover.show()">

--- a/docs/app/pages/components/components-sections/date-time-picker/date-range-picker/date-range-picker.component.less
+++ b/docs/app/pages/components/components-sections/date-time-picker/date-range-picker/date-range-picker.component.less
@@ -1,7 +1,16 @@
-.date-range-picker-popover {
+.date-range-picker-popover,
+.date-range-picker-now-btn-popover {
     max-width: none;
+}
 
+.date-range-picker-popover {
     .popover-content {
         padding: 4px 24px 24px;
+    }
+}
+
+.date-range-picker-now-btn-popover {
+    .popover-content {
+        padding: 4px 24px 0;
     }
 }

--- a/docs/app/pages/components/components-sections/date-time-picker/date-range-picker/snippets/app.css
+++ b/docs/app/pages/components/components-sections/date-time-picker/date-range-picker/snippets/app.css
@@ -1,7 +1,12 @@
-.date-range-picker-popover {
+.date-range-picker-popover,
+.date-range-picker-now-btn-popover {
     max-width: none;
 }
 
 .date-range-picker-popover .popover-content {
     padding: 4px 24px 24px;
+}
+
+.date-range-picker-now-btn-popover .popover-content {
+    padding: 4px 24px 0;
 }

--- a/docs/app/pages/components/components-sections/date-time-picker/date-range-picker/snippets/app.html
+++ b/docs/app/pages/components/components-sections/date-time-picker/date-range-picker/snippets/app.html
@@ -20,7 +20,8 @@
                     (ngModelChange)="onDateChange($event)"
                     [uxPopover]="popoverTemplate"
                     placement="bottom"
-                    popoverClass="date-range-picker-popover"
+                    [popoverClass]="showNowBtn ? 'date-range-picker-now-btn-popover' :
+                    'date-range-picker-popover'"
                     class="form-control"
                     aria-label="Selected date"
                     (keydown.enter)="popover.show()">

--- a/e2e/pages/app/date-range-picker/date-range-picker.testpage.component.html
+++ b/e2e/pages/app/date-range-picker/date-range-picker.testpage.component.html
@@ -22,3 +22,6 @@
     (endTimezoneChange)="onTimezoneChange(false, $event)">
 </ux-date-range-picker>
 
+<br>
+
+<button id="clear-btn" class="btn button-secondary" (click)="clear()">Clear</button>

--- a/e2e/pages/app/date-range-picker/date-range-picker.testpage.component.ts
+++ b/e2e/pages/app/date-range-picker/date-range-picker.testpage.component.ts
@@ -1,6 +1,6 @@
 import { formatDate } from '@angular/common';
 import { Component } from '@angular/core';
-import { DateTimePickerTimezone } from '@ux-aspects/ux-aspects';
+import { DateTimePickerTimezone, timezones } from '@ux-aspects/ux-aspects';
 
 @Component({
     selector: 'app-date-range-picker',
@@ -39,8 +39,8 @@ export class DateRangePickerTestPageComponent {
     showNowBtn: boolean = false;
 
     /** Store the currently selected timezones */
-    private _startTimezone: DateTimePickerTimezone = { name: 'GMT', offset: 0 };
-    private _endTimezone: DateTimePickerTimezone = { name: 'GMT', offset: 0 };
+    private _startTimezone: DateTimePickerTimezone = this.getCurrentTimezone();
+    private _endTimezone: DateTimePickerTimezone = this.getCurrentTimezone();
 
     /** Parse a date string when the input changes */
     onDateChange(date: string): void {
@@ -103,10 +103,21 @@ export class DateRangePickerTestPageComponent {
         this.onRangeChange();
     }
 
+    clear(): void {
+        this.start = null;
+        this.end = null;
+        this.date = null;
+        this.onRangeChange();
+    }
+
     /** Account for the timezone offset */
     private getNormalizedDate(date: Date, timezone: DateTimePickerTimezone): Date {
         const normalizedDate = new Date(date);
         normalizedDate.setMinutes(normalizedDate.getMinutes() + timezone.offset);
         return normalizedDate;
+    }
+
+    private getCurrentTimezone(): DateTimePickerTimezone {
+        return { ...timezones.find(timezone => timezone.offset === new Date().getTimezoneOffset()) };
     }
 }

--- a/e2e/tests/components/date-range-picker/date-range-picker.po.spec.ts
+++ b/e2e/tests/components/date-range-picker/date-range-picker.po.spec.ts
@@ -4,6 +4,7 @@ export class DateRangePickerPage {
 
     input = $('#date-range-input');
     dateRangePicker = $('ux-date-range-picker');
+    clearBtn = $('#clear-btn');
 
     async getPage(): Promise<void> {
         return await browser.get('#/date-range-picker');
@@ -142,6 +143,27 @@ export class DateRangePickerPage {
         const spinner = await pickerElement.$('.time-zone-spinner');
         const buttons = await spinner.$$('.spin-button');
         return buttons[1].click();
+    }
+
+    async goToPreviousMonth(picker: Picker): Promise<void> {
+        const datePicker: ElementFinder = await this.getPicker(picker);
+        const buttons: ElementFinder[] = await datePicker.$$('.header-navigation');
+        await buttons[0].click();
+    }
+
+    async goToNextMonth(picker: Picker): Promise<void> {
+        const datePicker: ElementFinder = await this.getPicker(picker);
+        const buttons: ElementFinder[] = await datePicker.$$('.header-navigation');
+        await buttons[1].click();
+    }
+
+    async getPickerTitle(picker: Picker): Promise<string> {
+        const datePicker: ElementFinder = await this.getPicker(picker);
+        return await datePicker.$('.header-title').getAttribute('innerText');
+    }
+
+    async clear(): Promise<void> {
+        await this.clearBtn.click();
     }
 }
 

--- a/src/components/date-range-picker/date-range-picker.component.less
+++ b/src/components/date-range-picker/date-range-picker.component.less
@@ -25,13 +25,16 @@ ux-date-range-picker {
         width: 64px;
         flex: none;
         color: @primary;
+        padding-top: 2px;
 
         > .hpe-icon {
             font-size: 1.5rem;
+            margin-bottom: 2px;
         }
 
         .duration {
             text-align: center;
+            margin: 0;
         }
     }
 

--- a/src/components/date-time-picker/day-view/day-view.component.ts
+++ b/src/components/date-time-picker/day-view/day-view.component.ts
@@ -317,7 +317,21 @@ export class DayViewComponent implements AfterViewInit, OnDestroy {
 
     /** Update the viewport when the range changes to ensure focus is present on a valid item */
     private onRangeChange(date: Date): void {
-        if (this._isRangeStart && !this._rangeStart || this._isRangeEnd && !this._rangeEnd) {
+
+        if (!(this._isRangeStart && !this._rangeStart || this._isRangeEnd && !this._rangeEnd)) {
+            return;
+        }
+
+        // get the month showing on the other date range picker
+        const currentDate = new Date(this.datePicker.year$.value, this.datePicker.month$.value);
+
+        // if we are the start date and we are after the end date - ONLY then should be change the visible month the match the end date
+        const startShouldUpdate = this._isRangeStart && !this._rangeStart && (currentDate.getFullYear() > date.getFullYear() || currentDate.getFullYear() === date.getFullYear() && currentDate.getMonth() > date.getMonth());
+
+        // if we are the end date and we are before the start date - ONLY then should be change the visible month the match the start date
+        const endShouldUpdate = this._isRangeEnd && !this._rangeEnd && (currentDate.getFullYear() < date.getFullYear() || currentDate.getFullYear() === date.getFullYear() && currentDate.getMonth() < date.getMonth());
+
+        if (startShouldUpdate || endShouldUpdate) {
             this.datePicker.setViewportMonth(date.getMonth());
             this.datePicker.setViewportYear(date.getFullYear());
             this.dayService.setFocus(date.getDate(), date.getMonth(), date.getFullYear());

--- a/src/directives/accessibility/focus-indicator/default-focus-indicator.directive.ts
+++ b/src/directives/accessibility/focus-indicator/default-focus-indicator.directive.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectorRef, Directive, ElementRef, Optional } from '@angular/core';
+import { Directive, ElementRef, NgZone, Optional } from '@angular/core';
 import { AccessibilityOptionsService } from '../options/accessibility-options.service';
 import { LocalFocusIndicatorOptions } from './focus-indicator-options/focus-indicator-options';
 import { FocusIndicatorDirective } from './focus-indicator.directive';
@@ -20,10 +20,10 @@ export class DefaultFocusIndicatorDirective extends FocusIndicatorDirective {
         elementRef: ElementRef,
         focusIndicatorService: FocusIndicatorService,
         optionsService: AccessibilityOptionsService,
-        changeDetectorRef: ChangeDetectorRef,
+        ngZone: NgZone,
         @Optional() localOptions: LocalFocusIndicatorOptions
     ) {
-        super(elementRef, focusIndicatorService, changeDetectorRef, optionsService, localOptions);
+        super(elementRef, focusIndicatorService, optionsService, ngZone, localOptions);
 
         // Enable programmatic focus by default
         this.programmaticFocusIndicator = true;

--- a/src/directives/accessibility/focus-indicator/focus-indicator.directive.ts
+++ b/src/directives/accessibility/focus-indicator/focus-indicator.directive.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectorRef, Directive, ElementRef, EventEmitter, Input, OnDestroy, OnInit, Optional, Output } from '@angular/core';
+import { Directive, ElementRef, EventEmitter, Input, NgZone, OnDestroy, OnInit, Optional, Output } from '@angular/core';
 import { takeUntil } from 'rxjs/operators';
 import { Subject } from 'rxjs/Subject';
 import { AccessibilityOptionsService } from '../options/accessibility-options.service';
@@ -70,8 +70,8 @@ export class FocusIndicatorDirective implements OnInit, OnDestroy {
     constructor(
         private readonly _elementRef: ElementRef,
         private readonly _focusIndicatorService: FocusIndicatorService,
-        private readonly _changeDetectorRef: ChangeDetectorRef,
         readonly optionsService: AccessibilityOptionsService,
+        private readonly _ngZone: NgZone,
         @Optional() readonly localOptions?: LocalFocusIndicatorOptions
     ) {
 
@@ -101,10 +101,7 @@ export class FocusIndicatorDirective implements OnInit, OnDestroy {
         // subscribe to the focus state to emit an event on change
         this._focusIndicator.isFocused$.pipe(takeUntil(this._onDestroy)).subscribe(isFocused => {
             // emit the latest value
-            this.indicator.emit(isFocused);
-
-            // inform the change detector that we need to run as focus monitor runs outside of NgZone
-            this._changeDetectorRef.detectChanges();
+            this._ngZone.run(() => this.indicator.emit(isFocused));
         });
     }
 


### PR DESCRIPTION
**Date Range Picker**
- Added new selection behaviour where the the range end will only change the displayed month on selection if it is before the start date and vice versa.
- Fixing alignment of the duration arrow and label
- Removing popover bottom padding when show now button is visible to match Rolands updated designs

**Protractor Tests**
- Fixing tests, they were failing locally due to timezones not being accounted for. The tests have now all been updated to take into account the local timezone
- Added new tests to cover the new selection behaviour

**Focus Indicator**
- I also found our date picker component has gotten very slow, after some performance profiling it turns out it was due to the `FocusIndicator`. When instantiated the `FocusIndicator` initially emits its focused state. The `@angular/cdk` focus monitor runs outside of `NgZone` so we manually triggered change detection to ensure the UI updates as expected. This is fine in most cases, but in the Date picker and date range picker where there are many buttons on screen all with focus indicators this can cause a delay when navigating between months for example where many new buttons are being instantiated all at once, all running change detection repeatedly. Instead, I have changed this to run inside `NgZone`, this will inform change detection that it needs to run but only after all the initialisation has occurred, resulting in change detection only running once at the end rather than ever time a button instantiates.

#### Ticket
https://portal.digitalsafe.net/browse/EL-3454

#### Documentation CI URL
https://pages.github.houston.softwaregrp.net/sepg-docs-qa/UXAspects_CI_UXAspects_EL-3454-Date-Range-Picker-Fixes
