### PR TITLE
EL-3413 - Calendar Drag Fix

### DIFF
--- a/src/directives/drag/drop.directive.ts
+++ b/src/directives/drag/drop.directive.ts
@@ -1,5 +1,5 @@
 import { Directive, EventEmitter, HostListener, Input, OnDestroy, Output } from '@angular/core';
-import { filter, takeUntil } from 'rxjs/operators';
+import { filter, takeUntil, tap } from 'rxjs/operators';
 import { Subject } from 'rxjs/Subject';
 import { DragService, UxDragEvent } from './drag.service';
 
@@ -34,7 +34,7 @@ export class DropDirective<T = any> implements OnDestroy {
 
     constructor(private _dragService: DragService<T>) {
         // subscribe to drag events
-        _dragService.onDragStart.pipe(filter(event => this.isDropAllowed(event.group)), takeUntil(this._onDestroy))
+        _dragService.onDragStart.pipe(tap(event => this._group = event.group), filter(event => this.isDropAllowed(event.group)), takeUntil(this._onDestroy))
             .subscribe(this.onDragStart.bind(this));
 
         _dragService.onDragEnd.pipe(filter(event => this.isDropAllowed(event.group)), takeUntil(this._onDestroy))
@@ -71,9 +71,8 @@ export class DropDirective<T = any> implements OnDestroy {
     }
 
     /** Update the dragging state */
-    onDragStart(event: UxDragEvent<T>): void {
+    onDragStart(): void {
         this.isDragging = true;
-        this._group = event.group;
     }
 
     /** Update the dragging state */


### PR DESCRIPTION
- Previously the stored `group` was set in the `onDragStart` function, however this function is only called if the `isDropAllowed` function returns true. So if an item is dragged (that drop is allowed) it will set the group, then the next time we drag an item (that is not allowed) the stored group still contains the previous group name.

- Changed to now always update the stored group as soon as dragging starts 

#### Ticket
https://portal.digitalsafe.net/browse/EL-3513

#### Documentation CI URL
https://pages.github.houston.softwaregrp.net/sepg-docs-qa/UXAspects_CI_UXAspects_EL-3513-Calendar-Drag-Fix
