### PR TITLE
EL-3559 - Side Panel Improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,6 @@ e2e/xml/
 .ng_build/
 .ng_pkg_build/
 target/
-.vscode/launch.json
+.vscode
 .idea
 *.iml

--- a/docs/app/pages/components/components-sections/panels/side-panel/side-panel.component.html
+++ b/docs/app/pages/components/components-sections/panels/side-panel/side-panel.component.html
@@ -1,7 +1,12 @@
 <div class="ux-side-panel-inline-container demo-side-panel-container">
 
     <div class="demo-content">
-        <button #launch type="button" class="btn button-primary"
+        <button
+            #launch
+            type="button"
+            class="btn button-primary"
+            uxFocusIndicator
+            programmaticFocusIndicator="false"
             (click)="open = !open; $event.stopPropagation()">
             Toggle Side Panel
         </button>

--- a/docs/app/pages/components/components-sections/panels/side-panel/snippets/app.html
+++ b/docs/app/pages/components/components-sections/panels/side-panel/snippets/app.html
@@ -1,7 +1,12 @@
 <div class="ux-side-panel-inline-container demo-side-panel-container">
 
     <div class="demo-content">
-        <button #launch type="button" class="btn button-primary"
+        <button
+            #launch
+            type="button"
+            class="btn button-primary"
+            uxFocusIndicator
+            programmaticFocusIndicator="false"
             (click)="open = !open; $event.stopPropagation()">
             Toggle Side Panel
         </button>

--- a/e2e/tests/components/side-panel/side-panel.e2e-spec.ts
+++ b/e2e/tests/components/side-panel/side-panel.e2e-spec.ts
@@ -1,5 +1,4 @@
 import { SidePanelPage } from './side-panel.po.spec';
