### PR TITLE
EL-3503 - Organization Chart Showcase

### DIFF
--- a/src/components/organization-chart/organization-chart.component.ts
+++ b/src/components/organization-chart/organization-chart.component.ts
@@ -174,7 +174,7 @@ export class OrganizationChartComponent<T> implements AfterViewInit, OnChanges, 
         this._nodesContainer = select(this.nodesContainer.nativeElement);
 
         // setup the zoom on the node layer
-        this._nodesContainer.call(this._zoom);
+        this._ngZone.runOutsideAngular(() => this._nodesContainer.call(this._zoom));
 
         // perform the initial render
         this.render();

--- a/src/components/typeahead/typeahead-event.ts
+++ b/src/components/typeahead/typeahead-event.ts
@@ -1,3 +1,3 @@
-export class TypeaheadOptionEvent {
-    constructor(public option: any) {}
+export class TypeaheadOptionEvent<T = any> {
+    constructor(public option: T) { }
 }

--- a/src/components/typeahead/typeahead.component.ts
+++ b/src/components/typeahead/typeahead.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectorRef, Component, ElementRef, EventEmitter, HostBinding, HostListener, Input, OnChanges, OnDestroy, Output, SimpleChanges, TemplateRef } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, EventEmitter, HostBinding, HostListener, Input, OnChanges, OnDestroy, Output, SimpleChanges, TemplateRef } from '@angular/core';
 import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 import { combineLatest } from 'rxjs/observable/combineLatest';
 import { distinctUntilChanged, takeUntil } from 'rxjs/operators';
@@ -13,6 +13,7 @@ let uniqueId = 0;
     selector: 'ux-typeahead',
     templateUrl: 'typeahead.component.html',
     providers: [TypeaheadService],
+    changeDetection: ChangeDetectionStrategy.OnPush,
     host: {
         'role': 'listbox',
         '[class.open]': 'open',
@@ -74,13 +75,13 @@ export class TypeaheadComponent<T = any> implements OnChanges, OnDestroy {
     @Input() loading = false;
 
     /** Specify a custom loading template */
-    @Input() loadingTemplate: TemplateRef<any>;
+    @Input() loadingTemplate: TemplateRef<{}>;
 
     /** Specify a custom option template */
-    @Input() optionTemplate: TemplateRef<any>;
+    @Input() optionTemplate: TemplateRef<TypeaheadOptionContext<T>>;
 
     /** Specify a custom template to display when there are no options */
-    @Input() noOptionsTemplate: TemplateRef<any>;
+    @Input() noOptionsTemplate: TemplateRef<{}>;
 
     /** Specify the currently active item */
     @Input() set active(item: T) {
@@ -91,7 +92,7 @@ export class TypeaheadComponent<T = any> implements OnChanges, OnDestroy {
     @Output() openChange = new EventEmitter<boolean>();
 
     /** Emit when an option is selected */
-    @Output() optionSelected = new EventEmitter<TypeaheadOptionEvent>();
+    @Output() optionSelected = new EventEmitter<TypeaheadOptionEvent<T>>();
 
     /** Emit whenever a highlighted item changes */
     @Output() highlightedChange = new EventEmitter<T>();
@@ -398,4 +399,9 @@ export interface TypeaheadOptionApi<T = any> {
 export interface TypeaheadVisibleOption<T = any> {
     value: T;
     key: string;
+}
+
+export interface TypeaheadOptionContext<T> {
+    option: T;
+    api: TypeaheadOptionApi<T>;
 }


### PR DESCRIPTION
Identified a few areas where performance can be improved:

**Organization Chart**
- Camera movement was running inside NgZone causing change detection when panning which was unnecessary

**Typeahead**
- Component was using `Default` Change Detection which is quite expensive especially when each item in the typeahead `key` and `display` properties are retrieved from function calls.
- Also added generic for typeahead events and replacing `any` with the correct type for template contexts for better type inference.


#### Ticket
https://portal.digitalsafe.net/browse/EL-3503

#### Documentation CI URL
https://pages.github.houston.softwaregrp.net/sepg-docs-qa/UXAspects_CI_UXAspects_EL-3503-Organization-Chart-Showcase
