### PR TITLE
EL-3441 - Focus styles

### DIFF
--- a/docs/app/components/edit-example-link/edit-example-link.component.html
+++ b/docs/app/components/edit-example-link/edit-example-link.component.html
@@ -1,4 +1,4 @@
-<a class="hyperlink-hover" tabindex="0" (keyup.enter)="linkClick($event)" (click)="linkClick($event)">
+<a class="hyperlink-hover" tabindex="0" (keyup.enter)="linkClick($event)" (click)="linkClick($event)" uxFocusIndicator>
     <i class="hpe-icon hpe-edit p-r-xs"></i>
     <ng-content></ng-content>
 </a>

--- a/docs/app/components/usage-link/usage-link.component.html
+++ b/docs/app/components/usage-link/usage-link.component.html
@@ -23,6 +23,7 @@
    (click)="pop.show(); $event.target?.blur()"
    (keyup.enter)="pop.toggle()"
    placement="bottom"
-   popoverClass="ux-usage-popover">
+   popoverClass="ux-usage-popover"
+   uxFocusIndicator>
     <i class="hpe-icon hpe-action p-r-xs"></i> Usage
 </a>

--- a/docs/app/pages/components/components-sections/drag-and-drop/drag-and-drop-cards/drag-and-drop-cards.component.less
+++ b/docs/app/pages/components/components-sections/drag-and-drop/drag-and-drop-cards/drag-and-drop-cards.component.less
@@ -70,7 +70,7 @@
     background-color: #fff;
 
     &:focus {
-        .aspects-outline();
+        .native-focus-outline();
     }
 }
 

--- a/docs/app/pages/components/components-sections/flippable-cards/flippable-cards/flippable-cards.component.less
+++ b/docs/app/pages/components/components-sections/flippable-cards/flippable-cards/flippable-cards.component.less
@@ -11,13 +11,6 @@
     color: #999;
     border: none;
     background: transparent;
-
-    &:focus {
-        outline: 2px dotted;
-        outline: auto -webkit-focus-ring-color;
-        outline-color: #00a7a2;
-        outline-offset: 0;
-    }
 }
 
 .flip-card-logo {

--- a/docs/app/pages/components/components-sections/flippable-cards/flippable-cards/snippets/app.css
+++ b/docs/app/pages/components/components-sections/flippable-cards/flippable-cards/snippets/app.css
@@ -13,13 +13,6 @@
     background: transparent;
 }
 
