### PR TITLE
EL-3540 - Date Range Picker Time

### DIFF
--- a/src/components/date-range-picker/date-range-picker.component.ts
+++ b/src/components/date-range-picker/date-range-picker.component.ts
@@ -121,16 +121,22 @@ export class DateRangePickerComponent implements OnDestroy {
     /** Calculate the number of days between the start and end date */
     get _duration(): number | null {
         if (this.rangeService.start && this.rangeService.end) {
-            return differenceBetweenDates(this.rangeService.start, this.rangeService.end);
+            return differenceBetweenDates(this.rangeService.start, this.rangeService.end, false);
         }
 
         if (this.rangeService.start && !this.rangeService.end && this.rangeService.hover) {
-            return this.rangeService.start.getTime() <= this.rangeService.hover.getTime() ? differenceBetweenDates(this.rangeService.start, this.rangeService.hover) : null;
+            // apply the time from the time picker
+            const hoverDate = new Date(this.rangeService.hover);
+            hoverDate.setHours(this.rangeService.endTime.hours, this.rangeService.endTime.minutes, this.rangeService.endTime.seconds);
+            return this.rangeService.start.getTime() <= hoverDate.getTime() ? differenceBetweenDates(this.rangeService.start, hoverDate, false) : null;
         }
 
         // if we only have one selected date and have a hover date
         if (this.rangeService.end && !this.rangeService.start && this.rangeService.hover) {
-            return this.rangeService.end.getTime() >= this.rangeService.hover.getTime() ? differenceBetweenDates(this.rangeService.end, this.rangeService.hover) : null;
+            // apply the time from the time picker
+            const hoverDate = new Date(this.rangeService.hover);
+            hoverDate.setHours(this.rangeService.startTime.hours, this.rangeService.startTime.minutes, this.rangeService.startTime.seconds);
+            return this.rangeService.end.getTime() >= hoverDate.getTime() ? differenceBetweenDates(this.rangeService.end, hoverDate, false) : null;
         }
     }
 
@@ -177,5 +183,4 @@ export class DateRangePickerComponent implements OnDestroy {
     private getDurationTitle(days: number): string {
         return days + ' ' + (days > 1 ? 'days' : 'day');
     }
-
 }

--- a/src/components/date-range-picker/date-range.service.ts
+++ b/src/components/date-range-picker/date-range.service.ts
@@ -45,6 +45,12 @@ export class DateRangeService {
     /** Indicate if we are currently changing the time */
     isChangingTime: boolean = false;
 
+    /** Store the current start time */
+    startTime: DateRangeTime = { hours: 0, minutes: 0, seconds: 0 };
+
+    /** Store the current end time */
+    endTime: DateRangeTime = { hours: 23, minutes: 59, seconds: 59 };
+
     setStartDate(date: Date | null): void {
 
         // if the start date is after the end date the clear the end date
@@ -85,10 +91,15 @@ export class DateRangeService {
             this.setDateMouseEnter(null);
         }
     }
-
 }
 
 export enum DateRangePicker {
     Start = 'start',
     End = 'end'
+}
+
+export interface DateRangeTime {
+    hours: number;
+    minutes: number;
+    seconds: number;
 }

--- a/src/components/date-time-picker/date-time-picker.utils.ts
+++ b/src/components/date-time-picker/date-time-picker.utils.ts
@@ -84,8 +84,13 @@ export function dateComparator(dateOne: Date, dateTwo: Date): boolean {
     return dateOne.getTime() === dateTwo.getTime();
 }
 
-/** Calculate the number of days between two dates */
-export function differenceBetweenDates(start: Date, end: Date): number | null {
+/**
+ * Calculate the number of days between two dates
+ * @param start The start date
+ * @param end The end date
+ * @param fullDay Whether or not we should take from 00:00 on the start date and 23:59 on the end date
+ */
+export function differenceBetweenDates(start: Date, end: Date, fullDay: boolean = true): number | null {
     if (!start || !end) {
         return null;
     }
@@ -95,8 +100,10 @@ export function differenceBetweenDates(start: Date, end: Date): number | null {
     const endDay = new Date(start.getTime() > end.getTime() ? start : end);
 
     // get the start of day
-    startDay.setHours(0, 0, 0, 0);
-    endDay.setHours(23, 59, 59, 0);
+    if (fullDay) {
+        startDay.setHours(0, 0, 0, 0);
+        endDay.setHours(23, 59, 59, 0);
+    }
 
     return Math.round((endDay.getTime() - startDay.getTime()) / millisecondsInDay);
 }

--- a/src/components/date-time-picker/time-view/time-view.component.ts
+++ b/src/components/date-time-picker/time-view/time-view.component.ts
@@ -1,11 +1,11 @@
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, HostListener, OnDestroy, Optional, OnInit } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, HostListener, OnDestroy, OnInit, Optional } from '@angular/core';
+import { combineLatest } from 'rxjs/observable/combineLatest';
 import { filter, takeUntil } from 'rxjs/operators';
 import { Subject } from 'rxjs/Subject';
 import { DateRangeOptions } from '../../date-range-picker/date-range-picker.directive';
 import { DateRangePicker, DateRangeService } from '../../date-range-picker/date-range.service';
 import { DateTimePickerService } from '../date-time-picker.service';
 import { compareDays } from '../date-time-picker.utils';
-import { combineLatest } from 'rxjs/observable/combineLatest';
 
 @Component({
     selector: 'ux-date-time-picker-time-view',
@@ -111,6 +111,13 @@ export class TimeViewComponent implements OnInit, OnDestroy {
             this.datepicker.hours = time.getHours();
             this.datepicker.minutes = time.getMinutes();
             this.datepicker.seconds = time.getSeconds();
+
+            // update the time in the range picker service
+            if (this._isRangeStart) {
+                this._rangeService.startTime = { hours: time.getHours(), minutes: time.getMinutes(), seconds: time.getSeconds() };
+            } else {
+                this._rangeService.endTime = { hours: time.getHours(), minutes: time.getMinutes(), seconds: time.getSeconds() };
+            }
 
             // if a date is currently selected we should update it
             if (this._isRangeStart && this._rangeStart) {


### PR DESCRIPTION
#### Checklist
<!-- Use an 'x' to check those which apply. -->
* [x] The contents of this PR are mine to submit. No third party code or other material is being committed.
* [x] New third party dependencies (if any) are linked via `package.json`. Third party dependencies are licenced under one of the following: Apache, MIT, BSD, Mozilla Public License, Eclipse Public License, or Oracle Binary Code License.
* [x] The code in this PR does not contain export-restricted encryption algorithms.

#### Ticket / Issue
<!-- Either a Jira URL or a description of the issue that this PR addresses. -->
https://portal.digitalsafe.net/browse/EL-3540

#### Description of Proposed Changes
<!-- Describe what was changed and how it addresses the original issue. -->
- Previously that date range duration always calculate the range based on 00:00 on the start date and 23:59 on the end date. I have updated this to now take into account the time provided by the time picker, so if the time was set to 7pm on both start and end time pickers the duration would be 2 days rather than 3 days

#### Documentation CI URL
<!-- Initiate a build at https://jenkins.swinfra.net/job/SEPG/view/Templates/job/New%20SEPG%20Build/build -->
<!-- Append the branch name to the following URL: -->
https://pages.github.houston.softwaregrp.net/sepg-docs-qa/UXAspects_CI_UXAspects_EL-3540-Date-Range-Picker-Duration
