### PR TITLE
Fix the release candidate build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,10 +6,10 @@ _SpecRunner.html
 jshint.log
 .awcache/
 docs/app/assets/licenses.txt
-src/fonts/hpe-icons.eot
-src/fonts/hpe-icons.ttf
-src/fonts/hpe-icons.woff
-src/fonts/hpe-icons.svg
+src/fonts/*-icons.eot
+src/fonts/*-icons.ttf
+src/fonts/*-icons.woff
+src/fonts/*-icons.svg
 src/styles/hpe-icons.less
 dist/
 .tscache/

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "build:library": "grunt build:library",
     "lint": "grunt lint",
     "package": "grunt package",
-    "package:release": "grunt package:release",
     "test": "karma start --single-run && grunt e2e",
     "test:e2e": "grunt e2e",
     "test:karma": "karma start --single-run"

--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,7 @@
                 <version>1.6.0</version>
                 <configuration>
                     <environmentVariables>
+                        <RE_BUILD_TYPE>${RE_BUILD_TYPE}</RE_BUILD_TYPE>
                         <VERSION>${project.version}</VERSION>
                     </environmentVariables>
                 </configuration>
@@ -124,22 +125,6 @@
                             <arguments>
                                 <argument>run</argument>
                                 <argument>package</argument>
-                            </arguments>
-                        </configuration>
-                    </execution>
-
-                    <!-- Stage for release -->
-                    <execution>
-                        <id>exec-npm-run-package-release</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>exec</goal>
-                        </goals>
-                        <configuration>
-                            <executable>npm</executable>
-                            <arguments>
-                                <argument>run</argument>
-                                <argument>package:release</argument>
                             </arguments>
                         </configuration>
                     </execution>


### PR DESCRIPTION
#### Checklist
<!-- Use an 'x' to check those which apply. -->
* [x] The contents of this PR are mine to submit. No third party code or other material is being committed.
* [x] New third party dependencies (if any) are linked via `package.json`. Third party dependencies are licenced under one of the following: Apache, MIT, BSD, Mozilla Public License, Eclipse Public License, or Oracle Binary Code License.
* [x] The code in this PR does not contain export-restricted encryption algorithms.

#### Ticket / Issue
<!-- Either a Jira URL or a description of the issue that this PR addresses. -->
Release candidate build failed, see: https://jenkins.swinfra.net/job/SEPG/job/UXAspects/view/Builds/job/UXAspects~UXAspects~master-2.0/15/console

#### Description of Proposed Changes
<!-- Describe what was changed and how it addresses the original issue. -->
RE_BUILD_TYPE env variable was not being passed through, so the RC package was not being created. Also, the package:release stage is no longer needed.

#### Documentation CI URL
<!-- Initiate a build at https://jenkins.swinfra.net/job/SEPG/view/Templates/job/New%20SEPG%20Build/build -->
<!-- Append the branch name to the following URL: -->
https://pages.github.houston.softwaregrp.net/sepg-docs-qa/UXAspects_CI_UXAspects_release-build-fix
