### PR TITLE
EL-3512 - Iconset Fixes

### DIFF
--- a/docs/app/pages/css/css-sections/icons/basic-usage/basic-usage.component.html
+++ b/docs/app/pages/css/css-sections/icons/basic-usage/basic-usage.component.html
@@ -1,13 +1,13 @@
 <div class="m-b">
-    <i class="hpe-icon hpe-alert text-muted" aria-hidden="true"></i>
-    <span class="sr-only">ALERT!</span> hpe-alert
+    <i class="ux-icon ux-icon-alert text-muted" aria-hidden="true"></i>
+    <span class="sr-only">ALERT!</span> ux-icon-alert
 </div>
 
 <hr>
 
-<p>Use the <code>.hpe-icon</code> class along with any class in the corresponding icon set listed above to create an icon.</p>
+<p>Use the <code>.ux-icon</code> class along with any class in the corresponding icon set listed above to create an icon.</p>
 <p>The example above uses <code>i</code> tags but it can also be used with <code>span</code> tags.</p>
-<p>If using an icon for decoration to avoid unintended or confusing outputs from assistive technologies you should use <code>aria-hidden="true"</code>. 
+<p>If using an icon for decoration to avoid unintended or confusing outputs from assistive technologies you should use <code>aria-hidden="true"</code>.
 If the icon has meaning, specify a label using <code>.sr-only</code> to convey that information to assistive technologies.</p>
 
 <uxd-snippet [content]="snippets.compiled.sampleHtml"></uxd-snippet>

--- a/docs/app/pages/css/css-sections/icons/basic-usage/basic-usage.component.html
+++ b/docs/app/pages/css/css-sections/icons/basic-usage/basic-usage.component.html
@@ -5,9 +5,9 @@
 
 <hr>
 
-<p>Use the <code>.ux-icon</code> class along with any class in the corresponding icon set listed above to create an icon.</p>
+<p>Use the <code>ux-icon</code> class along with any class in the corresponding icon set listed above to create an icon.</p>
 <p>The example above uses <code>i</code> tags but it can also be used with <code>span</code> tags.</p>
 <p>If using an icon for decoration to avoid unintended or confusing outputs from assistive technologies you should use <code>aria-hidden="true"</code>.
-If the icon has meaning, specify a label using <code>.sr-only</code> to convey that information to assistive technologies.</p>
+If the icon has meaning, specify a label using <code>sr-only</code> to convey that information to assistive technologies.</p>
 
 <uxd-snippet [content]="snippets.compiled.sampleHtml"></uxd-snippet>

--- a/docs/app/pages/css/css-sections/icons/basic-usage/snippets/sample.html
+++ b/docs/app/pages/css/css-sections/icons/basic-usage/snippets/sample.html
@@ -1,3 +1,3 @@
-<i class="hpe-icon hpe-alert" aria-hidden="true"></i>
+<i class="ux-icon ux-icon-alert" aria-hidden="true"></i>
 <span class="sr-only">ALERT!</span>
-hpe-alert
+ux-icon-alert

--- a/docs/app/pages/css/css-sections/icons/fixed-width/fixed-width.component.html
+++ b/docs/app/pages/css/css-sections/icons/fixed-width/fixed-width.component.html
@@ -12,6 +12,6 @@
 
 <hr>
 
-<p>Fixed width icons are useful when using the <code>hpe-icon</code> set and different width icons are causing misalignment. Use the <code>.hpe-fw</code> class.</p>
+<p>Fixed width icons are useful when using the <code>hpe-icon</code> set and different width icons are causing misalignment. Use the <code>hpe-fw</code> class.</p>
 
 <uxd-snippet [content]="snippets.compiled.sampleHtml"></uxd-snippet>

--- a/docs/app/pages/css/css-sections/icons/fixed-width/fixed-width.component.html
+++ b/docs/app/pages/css/css-sections/icons/fixed-width/fixed-width.component.html
@@ -12,6 +12,6 @@
 
 <hr>
 
