### PR TITLE
EL-3517 - Tab heading order

### DIFF
--- a/e2e/pages/app/tabs/tabs.testpage.component.html
+++ b/e2e/pages/app/tabs/tabs.testpage.component.html
@@ -27,3 +27,7 @@
 <div>
     <ux-radio-button id="stack-right-radio" name="stacked" option="right" [(value)]="stacked">Stacked Right</ux-radio-button>
 </div>
+
+<div>
+    <button id="add-tab-0" type="button" class="btn button-secondary" (click)="addTab(0)">Insert tab at index 0</button>
+</div>

--- a/e2e/pages/app/tabs/tabs.testpage.component.ts
+++ b/e2e/pages/app/tabs/tabs.testpage.component.ts
@@ -25,6 +25,10 @@ export class TabsTestPageComponent {
 
     private _stacked: TabStackType = 'none';
 
+    addTab(index: number): void {
+        this.tabs = [`New Tab ${index}`, ...this.tabs];
+    }
+
 }
 
 export type TabStackType = 'left' | 'right' | 'none';

--- a/e2e/tests/components/tabs/tabs.e2e-spec.ts
+++ b/e2e/tests/components/tabs/tabs.e2e-spec.ts
@@ -188,4 +188,23 @@ describe('Tabs Tests (Angular)', () => {
 
     });
 
+    it('should allow inserting a new tab at the leftmost position', async () => {
+
+        expect(await page.getSelectedTab()).toBe('Schedule');
+
+        // Add a tab at index 0
+        await page.addTab0.click();
+
+        expect(await page.getTabCount()).toBe(5);
+
+        expect(await page.getSelectedTab()).toBe('Schedule');
+
+        // Click the newly added tab
+        await page.clickTabAtIndex(0);
+
+        expect(await page.getSelectedTab()).toBe('New Tab 0');
+        expect(await page.getSelectedTabContent()).toBe('New Tab 0');
+
+    });
+
 });

--- a/e2e/tests/components/tabs/tabs.po.spec.ts
+++ b/e2e/tests/components/tabs/tabs.po.spec.ts
@@ -1,11 +1,12 @@
-import { $, $$, browser, Key } from 'protractor';
+import { $, $$, browser } from 'protractor';
 
 export class TabsTestPageComponent {
-        
+
     minimalCheckbox = $('#minimal-checkbox');
     stackNoneRadio = $('#stack-none-radio');
     stackLeftRadio = $('#stack-left-radio');
     stackRightRadio = $('#stack-right-radio');
+    addTab0 = $('#add-tab-0');
     tabsetHost = $('ux-tabset');
     tabset = $('.nav-tabs');
     tabs = $$('.nav-item');
@@ -41,7 +42,7 @@ export class TabsTestPageComponent {
         if (classes.includes('tabs-left')) {
             return 'left';
         }
-        
+
         if (classes.includes('tabs-right')) {
             return 'right';
         }


### PR DESCRIPTION
#### Checklist
<!-- Use an 'x' to check those which apply. -->
* [x] The contents of this PR are mine to submit. No third party code or other material is being committed.
* [x] New third party dependencies (if any) are linked via `package.json`. Third party dependencies are licenced under one of the following: Apache, MIT, BSD, Mozilla Public License, Eclipse Public License, or Oracle Binary Code License.
* [x] The code in this PR does not contain export-restricted encryption algorithms.

#### Ticket / Issue
<!-- Either a Jira URL or a description of the issue that this PR addresses. -->
https://portal.digitalsafe.net/browse/EL-3517

#### Description of Proposed Changes
<!-- Describe what was changed and how it addresses the original issue. -->
* Added tabs as ContentChildren to provide them to TabsetService in the correct order.
* Added one new test case for the issue.

#### Documentation CI URL
<!-- Initiate a build at https://jenkins.swinfra.net/job/SEPG/view/Templates/job/New%20SEPG%20Build/build -->
<!-- Append the branch name to the following URL: -->
https://pages.github.houston.softwaregrp.net/sepg-docs-qa/UXAspects_CI_UXAspects_EL-3517-tab-order
