### PR TITLE
EL-3564 Masthead Clickable Product Logo

### DIFF
--- a/docs/app/pages/components/components-sections/page-header/page-header/page-header.component.html
+++ b/docs/app/pages/components/components-sections/page-header/page-header/page-header.component.html
@@ -50,6 +50,9 @@
     <tr uxd-api-property name="backClick" type="EventEmitter">
         The event fired when the back button is clicked.
     </tr>
+    <tr uxd-api-property name="logoClick" type="EventEmitter">
+        The event fired when the image at the top left part of the header is clicked.
+    </tr>
 </uxd-api-properties>
 
 <p>The following interfaces are used within the configuration of the page header:</p>

--- a/src/components/page-header/page-header.component.html
+++ b/src/components/page-header/page-header.component.html
@@ -3,7 +3,7 @@
     <div *ngIf="!condensed" class="page-header-content">
 
         <!-- Logo/product acronym -->
-        <div class="page-header-logo-container" role="presentation" [style.backgroundColor]="logoBackground" [style.color]="logoForeground">
+        <div uxFocusIndicator class="page-header-logo-container" role="presentation" [style.backgroundColor]="logoBackground" [style.color]="logoForeground" (click)="logoClicked()">
             <img *ngIf="logo" [attr.src]="logo" [alt]="header" class="page-header-logo">
             <h1 *ngIf="header && !logo" class="page-header-acronym">{{header}}</h1>
         </div>

--- a/src/components/page-header/page-header.component.spec.ts
+++ b/src/components/page-header/page-header.component.spec.ts
@@ -1,0 +1,88 @@
+import { ComponentFixture, TestBed} from "@angular/core/testing";
+import {PageHeaderModule} from "./page-header.module";
+import {Component, } from "@angular/core";
+import {RouterModule} from "@angular/router";
+import {APP_BASE_HREF} from "@angular/common";
+
+@Component({
+    selector: 'app-page-header-test',
+    template: `
+        <ux-page-header
+            header="UX"
+            [backVisible]="true"
+            (backClick)="onBackClick()"
+            (logoClick)="onLogoClick()">
+        </ux-page-header>
+    `
+})
+export class PageHeaderTestComponent {
+
+    onLogoClick() :void {}
+
+    onBackClick() :void {}
+}
+
+describe('Page Header Component', () => {
+    let component: PageHeaderTestComponent;
+    let fixture: ComponentFixture<PageHeaderTestComponent>;
+    let nativeElement: HTMLElement;
+
+    beforeEach(async () => {
+        await TestBed.configureTestingModule({
+            imports: [
+                PageHeaderModule,
+                RouterModule.forRoot([])
+            ],
+            providers: [
+                { provide: APP_BASE_HREF, useValue: '/' }
+            ],
+            declarations: [PageHeaderTestComponent]
+        }).compileComponents();
+
+        fixture = TestBed.createComponent(PageHeaderTestComponent);
+        component = fixture.componentInstance;
+        nativeElement = fixture.nativeElement;
+
+        fixture.detectChanges();
+    });
+
+    /**
+     * We cannot do this in the existing E2E Page Header
+     * tests as in the Keppel theme the logo container
+     * is not visible and therefore we cannot perform the
+     * necessary click.
+     */
+    it ('should emit event on logo click', () => {
+
+        // find the logo container
+        const logoContainer: HTMLElement = nativeElement.querySelector('.page-header-logo-container');
+        expect(logoContainer).toBeTruthy();
+
+        // set up a spy for the onLogoClick function
+        spyOn(component, 'onLogoClick');
+        logoContainer.click();
+        expect(component.onLogoClick).toHaveBeenCalled();
+
+    });
+
+    it ('should emit event on back click', () => {
+
+        // Ensure back button is visible
+        const backButton: HTMLElement = nativeElement.querySelector('.page-header-back-button');
+        expect(backButton).toBeTruthy();
+
+        // set up a spy for the onBackClick function
+        spyOn(component, 'onBackClick');
+        backButton.click();
+        expect(component.onBackClick).toHaveBeenCalled();
+
+    });
+
+    it ('should have a product header of UX', () => {
+
+        //Checks that the page header us 'UX'
+        const pageHeader: HTMLElement = nativeElement.querySelector('.page-header-acronym');
+        expect(pageHeader.textContent).toContain('UX');
+    });
+
+});

--- a/src/components/page-header/page-header.component.ts
+++ b/src/components/page-header/page-header.component.ts
@@ -123,7 +123,10 @@ export class PageHeaderComponent {
     }
 
     /** Emit whenever the back button is clicked */
-    @Output() backClick = new EventEmitter();
+    @Output() backClick = new EventEmitter<MouseEvent>();
+
+    /** Emit whenever the product logo in the left corner is clicked. */
+    @Output() logoClick = new EventEmitter<MouseEvent>();
 
     /** @deprecated - Access a custom template title. Use subheaderTemplate instead */
     @ContentChild('title') titleTemplate: TemplateRef<any>;
@@ -152,5 +155,9 @@ export class PageHeaderComponent {
 
     select(item: PageHeaderNavigation): void {
         this._pageHeaderService.select(item);
+    }
+
+    logoClicked(): void {
+        this.logoClick.emit();
     }
 }


### PR DESCRIPTION
#### Checklist
<!-- Use an 'x' to check those which apply. -->
* [x] The contents of this PR are mine to submit. No third party code or other material is being committed.
* [x] New third party dependencies (if any) are linked via `package.json`. Third party dependencies are licenced under one of the following: Apache, MIT, BSD, Mozilla Public License, Eclipse Public License, or Oracle Binary Code License.
* [x] The code in this PR does not contain export-restricted encryption algorithms.

#### Ticket / Issue

https://portal.digitalsafe.net/browse/EL-3564

#### Description of Proposed Changes

- Whole of logo container is now clickable
- Event is emitted when clicked
- Unit Tests added for testing event emitted when logo is clicked, back button is clicked and to check the contents of the product header.

#### Documentation CI URL

https://pages.github.houston.softwaregrp.net/sepg-docs-qa/UXAspects_CI_UXAspects_EL-3564-Masthead-clickable-product-logo
