### PR TITLE
EL-3575 - Removed demoTagTemplate and added a code snippet to the docs

### DIFF
--- a/docs/app/pages/components/components-sections/input-controls/tags/snippets/app.html
+++ b/docs/app/pages/components/components-sections/input-controls/tags/snippets/app.html
@@ -13,8 +13,7 @@
                 [placeholder]="placeholder"
                 [showTypeaheadOnClick]="showTypeaheadOnClick"
                 [tagDelimiters]="tagDelimiters"
-                [tagPattern]="tagPatternRegExp"
-                [tagTemplate]="demoTagTemplate">
+                [tagPattern]="tagPatternRegExp">
 
                 <ux-typeahead *ngIf="typeaheadEnabled"
                     [filter]="input"
@@ -105,15 +104,3 @@
         </div>
     </ux-accordion-panel>
 </ux-accordion>
-
-<ng-template #demoTagTemplate let-tag="tag" let-index="index" let-api="api">
-    <i class="ux-icon ux-icon-tag"></i>
-    <span class="ux-tag-text">{{api.getTagDisplay(tag)}}</span>
-    <button *ngIf="api.canRemoveTagAt(index)"
-        uxFocusIndicator
-        type="button"
-        class="ux-tag-remove"
-        [disabled]="disabled"
-        (click)="api.removeTagAt(index); $event.stopPropagation();"
-        ><i class="ux-icon ux-icon-close"></i></button>
-</ng-template>

--- a/docs/app/pages/components/components-sections/input-controls/tags/snippets/tag-template.html
+++ b/docs/app/pages/components/components-sections/input-controls/tags/snippets/tag-template.html
@@ -1,0 +1,12 @@
+<ng-template #demoTagTemplate let-tag="tag" let-index="index" let-api="api">
+    <ux-icon [name]="tag.icon"></ux-icon>
+    <span class="ux-tag-text">{{tag.text}}</span>
+    <button *ngIf="api.canRemoveTagAt(index)"
+            uxFocusIndicator
+            type="button"
+            class="ux-tag-remove"
+            [disabled]="disabled"
+            (click)="api.removeTagAt(index); $event.stopPropagation();">
+        <ux-icon name="close"></ux-icon>
+    </button>
+</ng-template>

--- a/docs/app/pages/components/components-sections/input-controls/tags/tags.component.html
+++ b/docs/app/pages/components/components-sections/input-controls/tags/tags.component.html
@@ -13,8 +13,7 @@
                 [placeholder]="placeholder"
                 [showTypeaheadOnClick]="showTypeaheadOnClick"
                 [tagDelimiters]="tagDelimiters"
-                [tagPattern]="tagPatternRegExp"
-                [tagTemplate]="demoTagTemplate">
+                [tagPattern]="tagPatternRegExp">
 
                 <ux-typeahead *ngIf="typeaheadEnabled"
                     [filter]="input"
@@ -194,8 +193,8 @@
         this expression will not be added as tags.
     </tr>
     <tr uxd-api-property name="tagTemplate" type="TemplateRef">
-        <span>A template which will be rendered as the content of each tag. The following context
-            properties are available in the template:</span>
+        <p>A template which will be rendered as the content of each tag. The following context
+            properties are available in the template:</p>
         <ul>
             <li><code>tag: any</code> - the string or custom object representing the tag.</li>
             <li><code>index: number</code> - the zero-based index of the tag as it appears in the tag
@@ -204,6 +203,10 @@
             <code>removeTagAt</code> and <code>canRemoveTagAt</code>. See the section below for more
             information.</li>
         </ul>
+        <p>
+            The following code snippet shows how to use a custom template to display an icon alongside the tag text:
+        </p>
+        <uxd-snippet [content]="snippets.compiled.tagTemplateHtml"></uxd-snippet>
     </tr>
     <tr uxd-api-property name="tagClass" type="TagClassFunction">
         <p>A function which returns either a <code>string</code>, <code>string[]</code>, or


### PR DESCRIPTION
#### Checklist
<!-- Use an 'x' to check those which apply. -->
* [x] The contents of this PR are mine to submit. No third party code or other material is being committed.
* [x] New third party dependencies (if any) are linked via `package.json`. Third party dependencies are licenced under one of the following: Apache, MIT, BSD, Mozilla Public License, Eclipse Public License, or Oracle Binary Code License.
* [x] The code in this PR does not contain export-restricted encryption algorithms.

#### Ticket / Issue
<!-- Either a Jira URL or a description of the issue that this PR addresses. -->
https://portal.digitalsafe.net/browse/EL-3575

#### Description of Proposed Changes
<!-- Describe what was changed and how it addresses the original issue. -->
* As discussed with Roland (see ticket), removed the custom template from the example and added an inline code snippet.

#### Documentation CI URL
<!-- Initiate a build at https://jenkins.swinfra.net/job/SEPG/view/Templates/job/New%20SEPG%20Build/build -->
<!-- Append the branch name to the following URL: -->
https://pages.github.houston.softwaregrp.net/sepg-docs-qa/UXAspects_CI_UXAspects_EL-3575-remove-custom-icons
