### PR TITLE
EL-3605 - Tag Input Reactive Forms

### DIFF
--- a/src/components/tag-input/tag-input.component.less
+++ b/src/components/tag-input/tag-input.component.less
@@ -115,7 +115,9 @@ ux-tag-input {
         border-color: @form-control-focus-border;
     }
 
-    &.invalid {
+    &.invalid,
+    &.ng-invalid.ng-touched:not(.focus),
+    &.ng-invalid.ng-dirty {
         border-color: @critical;
     }
 


### PR DESCRIPTION
#### Checklist
<!-- Use an 'x' to check those which apply. -->
* [x] The contents of this PR are mine to submit. No third party code or other material is being committed.
* [x] New third party dependencies (if any) are linked via `package.json`. Third party dependencies are licenced under one of the following: Apache, MIT, BSD, Mozilla Public License, Eclipse Public License, or Oracle Binary Code License.
* [x] The code in this PR does not contain export-restricted encryption algorithms.

#### Ticket / Issue
<!-- Either a Jira URL or a description of the issue that this PR addresses. -->
https://portal.digitalsafe.net/browse/EL-3605

#### Description of Proposed Changes
<!-- Describe what was changed and how it addresses the original issue. -->
- Implemented `Validator` interface to ensure we remain compatible
- Added support for marking component as touched
- Added error styling based on the presence of the `ng-invalid` class which will get applied for both template and reactive form errors.

#### Documentation CI URL
<!-- Initiate a build at https://jenkins.swinfra.net/job/SEPG/view/Templates/job/New%20SEPG%20Build/build -->
<!-- Append the branch name to the following URL: -->
https://pages.github.houston.softwaregrp.net/sepg-docs-qa/UXAspects_CI_UXAspects_EL-3605-Tag-Reactive-Form
