### PR TITLE
EL-3581 - List Hover Action Fix

### DIFF
--- a/src/ng1/directives/listHoverActions/listHoverAction/listHoverAction.controller.js
+++ b/src/ng1/directives/listHoverActions/listHoverAction/listHoverAction.controller.js
@@ -39,7 +39,7 @@ export class ListHoverActionCtrl {
 
     // on click call the scope click function
     onClick() {
-        if (typeof this.$scope.click === 'function') {
+        if (typeof this.click === 'function') {
             this.click();
         }
     }


### PR DESCRIPTION
#### Checklist
<!-- Use an 'x' to check those which apply. -->
* [x] The contents of this PR are mine to submit. No third party code or other material is being committed.
* [x] New third party dependencies (if any) are linked via `package.json`. Third party dependencies are licenced under one of the following: Apache, MIT, BSD, Mozilla Public License, Eclipse Public License, or Oracle Binary Code License.
* [x] The code in this PR does not contain export-restricted encryption algorithms.

#### Ticket / Issue
<!-- Either a Jira URL or a description of the issue that this PR addresses. -->
https://portal.digitalsafe.net/browse/EL-3581

#### Description of Proposed Changes
<!-- Describe what was changed and how it addresses the original issue. -->
The listHoverActions directive had `bindToController` set to `true`, so the click function was being added directly to the controller, however we were previously trying to call it on the `$scope` object. Updated the function to point to the controller instead.

Here is a plunker that should show the clicks in action:
https://plnkr.co/edit/fF6w0Kys58Z6cSH2Lb0l?p=preview

#### Documentation CI URL
<!-- Initiate a build at https://jenkins.swinfra.net/job/SEPG/view/Templates/job/New%20SEPG%20Build/build -->
<!-- Append the branch name to the following URL: -->
https://pages.github.houston.softwaregrp.net/sepg-docs-qa/UXAspects_CI_UXAspects_EL-3581-List-Hover-Action-Fix
