### PR TITLE
EL-3587-date-range-picker

### DIFF
--- a/src/components/date-time-picker/date-time-picker.service.ts
+++ b/src/components/date-time-picker/date-time-picker.service.ts
@@ -1,7 +1,6 @@
 import { WeekDay } from '@angular/common';
 import { Injectable, OnDestroy, Optional } from '@angular/core';
 import { BehaviorSubject, Subject, Subscription } from 'rxjs';
-import { distinctUntilChanged } from 'rxjs/operators';
 import { DateTimePickerConfig } from './date-time-picker.config';
 import { dateComparator, DateTimePickerTimezone, meridians, months, monthsShort, timezones, weekdaysShort } from './date-time-picker.utils';
 
@@ -56,7 +55,7 @@ export class DateTimePickerService implements OnDestroy {
     constructor(@Optional() private _config: DateTimePickerConfig) {
 
         // when the active date changes set the currently selected date
-        this._subscription = this.selected$.pipe(distinctUntilChanged(dateComparator)).subscribe(date => {
+        this._subscription = this.selected$.subscribe(date => {
 
             // the month and year displayed in the viewport should reflect the newly selected items
             if (date instanceof Date) {
@@ -64,8 +63,10 @@ export class DateTimePickerService implements OnDestroy {
                 this.setViewportYear(date.getFullYear());
             }
 
-            // emit the new date to the component host
-            this.date$.next(date);
+            // emit the new date to the component host but only if they are different
+            if (dateComparator(date, this.date$.value)) {
+                this.date$.next(date);
+            }
         });
     }
 


### PR DESCRIPTION
#### Checklist
* [x] The contents of this PR are mine to submit. No third party code or other material is being committed.
* [x] New third party dependencies (if any) are linked via `package.json`. Third party dependencies are licenced under one of the following: Apache, MIT, BSD, Mozilla Public License, Eclipse Public License, or Oracle Binary Code License.
* [x] The code in this PR does not contain export-restricted encryption algorithms.

#### Ticket / Issue

https://portal.digitalsafe.net/browse/EL-3587

#### Description of Proposed Changes

- Selecting the today button if a selection has already been made now updates the date picker to the current day/month.

- Ran the date picker tests and date picker is working as expected.

- <code>pipe(distinctUntilChanged(dateComparator)).</code> was removed from the <code>selected$</code> subscription as if the two date values where the same then true was being return and changing the viewports was never being hit.

- <code>dateComparator(date, this.date$.value))</code> now moved to inside the <code>selected$</code> subscription and the date is only being emitted if the dates are different.

#### Documentation CI URL

https://pages.github.houston.softwaregrp.net/sepg-docs-qa/UXAspects_CI_UXAspects_EL-3587-date-range-picker