-<p>Fixed width icons are useful when different width icons are causing misalignment. Use the <code>.hpe-fw</code> class.</p>
+<p>Fixed width icons are useful when using the <code>hpe-icon</code> set and different width icons are causing misalignment. Use the <code>.hpe-fw</code> class.</p>
 
 <uxd-snippet [content]="snippets.compiled.sampleHtml"></uxd-snippet>

--- a/docs/app/pages/css/css-sections/icons/icon-buttons/icon-buttons.component.html
+++ b/docs/app/pages/css/css-sections/icons/icon-buttons/icon-buttons.component.html
@@ -1,17 +1,17 @@
 <p>
     <button type="button" class="btn button-secondary" aria-label="Refresh">
-        <span class="hpe-icon hpe-refresh" aria-hidden="true"></span>
+        <span class="ux-icon ux-icon-refresh" aria-hidden="true"></span>
     </button>
 </p>
 <p>
     <button type="button" class="btn button-primary">
-        <span class="hpe-icon hpe-add" aria-hidden="true"></span>&nbsp;Add
+        <span class="ux-icon ux-icon-add" aria-hidden="true"></span>&nbsp;Add
     </button>
 </p>
 
 <hr>
 
-<p>When placing an icon in a button ensure to use <code>aria-hidden="true"</code> attribute and if there is no text 
+<p>When placing an icon in a button ensure to use <code>aria-hidden="true"</code> attribute and if there is no text
 in the button ensure to use the <code>aria-label</code> attribute to support assistive technologies.</p>
 
 <uxd-snippet [content]="snippets.compiled.sampleHtml"></uxd-snippet>

--- a/docs/app/pages/css/css-sections/icons/icon-buttons/snippets/sample.html
+++ b/docs/app/pages/css/css-sections/icons/icon-buttons/snippets/sample.html
@@ -1,10 +1,10 @@
 <p>
     <button type="button" class="btn button-secondary" aria-label="Refresh">
-        <span class="hpe-icon hpe-refresh" aria-hidden="true"></span>
+        <span class="ux-icon ux-icon-refresh" aria-hidden="true"></span>
     </button>
 </p>
 <p>
     <button type="button" class="btn button-primary">
-        <span class="hpe-icon hpe-add" aria-hidden="true"></span>&nbsp;Add
+        <span class="ux-icon ux-icon-add" aria-hidden="true"></span>&nbsp;Add
     </button>
 </p>

--- a/docs/app/pages/css/css-sections/icons/icon-colors/icon-colors.component.html
+++ b/docs/app/pages/css/css-sections/icons/icon-colors/icon-colors.component.html
@@ -14,7 +14,7 @@
 
 <hr>
 
-<p>Changing an icon’s color involves changing the CSS color or using <code>.text-primary</code>, <code>.text-muted</code>, <code>.text-secondary</code> or <code>.text-error</code>.</p>
+<p>Changing an icon’s color involves changing the CSS color or using <code>text-primary</code>, <code>text-muted</code>, <code>text-secondary</code> or <code>text-error</code>.</p>
 <p>The color will not be communicated to users using assistive technologies, so include an <code>aria-label</code> if the color is used to convey meaning.</p>
 
 <uxd-snippet [content]="snippets.compiled.sampleHtml"></uxd-snippet>

--- a/docs/app/pages/css/css-sections/icons/icon-colors/icon-colors.component.html
+++ b/docs/app/pages/css/css-sections/icons/icon-colors/icon-colors.component.html
@@ -1,15 +1,15 @@
 <p>
-    <i class="hpe-icon hpe-folder hp-lg text-primary" aria-hidden="true"></i>&nbsp;text-primary
+    <i class="ux-icon ux-icon-folder text-primary" aria-hidden="true"></i>&nbsp;text-primary
 </p>
 <p>
-    <i class="hpe-icon hpe-pin hp-lg text-muted" aria-hidden="true"></i>&nbsp;text-muted
+    <i class="ux-icon ux-icon-pin text-muted" aria-hidden="true"></i>&nbsp;text-muted
 </p>
 
 <p>
