### PR TITLE
EL-3557 - Selection Item Disabled fix

### DIFF
--- a/docs/app/pages/components/components-sections/tables/selection/selection.component.html
+++ b/docs/app/pages/components/components-sections/tables/selection/selection.component.html
@@ -140,6 +140,9 @@
     <tr uxd-api-property name="uxSelectionItem" type="any" [required]="true">
         Defines the data associated with this item.
     </tr>
+    <tr uxd-api-property name="uxSelectionDisabled" type="boolean">
+        Defines if this specific item can be selected.
+    </tr>
     <tr uxd-api-property name="selected" type="boolean">
         Defines whether or not this item is currently selected.
     </tr>

--- a/e2e/pages/app/selection/selection.testpage.component.html
+++ b/e2e/pages/app/selection/selection.testpage.component.html
@@ -12,6 +12,7 @@
             id="row-{{ idx }}"
             class="clickable"
             [uxSelectionItem]="item"
+            [uxSelectionDisabled]="item.disabled"
             [(selected)]="item.selected">
 
             <td>
@@ -28,6 +29,7 @@
 
 <button id="select-all" class="btn btn-primary" (click)="select.selectAll()">Select All</button>
 <button id="deselect-all" class="btn btn-primary" (click)="select.deselectAll()">Deselect All</button>
+<button id="disable-item" class="btn btn-primary" (click)="setDisabled()">Disabled Item</button>
 
 <hr>
 