-.flip-card-btn:focus {
-    outline: 2px dotted;
-    outline: auto -webkit-focus-ring-color;
-    outline-color: #00a7a2;
-    outline-offset: 0;
-}
-
 .flip-card-logo {
     margin: 0 20px;
     transform: translateY(-5px);

--- a/docs/app/pages/components/components-sections/utilities/tabbable-list/snippets/app.css
+++ b/docs/app/pages/components/components-sections/utilities/tabbable-list/snippets/app.css
@@ -1,9 +1,5 @@
 .list-group-item:focus {
     z-index: 1;
-    outline: 2px dotted;
-    outline: auto -webkit-focus-ring-color;
-    outline-color: #00a7a2;
-    outline-offset: 0;
 }
 
 .list-group-item-heading {

--- a/docs/app/pages/components/components-sections/utilities/tabbable-list/tabbable-list.component.less
+++ b/docs/app/pages/components/components-sections/utilities/tabbable-list/tabbable-list.component.less
@@ -1,9 +1,5 @@
 .list-group-item:focus {
     z-index: 1;
-    outline: 2px dotted;
-    outline: auto -webkit-focus-ring-color;
-    outline-color: #00a7a2;
-    outline-offset: 0;
 }
 
 .list-group-item-heading {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "prepack": "mv src/package.json src_package.json",
     "postpack": "mv src_package.json src/package.json",
-    "start": "webpack-dev-server --config configs/webpack.dev.config.js",
+    "start": "node --max_old_space_size=8192 node_modules/webpack-dev-server/bin/webpack-dev-server.js --config configs/webpack.dev.config.js",
     "start:https": "npm run start -- --https --pfx configs/webpack.docs.dev.pfx",
     "start:e2e": "webpack-dev-server --config configs/webpack.e2e.config.js --progress --colors",
     "start:karma": "karma start",

--- a/src/components/card-tabs/card-tabset/card-tabset.component.less
+++ b/src/components/card-tabs/card-tabset/card-tabset.component.less
@@ -111,7 +111,7 @@ ux-card-tabset {
         z-index: 2;
 
         &:focus {
-            .aspects-outline();
+            .native-focus-outline();
         }
 
         &:hover {

--- a/src/components/checkbox/checkbox.component.less
+++ b/src/components/checkbox/checkbox.component.less
@@ -152,7 +152,7 @@ ux-checkbox {
 
         &.ux-checkbox-focused {
             .ux-checkbox-container {
-                .aspects-outline();
+                .focus-outline();
             }
         }
     }

--- a/src/components/date-time-picker/date-time-picker.component.less
+++ b/src/components/date-time-picker/date-time-picker.component.less
@@ -21,7 +21,7 @@ ux-date-time-picker {
         }
 
         &:focus {
-            .aspects-outline();
+            .native-focus-outline();
         }
 
         &:disabled {

--- a/src/components/date-time-picker/header/header.component.less
+++ b/src/components/date-time-picker/header/header.component.less
@@ -20,7 +20,7 @@ ux-date-time-picker-header {
             background-color: transparent;
 
             &:focus {
-                .aspects-outline();
+                .native-focus-outline();
             }
 
             &:hover:not(:disabled) {
@@ -47,7 +47,7 @@ ux-date-time-picker-header {
             background-color: transparent;
 
             &:focus {
-                .aspects-outline();
+                .native-focus-outline();
             }
 
             &.active {

--- a/src/components/date-time-picker/time-view/time-view.component.less
+++ b/src/components/date-time-picker/time-view/time-view.component.less
@@ -34,7 +34,7 @@ ux-date-time-picker-time-view {
             text-align: center;
 
             &:focus {
-                .aspects-outline();
+                .native-focus-outline();
             }
         }
     }

--- a/src/components/facets/facet-check-list/facet-check-list.component.less
+++ b/src/components/facets/facet-check-list/facet-check-list.component.less
@@ -20,7 +20,7 @@ ux-facet-check-list {
             max-width: 100%;
 
             &.ux-focus-indicator-active {
-                .aspects-outline();
+                .focus-outline();
             }
 
             ux-checkbox {

--- a/src/components/facets/facet-container.component.less
+++ b/src/components/facets/facet-container.component.less
@@ -63,7 +63,7 @@ ux-facet-container {
                     background: none;
 
                     &:focus {
-                        .aspects-outline();
+                        .native-focus-outline();
                     }
                 }
 

--- a/src/components/facets/facet-typeahead-list/facet-typeahead-list.component.less
+++ b/src/components/facets/facet-typeahead-list/facet-typeahead-list.component.less
@@ -45,7 +45,7 @@ ux-facet-typeahead-list {
                 }
 
                 &.ux-focus-indicator-active {
-                    .aspects-outline();
+                    .focus-outline();
                 }
 
                 ux-checkbox {

--- a/src/components/flippable-card/flippable-card.component.less
+++ b/src/components/flippable-card/flippable-card.component.less
@@ -4,7 +4,7 @@ ux-flippable-card {
     display: inline-block;
 
     &:focus {
-        .aspects-outline();
+        .native-focus-outline();
     }
 
     .ux-flipper.ux-flip-card {

--- a/src/components/hierarchy-bar/hierarchy-bar-collapsed/hierarchy-bar-collapsed.component.less
+++ b/src/components/hierarchy-bar/hierarchy-bar-collapsed/hierarchy-bar-collapsed.component.less
@@ -58,7 +58,7 @@ ux-hierarchy-bar-collapsed {
                 padding: 0 2px;
 
                 &:focus {
-                    .aspects-outline;
+                    .native-focus-outline;
                 }
 
                 > .hpe-icon {
@@ -83,7 +83,7 @@ ux-hierarchy-bar-collapsed {
 
             &:focus {
                 color: @primary;
-                .aspects-outline;
+                .native-focus-outline;
             }
         }
     }

--- a/src/components/hierarchy-bar/hierarchy-bar-node/hierarchy-bar-node.component.less
+++ b/src/components/hierarchy-bar/hierarchy-bar-node/hierarchy-bar-node.component.less
@@ -20,7 +20,7 @@ ux-hierarchy-bar-node {
         padding: 0;
 
         &:focus {
-            .aspects-outline;
+            .native-focus-outline;
         }
     }
 
@@ -57,7 +57,7 @@ ux-hierarchy-bar-node {
 
         &:focus {
             color: @primary;
-            .aspects-outline;
+            .native-focus-outline;
         }
     }
 }

--- a/src/components/hierarchy-bar/hierarchy-bar-popover-item/hierarchy-bar-popover-item.component.less
+++ b/src/components/hierarchy-bar/hierarchy-bar-popover-item/hierarchy-bar-popover-item.component.less
@@ -12,7 +12,7 @@ ux-hierarchy-bar-popover-item {
 
     &:focus.ux-focus-indicator-active {
         background-color: @organization-chart-hierarchy-bar-popover-hover;
-        .aspects-outline;
+        .focus-outline;
     }
 
     .hierarchy-bar-node-icon {

--- a/src/components/marquee-wizard/marquee-wizard.component.less
+++ b/src/components/marquee-wizard/marquee-wizard.component.less
@@ -63,7 +63,7 @@ ux-marquee-wizard {
                     outline: none;
 
                     &.cdk-keyboard-focused {
-                        .aspects-outline();
+                        .focus-outline();
                     }
                 }
             }

--- a/src/components/media-player/extensions/controls/controls.component.less
+++ b/src/components/media-player/extensions/controls/controls.component.less
@@ -37,7 +37,7 @@ ux-media-player-controls {
         }
 
         &:focus {
-            .aspects-outline();
+            .native-focus-outline();
         }
     }
 
@@ -70,7 +70,7 @@ ux-media-player-controls {
         }
 
         &:focus {
-            .aspects-outline();
+            .native-focus-outline();
         }
     }
 
@@ -138,7 +138,7 @@ ux-media-player-controls {
                 float: none;
 
                 &:focus {
-                    .aspects-outline();
+                    .native-focus-outline();
                 }
             }
 
@@ -205,7 +205,7 @@ ux-media-player-controls {
                     }
 
                     &:focus {
-                        .aspects-outline();
+                        .native-focus-outline();
                     }
 
                     &.active {

--- a/src/components/media-player/extensions/timeline/timeline.component.less
+++ b/src/components/media-player/extensions/timeline/timeline.component.less
@@ -19,7 +19,7 @@ ux-media-player-timeline {
         cursor: pointer;
 
         &:focus {
-            .aspects-outline();
+            .native-focus-outline();
         }
 
         .buffered-bar {

--- a/src/components/page-header/icon-menu/icon-menu.component.less
+++ b/src/components/page-header/icon-menu/icon-menu.component.less
@@ -23,7 +23,7 @@ ux-page-header-icon-menu {
             }
 
             &:focus {
-                .aspects-outline;
+                .native-focus-outline;
             }
         }
     }
@@ -54,7 +54,7 @@ ux-page-header-icon-menu {
                 font-size: 1rem;
 
                 &:focus {
-                    .aspects-outline;
+                    .native-focus-outline;
                 }
 
                 .hpe-icon {

--- a/src/components/page-header/navigation/navigation-item/navigation-item.component.less
+++ b/src/components/page-header/navigation/navigation-item/navigation-item.component.less
@@ -30,7 +30,7 @@ ux-page-header-horizontal-navigation-item {
         }
 
         &:focus {
-            .aspects-outline;
+            .native-focus-outline;
         }
 
         &.active,
@@ -78,7 +78,7 @@ ux-page-header-horizontal-navigation-item {
         }
 
         &:focus {
-            .aspects-outline;
+            .native-focus-outline;
         }
 
         .dropdown-item-title {

--- a/src/components/page-header/page-header.component.less
+++ b/src/components/page-header/page-header.component.less
@@ -62,7 +62,7 @@ ux-page-header {
                 }
 
                 &:focus {
-                    .aspects-outline;
+                    .native-focus-outline;
                 }
 
                 & > * {

--- a/src/components/partition-map/partition-map.component.less
+++ b/src/components/partition-map/partition-map.component.less
@@ -13,7 +13,7 @@ ux-partition-map {
 
         &:focus.ux-focus-indicator-active {
             outline: none !important;
-            box-shadow: none;
+            box-shadow: none !important;
 
             &.partition-map-segment-dark {
                 .partition-map-segment-content {

--- a/src/components/radiobutton/radiobutton.component.less
+++ b/src/components/radiobutton/radiobutton.component.less
@@ -136,7 +136,7 @@ ux-radio-button {
 
         &.ux-radio-button-focused {
             .ux-radio-button-container {
-                .aspects-outline();
+                .focus-outline();
             }
         }
     }

--- a/src/components/search-builder/search-builder-group/search-builder-group.component.less
+++ b/src/components/search-builder/search-builder-group/search-builder-group.component.less
@@ -89,7 +89,7 @@ ux-search-builder-group {
                     transition: opacity 300ms linear;
 
                     &:focus {
-                        .aspects-outline;
+                        .native-focus-outline;
                     }
                 }
             }
@@ -110,7 +110,7 @@ ux-search-builder-group {
             background-color: transparent;
 
             &:focus {
-                .aspects-outline;
+                .native-focus-outline;
             }
 
             .search-builder-group-add-field-icon {

--- a/src/components/select-list/select-list-item/select-list-item.component.less
+++ b/src/components/select-list/select-list-item/select-list-item.component.less
@@ -9,7 +9,7 @@ ux-select-list-item {
     }
 
     &:focus {
-        .aspects-outline();
+        .native-focus-outline();
     }
 
     &.selected {

--- a/src/components/spin-button/spin-button.component.less
+++ b/src/components/spin-button/spin-button.component.less
@@ -14,7 +14,7 @@ ux-spin-button {
         }
 
         &:focus {
-            .aspects-outline();
+            .native-focus-outline();
         }
 
         .hpe-icon {

--- a/src/components/table/table-column-resize/resizable-table-column.component.less
+++ b/src/components/table/table-column-resize/resizable-table-column.component.less
@@ -25,7 +25,7 @@
     cursor: ew-resize;
 
     &.cdk-keyboard-focused {
-        .aspects-outline();
+        .focus-outline();
     }
 
     .ux-resizable-table-column-handle-icon {

--- a/src/components/toggleswitch/toggleswitch.component.less
+++ b/src/components/toggleswitch/toggleswitch.component.less
@@ -81,7 +81,7 @@ ux-toggleswitch {
 
         &.ux-toggleswitch-focused {
             .ux-toggleswitch-bg {
-                .aspects-outline();
+                .focus-outline();
             }
         }
     }

--- a/src/components/wizard/wizard.component.less
+++ b/src/components/wizard/wizard.component.less
@@ -54,7 +54,7 @@ ux-wizard {
                     outline: none;
 
                     &.cdk-keyboard-focused {
-                        .aspects-outline();
+                        .focus-outline();
                     }
                 }
             }

--- a/src/directives/accessibility/focus-indicator/default-focus-indicator.directive.ts
+++ b/src/directives/accessibility/focus-indicator/default-focus-indicator.directive.ts
@@ -12,7 +12,7 @@ import { FocusIndicatorService } from './focus-indicator.service';
  * If the button has a uxFocusIndicator or uxMenuNavigationToggle directive applied we should skip this
  */
 @Directive({
-    selector: '.btn:not([uxFocusIndicator]):not([uxMenuNavigationToggle]), a[href]:not([uxFocusIndicator]):not([uxMenuNavigationToggle]), a[tabindex]:not([tabindex="-1"]):not([uxFocusIndicator]):not([uxMenuNavigationToggle])',
+    selector: '.btn:not([uxFocusIndicator]):not([uxMenuNavigationToggle]), a[href]:not([uxFocusIndicator]):not([uxMenuNavigationToggle])',
 })
 export class DefaultFocusIndicatorDirective extends FocusIndicatorDirective {
 

--- a/src/styles/breadcrumbs.less
+++ b/src/styles/breadcrumbs.less
@@ -14,7 +14,7 @@
             color: @breadcrumb-color;
 
             &:focus {
-                .aspects-outline;
+                .native-focus-outline;
             }
         }
     }

--- a/src/styles/buttons.less
+++ b/src/styles/buttons.less
@@ -76,19 +76,24 @@
         line-height: inherit;
     }
 
+    &,
     &:active,
     &.active {
-        box-shadow: @btn-active-shadow;
-
         &:focus,
         &.focus {
-            .aspects-outline;
+            outline: none;
+
+            .native-focus-outline();
+
+            &.ux-focus-indicator.ux-focus-indicator-active {
+                .focus-outline();
+            }
         }
     }
 
-    &:focus,
-    &.focus {
-        .aspects-outline;
+    &:active,
+    &.active {
+        box-shadow: @btn-active-shadow;
     }
 
     &:hover {
@@ -238,7 +243,8 @@
 
 .button-primary,
 .btn-primary {
-    &.disabled, &[disabled] {
+    &.disabled,
+    &[disabled] {
         .button-primary-disabled;
 
         &:hover,
@@ -701,7 +707,7 @@ button {
 
 .btn-back {
     &:focus {
-        .aspects-outline;
+        .native-focus-outline;
     }
 }
 
@@ -809,7 +815,7 @@ button {
 
     .dropdown-toggle {
         &:focus {
-            .aspects-outline;
+            .native-focus-outline;
 
             z-index: @button-group-front-z-index;
         }

--- a/src/styles/controls.less
+++ b/src/styles/controls.less
@@ -330,7 +330,7 @@ select {
 .multi-select-checkbox {
     &:hover,
     &:focus {
-        .aspects-outline;
+        .native-focus-outline;
     }
 }
 
@@ -1643,7 +1643,7 @@ fieldset[disabled] .datepicker table tr td span.active.disabled:hover.active {
 //JQuery knob input
 .dial {
     &:focus {
-        .aspects-outline;
+        .native-focus-outline;
     }
 }
 
@@ -1855,9 +1855,11 @@ tree-view > div:first-child > ol:nth-of-type(1) {
             line-height: 1em !important;
             border: none !important;
             margin-left: -5px;
-            .aspects-outline;
-
             padding-left: 5px;
+
+            &:focus {
+                .native-focus-outline();
+            }
         }
 
         .title-readonly:focus {
@@ -1904,12 +1906,12 @@ tree-view > div:first-child > ol:nth-of-type(1) {
 
     a:focus,
     span:focus {
-        .aspects-outline;
+        .native-focus-outline;
     }
 
     a:active,
     a:active:focus {
-        .aspects-outline;
+        .native-focus-outline;
     }
 
     .toggle {
@@ -2266,7 +2268,7 @@ table.select-table tr > td {
 }
 
 table.select-table tr:focus {
-    .aspects-outline();
+    .native-focus-outline();
 }
 
 table.select-table > tbody > tr.highlight {

--- a/src/styles/file-upload.less
+++ b/src/styles/file-upload.less
@@ -12,7 +12,7 @@
     margin-bottom: 24px;
 
     &:focus {
-        .aspects-outline();
+        .native-focus-outline();
     }
 }
 
@@ -68,6 +68,6 @@
     }
 
     &:focus {
-        .aspects-outline();
+        .native-focus-outline();
     }
 }

--- a/src/styles/filters.less
+++ b/src/styles/filters.less
@@ -154,7 +154,7 @@
         }
 
         &:focus {
-            .aspects-outline;
+            .native-focus-outline;
         }
 
         &.clear-selected {

--- a/src/styles/main.less
+++ b/src/styles/main.less
@@ -137,7 +137,7 @@ ol {
 }
 
 .aspects-focus-outline:focus {
-    .aspects-outline;
+    .native-focus-outline;
 }
 
 /* Plunker */

--- a/src/styles/mixins.less
+++ b/src/styles/mixins.less
@@ -37,17 +37,20 @@
     }
 }
 
-.aspects-outline {
+.focus-outline {
     outline: 2px dotted;
     outline: auto -webkit-focus-ring-color;
     outline-color: @aspects-outline;
     outline-offset: 0;
 }
 
-.elements-force-outline {
-    outline-style: solid;
-    outline-width: 1px;
-    .aspects-outline;
+.native-focus-outline {
+    &:not(.ux-focus-indicator) {
+        outline: 2px dotted;
+        outline: auto -webkit-focus-ring-color;
+        outline-color: @aspects-outline;
+        outline-offset: 0;
+    }
 }
 
 .btn-hover-active-color(light, @color, @percent) {

--- a/src/styles/modal.less
+++ b/src/styles/modal.less
@@ -422,7 +422,7 @@
         }
 
         &:focus {
-            .aspects-outline();
+            .native-focus-outline();
         }
     }
 }

--- a/src/styles/navigation.less
+++ b/src/styles/navigation.less
@@ -1002,7 +1002,7 @@ h4 {
         }
 
         &:focus {
-            .aspects-outline();
+            .native-focus-outline();
         }
     }
 

--- a/src/styles/notifications.less
+++ b/src/styles/notifications.less
@@ -29,7 +29,7 @@
         top: 4px;
 
         &:focus {
-            .aspects-outline;
+            .native-focus-outline;
         }
     }
 }
@@ -38,7 +38,7 @@
     .font-semibold;
 
     &:focus {
-        .aspects-outline;
+        .native-focus-outline;
     }
 }
 
@@ -230,7 +230,7 @@ ux-alert {
         background: transparent;
 
         &:focus {
-            .aspects-outline();
+            .native-focus-outline();
         }
     }
 

--- a/src/styles/panels.less
+++ b/src/styles/panels.less
@@ -38,7 +38,7 @@ a {
 .panel-heading {
     &:focus,
     a:focus {
-        .aspects-outline;
+        .native-focus-outline;
     }
 }
 

--- a/src/styles/scroll-bar.less
+++ b/src/styles/scroll-bar.less
@@ -113,10 +113,6 @@
     }
 }
 
-.scroll-container {
-    .aspects-outline;
-}
-
 .navbar-static-side-container {
     .jspDrag {
         left: 3px;

--- a/src/styles/splitter.less
+++ b/src/styles/splitter.less
@@ -115,7 +115,7 @@
 split {
     split-gutter {
         &:focus {
-            .aspects-outline();
+            .native-focus-outline();
         }
     }
 }

--- a/src/styles/tables.less
+++ b/src/styles/tables.less
@@ -197,7 +197,7 @@ table {
         padding: 0;
 
         &:focus {
-            .aspects-outline();
+            .native-focus-outline();
         }
     }
 }
@@ -504,7 +504,7 @@ table {
         }
 
         &.ux-selection-focused:focus {
-            .aspects-outline();
+            .native-focus-outline();
         }
     }
 }
@@ -1037,7 +1037,7 @@ table {
         }
 
         &:focus {
-            .aspects-outline();
+            .native-focus-outline();
         }
     }
 }
@@ -1193,6 +1193,6 @@ th {
  */
 .reorderable-row {
     &:focus {
-        .aspects-outline();
+        .native-focus-outline();
     }
 }

--- a/src/styles/tree-views.less
+++ b/src/styles/tree-views.less
@@ -32,7 +32,7 @@
 .treegrid-row {
     &:focus {
         background-color: @table-hover-bg;
-        .aspects-outline();
+        .native-focus-outline();
     }
 
     > td:first-child {

--- a/src/styles/utilities.less
+++ b/src/styles/utilities.less
@@ -530,10 +530,12 @@ ng\:form {
 // Support focus when cdk-keyboard-focus class is present
 .ux-keyboard-focus {
     &:focus {
-        outline: none !important;
+        &:not(.cdk-keyboard-focused) {
+            outline: none;
+        }
 
         &.cdk-keyboard-focused {
-            .aspects-outline() !important;
+            .focus-outline();
         }
     }
 }
@@ -541,10 +543,12 @@ ng\:form {
 // Support controlled focus using the uxFocus directive
 .ux-focus-indicator {
     &:focus {
-        outline: none !important;
+        &:not(.ux-focus-indicator-active) {
+            outline: none;
+        }
 
         &.ux-focus-indicator-active {
-            .aspects-outline() !important;
+            .focus-outline();
         }
     }
 }


### PR DESCRIPTION
* Plain `:focus` rules have been amended to only apply to elements which are not managed by the Angular uxFocusIndicator. The focus outline will then only apply when AccessibilityModule is not present.
* Due to the more specific focus rules, `!important` is removed from the `.ux-focus-indicator` and `.ux-keyboard-focus` rules, reducing the proliferation of the `!important` modifier.
* `.btn` has a `:focus` rule applied in bootstrap, so this is explicitly overridden.
* `.aspects-outline` has been renamed to discourage its former use.
* I also noticed some memory issues in dev mode, possibly related to the Less sourcemap change, so I raised the memory cap on node.
* Removed `a[tabindex]` selector from DefaultFocusIndicatorDirective. This was causing trouble with ux-pagination.
* Remove automatic focus indicator on partitions.

#### Ticket
https://portal.digitalsafe.net/browse/EL-3441

#### Documentation CI URL
https://pages.github.houston.softwaregrp.net/sepg-docs-qa/UXAspects_CI_UXAspects_EL-3441-focus-styles