-    <i class="hpe-icon hpe-shield-configure hp-lg text-secondary" aria-hidden="true"></i>&nbsp;text-secondary
+    <i class="ux-icon ux-icon-shield-configure text-secondary" aria-hidden="true"></i>&nbsp;text-secondary
 </p>
 <p>
-    <i class="hpe-icon hpe-alert hp-lg text-error" aria-hidden="true"></i>&nbsp;text-error
+    <i class="ux-icon ux-icon-alert text-error" aria-hidden="true"></i>&nbsp;text-error
 </p>
 
 <hr>

--- a/docs/app/pages/css/css-sections/icons/icon-colors/snippets/sample.html
+++ b/docs/app/pages/css/css-sections/icons/icon-colors/snippets/sample.html
@@ -1,4 +1,4 @@
-<p><i class="hpe-icon hpe-folder text-primary" aria-hidden="true"></i>&nbsp;text-primary</p>
-<p><i class="hpe-icon hpe-pin text-muted" aria-hidden="true"></i>&nbsp;text-muted</p>
-<p><i class="hpe-icon hpe-shield-configure text-secondary" aria-hidden="true"></i>&nbsp;text-secondary</p>
-<p><i class="hpe-icon hpe-alert text-error" aria-hidden="true"></i>&nbsp;text-error</p>
+<p><i class="ux-icon ux-icon-folder text-primary" aria-hidden="true"></i>&nbsp;text-primary</p>
+<p><i class="ux-icon ux-icon-pin text-muted" aria-hidden="true"></i>&nbsp;text-muted</p>
+<p><i class="ux-icon ux-icon-shield-configure text-secondary" aria-hidden="true"></i>&nbsp;text-secondary</p>
+<p><i class="ux-icon ux-icon-alert text-error" aria-hidden="true"></i>&nbsp;text-error</p>

--- a/docs/app/pages/css/css-sections/icons/icon-size/icon-size.component.html
+++ b/docs/app/pages/css/css-sections/icons/icon-size/icon-size.component.html
@@ -1,23 +1,23 @@
 <p>
-    <i class="hpe-icon hpe-cube hpe-lg text-muted" aria-hidden="true"></i>&nbsp;hpe-lg
+    <i class="ux-icon ux-icon-cube ux-lg text-muted" aria-hidden="true"></i>&nbsp;ux-lg
 </p>
 <p>
-    <i class="hpe-icon hpe-cube hpe-2x text-muted" aria-hidden="true"></i>&nbsp;hpe-2x
+    <i class="ux-icon ux-icon-cube ux-2x text-muted" aria-hidden="true"></i>&nbsp;ux-2x
 </p>
 <p>
-    <i class="hpe-icon hpe-cube hpe-3x text-muted" aria-hidden="true"></i>&nbsp;hpe-3x
+    <i class="ux-icon ux-icon-cube ux-3x text-muted" aria-hidden="true"></i>&nbsp;ux-3x
 </p>
 <p>
-    <i class="hpe-icon hpe-cube hpe-4x text-muted" aria-hidden="true"></i>&nbsp;hpe-4x
+    <i class="ux-icon ux-icon-cube ux-4x text-muted" aria-hidden="true"></i>&nbsp;ux-4x
 </p>
 <p>
-    <i class="hpe-icon hpe-cube hpe-5x text-muted" aria-hidden="true"></i>&nbsp;hpe-5x
+    <i class="ux-icon ux-icon-cube ux-5x text-muted" aria-hidden="true"></i>&nbsp;ux-5x
 </p>
 
 <hr>
 
-<p>To increase the relative size of the icon use <code>hpe-lg</code>, <code>hpe-2x</code>, <code>hpe-3x</code>, <code>hpe-4x</code>, <code>hpe-5x</code>
-. 
+<p>To increase the relative size of the icon use <code>ux-lg</code>, <code>ux-2x</code>, <code>ux-3x</code>, <code>ux-4x</code>, <code>ux-5x</code>
+.
 If icons appear to be chopped off along the bottom ensure the <code>line-height</code> is sufficient.</p>
 
 <uxd-snippet [content]="snippets.compiled.sampleHtml"></uxd-snippet>

