### PR TITLE
EL-3503 - Organization Chart Showcase

### DIFF
--- a/src/components/organization-chart/organization-chart.component.ts
+++ b/src/components/organization-chart/organization-chart.component.ts
@@ -348,11 +348,6 @@ export class OrganizationChartComponent<T> implements AfterViewInit, OnChanges, 
         // emit the latest selection
         this.selectedChange.next(this._selected);
 
-        // update the tab indexes and aria labels
-        if (this._isInitialised) {
-            this.render();
-        }
-
         // add the styling to the selected node
         this._renderer.addClass(this.getNodeElement(this._selected), 'ux-organization-chart-node-selected');
 


### PR DESCRIPTION
- The select functionality was performing a re-render which is not required. Previously the `render` function updated the aria labels and tab index but this was later moved to the `setNodeAttributes` function instead. By having the select call the `render` function this could interrupt any transitions that are currently happening, so for example, if we are performing a `reveal` and selecting at the same time, the reveal animation can get interrupted because select called `render` again unnecessarily.

#### Ticket
https://portal.digitalsafe.net/browse/EL-3503

#### Documentation CI URL
https://pages.github.houston.softwaregrp.net/sepg-docs-qa/UXAspects_CI_UXAspects_EL-3503-Organization-Chart-Showcase-2
