### PR TITLE
EL_3594 - Tree Grid Expand Top Level

### DIFF
--- a/src/ng1/directives/treegrid/treegrid.controller.js
+++ b/src/ng1/directives/treegrid/treegrid.controller.js
@@ -49,6 +49,7 @@ export function TreeGridController($scope, $q, multipleSelectProvider, $timeout)
     vm.treeData = [];
     vm.selectionModel = new SelectionModel();
     vm.allSelected = false;
+    vm.initialized = false;
 
     // private fields
     vm._selected = [];
@@ -96,6 +97,9 @@ export function TreeGridController($scope, $q, multipleSelectProvider, $timeout)
             optionsWatcher();
             reloadWatcher();
         });
+
+        // mark data as initialised
+        vm.initialized = true;
     };
 
     // Retrieves array for ng-repeat of grid rows
@@ -218,9 +222,9 @@ export function TreeGridController($scope, $q, multipleSelectProvider, $timeout)
         getTreeData(getChildren(), 0)
             .then(rows => vm.treeData = rows)
             .then(function () {
-                // Expand top level items if configured
+                // Expand top level items if configured and it is the initial render
                 var promises = vm.treeData
-                    .filter(row => row.canExpand && (vm.allOptions.expandTopLevel || row.expanded))
+                    .filter(row => row.canExpand && ((vm.allOptions.expandTopLevel && !vm.initialized) || row.expanded))
                     .map(row => expand(row));
                 return $q.all(promises);
             })


### PR DESCRIPTION
#### Checklist
<!-- Use an 'x' to check those which apply. -->
* [x] The contents of this PR are mine to submit. No third party code or other material is being committed.
* [x] New third party dependencies (if any) are linked via `package.json`. Third party dependencies are licenced under one of the following: Apache, MIT, BSD, Mozilla Public License, Eclipse Public License, or Oracle Binary Code License.
* [x] The code in this PR does not contain export-restricted encryption algorithms.

#### Ticket / Issue
<!-- Either a Jira URL or a description of the issue that this PR addresses. -->
https://portal.digitalsafe.net/browse/EL-3594

#### Description of Proposed Changes
<!-- Describe what was changed and how it addresses the original issue. -->
- Previously every time the tree grid was rendered the expanded state was based on it the item was expanded or the expand top level option was set. Now I have updated it to only check the expand top level option on initial render, then afterwards base it on the expanded state only

#### Documentation CI URL
<!-- Initiate a build at https://jenkins.swinfra.net/job/SEPG/view/Templates/job/New%20SEPG%20Build/build -->
<!-- Append the branch name to the following URL: -->
https://pages.github.houston.softwaregrp.net/sepg-docs-qa/UXAspects_CI_UXAspects_EL-3594-Tree-Grid-Expand-Top-Level