--- a/docs/app/pages/css/css-sections/icons/icon-size/snippets/sample.html
+++ b/docs/app/pages/css/css-sections/icons/icon-size/snippets/sample.html
@@ -1,5 +1,5 @@
-<i class="hpe-icon hpe-cube hpe-lg" aria-hidden="true"></i>&nbsp;hpe-lg
-<i class="hpe-icon hpe-cube hpe-2x" aria-hidden="true"></i>&nbsp;hpe-2x
-<i class="hpe-icon hpe-cube hpe-3x" aria-hidden="true"></i>&nbsp;hpe-3x
-<i class="hpe-icon hpe-cube hpe-4x" aria-hidden="true"></i>&nbsp;hpe-4x
-<i class="hpe-icon hpe-cube hpe-5x" aria-hidden="true"></i>&nbsp;hpe-5x
+<i class="ux-icon ux-icon-cube ux-lg" aria-hidden="true"></i>&nbsp;ux-lg
+<i class="ux-icon ux-icon-cube ux-2x" aria-hidden="true"></i>&nbsp;ux-2x
+<i class="ux-icon ux-icon-cube ux-3x" aria-hidden="true"></i>&nbsp;ux-3x
+<i class="ux-icon ux-icon-cube ux-4x" aria-hidden="true"></i>&nbsp;ux-4x
+<i class="ux-icon ux-icon-cube ux-5x" aria-hidden="true"></i>&nbsp;ux-5x

--- a/docs/app/pages/css/css-sections/icons/rotate-flip-icons/rotate-flip-icons.component.html
+++ b/docs/app/pages/css/css-sections/icons/rotate-flip-icons/rotate-flip-icons.component.html
@@ -1,29 +1,29 @@
 <p>
-    <i class="hpe-icon hpe-tab-up text-muted" aria-hidden="true"></i> no rotation
+    <i class="ux-icon ux-icon-tab-up text-muted" aria-hidden="true"></i> no rotation
 </p>
 <p>
-    <i class="hpe-icon hpe-tab-up hpe-rotate-90 text-muted" aria-hidden="true"></i>&nbsp;hpe-rotate-90
+    <i class="ux-icon ux-icon-tab-up ux-rotate-90 text-muted" aria-hidden="true"></i>&nbsp;ux-rotate-90
 </p>
 <p>
-    <i class="hpe-icon hpe-tab-up hpe-rotate-180 text-muted" aria-hidden="true"></i>&nbsp;hpe-rotate-180
+    <i class="ux-icon ux-icon-tab-up ux-rotate-180 text-muted" aria-hidden="true"></i>&nbsp;ux-rotate-180
 </p>
 <p>
-    <i class="hpe-icon hpe-tab-up hpe-rotate-270 text-muted" aria-hidden="true"></i>&nbsp;hpe-rotate-270
+    <i class="ux-icon ux-icon-tab-up ux-rotate-270 text-muted" aria-hidden="true"></i>&nbsp;ux-rotate-270
 </p>
 <p>
-    <i class="hpe-icon hpe-iteration text-muted" aria-hidden="true"></i>&nbsp;no flip
+    <i class="ux-icon ux-icon-iteration text-muted" aria-hidden="true"></i>&nbsp;no flip
 </p>
 <p>
-    <i class="hpe-icon hpe-iteration hpe-flip-vertical text-muted" aria-hidden="true"></i>&nbsp;hpe-flip-vertical
+    <i class="ux-icon ux-icon-iteration ux-flip-vertical text-muted" aria-hidden="true"></i>&nbsp;ux-flip-vertical
 </p>
 <p>
