### PR TITLE
EL-3519 - Select - duplicate page load attempts

### DIFF
--- a/e2e/tests/components/select/standard/select.e2e-spec.ts
+++ b/e2e/tests/components/select/standard/select.e2e-spec.ts
@@ -20,18 +20,6 @@ describe('Select Tests', () => {
 
         // selected location(s) - null
         expect<any>(page.getSelectedLocationText()).toBe('null');
-
-        // expand panel and check inital state
-        expect(page.checkSelectedOptionsButton()).toBeTruthy();
-        expect(page.checkSelectedDirectionButton()).toBeTruthy();
-        expect(page.confirmIsChecked(page.checkboxMulti)).toBeFalsy();
-        expect(page.confirmIsChecked(page.checkboxDisabled)).toBeFalsy();
-        expect(page.confirmIsChecked(page.checkboxAllowNull)).toBeFalsy();
-        expect(page.confirmIsChecked(page.checkboxPaging)).toBeFalsy();
-        expect(page.confirmAllowNullIsDisabled()).toBeFalsy();
-        expect(page.confirmPageSizeIsDisabled()).toBeTruthy();
-        expect(page.confirmPageSizeButtonIsDisabled('down')).toBeTruthy();
-        expect(page.confirmPageSizeButtonIsDisabled('up')).toBeTruthy();
     });
 
     it('should display correct text', () => {
@@ -60,46 +48,6 @@ describe('Select Tests', () => {
 
         page.clickOnDropdown(false);
         expect(page.confirmDropdownIsExpanded()).toBeFalsy();
-
-    });
-
-    it('should react to button clicks', () => {
-
-        // options radio button
-        page.clickOnObjects();
-        expect(page.checkSelectedOptionsButton()).toBeFalsy();
-        page.clickOnStrings();
-        expect(page.checkSelectedOptionsButton()).toBeTruthy();
-
-        // multiple checkbox
-        page.clickOnCheckbox(page.checkboxMulti);
-        expect(page.confirmIsChecked(page.checkboxMulti)).toBeTruthy();
-        page.clickOnCheckbox(page.checkboxMulti);
-        expect(page.confirmIsChecked(page.checkboxMulti)).toBeFalsy();
-
-        // disabled checkbox
-        page.clickOnCheckbox(page.checkboxDisabled);
-        expect(page.confirmIsChecked(page.checkboxDisabled)).toBeTruthy();
-        page.clickOnCheckbox(page.checkboxDisabled);
-        expect(page.confirmIsChecked(page.checkboxDisabled)).toBeFalsy();
-
-        // allowNull checkbox
-        page.clickOnCheckbox(page.checkboxAllowNull);
-        expect(page.confirmIsChecked(page.checkboxAllowNull)).toBeTruthy();
-        page.clickOnCheckbox(page.checkboxAllowNull);
-        expect(page.confirmIsChecked(page.checkboxAllowNull)).toBeFalsy();
-
-        // dropDirection radio button
-        page.clickOnDropDirectionUp();
-        expect(page.checkSelectedDirectionButton()).toBeFalsy();
-        page.clickOnDropDirectionDown();
-        expect(page.checkSelectedDirectionButton()).toBeTruthy();
-
-        // Enable Option Paging button
-        page.clickOnCheckbox(page.checkboxPaging);
-        expect(page.confirmIsChecked(page.checkboxPaging)).toBeTruthy();
-        page.clickOnCheckbox(page.checkboxPaging);
-        expect(page.confirmIsChecked(page.checkboxPaging)).toBeFalsy();
 
     });
 
@@ -381,26 +329,7 @@ describe('Select Tests', () => {
 
     it('should react to changes in the status of the "allowNull" checkbox', () => {
 
-        // unselectable in multiple mode
-        page.clickOnCheckbox(page.checkboxMulti);
-        expect(page.confirmAllowNullIsDisabled()).toBeTruthy();
-        page.clickOnCheckbox(page.checkboxAllowNull);
-        expect(page.confirmIsChecked(page.checkboxAllowNull)).toBeFalsy();
-
-        // checked but disabled
-        page.clickOnCheckbox(page.checkboxMulti);
-        page.clickOnCheckbox(page.checkboxAllowNull);
-        page.clickOnCheckbox(page.checkboxMulti);
-        expect(page.confirmIsChecked(page.checkboxAllowNull)).toBeTruthy();
-        expect(page.confirmAllowNullIsDisabled()).toBeTruthy();
-
-        // checked & enabled after unchecking multiple button
-        page.clickOnCheckbox(page.checkboxMulti);
-        expect(page.confirmIsChecked(page.checkboxAllowNull)).toBeTruthy();
-        expect(page.confirmAllowNullIsDisabled()).toBeFalsy();
-
         // prevent deletion of text when allowNull is unchecked
-        page.clickOnCheckbox(page.checkboxAllowNull);
         page.clickOnDropdown(false);
         page.clickOnCountry(false, 190);
         expect<any>(page.getSelectedLocationText()).toBe('"Saint Martin (French part)"');
@@ -449,22 +378,6 @@ describe('Select Tests', () => {
         page.clickOnDropdown(true);
         page.clickOnCountry(true, 230);
         expect<any>(page.getDropdownPlaceholderText(true)).toEqual('Pick a country');
-
-    });
-
-    it('should react to changes in the status of the "Enable Option Paging" button', () => {
-
-        // enable paging
-        page.clickOnCheckbox(page.checkboxPaging);
-        expect(page.confirmPageSizeIsDisabled()).toBeFalsy();
-        expect(page.confirmPageSizeButtonIsDisabled('down')).toBeFalsy();
-        expect(page.confirmPageSizeButtonIsDisabled('up')).toBeFalsy();
-
-        // disable paging
-        page.clickOnCheckbox(page.checkboxPaging);
-        expect(page.confirmPageSizeIsDisabled()).toBeTruthy();
-        expect(page.confirmPageSizeButtonIsDisabled('down')).toBeTruthy();
-        expect(page.confirmPageSizeButtonIsDisabled('up')).toBeTruthy();
 
     });
 

--- a/src/components/select/select.component.ts
+++ b/src/components/select/select.component.ts
@@ -192,9 +192,9 @@ export class SelectComponent<T> implements OnInit, OnChanges, OnDestroy, Control
 
         // Changes to the input field
         this._input$.pipe(
-            takeUntil(this._onDestroy),
             filter(() => this.allowNull),
-            filter(value => !this.multiple && value !== this.getDisplay(this.value))
+            filter(value => !this.multiple && value !== this.getDisplay(this.value)),
+            takeUntil(this._onDestroy)
         ).subscribe(() => this.value = null);
 
         // Set up filter from input
@@ -205,16 +205,16 @@ export class SelectComponent<T> implements OnInit, OnChanges, OnDestroy, Control
 
         // Open the dropdown when filter is nonempty.
         this.filter$.pipe(
-            takeUntil(this._onDestroy),
-            filter(value => value && value.length > 0)
+            filter(value => value && value.length > 0),
+            takeUntil(this._onDestroy)
         ).subscribe(() => this.dropdownOpen = true);
 
         // Update the single-select input when the model changes
         this._value$.pipe(
-            takeUntil(this._onDestroy),
             distinctUntilChanged(),
             delay(0),
-            filter(value => value !== null && !this.multiple)
+            filter(value => value !== null && !this.multiple),
+            takeUntil(this._onDestroy)
         ).subscribe(value => {
             this.input = this.getDisplay(value);
         });

--- a/src/components/typeahead/typeahead.component.html
+++ b/src/components/typeahead/typeahead.component.html
@@ -2,7 +2,7 @@
     [uxInfiniteScroll]="loadOptionsCallback"
     [collection]="visibleOptions$ | async"
     (collectionChange)="visibleOptions$.next($event)"
-    [enabled]="isInfiniteScroll()"
+    [enabled]="hasBeenOpened && isInfiniteScroll()"
     [filter]="filter"
     [loadOnScroll]="true"
     [pageSize]="pageSize"

--- a/src/components/typeahead/typeahead.component.ts
+++ b/src/components/typeahead/typeahead.component.ts
@@ -100,12 +100,13 @@ export class TypeaheadComponent<T = any> implements OnChanges, OnDestroy {
     /** Emit the highlighted element when it changes */
     @Output() highlightedElementChange = new EventEmitter<HTMLElement>();
 
-    loadOptionsCallback: InfiniteScrollLoadFunction;
-    visibleOptions$ = new BehaviorSubject<TypeaheadVisibleOption<T>[]>([]);
+    activeKey: string = null;
     clicking = false;
+    hasBeenOpened = false;
     highlighted$ = new BehaviorSubject<TypeaheadVisibleOption<T>>(null);
     highlightedKey: string = null;
-    activeKey: string = null;
+    loadOptionsCallback: InfiniteScrollLoadFunction;
+    visibleOptions$ = new BehaviorSubject<TypeaheadVisibleOption<T>[]>([]);
 
     get highlighted(): T {
         const value = this.highlighted$.getValue();
@@ -150,10 +151,11 @@ export class TypeaheadComponent<T = any> implements OnChanges, OnDestroy {
             return null;
         };
 
-        this._service.open$.pipe(distinctUntilChanged(), takeUntil(this._onDestroy)).subscribe((next) => {
-            this.openChange.emit(next);
+        this._service.open$.pipe(distinctUntilChanged(), takeUntil(this._onDestroy)).subscribe((isOpen) => {
+            this.openChange.emit(isOpen);
 
-            if (next) {
+            if (isOpen) {
+                this.hasBeenOpened = true;
                 this.initOptions();
             }
         });


### PR DESCRIPTION
#### Checklist
<!-- Use an 'x' to check those which apply. -->
* [x] The contents of this PR are mine to submit. No third party code or other material is being committed.
* [x] New third party dependencies (if any) are linked via `package.json`. Third party dependencies are licenced under one of the following: Apache, MIT, BSD, Mozilla Public License, Eclipse Public License, or Oracle Binary Code License.
* [x] The code in this PR does not contain export-restricted encryption algorithms.

#### Ticket / Issue
<!-- Either a Jira URL or a description of the issue that this PR addresses. -->
https://portal.digitalsafe.net/browse/EL-3519

#### Description of Proposed Changes
<!-- Describe what was changed and how it addresses the original issue. -->
* `hasBeenOpened` added to the typeahead component to track when it has been opened for the first time. Infinite scroll is disabled until this becomes true. This resolves the reported issue as well as the current behavior in the documentation where all the pages start loading as soon as paging is enabled.
* Moved `takeUntil` to the end of the `pipe` functions.
* Removed some irrelevant tests (testing functionality of code that only exists on the test page).

#### Documentation CI URL
<!-- Initiate a build at https://jenkins.swinfra.net/job/SEPG/view/Templates/job/New%20SEPG%20Build/build -->
<!-- Append the branch name to the following URL: -->
https://pages.github.houston.softwaregrp.net/sepg-docs-qa/UXAspects_CI_UXAspects_EL-3519-select-load
