### PR TITLE
Fixing backwards compatibility

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -19,7 +19,7 @@ module.exports = function(grunt) {
 
     // Register Tasks
     grunt.registerTask('lint', ['tslint:library', 'tslint:documentation', 'jshint:ng1', 'stylelint', 'tslint:e2e']);
-    grunt.registerTask('library', ['clean:library', 'run:angular_components_build', 'run:webpack_ng1']);
+    grunt.registerTask('library', ['clean:library', 'run:angular_components_build', 'execute:typescriptTransform', 'run:webpack_ng1']);
     grunt.registerTask('styles', ['clean:styles', 'execute:less']);
     grunt.registerTask('scripts', ['execute:iconset']);
     grunt.registerTask('assets', ['copy:fonts', 'copy:images', 'copy:ng1', 'copy:styles', 'copy:md']);

--- a/grunt/execute.js
+++ b/grunt/execute.js
@@ -18,7 +18,7 @@ module.exports = {
         src: [ join(cwd(), 'scripts', 'protractor.js') ]
     },
     typescriptTransform: {
-        src: [ join(cwd(), 'scripts', 'typescript-compat.js') ]
+        src: [ join(cwd(), 'scripts', 'typescript-transforms.js') ]
     },
     version: {
         src: [ join(cwd(), 'scripts', 'version.js') ]

--- a/grunt/execute.js
+++ b/grunt/execute.js
@@ -17,6 +17,9 @@ module.exports = {
     protractor: {
         src: [ join(cwd(), 'scripts', 'protractor.js') ]
     },
+    typescriptTransform: {
+        src: [ join(cwd(), 'scripts', 'typescript-compat.js') ]
+    },
     version: {
         src: [ join(cwd(), 'scripts', 'version.js') ]
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -20940,6 +20940,12 @@
         "yn": "^2.0.0"
       }
     },
+    "ts-transform-readonly-array": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/ts-transform-readonly-array/-/ts-transform-readonly-array-0.0.1.tgz",
+      "integrity": "sha512-wZXHdhZZjKOc2J+np35wx50o/LXdrj4Dr0mK4WEir9OkXt8iWaYPLZliQUDWY6XTHy12r3AYtzSAc3B/XiCNVg==",
+      "dev": true
+    },
     "tsickle": {
       "version": "0.33.1",
       "resolved": "https://registry.npmjs.org/tsickle/-/tsickle-0.33.1.tgz",

--- a/package.json
+++ b/package.json
@@ -155,6 +155,7 @@
     "time-grunt": "1.4.0",
     "to-string-loader": "1.1.5",
     "ts-node": "^7.0.1",
+    "ts-transform-readonly-array": "0.0.1",
     "tsickle": "^0.33.1",
     "tslint": "^5.11.0",
     "typescript": "~3.4.5",

--- a/scripts/typescript-compat.js
+++ b/scripts/typescript-compat.js
@@ -1,7 +1,5 @@
-/**
- * Typescript 3.4 (Angular 8+) compiles `ReadonlyArray` to `readonly` which
- * is a breaking change and causes Angular < 8 to fail
- */
+// Apply TypeScript transformations to ensure backwards compatibility
+// with older versions of TypeScript and Angular
 
 const glob = require('glob');
 const { join } = require('path');
@@ -10,7 +8,11 @@ const ts = require('typescript');
 const { readFileSync, writeFileSync } = require('fs');
 const { transformerFactory } = require('ts-transform-readonly-array');
 
-async function transform() {
+/**
+ * Typescript 3.4 (Angular 8+) compiles `ReadonlyArray` to `readonly` which
+ * is a breaking change and causes Angular < 8 to fail
+ */
+async function transformDeclarations() {
 
     // get all the declaration files
     const declarations = await getDeclarations();
@@ -18,48 +20,96 @@ async function transform() {
     for (const declaration of declarations) {
         // get the absolute file path
         const path = join(cwd(), 'dist', declaration);
-
-        // load the contents of the file
-        const content = readFileSync(path, 'utf8');
-
-        // convert the file to a source file
-        const sourceFile = ts.createSourceFile(path, content, ts.ScriptTarget.ES2015, true);
-
-        // create a printer to emit the modified file as a string
-        const printer = ts.createPrinter();
-
-        // perform the transformation
-        const result = ts.transform(sourceFile, [transformerFactory]);
-
-        // get the transformed result
-        const transformedSourceFile = result.transformed[0];
-
-        // convert the transformed file
-        const newContent = printer.printFile(transformedSourceFile);
-
-        // cleanup afterwards
-        result.dispose();
-
-        // if the content has changed then we should output the new file
-        if (content !== newContent) {
-            writeFileSync(path, newContent);
-        }
+        applyTransform(path, transformerFactory);
     }
 }
 
 function getDeclarations() {
     return new Promise(resolve => {
-        glob('**/*.d.ts', {
-            cwd: join(cwd(), 'dist')
-        }, (error, matches) => {
-
-            if (error) {
-                process.exit(1);
-            }
-
-            resolve(matches);
-        });
+        glob('**/*.d.ts', { cwd: join(cwd(), 'dist'), ignore: '**/ng1/*.js' }, (error, matches) => resolve(matches));
     });
 }
 
-transform();
+// Angular 8 deprecated `defineInjectable` in favor of `ɵɵdefineInjectable`.
+// `defineInjectable` is still available until Angular 11, so we should modify
+// the imports and function calls to use the version supported in older
+// versions of Angular
+async function transformImports() {
+    // get all the declaration files
+    const bundles = await getBundles();
+
+    for (const bundle of bundles) {
+        // get the absolute file path
+        const path = join(cwd(), 'dist', bundle);
+
+        applyTransform(path, injectableTransformerFactory);
+    }
+}
+
+function applyTransform(path, transformer) {
+
+    // load the contents of the file
+    const content = readFileSync(path, 'utf8');
+
+    // convert the file to a source file
+    const sourceFile = ts.createSourceFile(path, content, ts.ScriptTarget.ES2015, true);
+
+    // create a printer to emit the modified file as a string
+    const printer = ts.createPrinter();
+
+    // perform the transformation
+    const result = ts.transform(sourceFile, [transformer]);
+
+    // get the transformed result
+    const transformedSourceFile = result.transformed[0];
+
+    // convert the transformed file
+    const newContent = printer.printFile(transformedSourceFile);
+
+    // cleanup afterwards
+    result.dispose();
+
+    // if the content has changed then we should output the new file
+    if (content !== newContent) {
+        writeFileSync(path, newContent);
+    }
+}
+
+/** Fetch all build javascript files */
+function getBundles() {
+    return new Promise(resolve => {
+        glob('**/*.js', { cwd: join(cwd(), 'dist') }, (error, matches) => resolve(matches));
+    });
+}
+
+/** 
+ * Perform an identifier rename from `defineInjectable` to `ɵɵdefineInjectable`.
+ * 
+ * There are two possible places where this is used:
+ * 1. In an import statement
+ * 2. As an identifier on a static function
+ */
+const injectableTransformerFactory = (context) => (bundle) => {
+    function visitor(node) {
+
+        if (node.getText() === 'ɵɵdefineInjectable') {
+
+            // rename `ɵɵdefineInjectable` identifier to `defineInjectable`
+            if (ts.isIdentifier(node)) {
+                return ts.createIdentifier('defineInjectable');
+            }
+
+            // rename `ɵɵdefineInjectable` import to `defineInjectable`
+            if (ts.isImportSpecifier(node)) {
+                return ts.createImportSpecifier(undefined, ts.createIdentifier('defineInjectable'));
+            }
+        }
+
+        return ts.visitEachChild(node, visitor, context);
+    }
+    return ts.visitNode(bundle, visitor);
+};
+
+
+transformDeclarations();
+transformImports();

--- a/scripts/typescript-compat.js
+++ b/scripts/typescript-compat.js
@@ -1,0 +1,65 @@
+/**
+ * Typescript 3.4 (Angular 8+) compiles `ReadonlyArray` to `readonly` which
+ * is a breaking change and causes Angular < 8 to fail
+ */
+
+const glob = require('glob');
+const { join } = require('path');
+const { cwd } = require('process');
+const ts = require('typescript');
+const { readFileSync, writeFileSync } = require('fs');
+const { transformerFactory } = require('ts-transform-readonly-array');
+
+async function transform() {
+
+    // get all the declaration files
+    const declarations = await getDeclarations();
+
+    for (const declaration of declarations) {
+        // get the absolute file path
+        const path = join(cwd(), 'dist', declaration);
+
+        // load the contents of the file
+        const content = readFileSync(path, 'utf8');
+
+        // convert the file to a source file
+        const sourceFile = ts.createSourceFile(path, content, ts.ScriptTarget.ES2015, true);
+
+        // create a printer to emit the modified file as a string
+        const printer = ts.createPrinter();
+
+        // perform the transformation
+        const result = ts.transform(sourceFile, [transformerFactory]);
+
+        // get the transformed result
+        const transformedSourceFile = result.transformed[0];
+
+        // convert the transformed file
+        const newContent = printer.printFile(transformedSourceFile);
+
+        // cleanup afterwards
+        result.dispose();
+
+        // if the content has changed then we should output the new file
+        if (content !== newContent) {
+            writeFileSync(path, newContent);
+        }
+    }
+}
+
+function getDeclarations() {
+    return new Promise(resolve => {
+        glob('**/*.d.ts', {
+            cwd: join(cwd(), 'dist')
+        }, (error, matches) => {
+
+            if (error) {
+                process.exit(1);
+            }
+
+            resolve(matches);
+        });
+    });
+}
+
+transform();

--- a/scripts/typescript-transforms.js
+++ b/scripts/typescript-transforms.js
@@ -26,7 +26,7 @@ async function transformDeclarations() {
 
 function getDeclarations() {
     return new Promise(resolve => {
-        glob('**/*.d.ts', { cwd: join(cwd(), 'dist'), ignore: '**/ng1/*.js' }, (error, matches) => resolve(matches));
+        glob('**/*.d.ts', { cwd: join(cwd(), 'dist'), ignore: ['**/ng1/*.js', '**/docs/**/*.js'] }, (error, matches) => resolve(matches));
     });
 }
 
@@ -82,10 +82,11 @@ function getBundles() {
     });
 }
 
-/** 
- * Perform an identifier rename from `defineInjectable` to `ɵɵdefineInjectable`.
- * 
- * There are two possible places where this is used:
+/**
+ * Perform an identifier rename from `defineInjectable` to `ɵɵdefineInjectable`
+ * and `ɵɵinject` to `inject`.
+ *
+ * There are only two possible places where these is used:
  * 1. In an import statement
  * 2. As an identifier on a static function
  */
@@ -102,6 +103,19 @@ const injectableTransformerFactory = (context) => (bundle) => {
             // rename `ɵɵdefineInjectable` import to `defineInjectable`
             if (ts.isImportSpecifier(node)) {
                 return ts.createImportSpecifier(undefined, ts.createIdentifier('defineInjectable'));
+            }
+        }
+
+        if (node.getText() === 'ɵɵinject') {
+
+            // rename `ɵɵinject` identifier to `inject`
+            if (ts.isIdentifier(node)) {
+                return ts.createIdentifier('inject');
+            }
+
+            // rename `ɵɵinject` import to `inject`
+            if (ts.isImportSpecifier(node)) {
+                return ts.createImportSpecifier(undefined, ts.createIdentifier('inject'));
             }
         }
 


### PR DESCRIPTION
#### Checklist
<!-- Use an 'x' to check those which apply. -->
* [x] The contents of this PR are mine to submit. No third party code or other material is being committed.
* [x] New third party dependencies (if any) are linked via `package.json`. Third party dependencies are licenced under one of the following: Apache, MIT, BSD, Mozilla Public License, Eclipse Public License, or Oracle Binary Code License.
* [x] The code in this PR does not contain export-restricted encryption algorithms.

#### Ticket / Issue
<!-- Either a Jira URL or a description of the issue that this PR addresses. -->
N/A

#### Description of Proposed Changes
<!-- Describe what was changed and how it addresses the original issue. -->
1. TypeScript converted `ReadonlyArray<T>` to `readonly T[]` which breaks in versions lower than 3.4
2. Angular 8 renamed `defineInjectable` and `inject` (https://angular.io/api/core/defineInjectable) and instead the import should now be `ɵɵdefineInjectable` and `ɵɵinject`, there is no change in functionality, just a rename to indicate it is a private function. While the old imports are still available until Angular 11, as we are now using the Angular 8 compiler it has been updated to use the private imports.

Both of these can be solved with TypeScripts transform API, which I have added as as step after the library build.

After this is run the package now build successfully in Angular 6, 7 and 8 in production mode.

#### Documentation CI URL
<!-- Initiate a build at https://jenkins.swinfra.net/job/SEPG/view/Templates/job/New%20SEPG%20Build/build -->
<!-- Append the branch name to the following URL: -->
https://pages.github.houston.softwaregrp.net/sepg-docs-qa/UXAspects_CI_UXAspects_Fixing-Backwards-Compatibility
