### PR TITLE
EL-3528 - Column Resizing Fix

### DIFF
--- a/src/components/table/table-column-resize/resizable-table-cell.directive.ts
+++ b/src/components/table/table-column-resize/resizable-table-cell.directive.ts
@@ -1,4 +1,5 @@
 import { Directive, ElementRef, OnDestroy, OnInit, Renderer2 } from '@angular/core';
+import { combineLatest } from 'rxjs/observable/combineLatest';
 import { takeUntil } from 'rxjs/operators';
 import { Subject } from 'rxjs/Subject';
 import { ColumnUnit, ResizableTableService } from './resizable-table.service';
@@ -15,7 +16,7 @@ export class ResizableTableCellDirective implements OnInit, OnDestroy {
 
     ngOnInit(): void {
         // update the sizes when columns are resized
-        this._table.onResize$.pipe(takeUntil(this._onDestroy)).subscribe(() => {
+        combineLatest(this._table.onResize$, this._table.isResizing$).pipe(takeUntil(this._onDestroy)).subscribe(() => {
             this.setColumnWidth();
             this.setColumnFlex();
         });
@@ -33,7 +34,7 @@ export class ResizableTableCellDirective implements OnInit, OnDestroy {
 
     /** Set the width of the column */
     private setColumnWidth(): void {
-        const width = this._table.isResizing || this._table.getColumnDisabled(this.getCellIndex()) ?
+        const width = this._table.isResizing$.value || this._table.getColumnDisabled(this.getCellIndex()) ?
             `${this._table.getColumnWidth(this.getCellIndex(), ColumnUnit.Pixel)}px` :
             `${this._table.getColumnWidth(this.getCellIndex(), ColumnUnit.Percentage)}%`;
 
@@ -43,7 +44,7 @@ export class ResizableTableCellDirective implements OnInit, OnDestroy {
     /** Set the flex value of the column */
     private setColumnFlex(): void {
         // if we are resizing then always return 'none' to allow free movement
-        if (this._table.isResizing || this._table.getColumnDisabled(this.getCellIndex())) {
+        if (this._table.isResizing$.value || this._table.getColumnDisabled(this.getCellIndex())) {
             this._renderer.setStyle(this._elementRef.nativeElement, 'flex', 'none');
             return;
         }

--- a/src/components/table/table-column-resize/resizable-table-column.component.ts
+++ b/src/components/table/table-column-resize/resizable-table-column.component.ts
@@ -19,6 +19,15 @@ export class ResizableTableColumnComponent implements OnDestroy {
     /** Define the width of a column */
     @Input() set width(width: number) {
 
+        // there may be cases where columns are created with an `*ngFor` and a width
+        // may be specified on *some* columns and not others. This this setter will
+        // still be called whenever the value is empty and this will mark this column
+        // as having a fixed width, even though it doesn't. So we should only proceed
+        // whenever there is an actual numeric value passed in.
+        if (width === null || width === undefined) {
+            return;
+        }
+
         // ensure width is a valid number
         this._width = coerceNumberProperty(width);
 
@@ -157,7 +166,7 @@ export class ResizableTableColumnComponent implements OnDestroy {
         }
 
 
-        const width = this._table.isResizing ?
+        const width = this._table.isResizing$.value ?
             `${this._table.getColumnWidth(this.getCellIndex(), ColumnUnit.Pixel)}px` :
             `${this._table.getColumnWidth(this.getCellIndex(), ColumnUnit.Percentage)}%`;
 
@@ -169,7 +178,7 @@ export class ResizableTableColumnComponent implements OnDestroy {
     private setColumnFlex(): void {
 
         // if we are resizing then always return 'none' to allow free movement
-        if (this._table.isResizing || this.disabled) {
+        if (this._table.isResizing$.value || this.disabled) {
             this._renderer.setStyle(this._elementRef.nativeElement, 'flex', 'none');
         }
 

--- a/src/components/table/table-column-resize/resizable-table.service.ts
+++ b/src/components/table/table-column-resize/resizable-table.service.ts
@@ -10,7 +10,7 @@ export class ResizableTableService implements OnDestroy {
     isInitialised$ = new BehaviorSubject<boolean>(false);
 
     /** Determine if we are currently resizing */
-    isResizing: boolean = false;
+    isResizing$ = new BehaviorSubject<boolean>(false);
 
     /** Store the percentage widths of each column */
     columns: ReadonlyArray<number> = [];
@@ -137,7 +137,7 @@ export class ResizableTableService implements OnDestroy {
 
     /** Update the resizing state */
     setResizing(isResizing: boolean): void {
-        this.isResizing = isResizing;
+        this.isResizing$.next(isResizing);
     }
 
     /** Get the width of a column in a specific unit */


### PR DESCRIPTION
#### Checklist
<!-- Use an 'x' to check those which apply. -->
* [x] The contents of this PR are mine to submit. No third party code or other material is being committed.
* [x] New third party dependencies (if any) are linked via `package.json`. Third party dependencies are licenced under one of the following: Apache, MIT, BSD, Mozilla Public License, Eclipse Public License, or Oracle Binary Code License.
* [x] The code in this PR does not contain export-restricted encryption algorithms.

#### Ticket / Issue
<!-- Either a Jira URL or a description of the issue that this PR addresses. -->
https://portal.digitalsafe.net/browse/EL-3528

#### Description of Proposed Changes
<!-- Describe what was changed and how it addresses the original issue. -->
- Updated the `width` input to only mark a column as fixed if a value was actually provided, previously if columns were added with an `ngFor` and only some had a width specified, the `width` setter was getting called with `undefined` and being marked as a fixed width column.
- Hiding horizontal overflow while dragging. To prevent jankiness when dragging we have to specify the column widths as pixels, however pixels are not as precise as percentages so when converting between the two there is a chance that overflow may occur based on the conversion, so hiding horizontal overflow while dragging.
- Also fixed a bug where when dragging ends the column widths were not getting set back to percentages as they should have.

#### Documentation CI URL
<!-- Initiate a build at https://jenkins.swinfra.net/job/SEPG/view/Templates/job/New%20SEPG%20Build/build -->
<!-- Append the branch name to the following URL: -->
https://pages.github.houston.softwaregrp.net/sepg-docs-qa/UXAspects_CI_UXAspects_EL-3528-Column-Resizing