-import { protractor } from 'protractor';
 
 describe('Side Panel', () => {
 
@@ -13,14 +12,13 @@ describe('Side Panel', () => {
     describe('in the default state', () => {
 
         it('should be hidden initially', async () => {
-            expect(page.panel.getAttribute('class')).not.toContain('open');
-            expect(await page.panelHost.getCssValue('position')).toBe('fixed');
-            expect(await page.getRightOffsetFromWindow()).toBe(0);
+            expect(await page.isPanelOpen()).toBeFalsy();
         });
 
         it('should be visible when open', async () => {
             await page.toggle.click();
             expect(page.panel.getAttribute('class')).toContain('open');
+            expect(await page.panelHost.getCssValue('position')).toBe('fixed');
             expect(await page.getRightOffsetFromWindow()).toBe(200);
             expect(await page.getPanelWidth()).toBe(200);
             expect(page.getPanelHeight()).toBe(page.getViewportHeight());
@@ -30,8 +28,7 @@ describe('Side Panel', () => {
             await page.toggle.click();
             expect(page.panel.getAttribute('class')).toContain('open');
             await page.panelClose.click();
-            expect(page.panel.getAttribute('class')).not.toContain('open');
-            expect(await page.getRightOffsetFromWindow()).toBe(0);
+            expect(await page.isPanelOpen()).toBeFalsy();
         });
 
         it('should not close on external click', async () => {
@@ -52,14 +49,13 @@ describe('Side Panel', () => {
         });
 
         it('should be hidden initially', async () => {
-            expect(page.panel.getAttribute('class')).not.toContain('open');
-            expect(await page.getInlinePanelWidth()).toBe(0);
-            expect(await page.panelHost.getCssValue('position')).toBe('static');
+            expect(await page.isPanelOpen()).toBeFalsy();
         });
 
         it('should be visible when open', async () => {
             await page.toggle.click();
             expect(page.panel.getAttribute('class')).toContain('open');
+            expect(await page.panelHost.getCssValue('position')).toBe('static');
             expect(await page.getInlinePanelWidth()).toBe(200);
             expect(await page.getInlinePanelHeight()).toBe(300);
         });
@@ -82,9 +78,7 @@ describe('Side Panel', () => {
         });
 
         it('should be hidden initially', async () => {
-            expect(page.panel.getAttribute('class')).not.toContain('open');
-            expect(await page.getRightOffsetFromContainer()).toBe(0);
-            expect(await page.panelHost.getCssValue('position')).toBe('absolute');
+            expect(await page.isPanelOpen()).toBeFalsy();
         });
 
         it('should be visible when open', async () => {
@@ -93,6 +87,7 @@ describe('Side Panel', () => {
             expect(await page.getRightOffsetFromContainer()).toBe(200);
             expect(await page.getPanelWidth()).toBe(200);
             expect(page.getPanelHeight()).toBe(page.getContainerHeight());
+            expect(await page.panelHost.getCssValue('position')).toBe('absolute');
         });
 
         it('should not close on external click', async () => {

--- a/e2e/tests/components/side-panel/side-panel.po.spec.ts
+++ b/e2e/tests/components/side-panel/side-panel.po.spec.ts
@@ -1,4 +1,4 @@
-import { browser, $, ElementFinder, Key } from 'protractor';
+import { $, browser, ElementFinder } from 'protractor';
 
 export class SidePanelPage {
 
@@ -22,6 +22,10 @@ export class SidePanelPage {
 
     getPage() {
         browser.get('#/side-panel');
+    }
+
+    async isPanelOpen(): Promise<boolean> {
+        return this.panelHost.isPresent();
     }
 
     async getPanelWidth(): Promise<number> {

--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -1,3 +1,3 @@
 export * from './colors/index';
 export * from './operators/index';
-
+export * from './utilities/trigger-source';

--- a/src/common/utilities/trigger-source.ts
+++ b/src/common/utilities/trigger-source.ts
@@ -1,0 +1,17 @@
+/**
+ * A button will trigger a click event whenever the a mouse click occurs or the enter key is pressed.
+ * These functions can be used to identify if a `click` event was caused by the keyboard or
+ * by a mouse.
+ *
+ * The `event.detail` property will change based on the source of the event.
+ * A mouse click will have varying values based on the browser, however
+ * the enter key will always have a value of `0` so we can check against that
+ */
+
+export function isKeyboardTrigger(event: MouseEvent | KeyboardEvent): boolean {
+    return event.detail === 0;
+}
+
+export function isMouseTrigger(event: MouseEvent | KeyboardEvent): boolean {
+    return !isKeyboardTrigger(event);
+}

--- a/src/components/item-display-panel/item-display-panel.component.html
+++ b/src/components/item-display-panel/item-display-panel.component.html
@@ -5,11 +5,19 @@
     [style.top]="cssTop"
     [@panelState]="animationPanelState"
     [tabindex]="open ? 0 : -1"
-    [focusIf]="open && focusOnShow">
+    [focusIf]="open && focusOnShow"
+    *ngIf="open">
 
     <div class="ux-side-panel-header" [class.item-display-panel-shadow]="shadow">
         <h3>{{ header }}</h3>
-        <button *ngIf="closeVisible" aria-label="Close" i18n-aria-label type="button" class="btn btn-lg btn-link btn-icon button-secondary" (click)="visible = false">
+
+        <button *ngIf="closeVisible"
+                uxFocusIndicator
+                aria-label="Close"
+                i18n-aria-label
+                type="button"
+                class="btn btn-lg btn-link btn-icon button-secondary"
+                (click)="visible = false">
             <i class="hpe-icon hpe-close"></i>
         </button>
     </div>

--- a/src/components/item-display-panel/item-display-panel.component.ts
+++ b/src/components/item-display-panel/item-display-panel.component.ts
@@ -1,5 +1,6 @@
 import { Component, ContentChild, Directive, ElementRef, EventEmitter, Input, OnInit, Output, ViewChild } from '@angular/core';
 import { distinctUntilChanged, takeUntil } from 'rxjs/operators';
+import { FocusIndicatorOriginService } from '../../directives/accessibility/index';
 import { sidePanelStateAnimation } from '../side-panel/side-panel-animations';
 import { SidePanelComponent } from '../side-panel/side-panel.component';
 import { SidePanelService } from '../side-panel/side-panel.service';
@@ -72,8 +73,8 @@ export class ItemDisplayPanelComponent extends SidePanelComponent implements OnI
         return this.open;
     }
 
-    constructor(service: SidePanelService, elementRef: ElementRef) {
-        super(service, elementRef);
+    constructor(service: SidePanelService, elementRef: ElementRef, focusOrigin: FocusIndicatorOriginService) {
+        super(service, elementRef, focusOrigin);
 
         this.animate = false;
         this.closeOnExternalClick = true;

--- a/src/components/item-display-panel/item-display-panel.module.ts
+++ b/src/components/item-display-panel/item-display-panel.module.ts
@@ -1,5 +1,6 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
+import { AccessibilityModule } from '../../directives/accessibility';
 import { FocusIfModule } from '../../directives/focus-if/focus-if.module';
 import { ItemDisplayPanelComponent, ItemDisplayPanelContentDirective, ItemDisplayPanelFooterDirective } from './item-display-panel.component';
 
@@ -11,10 +12,11 @@ const DECLARATIONS = [
 
 @NgModule({
     imports: [
+        AccessibilityModule,
         CommonModule,
         FocusIfModule
     ],
     exports: DECLARATIONS,
     declarations: DECLARATIONS
 })
-export class ItemDisplayPanelModule {}
+export class ItemDisplayPanelModule { }

--- a/src/components/item-display-panel/item-display-panel.module.ts
+++ b/src/components/item-display-panel/item-display-panel.module.ts
@@ -1,6 +1,6 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
-import { AccessibilityModule } from '../../directives/accessibility';
+import { AccessibilityModule } from '../../directives/accessibility/index';
 import { FocusIfModule } from '../../directives/focus-if/focus-if.module';
 import { ItemDisplayPanelComponent, ItemDisplayPanelContentDirective, ItemDisplayPanelFooterDirective } from './item-display-panel.component';
 

--- a/src/components/menu/menu-item/menu-item.component.ts
+++ b/src/components/menu/menu-item/menu-item.component.ts
@@ -2,6 +2,7 @@ import { FocusableOption, FocusOrigin } from '@angular/cdk/a11y';
 import { ChangeDetectionStrategy, Component, ElementRef, HostListener, Input, OnDestroy, OnInit, Renderer2 } from '@angular/core';
 import { BehaviorSubject, Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
+import { isKeyboardTrigger } from '../../../common/index';
 import { FocusIndicator, FocusIndicatorService } from '../../../directives/accessibility/index';
 import { MenuComponent } from '../menu/menu.component';
 import { MenuItemType } from './menu-item-type.enum';
@@ -114,7 +115,7 @@ export class MenuItemComponent implements OnInit, OnDestroy, FocusableOption {
     @HostListener('keydown.enter', ['$event'])
     _onClick(event: MouseEvent | KeyboardEvent): void {
         if (!this.disabled) {
-            this.onClick$.next(event.detail === 0 ? 'keyboard' : 'mouse');
+            this.onClick$.next(isKeyboardTrigger(event) ? 'keyboard' : 'mouse');
         }
     }
 

--- a/src/components/side-panel/side-panel-animations.ts
+++ b/src/components/side-panel/side-panel-animations.ts
@@ -9,23 +9,18 @@ export enum SidePanelAnimationState {
 export const sidePanelStateAnimation: AnimationTriggerMetadata = trigger('panelState', [
     state(
         SidePanelAnimationState.Closed,
-        style({
-            visibility: 'hidden'
-        })
+        style({ visibility: 'hidden' })
     ),
     state(
         `${SidePanelAnimationState.Open}, ${SidePanelAnimationState.OpenImmediate}`,
-        style({
-            visibility: 'visible',
-            transform: 'none'
-        })
+        style({ visibility: 'visible', transform: 'none' })
     ),
     transition(
-        `${SidePanelAnimationState.Closed} <=> ${SidePanelAnimationState.Open}`,
+        `void <=> ${SidePanelAnimationState.Open}`,
         animate('0.2s cubic-bezier(0.49, 1, 0.38, 0.98)')
     ),
     transition(
-        `${SidePanelAnimationState.Closed} <=> ${SidePanelAnimationState.OpenImmediate}`,
+        `void <=> ${SidePanelAnimationState.OpenImmediate}`,
         animate('0s')
     )
 ]);

--- a/src/components/side-panel/side-panel-close.directive.ts
+++ b/src/components/side-panel/side-panel-close.directive.ts
@@ -1,4 +1,6 @@
 import { Directive, HostListener } from '@angular/core';
+import { isKeyboardTrigger } from '../../common/index';
+import { FocusIndicatorOriginService } from '../../directives/accessibility/index';
 import { SidePanelService } from './side-panel.service';
 
 @Directive({
@@ -6,10 +8,17 @@ import { SidePanelService } from './side-panel.service';
 })
 export class SidePanelCloseDirective {
 
-    constructor(private _service: SidePanelService) { }
+    constructor(
+        private readonly _service: SidePanelService,
+        private readonly _focusOrigin: FocusIndicatorOriginService
+    ) { }
 
-    @HostListener('click')
-    clickHandler() {
+    @HostListener('click', ['$event'])
+    onClick(event: MouseEvent | KeyboardEvent): void {
+        // determine the correct origin for the trigger event
+        this._focusOrigin.setOrigin(isKeyboardTrigger(event) ? 'keyboard' : 'mouse');
+
+        // close the side panel menu
         this._service.close();
     }
 }

--- a/src/components/side-panel/side-panel.component.html
+++ b/src/components/side-panel/side-panel.component.html
@@ -11,6 +11,7 @@
     [@panelState]="animationPanelState"
     [focusIf]="open && focusOnShow"
     [focusIfScroll]="false"
-    [cdkTrapFocus]="open && modal">
+    [cdkTrapFocus]="open && modal"
+    *ngIf="open">
     <ng-content></ng-content>
 </div>

--- a/src/components/side-panel/side-panel.component.ts
+++ b/src/components/side-panel/side-panel.component.ts
@@ -1,6 +1,6 @@
 import { ChangeDetectionStrategy, Component, ElementRef, EventEmitter, HostBinding, HostListener, Input, OnDestroy, OnInit, Output } from '@angular/core';
 import { Subject } from 'rxjs';
-import { takeUntil } from 'rxjs/operators';
+import { distinctUntilChanged, takeUntil } from 'rxjs/operators';
 import { FocusIndicatorOriginService } from '../../directives/accessibility/index';
 import { SidePanelAnimationState, sidePanelStateAnimation } from './side-panel-animations';
 import { SidePanelService } from './side-panel.service';
@@ -107,7 +107,7 @@ export class SidePanelComponent implements OnInit, OnDestroy {
         private readonly _focusOrigin: FocusIndicatorOriginService) { }
 
     ngOnInit(): void {
-        this.service.open$.pipe(takeUntil(this._onDestroy)).subscribe(isOpen => {
+        this.service.open$.pipe(distinctUntilChanged(), takeUntil(this._onDestroy)).subscribe(isOpen => {
             this.animationPanelState = isOpen
                 ? this.animate
                     ? SidePanelAnimationState.Open

--- a/src/components/side-panel/side-panel.component.ts
+++ b/src/components/side-panel/side-panel.component.ts
@@ -1,7 +1,8 @@
-import { Component, ElementRef, EventEmitter, HostBinding, HostListener, Input, OnDestroy, OnInit, Output } from '@angular/core';
-import { takeUntil } from 'rxjs/operators';
+import { ChangeDetectionStrategy, Component, ElementRef, EventEmitter, HostBinding, HostListener, Input, OnDestroy, OnInit, Output } from '@angular/core';
 import { Subject } from 'rxjs';
-import { sidePanelStateAnimation, SidePanelAnimationState } from './side-panel-animations';
+import { takeUntil } from 'rxjs/operators';
+import { FocusIndicatorOriginService } from '../../directives/accessibility';
+import { SidePanelAnimationState, sidePanelStateAnimation } from './side-panel-animations';
 import { SidePanelService } from './side-panel.service';
 
 @Component({
@@ -10,6 +11,7 @@ import { SidePanelService } from './side-panel.service';
     templateUrl: 'side-panel.component.html',
     providers: [SidePanelService],
     animations: [sidePanelStateAnimation],
+    changeDetection: ChangeDetectionStrategy.OnPush,
     host: {
         class: 'ux-side-panel'
     }
@@ -19,7 +21,7 @@ export class SidePanelComponent implements OnInit, OnDestroy {
     @Input()
     @HostBinding('class.open')
     get open(): boolean {
-        return this.service.open$.value;
+        return this._isOpen;
     }
 
     set open(value: boolean) {
@@ -56,7 +58,7 @@ export class SidePanelComponent implements OnInit, OnDestroy {
     @Output()
     openChange = new EventEmitter<boolean>();
 
-    get position() {
+    get position(): string {
         if (this.inline) {
             return 'static';
         }
@@ -88,53 +90,64 @@ export class SidePanelComponent implements OnInit, OnDestroy {
         return null;
     }
 
-    get hostWidth() {
+    get hostWidth(): string {
         return this.inline ? '100%' : this.cssWidth;
     }
 
-    animationPanelState: SidePanelAnimationState;
+    animationPanelState: SidePanelAnimationState = SidePanelAnimationState.Closed;
+
+    /** Store the current open state */
+    private _isOpen: boolean = false;
 
     protected _onDestroy = new Subject<void>();
 
-    constructor(protected service: SidePanelService, private _elementRef: ElementRef) {}
+    constructor(
+        protected readonly service: SidePanelService,
+        private readonly _elementRef: ElementRef,
+        private readonly _focusOrigin: FocusIndicatorOriginService) { }
 
-    ngOnInit() {
+    ngOnInit(): void {
         this.service.open$.pipe(takeUntil(this._onDestroy)).subscribe(isOpen => {
             this.animationPanelState = isOpen
                 ? this.animate
                     ? SidePanelAnimationState.Open
                     : SidePanelAnimationState.OpenImmediate
                 : SidePanelAnimationState.Closed;
+
+            // only if the open state changed should we emit the latest value
             this.openChange.emit(isOpen);
+            this._isOpen = isOpen;
         });
     }
 
-    ngOnDestroy() {
+    ngOnDestroy(): void {
         this._onDestroy.next();
         this._onDestroy.complete();
     }
 
-    openPanel() {
+    openPanel(): void {
         this.service.open();
     }
 
-    @HostListener('document:keyup.escape')
-    closePanel() {
+    closePanel(): void {
         this.service.close();
     }
 
-    @HostListener('document:click', ['$event'])
-    clickHandler(event: MouseEvent) {
+    @HostListener('document:keyup.escape')
+    _onDocumentEscape(): void {
+        if (this.open) {
+            this._focusOrigin.setOrigin('keyboard');
+            this.closePanel();
+        }
+    }
+
+    @HostListener('document:click', ['$event.target'])
+    _onDocumentClick(target: HTMLElement): void {
         if (!this.open || !this.closeOnExternalClick) {
             return;
         }
 
-        const target = event.target as HTMLElement;
-
-        if (
-            !this._elementRef.nativeElement.contains(target) ||
-            (target && target.classList.contains('modal-backdrop'))
-        ) {
+        if (!this._elementRef.nativeElement.contains(target) || (target && target.classList.contains('modal-backdrop'))) {
             this.closePanel();
         }
     }

--- a/src/components/side-panel/side-panel.component.ts
+++ b/src/components/side-panel/side-panel.component.ts
@@ -1,7 +1,7 @@
 import { ChangeDetectionStrategy, Component, ElementRef, EventEmitter, HostBinding, HostListener, Input, OnDestroy, OnInit, Output } from '@angular/core';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
-import { FocusIndicatorOriginService } from '../../directives/accessibility';
+import { FocusIndicatorOriginService } from '../../directives/accessibility/index';
 import { SidePanelAnimationState, sidePanelStateAnimation } from './side-panel-animations';
 import { SidePanelService } from './side-panel.service';
 

--- a/src/components/side-panel/side-panel.module.ts
+++ b/src/components/side-panel/side-panel.module.ts
@@ -1,6 +1,7 @@
 import { A11yModule } from '@angular/cdk/a11y';
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
+import { AccessibilityModule } from '../../directives/accessibility/index';
 import { FocusIfModule } from '../../directives/focus-if/focus-if.module';
 import { SidePanelCloseDirective } from './side-panel-close.directive';
 import { SidePanelComponent } from './side-panel.component';
@@ -12,6 +13,7 @@ const EXPORTS = [
 
 @NgModule({
     imports: [
+        AccessibilityModule,
         CommonModule,
         A11yModule,
         FocusIfModule

--- a/src/components/side-panel/side-panel.service.ts
+++ b/src/components/side-panel/side-panel.service.ts
@@ -1,16 +1,17 @@
 import { Injectable } from '@angular/core';
-import { BehaviorSubject } from 'rxjs';
+import { Subject } from 'rxjs';
 
 @Injectable()
 export class SidePanelService {
 
-    open$ = new BehaviorSubject<boolean>(false);
+    /** Emit the open state when it changes */
+    open$ = new Subject<boolean>();
 
-    open() {
+    open(): void {
         this.open$.next(true);
     }
 
-    close() {
+    close(): void {
         this.open$.next(false);
     }
 }

--- a/src/directives/accessibility/focus-indicator/focus-indicator.directive.ts
+++ b/src/directives/accessibility/focus-indicator/focus-indicator.directive.ts
@@ -1,4 +1,5 @@
 import { FocusOrigin } from '@angular/cdk/a11y';
+import { coerceBooleanProperty } from '@angular/cdk/coercion';
 import { Directive, ElementRef, EventEmitter, Input, NgZone, OnDestroy, OnInit, Optional, Output } from '@angular/core';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
@@ -14,7 +15,11 @@ import { FocusIndicatorService } from './focus-indicator.service';
 export class FocusIndicatorDirective implements OnInit, OnDestroy {
 
     /** Specify whether or not we should mark this element as having focus if a child is focused */
-    @Input() set checkChildren(checkChildren: boolean) {
+    @Input() set checkChildren(checkChildren: boolean | string) {
+
+        // allow a string to be used so we can skip checking a binding for performance benefits
+        checkChildren = coerceBooleanProperty(checkChildren);
+
         if (checkChildren !== null && checkChildren !== undefined) {
             this._checkChildren = checkChildren;
             this.setOptions();
@@ -22,7 +27,11 @@ export class FocusIndicatorDirective implements OnInit, OnDestroy {
     }
 
     /** Indicate whether or not mouse events should cause the focus indicator to appear - will override any global setting */
-    @Input() set mouseFocusIndicator(mouseFocusIndicator: boolean) {
+    @Input() set mouseFocusIndicator(mouseFocusIndicator: boolean | string) {
+
+        // allow a string to be used so we can skip checking a binding for performance benefits
+        mouseFocusIndicator = coerceBooleanProperty(mouseFocusIndicator);
+
         if (mouseFocusIndicator !== null && mouseFocusIndicator !== undefined) {
             this._options.set('mouseFocusIndicator', mouseFocusIndicator);
             this.setOptions();
@@ -30,7 +39,11 @@ export class FocusIndicatorDirective implements OnInit, OnDestroy {
     }
 
     /** Indicate whether or not touch events should cause the focus indicator to appear - will override any global setting */
-    @Input() set touchFocusIndicator(touchFocusIndicator: boolean) {
+    @Input() set touchFocusIndicator(touchFocusIndicator: boolean | string) {
+
+        // allow a string to be used so we can skip checking a binding for performance benefits
+        touchFocusIndicator = coerceBooleanProperty(touchFocusIndicator);
+
         if (touchFocusIndicator !== null && touchFocusIndicator !== undefined) {
             this._options.set('touchFocusIndicator', touchFocusIndicator);
             this.setOptions();
@@ -38,7 +51,11 @@ export class FocusIndicatorDirective implements OnInit, OnDestroy {
     }
 
     /** Indicate whether or not keyboard events should cause the focus indicator to appear - will override any global setting */
-    @Input() set keyboardFocusIndicator(keyboardFocusIndicator: boolean) {
+    @Input() set keyboardFocusIndicator(keyboardFocusIndicator: boolean | string) {
+
+        // allow a string to be used so we can skip checking a binding for performance benefits
+        keyboardFocusIndicator = coerceBooleanProperty(keyboardFocusIndicator);
+
         if (keyboardFocusIndicator !== null && keyboardFocusIndicator !== undefined) {
             this._options.set('keyboardFocusIndicator', keyboardFocusIndicator);
             this.setOptions();
@@ -46,7 +63,11 @@ export class FocusIndicatorDirective implements OnInit, OnDestroy {
     }
 
     /** Indicate whether or not programmatic events should cause the focus indicator to appear - will override any global setting */
-    @Input() set programmaticFocusIndicator(programmaticFocusIndicator: boolean) {
+    @Input() set programmaticFocusIndicator(programmaticFocusIndicator: boolean | string) {
+
+        // allow a string to be used so we can skip checking a binding for performance benefits
+        programmaticFocusIndicator = coerceBooleanProperty(programmaticFocusIndicator);
+
         if (programmaticFocusIndicator !== null && programmaticFocusIndicator !== undefined) {
             this._options.set('programmaticFocusIndicator', programmaticFocusIndicator);
             this.setOptions();


### PR DESCRIPTION
#### Checklist
<!-- Use an 'x' to check those which apply. -->
* [x] The contents of this PR are mine to submit. No third party code or other material is being committed.
* [x] New third party dependencies (if any) are linked via `package.json`. Third party dependencies are licenced under one of the following: Apache, MIT, BSD, Mozilla Public License, Eclipse Public License, or Oracle Binary Code License.
* [x] The code in this PR does not contain export-restricted encryption algorithms.

#### Ticket / Issue
<!-- Either a Jira URL or a description of the issue that this PR addresses. -->
https://portal.digitalsafe.net/browse/EL-3559

#### Description of Proposed Changes
<!-- Describe what was changed and how it addresses the original issue. -->
- Side Panel content is now not inserted into the DOM until it is opened
- Side panel now uses `OnPush` change detection for better performance
- Updated tests
- The `openChange` event was emitted initially even though it did not change. Now only emits once a change has occurred
- Pressing escape previously triggered the close event even if the side panel was not open
- Added utility functions to determine if a `click` event is triggered by the mouse or by the enter key
- Updated focus indicator directive to coerce boolean values, this way we can set the values using a string instead of a binding if the values never change, allowing Angular to skip checking these during change detection eg. `[programmaticFocusIndicator]="false"` could now just be `programmaticFocusIndicator="false"` and will now only be initially set.

#### Documentation CI URL
<!-- Initiate a build at https://jenkins.swinfra.net/job/SEPG/view/Templates/job/New%20SEPG%20Build/build -->
<!-- Append the branch name to the following URL: -->
https://pages.github.houston.softwaregrp.net/sepg-docs-qa/UXAspects_CI_UXAspects_EL-3559-Side-Panel-Improvements
