### PR TITLE
Adding ability to add/remove tag icon in customize example section

### DIFF
--- a/docs/app/pages/components/components-sections/input-controls/tags/snippets/app.css
+++ b/docs/app/pages/components/components-sections/input-controls/tags/snippets/app.css
@@ -1,6 +1,6 @@
 ux-tag-input > ol > li.ux-tag {
-     padding: 0 8px;
- }
+    padding: 0 8px;
+}
 
 .ux-icon-tag {
     margin-right: 8px;

--- a/docs/app/pages/components/components-sections/input-controls/tags/snippets/app.html
+++ b/docs/app/pages/components/components-sections/input-controls/tags/snippets/app.html
@@ -42,14 +42,17 @@
 <ux-accordion>
     <ux-accordion-panel class="accordion-chevron" heading="Customize Example...">
         <div class="row">
-            <div class="col-md-4 col-sm-12">
+            <div class="col-md-3 col-sm-12">
                 <ux-checkbox [(value)]="addOnPaste">addOnPaste</ux-checkbox>
             </div>
-            <div class="col-md-4 col-sm-12">
+            <div class="col-md-3 col-sm-12">
                 <ux-checkbox [(value)]="disabled">disabled</ux-checkbox>
             </div>
-            <div class="col-md-4 col-sm-12">
+            <div class="col-md-3 col-sm-12">
                 <ux-checkbox [(value)]="enforceTagLimits">enforceTagLimits</ux-checkbox>
+            </div>
+            <div class="col-md-3 col-sm-12">
+                <ux-checkbox [(value)]="addTagIcon">addTagIcon</ux-checkbox>
             </div>
         </div>
         <div class="row m-t-md">
@@ -107,7 +110,7 @@
 </ux-accordion>
 
 <ng-template #demoTagTemplate let-tag="tag" let-index="index" let-api="api">
-    <span class="m-r-sm"><i class="hpe-icon hpe-tag"></i></span>
+    <i class="ux-icon ux-icon-tag" *ngIf="addTagIcon"></i>
     <span class="ux-tag-text">{{api.getTagDisplay(tag)}}</span>
     <button *ngIf="api.canRemoveTagAt(index)"
         uxFocusIndicator
@@ -115,5 +118,5 @@
         class="ux-tag-remove"
         [disabled]="disabled"
         (click)="api.removeTagAt(index); $event.stopPropagation();"
-        ><i class="hpe-icon hpe-close"></i></button>
+        ><i class="ux-icon ux-icon-close"></i></button>
 </ng-template>

--- a/docs/app/pages/components/components-sections/input-controls/tags/snippets/app.ts
+++ b/docs/app/pages/components/components-sections/input-controls/tags/snippets/app.ts
@@ -2,7 +2,8 @@ import { Component } from '@angular/core';
 
 @Component({
     selector: 'app',
-    templateUrl: './app.component.html'
+    templateUrl: './app.component.html',
+    styleUrls: ['./app.component.css']
 })
 export class AppComponent {
     tags = ['Alpha', 'Beta', 'Kappa'];
@@ -15,6 +16,7 @@ export class AppComponent {
 
     addOnPaste: boolean = true;
     disabled: boolean = false;
+    addTagIcon: boolean = false;
     enforceTagLimits: boolean = false;
     freeInput: boolean = true;
     minTags: number = 1;

--- a/docs/app/pages/components/components-sections/input-controls/tags/tags.component.html
+++ b/docs/app/pages/components/components-sections/input-controls/tags/tags.component.html
@@ -43,14 +43,17 @@
         <ux-accordion>
             <ux-accordion-panel class="accordion-chevron" heading="Customize Example...">
                 <div class="row uxd-customize-row">
-                    <div class="col-md-4 col-sm-12">
+                    <div class="col-md-3 col-sm-12">
                         <ux-checkbox [(value)]="addOnPaste">addOnPaste</ux-checkbox>
                     </div>
-                    <div class="col-md-4 col-sm-12">
+                    <div class="col-md-3 col-sm-12">
                         <ux-checkbox [(value)]="disabled">disabled</ux-checkbox>
                     </div>
-                    <div class="col-md-4 col-sm-12">
+                    <div class="col-md-3 col-sm-12">
                         <ux-checkbox [(value)]="enforceTagLimits">enforceTagLimits</ux-checkbox>
+                    </div>
+                    <div class="col-md-3 col-sm-12">
+                        <ux-checkbox [(value)]="addTagIcon">addTagIcon</ux-checkbox>
                     </div>
                 </div>
                 <div class="row uxd-customize-row">
@@ -106,7 +109,7 @@
 </div>
 
 <ng-template #demoTagTemplate let-tag="tag" let-index="index" let-api="api">
-    <span class="m-r-sm"><i class="hpe-icon hpe-tag"></i></span>
+    <i class="ux-icon ux-icon-tag tag-padding" *ngIf="addTagIcon"></i>
     <span class="ux-tag-text">{{api.getTagDisplay(tag)}}</span>
     <button *ngIf="api.canRemoveTagAt(index)"
             uxFocusIndicator
@@ -114,7 +117,7 @@
             class="ux-tag-remove"
             [disabled]="disabled"
             (click)="api.removeTagAt(index); $event.stopPropagation();">
-        <i class="hpe-icon hpe-close"></i>
+        <i class="ux-icon ux-icon-close"></i>
     </button>
 </ng-template>
 

--- a/docs/app/pages/components/components-sections/input-controls/tags/tags.component.html
+++ b/docs/app/pages/components/components-sections/input-controls/tags/tags.component.html
@@ -109,7 +109,7 @@
 </div>
 
 <ng-template #demoTagTemplate let-tag="tag" let-index="index" let-api="api">
-    <i class="ux-icon ux-icon-tag tag-padding" *ngIf="addTagIcon"></i>
+    <i class="ux-icon ux-icon-tag" *ngIf="addTagIcon"></i>
     <span class="ux-tag-text">{{api.getTagDisplay(tag)}}</span>
     <button *ngIf="api.canRemoveTagAt(index)"
             uxFocusIndicator

--- a/docs/app/pages/components/components-sections/input-controls/tags/tags.component.html
+++ b/docs/app/pages/components/components-sections/input-controls/tags/tags.component.html
@@ -413,4 +413,7 @@
     <ux-tab heading="TypeScript">
         <uxd-snippet language="javascript" [content]="snippets.compiled.appTs"></uxd-snippet>
     </ux-tab>
+    <ux-tab heading="CSS">
+        <uxd-snippet language="css" [content]="snippets.compiled.appCss"></uxd-snippet>
+    </ux-tab>
 </ux-tabset>

--- a/docs/app/pages/components/components-sections/input-controls/tags/tags.component.less
+++ b/docs/app/pages/components/components-sections/input-controls/tags/tags.component.less
@@ -1,0 +1,7 @@
+ux-tag-input > ol > li.ux-tag {
+     padding: 0 8px;
+ }
+
+.tag-padding {
+    margin-right: 8px;
+}

--- a/docs/app/pages/components/components-sections/input-controls/tags/tags.component.ts
+++ b/docs/app/pages/components/components-sections/input-controls/tags/tags.component.ts
@@ -8,7 +8,7 @@ import { IPlaygroundProvider } from '../../../../../interfaces/IPlaygroundProvid
 @Component({
     selector: 'uxd-components-tags',
     templateUrl: 'tags.component.html',
-    styleUrls: ['tags.component.less'],
+    styleUrls: ['./tags.component.less'],
 })
 @DocumentationSectionComponent('ComponentsTagsComponent')
 export class ComponentsTagsComponent extends BaseDocumentationSection implements IPlaygroundProvider {
@@ -53,7 +53,8 @@ export class ComponentsTagsComponent extends BaseDocumentationSection implements
     playground: IPlayground = {
         files: {
             'app.component.ts': this.snippets.raw.appTs,
-            'app.component.html': this.snippets.raw.appHtml
+            'app.component.html': this.snippets.raw.appHtml,
+            'app.component.css': this.snippets.raw.appCss
         },
         modules: [{
             imports: ['TagInputModule', 'TypeaheadModule', 'CheckboxModule', 'RadioButtonModule', 'NumberPickerModule', 'AccordionModule'],

--- a/docs/app/pages/components/components-sections/input-controls/tags/tags.component.ts
+++ b/docs/app/pages/components/components-sections/input-controls/tags/tags.component.ts
@@ -7,7 +7,8 @@ import { IPlaygroundProvider } from '../../../../../interfaces/IPlaygroundProvid
 
 @Component({
     selector: 'uxd-components-tags',
-    templateUrl: 'tags.component.html'
+    templateUrl: 'tags.component.html',
+    styleUrls: ['tags.component.less'],
 })
 @DocumentationSectionComponent('ComponentsTagsComponent')
 export class ComponentsTagsComponent extends BaseDocumentationSection implements IPlaygroundProvider {
@@ -22,6 +23,7 @@ export class ComponentsTagsComponent extends BaseDocumentationSection implements
 
     addOnPaste: boolean = true;
     disabled: boolean = false;
+    addTagIcon: boolean = false;
     enforceTagLimits: boolean = false;
     freeInput: boolean = true;
     minTags: number = 1;


### PR DESCRIPTION
#### Checklist
<!-- Use an 'x' to check those which apply. -->
* [x] The contents of this PR are mine to submit. No third party code or other material is being committed.
* [x] New third party dependencies (if any) are linked via `package.json`. Third party dependencies are licenced under one of the following: Apache, MIT, BSD, Mozilla Public License, Eclipse Public License, or Oracle Binary Code License.
* [x] The code in this PR does not contain export-restricted encryption algorithms.

#### Ticket / Issue

https://portal.digitalsafe.net/browse/EL-3575

#### Description of Proposed Changes

- Adding in ability to add/remove tag icon in 'customize example' dropdown
- Changed icon types from hpe to ux 
- Added in styling so tag was 8px horizontally padded

#### Documentation CI URL

https://pages.github.houston.softwaregrp.net/sepg-docs-qa/UXAspects_CI_UXAspects_EL-3575-tag-input