-    <i class="hpe-icon hpe-iteration hpe-flip-horizontal text-muted" aria-hidden="true"></i>&nbsp;hpe-flip-horizontal
+    <i class="ux-icon ux-icon-iteration ux-flip-horizontal text-muted" aria-hidden="true"></i>&nbsp;ux-flip-horizontal
 </p>
 
 <hr>
 
-<p>An icon’s rotation can be controlled using the following classes <code>.hpe-rotate-90</code>, <code>.hpe-rotate-180</code> and <code>.hpe-rotate-270</code>.
+<p>An icon’s rotation can be controlled using the following classes <code>.ux-rotate-90</code>, <code>.ux-rotate-180</code> and <code>.ux-rotate-270</code>.
 e
-An icon can be flipped using <code>.hpe-flip-vertical</code> or <code>.hpe-flip-horizontal</code>.</p>
+An icon can be flipped using <code>.ux-flip-vertical</code> or <code>.ux-flip-horizontal</code>.</p>
 
 <uxd-snippet [content]="snippets.compiled.sampleHtml"></uxd-snippet>

--- a/docs/app/pages/css/css-sections/icons/rotate-flip-icons/rotate-flip-icons.component.html
+++ b/docs/app/pages/css/css-sections/icons/rotate-flip-icons/rotate-flip-icons.component.html
@@ -16,8 +16,7 @@
 
 <hr>
 
-<p>An icon’s rotation can be controlled using the following classes <code>.ux-rotate-90</code>, <code>.ux-rotate-180</code> and <code>.ux-rotate-270</code>.
-e
-An icon can be flipped using <code>.ux-flip-vertical</code> or <code>.ux-flip-horizontal</code>.</p>
+<p>An icon’s rotation can be controlled using the following classes <code>ux-rotate-90</code>, <code>ux-rotate-180</code> and <code>ux-rotate-270</code>.
+An icon can be flipped using <code>ux-flip-vertical</code> or <code>ux-flip-horizontal</code>.</p>
 
 <uxd-snippet [content]="snippets.compiled.sampleHtml"></uxd-snippet>

--- a/docs/app/pages/css/css-sections/icons/rotate-flip-icons/rotate-flip-icons.component.html
+++ b/docs/app/pages/css/css-sections/icons/rotate-flip-icons/rotate-flip-icons.component.html
@@ -1,7 +1,4 @@
 <p>
-    <i class="ux-icon ux-icon-tab-up text-muted" aria-hidden="true"></i> no rotation
-</p>
-<p>
     <i class="ux-icon ux-icon-tab-up ux-rotate-90 text-muted" aria-hidden="true"></i>&nbsp;ux-rotate-90
 </p>
 <p>
@@ -9,9 +6,6 @@
 </p>
 <p>
     <i class="ux-icon ux-icon-tab-up ux-rotate-270 text-muted" aria-hidden="true"></i>&nbsp;ux-rotate-270
-</p>
-<p>
-    <i class="ux-icon ux-icon-iteration text-muted" aria-hidden="true"></i>&nbsp;no flip
 </p>
 <p>
     <i class="ux-icon ux-icon-iteration ux-flip-vertical text-muted" aria-hidden="true"></i>&nbsp;ux-flip-vertical