--- a/e2e/pages/app/selection/selection.testpage.component.ts
+++ b/e2e/pages/app/selection/selection.testpage.component.ts
@@ -5,8 +5,8 @@ import { Component } from '@angular/core';
     templateUrl: './selection.testpage.component.html'
 })
 export class SelectionTestPageComponent {
-    
-    data: TableData[] = [
+
+    data: ReadonlyArray<TableData> = [
         {
             name: 'Document 1',
             author: 'John Smith',
@@ -28,13 +28,23 @@ export class SelectionTestPageComponent {
             selected: false
         }
     ];
-    
+
     selection: TableData[] = [];
     mode: string = 'simple';
+
+    setDisabled(): void {
+        this.data = [...this.data, {
+            name: 'Document 5',
+            author: 'John Smith',
+            selected: false,
+            disabled: true
+        }];
+    }
 }
 
 export interface TableData {
     name: string;
     author: string;
     selected: boolean;
+    disabled?: boolean;
 }

--- a/e2e/tests/components/selection/selection.e2e-spec.ts
+++ b/e2e/tests/components/selection/selection.e2e-spec.ts
@@ -12,16 +12,13 @@ describe('Selection Tests', () => {
     it('should have correct initial state', async () => {
 
         // all table rows should be correctly rendered
-        expect<any>(page.row0.isPresent()).toBe(true);
-        expect<any>(page.row1.isPresent()).toBe(true);
-        expect<any>(page.row2.isPresent()).toBe(true);
-        expect<any>(page.row3.isPresent()).toBe(true);
+        page.rows.forEach(async row => expect(await row.isPresent()).toBeTruthy());
 
         // tabindex should be disabled on the child buttons
-        expect<any>(page.getRowButtonTabIndex(page.row0)).toBe('-1');
-        expect<any>(page.getRowButtonTabIndex(page.row1)).toBe('-1');
-        expect<any>(page.getRowButtonTabIndex(page.row2)).toBe('-1');
-        expect<any>(page.getRowButtonTabIndex(page.row3)).toBe('-1');
+        page.rows.forEach(async row => expect(await page.getRowButtonTabIndex(row)).toBe('-1'));
+
+        // expect all rows to be deselected
+        page.rows.forEach(async row => expect(await page.isRowSelected(row)).toBeFalsy());
 
         // no table rows are selected
         expect(await page.getSelection()).toBe('[]');
@@ -32,6 +29,9 @@ describe('Selection Tests', () => {
         // click the first row
         await page.clickSelectRow(page.row0);
 
+        // expect the row to be selected
+        expect(await page.isRowSelected(page.row0)).toBeTruthy();
+
         // the selection should be updated
         expect(await page.getSelection()).toBe('[ { "name": "Document 1", "author": "John Smith", "selected": true } ]');
     });
@@ -41,11 +41,17 @@ describe('Selection Tests', () => {
         // click the first row
         await page.clickSelectRow(page.row0);
 
+        // expect the row to be selected
+        expect(await page.isRowSelected(page.row0)).toBeTruthy();
+
         // the selection should be updated
         expect(await page.getSelection()).toBe('[ { "name": "Document 1", "author": "John Smith", "selected": true } ]');
 
         // click the first row again
         await page.clickSelectRow(page.row0);
+
+        // expect the row to not be selected
+        expect(await page.isRowSelected(page.row0)).toBeFalsy();
 
         // the selection should be updated
         expect(await page.getSelection()).toBe('[]');
@@ -56,11 +62,17 @@ describe('Selection Tests', () => {
         // click the first row
         await page.clickSelectRow(page.row0);
 
+        // expect the row to be selected
+        expect(await page.isRowSelected(page.row0)).toBeTruthy();
+
         // the selection should be updated
         expect(await page.getSelection()).toBe('[ { "name": "Document 1", "author": "John Smith", "selected": true } ]');
 
         // click the second row
         await page.clickSelectRow(page.row1);
+
+        // expect the row to be selected
+        expect(await page.isRowSelected(page.row1)).toBeTruthy();
 
         // the selection should be updated
         expect(await page.getSelection()).toBe('[ { "name": "Document 1", "author": "John Smith", "selected": true }, { "name": "Document 2", "author": "John Smith", "selected": true } ]');
@@ -71,6 +83,9 @@ describe('Selection Tests', () => {
         // select all
         await page.selectAll();
 
+        // expect the rows to be selected
+        page.rows.forEach(async row => expect(await page.isRowSelected(row)).toBeTruthy());
+
         // the selection should be updated
         expect(await page.getSelection()).toBe('[ { "name": "Document 1", "author": "John Smith", "selected": true }, { "name": "Document 2", "author": "John Smith", "selected": true }, { "name": "Document 3", "author": "John Smith", "selected": true }, { "name": "Document 4", "author": "John Smith", "selected": true } ]');
     });
@@ -80,11 +95,17 @@ describe('Selection Tests', () => {
         // select all
         await page.selectAll();
 
+        // expect the rows to be selected
+        page.rows.forEach(async row => expect(await page.isRowSelected(row)).toBeTruthy());
+
         // the selection should be updated
         expect(await page.getSelection()).toBe('[ { "name": "Document 1", "author": "John Smith", "selected": true }, { "name": "Document 2", "author": "John Smith", "selected": true }, { "name": "Document 3", "author": "John Smith", "selected": true }, { "name": "Document 4", "author": "John Smith", "selected": true } ]');
 
         // deselect all
         await page.deselectAll();
+
+        // expect the rows to be deselected
+        page.rows.forEach(async row => expect(await page.isRowSelected(row)).toBeFalsy());
 
         // the selection should be updated
         expect(await page.getSelection()).toBe('[]');
@@ -97,11 +118,17 @@ describe('Selection Tests', () => {
 
         await page.clickSelectRow(page.row0);
 
+        // expect the row to be selected
+        expect(await page.isRowSelected(page.row0)).toBeTruthy();
+
         // first row should be selected
         expect(await page.getSelection()).toBe('[ { "name": "Document 1", "author": "John Smith", "selected": true } ]');
 
         // press keys
         await page.spacebar();
+
+        // expect the row to be deselected
+        expect(await page.isRowSelected(page.row0)).toBeFalsy();
 
         // nothing should be selected
         expect(await page.getSelection()).toBe('[]');
@@ -114,6 +141,9 @@ describe('Selection Tests', () => {
 
         await page.clickSelectRow(page.row0);
 
+        // expect the row to be selected
+        expect(await page.isRowSelected(page.row0)).toBeTruthy();
+
         // first row should be selected
         expect(await page.getSelection()).toBe('[ { "name": "Document 1", "author": "John Smith", "selected": true } ]');
 
@@ -121,12 +151,19 @@ describe('Selection Tests', () => {
         await page.arrowDown();
         await page.spacebar();
 
+        // expect the row to be selected
+        expect(await page.isRowSelected(page.row1)).toBeTruthy();
+
         // first two rows should be selected
         expect(await page.getSelection()).toBe('[ { "name": "Document 1", "author": "John Smith", "selected": true }, { "name": "Document 2", "author": "John Smith", "selected": true } ]');
 
         // press keys
         await page.arrowUp();
         await page.spacebar();
+
+        // expect the row selection to be updated
+        expect(await page.isRowSelected(page.row0)).toBeFalsy();
+        expect(await page.isRowSelected(page.row1)).toBeTruthy();
 
         // only the second row should be focused
         expect(await page.getSelection()).toBe('[ { "name": "Document 2", "author": "John Smith", "selected": true } ]');
@@ -143,11 +180,23 @@ describe('Selection Tests', () => {
 
         await page.clickSelectRow(page.row0);
 
+        // expect the row to be selected
+        expect(await page.isRowSelected(page.row0)).toBeTruthy();
+        expect(await page.isRowSelected(page.row1)).toBeFalsy();
+        expect(await page.isRowSelected(page.row2)).toBeFalsy();
+        expect(await page.isRowSelected(page.row3)).toBeFalsy();
+
         // first row should be selected
         expect(await page.getSelection()).toBe('[ { "name": "Document 1", "author": "John Smith", "selected": true } ]', '1. initial click');
 
         // press down
         await page.arrowDown();
+
+        // expect the rows to be selected
+        expect(await page.isRowSelected(page.row0)).toBeFalsy();
+        expect(await page.isRowSelected(page.row1)).toBeTruthy();
+        expect(await page.isRowSelected(page.row2)).toBeFalsy();
+        expect(await page.isRowSelected(page.row3)).toBeFalsy();
 
         // second row should be selected
         expect(await page.getSelection()).toBe('[ { "name": "Document 2", "author": "John Smith", "selected": true } ]', '2. down');
@@ -155,11 +204,23 @@ describe('Selection Tests', () => {
         // press shift+down
         await page.arrowDown(true);
 
+        // expect the rows to be selected
+        expect(await page.isRowSelected(page.row0)).toBeFalsy();
+        expect(await page.isRowSelected(page.row1)).toBeTruthy();
+        expect(await page.isRowSelected(page.row2)).toBeTruthy();
+        expect(await page.isRowSelected(page.row3)).toBeFalsy();
+
         // second and third
         expect(await page.getSelection()).toBe('[ { "name": "Document 2", "author": "John Smith", "selected": true }, { "name": "Document 3", "author": "John Smith", "selected": true } ]', '3. shift+down');
 
         // press ctrl+down
         await page.arrowDown(false, true);
+
+        // expect the rows to be selected
+        expect(await page.isRowSelected(page.row0)).toBeFalsy();
+        expect(await page.isRowSelected(page.row1)).toBeTruthy();
+        expect(await page.isRowSelected(page.row2)).toBeTruthy();
+        expect(await page.isRowSelected(page.row3)).toBeFalsy();
 
         // second and third (still)
         expect(await page.getSelection()).toBe('[ { "name": "Document 2", "author": "John Smith", "selected": true }, { "name": "Document 3", "author": "John Smith", "selected": true } ]', '4. ctrl+down');
@@ -167,11 +228,23 @@ describe('Selection Tests', () => {
         // press space
         await page.spacebar();
 
+        // expect the rows to be selected
+        expect(await page.isRowSelected(page.row0)).toBeFalsy();
+        expect(await page.isRowSelected(page.row1)).toBeTruthy();
+        expect(await page.isRowSelected(page.row2)).toBeTruthy();
+        expect(await page.isRowSelected(page.row3)).toBeTruthy();
+
         // second, third, and fourth
         expect(await page.getSelection()).toBe('[ { "name": "Document 2", "author": "John Smith", "selected": true }, { "name": "Document 3", "author": "John Smith", "selected": true }, { "name": "Document 4", "author": "John Smith", "selected": true } ]', '5. space');
 
         // press down
         await page.arrowDown();
+
+        // expect the rows to be selected
+        expect(await page.isRowSelected(page.row0)).toBeFalsy();
+        expect(await page.isRowSelected(page.row1)).toBeFalsy();
+        expect(await page.isRowSelected(page.row2)).toBeFalsy();
+        expect(await page.isRowSelected(page.row3)).toBeTruthy();
 
         // fourth
         expect(await page.getSelection()).toBe('[ { "name": "Document 4", "author": "John Smith", "selected": true } ]', '6. down');
@@ -186,6 +259,9 @@ describe('Selection Tests', () => {
         // click the first row
         await page.clickSelectRow(page.row0);
 
+        // expect the row to be selected
+        expect(await page.isRowSelected(page.row0)).toBeTruthy();
+
         // the selection should be updated
         expect(await page.getSelection()).toBe('[ { "name": "Document 1", "author": "John Smith", "selected": true } ]');
     });
@@ -198,11 +274,17 @@ describe('Selection Tests', () => {
         // click the first row
         await page.clickSelectRow(page.row0);
 
+        // expect the row to be selected
+        expect(await page.isRowSelected(page.row0)).toBeTruthy();
+
         // the selection should be updated
         expect(await page.getSelection()).toBe('[ { "name": "Document 1", "author": "John Smith", "selected": true } ]');
 
         // click the first row again
         await page.clickSelectRow(page.row0);
+
+        // expect the row to be selected
+        expect(await page.isRowSelected(page.row0)).toBeTruthy();
 
         // the selection should be updated
         expect(await page.getSelection()).toBe('[ { "name": "Document 1", "author": "John Smith", "selected": true } ]');
@@ -216,11 +298,18 @@ describe('Selection Tests', () => {
         // click the first row
         await page.clickSelectRow(page.row0);
 
+        // expect the row to be selected
+        expect(await page.isRowSelected(page.row0)).toBeTruthy();
+
         // the selection should be updated
         expect(await page.getSelection()).toBe('[ { "name": "Document 1", "author": "John Smith", "selected": true } ]');
 
         // click the second row
         await page.clickSelectRow(page.row1);
+
+        // expect the rows to be updated
+        expect(await page.isRowSelected(page.row0)).toBeFalsy();
+        expect(await page.isRowSelected(page.row1)).toBeTruthy();
 
         // the selection should be updated
         expect(await page.getSelection()).toBe('[ { "name": "Document 2", "author": "John Smith", "selected": true } ]');
@@ -234,6 +323,9 @@ describe('Selection Tests', () => {
         // select all
         await page.selectAll();
 
+        // expect all rows to be selected
+        page.rows.forEach(async row => expect(await page.isRowSelected(row)).toBeTruthy());
+
         // the selection should be updated
         expect(await page.getSelection()).toBe('[ { "name": "Document 1", "author": "John Smith", "selected": true }, { "name": "Document 2", "author": "John Smith", "selected": true }, { "name": "Document 3", "author": "John Smith", "selected": true }, { "name": "Document 4", "author": "John Smith", "selected": true } ]');
     });
@@ -246,11 +338,17 @@ describe('Selection Tests', () => {
         // select all
         await page.selectAll();
 
+        // expect all rows to be selected
+        page.rows.forEach(async row => expect(await page.isRowSelected(row)).toBeTruthy());
+
         // the selection should be updated
         expect(await page.getSelection()).toBe('[ { "name": "Document 1", "author": "John Smith", "selected": true }, { "name": "Document 2", "author": "John Smith", "selected": true }, { "name": "Document 3", "author": "John Smith", "selected": true }, { "name": "Document 4", "author": "John Smith", "selected": true } ]');
 
         // deselect all
         await page.deselectAll();
+
+        // expect all rows to be deselected
+        page.rows.forEach(async row => expect(await page.isRowSelected(row)).toBeFalsy());
 
         // the selection should be updated
         expect(await page.getSelection()).toBe('[]');
@@ -266,11 +364,17 @@ describe('Selection Tests', () => {
 
         await page.clickSelectRow(page.row0);
 
+        // expect the row to be selected
+        expect(await page.isRowSelected(page.row0)).toBeTruthy();
+
         // first row should be selected
         expect(await page.getSelection()).toBe('[ { "name": "Document 1", "author": "John Smith", "selected": true } ]');
 
         // press keys
         await page.spacebar();
+
+        // expect the row to be selected
+        expect(await page.isRowSelected(page.row0)).toBeFalsy();
 
         // nothing should be selected
         expect(await page.getSelection()).toBe('[]');
@@ -286,6 +390,9 @@ describe('Selection Tests', () => {
 
         await page.clickSelectRow(page.row0);
 
+        // expect the row to be selected
+        expect(await page.isRowSelected(page.row0)).toBeTruthy();
+
         // first row should be selected
         expect(await page.getSelection()).toBe('[ { "name": "Document 1", "author": "John Smith", "selected": true } ]');
 
@@ -293,12 +400,20 @@ describe('Selection Tests', () => {
         await page.arrowDown();
         await page.spacebar();
 
+        // expect the row to be selected
+        expect(await page.isRowSelected(page.row0)).toBeFalsy();
+        expect(await page.isRowSelected(page.row1)).toBeTruthy();
+
         // first two rows should be selected
         expect(await page.getSelection()).toBe('[ { "name": "Document 2", "author": "John Smith", "selected": true } ]');
 
         // press keys
         await page.arrowUp();
         await page.spacebar();
+
+        // expect the row to be selected
+        expect(await page.isRowSelected(page.row0)).toBeTruthy();
+        expect(await page.isRowSelected(page.row1)).toBeFalsy();
 
         // only the second row should be focused
         expect(await page.getSelection()).toBe('[ { "name": "Document 1", "author": "John Smith", "selected": true } ]');
@@ -316,11 +431,18 @@ describe('Selection Tests', () => {
         // click the first row
         await page.clickSelectRow(page.row0);
 
+        // expect the row to be selected
+        expect(await page.isRowSelected(page.row0)).toBeTruthy();
+
         // the selection should be updated
         expect(await page.getSelection()).toBe('[ { "name": "Document 1", "author": "John Smith", "selected": true } ]');
 
         // ctrl + click the second row
         await page.clickSelectRow(page.row1, false, true);
+
+        // expect the row to be selected
+        expect(await page.isRowSelected(page.row0)).toBeTruthy();
+        expect(await page.isRowSelected(page.row1)).toBeTruthy();
 
         // the selection should be updated
         expect(await page.getSelection()).toBe('[ { "name": "Document 1", "author": "John Smith", "selected": true }, { "name": "Document 2", "author": "John Smith", "selected": true } ]');
@@ -338,11 +460,17 @@ describe('Selection Tests', () => {
         // click the first row
         await page.clickSelectRow(page.row0);
 
+        // expect the row to be selected
+        expect(await page.isRowSelected(page.row0)).toBeTruthy();
+
         // the selection should be updated
         expect(await page.getSelection()).toBe('[ { "name": "Document 1", "author": "John Smith", "selected": true } ]');
 
         // shift + click the last row
         await page.clickSelectRow(page.row3, true);
+
+        // expect the rows to be selected
+        page.rows.forEach(async row => expect(await page.isRowSelected(row)).toBeTruthy());
 
         // the selection should be updated
         expect(await page.getSelection()).toBe('[ { "name": "Document 1", "author": "John Smith", "selected": true }, { "name": "Document 2", "author": "John Smith", "selected": true }, { "name": "Document 3", "author": "John Smith", "selected": true }, { "name": "Document 4", "author": "John Smith", "selected": true } ]');
@@ -366,6 +494,48 @@ describe('Selection Tests', () => {
         // tabindex should be disabled again on blur
         expect<any>(page.getRowButtonTabIndex(page.row0)).toBe('-1');
         expect<any>(page.getRowButtonTabIndex(page.row1)).toBe('5');
+    });
+
+    it('should allow individual items to be disabled', async () => {
+
+        // add a disabled items
+        await page.addDisabledItem();
+
+        // try and select the disabled item
+        await page.clickSelectRow(page.row4);
+
+        // expect the row to be deselected
+        expect(await page.isRowSelected(page.row4)).toBeFalsy();
+
+        // the selection should be updated
+        expect(await page.getSelection()).toBe('[]');
+
+        // other rows should still be selectable
+        await page.clickSelectRow(page.row0);
+
+        // expect the row to be selected
+        expect(await page.isRowSelected(page.row0)).toBeTruthy();
+
+        // the selection should be updated
+        expect(await page.getSelection()).toBe('[ { "name": "Document 1", "author": "John Smith", "selected": true } ]');
+    });
+
+    it('should not allow select all on individually disabled items', async () => {
+
+        // add a disabled items
+        await page.addDisabledItem();
+
+        // select all
+        await page.selectAll();
+
+        // expect the enabled rows to be selected
+        page.rows.forEach(async row => expect(await page.isRowSelected(row)).toBeTruthy());
+
+        // expect the disabled row to not be selected
+        expect(await page.isRowSelected(page.row4)).toBeFalsy();
+
+        // the selection should be updated
+        expect(await page.getSelection()).toBe('[ { "name": "Document 1", "author": "John Smith", "selected": true }, { "name": "Document 2", "author": "John Smith", "selected": true }, { "name": "Document 3", "author": "John Smith", "selected": true }, { "name": "Document 4", "author": "John Smith", "selected": true } ]');
     });
 
 });

--- a/e2e/tests/components/selection/selection.po.spec.ts
+++ b/e2e/tests/components/selection/selection.po.spec.ts
@@ -10,8 +10,11 @@ export class SelectionPage {
     row1 = element(by.id('row-1'));
     row2 = element(by.id('row-2'));
     row3 = element(by.id('row-3'));
+    row4 = element(by.id('row-4'));
     selectAllBtn = element(by.id('select-all'));
     deselectAllBtn = element(by.id('deselect-all'));
+    disableItemBtn = element(by.id('disable-item'));
+    rows: ElementFinder[] = [this.row0, this.row1, this.row2, this.row3];
 
     getPage(): void {
         browser.get('#/selection');
@@ -31,6 +34,10 @@ export class SelectionPage {
 
     async setRowAltMode() {
         return await this.rowAltMode.click();
+    }
+
+    async addDisabledItem() {
+        return await this.disableItemBtn.click();
     }
 
     async clickSelectRow(row: ElementFinder, shift: boolean = false, ctrl: boolean = false) {
@@ -82,4 +89,8 @@ export class SelectionPage {
         return btn.getAttribute('tabindex');
     }
 
+    async isRowSelected(row: ElementFinder): Promise<boolean> {
+        const classes = await row.getAttribute('class');
+        return classes.indexOf('ux-selection-selected') > -1;
+    }
 }

--- a/src/components/checkbox/checkbox.component.ts
+++ b/src/components/checkbox/checkbox.component.ts
@@ -1,7 +1,7 @@
-import { Component, EventEmitter, forwardRef, Input, Output } from '@angular/core';
+import { Component, EventEmitter, ExistingProvider, forwardRef, Input, Output } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 
-export const CHECKBOX_VALUE_ACCESSOR: any = {
+export const CHECKBOX_VALUE_ACCESSOR: ExistingProvider = {
     provide: NG_VALUE_ACCESSOR,
     useExisting: forwardRef(() => CheckboxComponent),
     multi: true
@@ -14,7 +14,7 @@ let uniqueCheckboxId = 0;
     templateUrl: './checkbox.component.html',
     providers: [CHECKBOX_VALUE_ACCESSOR]
 })
-export class CheckboxComponent implements ControlValueAccessor {
+export class CheckboxComponent<T = number> implements ControlValueAccessor {
 
     private _checkboxId: string = `ux-checkbox-${++uniqueCheckboxId}`;
 
@@ -40,7 +40,7 @@ export class CheckboxComponent implements ControlValueAccessor {
      * If `value` is set to the indeterminate value specified using this attribute, it will neither
      * display the checkbox as checked or unchecked, and will instead show the indeterminate variation.
      */
-    @Input() indeterminateValue: any = -1;
+    @Input() indeterminateValue: T | number = -1;
 
     /** Specify if the checkbox should be disabled. */
     @Input() disabled: boolean = false;
@@ -52,7 +52,7 @@ export class CheckboxComponent implements ControlValueAccessor {
     @Input('aria-labelledby') ariaLabelledby: string = null;
 
     /** Emits when `value` has been changed. */
-    @Output() valueChange: EventEmitter<any> = new EventEmitter<any>();
+    @Output() valueChange = new EventEmitter<boolean | T>(false);
 
     /** Determines if the checkbox should be checked, unchecked or indeterminate. */
     @Input()
@@ -60,14 +60,14 @@ export class CheckboxComponent implements ControlValueAccessor {
         return this._value;
     }
 
-    set value(value: any) {
+    set value(value: boolean | T) {
         this._value = value;
 
         // determine if it is in the indeterminate state
         this.indeterminate = this._value === this.indeterminateValue;
 
         // determine the checked state
-        this.ariaChecked = this.indeterminate ? 'mixed' : this._value;
+        this.ariaChecked = this.indeterminate ? 'mixed' : this._value as boolean;
 
         // invoke change event
         this.valueChange.emit(this._value);
@@ -81,14 +81,14 @@ export class CheckboxComponent implements ControlValueAccessor {
         return `${this.id || this._checkboxId}-input`;
     }
 
-    private _value: any = false;
+    private _value: boolean | T = false;
 
     indeterminate: boolean = false;
     ariaChecked: boolean | string;
     focused: boolean = false;
 
     onTouchedCallback: () => void = () => { };
-    onChangeCallback: (_: any) => void = () => { };
+    onChangeCallback: (_: boolean | T) => void = () => { };
 
     toggle(): void {
 
@@ -107,17 +107,17 @@ export class CheckboxComponent implements ControlValueAccessor {
 
     // Functions required to update ngModel
 
-    writeValue(value: any): void {
+    writeValue(value: boolean | T): void {
         if (value !== this._value) {
             this._value = value;
         }
     }
 
-    registerOnChange(fn: any): void {
+    registerOnChange(fn: (_: boolean | T) => void): void {
         this.onChangeCallback = fn;
     }
 
-    registerOnTouched(fn: any): void {
+    registerOnTouched(fn: () => void): void {
         this.onTouchedCallback = fn;
     }
 

--- a/src/directives/selection/selection.service.ts
+++ b/src/directives/selection/selection.service.ts
@@ -9,6 +9,7 @@ import { SimpleSelectionStrategy } from './strategies/simple-selection.strategy'
 @Injectable()
 export class SelectionService<T> implements OnDestroy {
 
+    /** Store the current set of selectable items and ensure an item can be focused */
     set dataset(dataset: ReadonlyArray<T>) {
         this._dataset = dataset;
         if (this._dataset.indexOf(this._active) === -1) {
@@ -16,28 +17,57 @@ export class SelectionService<T> implements OnDestroy {
         }
     }
 
+    /** Get the current set of selectable items */
     get dataset(): ReadonlyArray<T> {
         return this._dataset;
     }
 
+    /** The active selection strategy that defines how selections can be made */
     strategy: SelectionStrategy<T> = new SimpleSelectionStrategy<T>(this);
+
+    /** Define if selections can be performed on any items */
     isEnabled: boolean = true;
+
+    /** Define if the mouse can be used to perform selections */
     isClickEnabled: boolean = true;
+
+    /** Define if the keyboard can be used to perform selections */
     isKeyboardEnabled: boolean = true;
 
-    focus$ = new BehaviorSubject<T>(null);
-    active$ = new BehaviorSubject<T>(null);
-    selection$ = new BehaviorSubject<T[]>([]);
+    /** Define the currently focused item */
+    readonly focus$ = new BehaviorSubject<T>(null);
 
+    /** Define the currently active item */
+    readonly active$ = new BehaviorSubject<T>(null);
+
+    /** Store the current list of selected items as an array */
+    readonly selection$ = new BehaviorSubject<T[]>([]);
+
+    /** Store the active item */
     private _active: T;
+
+    /** Store the current set of selectable items */
     private _dataset: ReadonlyArray<T> = [];
-    private _selection = new Set();
+
+    /** Store the selection strategy that should be destroyed */
     private _strategyToDestroy: SelectionStrategy<T> = this.strategy;
 
+    /** Store the current selection in a set */
+    private readonly _selection = new Set<T>();
+
+    /** Store the current disabled items in a set */
+    private readonly _disabled = new Set<T>();
+
     ngOnDestroy(): void {
+        // destroy the active stategy
         if (this._strategyToDestroy) {
             this._strategyToDestroy.destroy();
         }
+
+        // complete all observables
+        this.focus$.complete();
+        this.active$.complete();
+        this.selection$.complete();
     }
 
     /**
@@ -45,6 +75,9 @@ export class SelectionService<T> implements OnDestroy {
      * to the list of selected items
      */
     select(...selections: T[]): void {
+
+        // filter out any disabled items
+        selections = selections.filter(item => !this._disabled.has(item));
 
         // add each selection to the set
         selections.forEach(selection => this._selection.add(selection));
@@ -57,6 +90,9 @@ export class SelectionService<T> implements OnDestroy {
      * Deselect all currently selected items and replace with a new selection
      */
     selectOnly(...selection: T[]): void {
+
+        // filter out any disabled items
+        selection = selection.filter(item => !this._disabled.has(item));
 
         // remove all currently selected items
         this._selection.clear();
@@ -72,6 +108,7 @@ export class SelectionService<T> implements OnDestroy {
      * Remove an item from the list of selected items
      */
     deselect(...selections: T[]): void {
+
         // remove each item from the set
         selections.forEach(selection => this._selection.delete(selection));
 
@@ -217,6 +254,17 @@ export class SelectionService<T> implements OnDestroy {
 
         // emit the selection change information
         this.selectionHasMutated();
+    }
+
+    /** Store the disabled state of an item */
+    setItemDisabled(item: T, isDisabled: boolean): void {
+
+        // update the internal list of disabled items
+        if (isDisabled && !this._disabled.has(item)) {
+            this._disabled.add(item);
+        } else if (!isDisabled) {
+            this._disabled.delete(item);
+        }
     }
 
     private selectionHasMutated(): void {


### PR DESCRIPTION
#### Checklist
<!-- Use an 'x' to check those which apply. -->
* [x] The contents of this PR are mine to submit. No third party code or other material is being committed.
* [x] New third party dependencies (if any) are linked via `package.json`. Third party dependencies are licenced under one of the following: Apache, MIT, BSD, Mozilla Public License, Eclipse Public License, or Oracle Binary Code License.
* [x] The code in this PR does not contain export-restricted encryption algorithms.

#### Ticket / Issue
<!-- Either a Jira URL or a description of the issue that this PR addresses. -->
https://portal.digitalsafe.net/browse/EL-3557

#### Description of Proposed Changes
<!-- Describe what was changed and how it addresses the original issue. -->
- In the plunker that was provided in the ticket they were using the `selected` input to essentially disabled certain items (https://plnkr.co/edit/ylfe6rin0pngNDMEMZAA?p=preview), which was not really what it was designed for. The reason this method did not work, is because on a disabled item, they were setting the `[selected]` value to `false`. Then the user clicks on the item and the directive marks the item as selected, however they are still saying the value for the `[selected]` input is `false`, or in other words, the value has not changed, so Angular does not re-evaluated the input so the selected state does not change.
- I have introduced a new `[uxSelectionDisabled]` option which can be applied to each item in the list. Previously we only had the option to disable the whole list, not individual items.
- Updated documentation
- Updated a lot of the tests to now also check the correct classes are applied
- Added two new tests for the new disabled input
- Looked into the expression changed issue, which was being caused by the `selectAll` checkbox at the top of the table. As part of looking into this I went through the checkbox and fixed a lot of typings which were previously `any` when they could have been properly typed. Turns out the issue seems to be caused due to the inconsistency of the selected state, so by using this new disabled property the error seems to now have gone away.

This plunker should show the new disabled option working: https://plnkr.co/edit/VWeYcbNaYTMmfF1tYJ6g?p=preview

#### Documentation CI URL
<!-- Initiate a build at https://jenkins.swinfra.net/job/SEPG/view/Templates/job/New%20SEPG%20Build/build -->
<!-- Append the branch name to the following URL: -->
https://pages.github.houston.softwaregrp.net/sepg-docs-qa/UXAspects_CI_UXAspects_EL-3557-Selection-Directive
