### PR TITLE
EL-3482 - Partition Map Segment Events

### DIFF
--- a/docs/app/pages/charts/charts-sections/partition-map/partition-map/partition-map.component.html
+++ b/docs/app/pages/charts/charts-sections/partition-map/partition-map/partition-map.component.html
@@ -78,8 +78,12 @@
 
 <p>
     Additionally the content of a segment can be customized by adding a child <code>ng-template</code> identified as <code>#partitionMapSegment</code>.
-    This custom template can be used to add functionality such as a tooltip or popover. The template context provides access to several variables
-    that can be used to display information within the segment:
+    This custom template can be used to add functionality such as a tooltip or popover. The custom template can use the <code>segmentFocus</code> and
+    <code>segmentBlur</code> events to trigger events when the segment is focused or blurred.
+</p>
+
+<p>
+    The template context provides access to several variables that can be used to display information within the segment:
 </p>
 
 <uxd-api-properties tableTitle="Partition Map Segment Template Context">

--- a/src/components/partition-map/events/partition-map-segment-events.directive.ts
+++ b/src/components/partition-map/events/partition-map-segment-events.directive.ts
@@ -1,0 +1,57 @@
+import { AfterViewInit, Directive, ElementRef, EventEmitter, OnDestroy, Output } from '@angular/core';
+import { fromEvent } from 'rxjs/observable/fromEvent';
+import { takeUntil } from 'rxjs/operators';
+import { Subject } from 'rxjs/Subject';
+
+@Directive({
+    selector: '[segmentFocus],[segmentBlur]',
+})
+export class PartitionMapSegmentEventsDirective implements AfterViewInit, OnDestroy {
+
+    /** Emit when the segment receives focus */
+    @Output() segmentFocus = new EventEmitter<FocusEvent>();
+
+    /** Emit when the segment is blurred */
+    @Output() segmentBlur = new EventEmitter<FocusEvent>();
+
+    /** Unsubscribe from observables */
+    private _onDestroy = new Subject<void>();
+
+    constructor(private _elementRef: ElementRef) { }
+
+    ngAfterViewInit(): void {
+        // Get the parent segment element
+        // Note we cannot use DI to get the element as this is a template
+        // and the context has no knowledge of the partition map template
+        const segment = this.getSegmentElement();
+
+        if (segment) {
+            fromEvent<FocusEvent>(segment, 'focus')
+                .pipe(takeUntil(this._onDestroy))
+                .subscribe(event => this.segmentFocus.emit(event));
+
+            fromEvent<FocusEvent>(segment, 'blur')
+                .pipe(takeUntil(this._onDestroy))
+                .subscribe(event => this.segmentBlur.emit(event));
+        }
+    }
+
+    ngOnDestroy(): void {
+        this._onDestroy.next();
+        this._onDestroy.complete();
+    }
+
+    /**
+     * Find the parent element that is a partition map segment
+     */
+    private getSegmentElement(): HTMLElement {
+        let ancestor = (this._elementRef.nativeElement as HTMLElement).parentElement;
+
+        while (ancestor !== null) {
+            if (ancestor.classList.contains('partition-map-segment')) {
+                return ancestor;
+            }
+            ancestor = ancestor.parentElement;
+        }
+    }
+}

--- a/src/components/partition-map/index.ts
+++ b/src/components/partition-map/index.ts
@@ -1,3 +1,3 @@
+export * from './events/partition-map-segment-events.directive';
 export * from './partition-map.component';
 export * from './partition-map.module';
-

--- a/src/components/partition-map/partition-map.module.ts
+++ b/src/components/partition-map/partition-map.module.ts
@@ -4,6 +4,7 @@ import { NgModule } from '@angular/core';
 import { AccessibilityModule } from '../../directives/accessibility/index';
 import { ResizeModule } from '../../directives/resize/index';
 import { ColorServiceModule } from '../../services/color/index';
+import { PartitionMapSegmentEventsDirective } from './events/partition-map-segment-events.directive';
 import { PartitionMapComponent } from './partition-map.component';
 
 @NgModule({
@@ -15,10 +16,12 @@ import { PartitionMapComponent } from './partition-map.component';
         ResizeModule
     ],
     declarations: [
-        PartitionMapComponent
+        PartitionMapComponent,
+        PartitionMapSegmentEventsDirective
     ],
     exports: [
-        PartitionMapComponent
+        PartitionMapComponent,
+        PartitionMapSegmentEventsDirective
     ]
 })
 export class PartitionMapModule { }


### PR DESCRIPTION
#### Checklist
<!-- Use an 'x' to check those which apply. -->
* [x] The contents of this PR are mine to submit. No third party code or other material is being committed.
* [x] New third party dependencies (if any) are linked via `package.json`. Third party dependencies are licenced under one of the following: Apache, MIT, BSD, Mozilla Public License, Eclipse Public License, or Oracle Binary Code License.
* [x] The code in this PR does not contain export-restricted encryption algorithms.

#### Ticket / Issue
<!-- Either a Jira URL or a description of the issue that this PR addresses. -->
https://portal.digitalsafe.net/browse/EL-3482

#### Description of Proposed Changes
<!-- Describe what was changed and how it addresses the original issue. -->
Added a directive that allows a custom partition map segment template to trigger events on `segmentFocus` and `segmentBlur`.

#### Documentation CI URL
<!-- Initiate a build at https://jenkins.swinfra.net/job/SEPG/view/Templates/job/New%20SEPG%20Build/build -->
<!-- Append the branch name to the following URL: -->
https://pages.github.houston.softwaregrp.net/sepg-docs-qa/UXAspects_CI_UXAspects_EL-3482-Partition-Map-Segment-Events