--- a/docs/app/pages/css/css-sections/icons/rotate-flip-icons/snippets/sample.html
+++ b/docs/app/pages/css/css-sections/icons/rotate-flip-icons/snippets/sample.html
@@ -1,7 +1,7 @@
-<p><i class="hpe-icon hpe-tab-up " aria-hidden="true"></i> no rotation</p>
-<p><i class="hpe-icon hpe-tab-up hpe-rotate-90" aria-hidden="true"></i>&nbsp;hpe-rotate-90</p>
-<p><i class="hpe-icon hpe-tab-up hpe-rotate-180" aria-hidden="true"></i>&nbsp;hpe-rotate-180</p>
-<p><i class="hpe-icon hpe-tab-up hpe-rotate-270" aria-hidden="true"></i>&nbsp;hpe-rotate-270</p>
-<p><i class="hpe-icon hpe-iteration" aria-hidden="true"></i>&nbsp;no flip</p>
-<p><i class="hpe-icon hpe-iteration hpe-flip-vertical" aria-hidden="true"></i>&nbsp;hpe-flip-vertical</p>
-<p><i class="hpe-icon hpe-iteration hpe-flip-horizontal" aria-hidden="true"></i>&nbsp;hpe-flip-horizontal</p>
+<p><i class="ux-icon ux-icon-tab-up " aria-hidden="true"></i> no rotation</p>
+<p><i class="ux-icon ux-icon-tab-up ux-rotate-90" aria-hidden="true"></i>&nbsp;ux-rotate-90</p>
+<p><i class="ux-icon ux-icon-tab-up ux-rotate-180" aria-hidden="true"></i>&nbsp;ux-rotate-180</p>
+<p><i class="ux-icon ux-icon-tab-up ux-rotate-270" aria-hidden="true"></i>&nbsp;ux-rotate-270</p>
+<p><i class="ux-icon ux-icon-iteration" aria-hidden="true"></i>&nbsp;no flip</p>
+<p><i class="ux-icon ux-icon-iteration ux-flip-vertical" aria-hidden="true"></i>&nbsp;ux-flip-vertical</p>
+<p><i class="ux-icon ux-icon-iteration ux-flip-horizontal" aria-hidden="true"></i>&nbsp;ux-flip-horizontal</p>

--- a/docs/app/pages/css/css-sections/icons/rotate-flip-icons/snippets/sample.html
+++ b/docs/app/pages/css/css-sections/icons/rotate-flip-icons/snippets/sample.html
@@ -1,7 +1,5 @@
-<p><i class="ux-icon ux-icon-tab-up " aria-hidden="true"></i> no rotation</p>
 <p><i class="ux-icon ux-icon-tab-up ux-rotate-90" aria-hidden="true"></i>&nbsp;ux-rotate-90</p>
 <p><i class="ux-icon ux-icon-tab-up ux-rotate-180" aria-hidden="true"></i>&nbsp;ux-rotate-180</p>
 <p><i class="ux-icon ux-icon-tab-up ux-rotate-270" aria-hidden="true"></i>&nbsp;ux-rotate-270</p>
-<p><i class="ux-icon ux-icon-iteration" aria-hidden="true"></i>&nbsp;no flip</p>
 <p><i class="ux-icon ux-icon-iteration ux-flip-vertical" aria-hidden="true"></i>&nbsp;ux-flip-vertical</p>
 <p><i class="ux-icon ux-icon-iteration ux-flip-horizontal" aria-hidden="true"></i>&nbsp;ux-flip-horizontal</p>


### PR DESCRIPTION
#### Checklist
<!-- Use an 'x' to check those which apply. -->
* [x] The contents of this PR are mine to submit. No third party code or other material is being committed.
* [x] New third party dependencies (if any) are linked via `package.json`. Third party dependencies are licenced under one of the following: Apache, MIT, BSD, Mozilla Public License, Eclipse Public License, or Oracle Binary Code License.
* [x] The code in this PR does not contain export-restricted encryption algorithms.

#### Ticket / Issue
<!-- Either a Jira URL or a description of the issue that this PR addresses. -->
https://portal.digitalsafe.net/browse/EL-3512

#### Description of Proposed Changes
<!-- Describe what was changed and how it addresses the original issue. -->
- Updating icon sections to use `ux` icons and modifier classes instead of `hpe`. Note, the fixed width section I have kept using the `hpe` icons as this is not relevant to the new iconset due to them being a consistent size already.

#### Documentation CI URL
<!-- Initiate a build at https://jenkins.swinfra.net/job/SEPG/view/Templates/job/New%20SEPG%20Build/build -->
<!-- Append the branch name to the following URL: -->
https://pages.github.houston.softwaregrp.net/sepg-docs-qa/UXAspects_CI_UXAspects_EL-3512-Iconset-Fixes
