### PR TITLE
EL-3482 - Partition Map Showcase

### DIFF
--- a/docs/app/pages/charts/charts-sections/partition-map/partition-map/partition-map.component.html
+++ b/docs/app/pages/charts/charts-sections/partition-map/partition-map/partition-map.component.html
@@ -6,7 +6,7 @@
              (mouseleave)="tooltip.hide()"
              (click)="tooltip.hide()">
 
-            <span class="partion-map-segment-label"
+            <span class="partition-map-segment-label"
                   #tooltip="ux-tooltip"
                   [uxTooltip]="segment.name + ': ' + value"
                   tooltipClass="partition-map-tooltip"
@@ -88,6 +88,9 @@
     </tr>
     <tr uxd-api-property name="value" type="number">
         The amount this segment represents. If this segment has children, the value will represent the sum of all child values.
+    </tr>
+    <tr uxd-api-property name="expanded" type="boolean">
+        This represents the expanded state of the segment.
     </tr>
     <tr uxd-api-property name="color" type="string">
         The background color of this segment.

--- a/docs/app/pages/charts/charts-sections/partition-map/partition-map/partition-map.component.html
+++ b/docs/app/pages/charts/charts-sections/partition-map/partition-map/partition-map.component.html
@@ -95,6 +95,9 @@
     <tr uxd-api-property name="color" type="string">
         The background color of this segment.
     </tr>
+    <tr uxd-api-property name="children" type="PartitionMapCustomSegmentContext[]">
+        The contexts for all child segments.
+    </tr>
 </uxd-api-properties>
 
 <ux-tabset [minimal]="false">

--- a/docs/app/pages/charts/charts-sections/partition-map/partition-map/snippets/app.html
+++ b/docs/app/pages/charts/charts-sections/partition-map/partition-map/snippets/app.html
@@ -6,7 +6,7 @@
              (mouseleave)="tooltip.hide()"
              (click)="tooltip.hide()">
 
-            <span class="partion-map-segment-label"
+            <span class="partition-map-segment-label"
                   #tooltip="ux-tooltip"
                   [uxTooltip]="segment.name + ': ' + value"
                   [tooltipDelay]="500"

--- a/src/components/partition-map/partition-map.component.html
+++ b/src/components/partition-map/partition-map.component.html
@@ -27,7 +27,7 @@
        <!-- Show custom template if provided -->
       <ng-container *ngIf="segmentTemplate"
         [ngTemplateOutlet]="segmentTemplate"
-        [ngTemplateOutletContext]="{ segment: segment.data, value: _getSegmentValue(segment.data), color: _getBackgroundColor(segment), expanded: !_isCollapsed(segment) }">
+        [ngTemplateOutletContext]="_getContext(segment)">
       </ng-container>
     </div>
 

--- a/src/components/partition-map/partition-map.component.html
+++ b/src/components/partition-map/partition-map.component.html
@@ -20,14 +20,14 @@
      <div class="partition-map-segment-content" [class.partition-map-segment-content-hidden]="_getSegmentContentHidden(segment)">
 
       <!-- Show default template if provided -->
-      <span class="partion-map-segment-label" *ngIf="!segmentTemplate">
+      <span class="partition-map-segment-label" *ngIf="!segmentTemplate">
         {{ segment.data.name }}
       </span>
 
        <!-- Show custom template if provided -->
       <ng-container *ngIf="segmentTemplate"
         [ngTemplateOutlet]="segmentTemplate"
-        [ngTemplateOutletContext]="{ segment: segment.data, value: _getSegmentValue(segment.data), color: _getBackgroundColor(segment) }">
+        [ngTemplateOutletContext]="{ segment: segment.data, value: _getSegmentValue(segment.data), color: _getBackgroundColor(segment), expanded: !_isCollapsed(segment) }">
       </ng-container>
     </div>
 

--- a/src/components/partition-map/partition-map.component.less
+++ b/src/components/partition-map/partition-map.component.less
@@ -55,13 +55,13 @@ ux-partition-map {
         }
 
         &.partition-map-segment-content-hidden {
-            .partion-map-segment-label {
+            .partition-map-segment-label {
                 opacity: 0;
             }
         }
     }
 
-    .partion-map-segment-label {
+    .partition-map-segment-label {
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;

--- a/src/components/partition-map/partition-map.component.ts
+++ b/src/components/partition-map/partition-map.component.ts
@@ -807,6 +807,7 @@ export interface PartitionMapCustomSegmentContext {
     segment: PartitionMapSegment;
     color: string;
     value: number;
+    expanded: boolean;
 }
 
 /** An object of this interface is passed to the announcer function */

--- a/src/components/partition-map/partition-map.component.ts
+++ b/src/components/partition-map/partition-map.component.ts
@@ -358,6 +358,23 @@ export class PartitionMapComponent implements OnInit, OnDestroy {
         return (segment as PartitionMapSegmentWithChildren).children.reduce((value, child) => value + this._getSegmentValue(child), 0);
     }
 
+    _getContext(segment: HierarchyRectangularNode<PartitionMapSegment>): PartitionMapCustomSegmentContext {
+        const context: PartitionMapCustomSegmentContext = {
+            segment: segment.data,
+            value: this._getSegmentValue(segment.data),
+            color: this._getBackgroundColor(segment),
+            expanded: !this._isCollapsed(segment),
+            children: []
+        };
+
+        // map the children to their contexts
+        if (segment.children) {
+            context.children = segment.children.map(this._getContext.bind(this));
+        }
+
+        return context;
+    }
+
     /** Convert the public facing data structure into the layout format we require */
     private setDataset(dataset: Readonly<PartitionMapSegment>): void {
 
@@ -808,6 +825,7 @@ export interface PartitionMapCustomSegmentContext {
     color: string;
     value: number;
     expanded: boolean;
+    children: PartitionMapCustomSegmentContext[];
 }
 
 /** An object of this interface is passed to the announcer function */


### PR DESCRIPTION
- Fixing a typo in a class name
- Added `expanded` option to the context to know the expanded state of a segment
- Added `children` option to the context so we can access the color and expanded state of child items

#### Ticket
https://portal.digitalsafe.net/browse/EL-3482

#### Documentation CI URL
https://pages.github.houston.softwaregrp.net/sepg-docs-qa/UXAspects_CI_UXAspects_EL-3482-Partition-Map-Showcase
