### PR TITLE
EL-3552 - Add size selector to the Icons documentation

### DIFF
--- a/docs/app/pages/css/css-sections/icons/icons.module.ts
+++ b/docs/app/pages/css/css-sections/icons/icons.module.ts
@@ -16,6 +16,7 @@ import { CssUxIconsComponent } from './ux-icons/ux-icons.component';
 import { IconModule, TabsetModule, TooltipModule } from '@ux-aspects/ux-aspects';
 import { IconPreviewComponent } from './ux-icons/icon-preview/icon-preview.component';
 import { IconSnippetComponent } from './ux-icons/icon-preview/icon-snippet/icon-snippet.component';
+import { ButtonsModule } from 'ngx-bootstrap';
 
 
 const SECTIONS = [
@@ -51,7 +52,8 @@ const ROUTES = [
         TooltipModule,
         PopoverModule,
         TabsetModule,
-        RouterModule.forChild(ROUTES)
+        RouterModule.forChild(ROUTES),
+        ButtonsModule
     ],
     exports: SECTIONS,
     declarations: [

--- a/docs/app/pages/css/css-sections/icons/icons.module.ts
+++ b/docs/app/pages/css/css-sections/icons/icons.module.ts
@@ -16,7 +16,7 @@ import { CssUxIconsComponent } from './ux-icons/ux-icons.component';
 import { IconModule, TabsetModule, TooltipModule } from '@ux-aspects/ux-aspects';
 import { IconPreviewComponent } from './ux-icons/icon-preview/icon-preview.component';
 import { IconSnippetComponent } from './ux-icons/icon-preview/icon-snippet/icon-snippet.component';
-import { ButtonsModule } from 'ngx-bootstrap';
+import { ButtonsModule } from 'ngx-bootstrap/buttons';
 
 
 const SECTIONS = [

--- a/docs/app/pages/css/css-sections/icons/ux-icons/icon-preview/icon-preview.component.html
+++ b/docs/app/pages/css/css-sections/icons/ux-icons/icon-preview/icon-preview.component.html
@@ -11,6 +11,7 @@
 
     <ux-icon
         class="p-r-xs"
+        [size]="iconSizeValue"
         [name]="name">
     </ux-icon>
 

--- a/docs/app/pages/css/css-sections/icons/ux-icons/icon-preview/icon-preview.component.html
+++ b/docs/app/pages/css/css-sections/icons/ux-icons/icon-preview/icon-preview.component.html
@@ -11,7 +11,7 @@
 
     <ux-icon
         class="p-r-xs"
-        [size]="iconSizeValue"
+        [size]="size"
         [name]="name">
     </ux-icon>
 

--- a/docs/app/pages/css/css-sections/icons/ux-icons/icon-preview/icon-preview.component.less
+++ b/docs/app/pages/css/css-sections/icons/ux-icons/icon-preview/icon-preview.component.less
@@ -5,6 +5,8 @@
     font-weight: 400;
     text-align: left;
     width: 100%;
+    align-items: center;
+    display: flex;
 }
 
 .usage-text {

--- a/docs/app/pages/css/css-sections/icons/ux-icons/icon-preview/icon-preview.component.ts
+++ b/docs/app/pages/css/css-sections/icons/ux-icons/icon-preview/icon-preview.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, ElementRef, HostListener, Input, OnInit, ViewChild } from '@angular/core';
+import { ChangeDetectionStrategy, Component, ElementRef, HostListener, Input, OnChanges, ViewChild } from '@angular/core';
 import { PopoverDirective } from '@ux-aspects/ux-aspects';
 
 @Component({
@@ -7,12 +7,12 @@ import { PopoverDirective } from '@ux-aspects/ux-aspects';
     styleUrls: ['./icon-preview.component.less'],
     changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class IconPreviewComponent implements OnInit {
+export class IconPreviewComponent implements OnChanges {
     @Input() name: string;
     @Input() classname: string;
     @Input() iconset: string;
     @Input() iconSetClass: string;
-    @Input() iconSizeValue: string;
+    @Input() size: string;
 
     uxComponentSnippet: string;
     iconSnippet: string;
@@ -21,8 +21,12 @@ export class IconPreviewComponent implements OnInit {
 
     @ViewChild(PopoverDirective, { static: true }) popover: PopoverDirective;
 
-    ngOnInit(): void {
-        this.uxComponentSnippet = `<ux-icon name="${this.name}" size="${this.iconSizeValue}"></ux-icon>`;
+    ngOnChanges(): void {
+        if (this.size === '16px') {
+            this.uxComponentSnippet = `<ux-icon name="${this.name}"></ux-icon>`;
+        } else {
+            this.uxComponentSnippet = `<ux-icon name="${this.name}" size="${this.size}"></ux-icon>`;
+        }
 
         this.iconSnippet = `<i class="${this.iconSetClass} ${this.classname}"></i>`;
     }

--- a/docs/app/pages/css/css-sections/icons/ux-icons/icon-preview/icon-preview.component.ts
+++ b/docs/app/pages/css/css-sections/icons/ux-icons/icon-preview/icon-preview.component.ts
@@ -12,6 +12,7 @@ export class IconPreviewComponent implements OnInit {
     @Input() classname: string;
     @Input() iconset: string;
     @Input() iconSetClass: string;
+    @Input() iconSizeValue: string;
 
     uxComponentSnippet: string;
     iconSnippet: string;
@@ -21,7 +22,7 @@ export class IconPreviewComponent implements OnInit {
     @ViewChild(PopoverDirective, { static: true }) popover: PopoverDirective;
 
     ngOnInit(): void {
-        this.uxComponentSnippet = `<ux-icon name="${this.name}"></ux-icon>`;
+        this.uxComponentSnippet = `<ux-icon name="${this.name}" size="${this.iconSizeValue}"></ux-icon>`;
 
         this.iconSnippet = `<i class="${this.iconSetClass} ${this.classname}"></i>`;
     }

--- a/docs/app/pages/css/css-sections/icons/ux-icons/icon-preview/icon-preview.component.ts
+++ b/docs/app/pages/css/css-sections/icons/ux-icons/icon-preview/icon-preview.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, ElementRef, HostListener, Input, OnChanges, ViewChild } from '@angular/core';
+import { ChangeDetectionStrategy, Component, ElementRef, HostListener, Input, OnInit, ViewChild } from '@angular/core';
 import { PopoverDirective } from '@ux-aspects/ux-aspects';
 
 @Component({
@@ -7,7 +7,7 @@ import { PopoverDirective } from '@ux-aspects/ux-aspects';
     styleUrls: ['./icon-preview.component.less'],
     changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class IconPreviewComponent implements OnChanges {
+export class IconPreviewComponent implements OnInit {
     @Input() name: string;
     @Input() classname: string;
     @Input() iconset: string;
@@ -21,12 +21,8 @@ export class IconPreviewComponent implements OnChanges {
 
     @ViewChild(PopoverDirective, { static: true }) popover: PopoverDirective;
 
-    ngOnChanges(): void {
-        if (this.size === '16px') {
-            this.uxComponentSnippet = `<ux-icon name="${this.name}"></ux-icon>`;
-        } else {
-            this.uxComponentSnippet = `<ux-icon name="${this.name}" size="${this.size}"></ux-icon>`;
-        }
+    ngOnInit(): void {
+        this.uxComponentSnippet = `<ux-icon name="${this.name}"></ux-icon>`;
 
         this.iconSnippet = `<i class="${this.iconSetClass} ${this.classname}"></i>`;
     }

--- a/docs/app/pages/css/css-sections/icons/ux-icons/ux-icons.component.html
+++ b/docs/app/pages/css/css-sections/icons/ux-icons/ux-icons.component.html
@@ -5,8 +5,8 @@
     [routerLink]="[uxIconComponentRoute]"><code>ux-icon</code> component</a> along with one of the
     following names. Click on an icon to view its implementation.</p>
 
-<div class="row m-b-md">
-    <div class="col-xs-6">
+<div class="row m-b-md icon-search-container">
+    <div class="col-xs-5">
 
         <!-- Show the standard select component in the keppel site -->
         <ux-select *ngIf="isKeppel" [(value)]="iconset" (valueChange)="updateIconset(iconset); search()" [options]="iconsets" [readonlyInput]="true"></ux-select>
@@ -23,6 +23,28 @@
                [(ngModel)]="query"
                (ngModelChange)="search()">
     </div>
+
+    <div *ngIf="iconSetClass === 'ux-icon'" class="col-xs-6 icon-resize-container">
+        <div class="icon-resize-text">Icon Size</div>
+        <div class="btn-group icon-resize-buttons">
+            <button type="button"
+                    class="btn button-toggle-primary icon-resize-button"
+                    [(ngModel)]="iconSizeValue"
+                    btnRadio="16px">16px
+            </button>
+            <button type="button"
+                    class="btn button-toggle-primary icon-resize-button"
+                    [(ngModel)]="iconSizeValue"
+                    btnRadio="24px">24px
+            </button>
+            <button type="button"
+                    class="btn button-toggle-primary icon-resize-button"
+                    [(ngModel)]="iconSizeValue"
+                    btnRadio="32px">32px
+            </button>
+        </div>
+    </div>
+
 </div>
 
 <div class="row">
@@ -31,6 +53,7 @@
             [name]="icon.name"
             [classname]="icon.classname"
             [iconset]="iconset"
+            [iconSizeValue]="iconSizeValue"
             [iconSetClass]="iconSetClass">
         </uxd-icon-preview>
     </div>

--- a/docs/app/pages/css/css-sections/icons/ux-icons/ux-icons.component.html
+++ b/docs/app/pages/css/css-sections/icons/ux-icons/ux-icons.component.html
@@ -1,66 +1,75 @@
 <p *ngIf="iconSetClass === 'hpe-icon'">To use an icon simply apply the <code>{{ iconSetClass }}</code>
     class along with one of the following classes:</p>
 
-<p  *ngIf="iconSetClass === 'ux-icon'">To use an icon apply the <a fragment="icon"
+<p *ngIf="iconSetClass === 'ux-icon'">To use an icon apply the <a fragment="icon"
     [routerLink]="[uxIconComponentRoute]"><code>ux-icon</code> component</a> along with one of the
     following names. Click on an icon to view its implementation.</p>
 
-<div class="row m-b-md icon-search-container">
+<div class="row m-b-md">
 
-    <div class="icon-search-items-container col-xs-6">
-        <input #input
-               type="text"
-               class="form-control"
-               placeholder="Search UX Aspects Icons..."
-               [(ngModel)]="query"
-               (ngModelChange)="search()">
+    <div class="col-lg-4 col-md-12 col-sm-12">
+
+        <div class="icon-search-items-container">
+
+            <input #input
+                   type="text"
+                   class="form-control"
+                   placeholder="Search UX Aspects Icons..."
+                   [(ngModel)]="query"
+                   (ngModelChange)="search()">
+
+        </div>
     </div>
 
-    <div [class.col-xs-4]="iconSetClass === 'ux-icon'"
-         [class.col-xs-6]="iconSetClass === 'hpe-icon'"
-         [class.icon-set-selector-alignment]="iconSetClass === 'ux-icon'"
-         class="icon-search-items-container">
+    <div class="col-lg-4 col-md-12 col-sm-12">
 
-        <div class="icon-selector-text">Icon Set</div>
+        <div class="icon-search-items-container">
 
-        <!-- Show the standard select component in the keppel site -->
-        <ux-select [class.icon-set-dropdown]="iconSetClass === 'ux-icon'"
-                   *ngIf="isKeppel"
-                   [(value)]="iconset"
-                   (valueChange)="updateIconset(iconset); search()"
-                   [options]="iconsets"
-                   [readonlyInput]="true">
-        </ux-select>
+            <div class="icon-selector-text">Icon Set</div>
 
-        <!-- Show the combobox variant in the MF site -->
-        <ux-combobox *ngIf="!isKeppel"
-                     [(value)]="iconset"
-                     (valueChange)="updateIconset(iconset); search()"
-                     [options]="iconsets"
-                     [readonlyInput]="true">
-        </ux-combobox>
+            <!-- Show the standard select component in the keppel site -->
+            <ux-select *ngIf="isKeppel"
+                       [class.icon-set-dropdown]="iconSetClass === 'ux-icon'"
+                       [(value)]="iconset"
+                       (valueChange)="updateIconset(iconset); search()"
+                       [options]="iconsets"
+                       [readonlyInput]="true">
+            </ux-select>
+
+            <!-- Show the combobox variant in the MF site -->
+            <ux-combobox *ngIf="!isKeppel"
+                         [(value)]="iconset"
+                         (valueChange)="updateIconset(iconset); search()"
+                         [options]="iconsets"
+                         [readonlyInput]="true">
+            </ux-combobox>
+
+        </div>
+
     </div>
 
-    <div *ngIf="iconSetClass === 'ux-icon'"
-         class="col-xs-4 icon-search-items-container icon-resize-container-alignment">
+    <div class="col-lg-4 col-md-12 col-sm-12">
 
-        <div class="icon-selector-text">Icon Size</div>
-        <div class="btn-group icon-resize-buttons">
-            <button type="button"
-                    class="btn button-toggle-primary icon-resize-button"
-                    [(ngModel)]="size"
-                    btnRadio="16px">16px
-            </button>
-            <button type="button"
-                    class="btn button-toggle-primary icon-resize-button"
-                    [(ngModel)]="size"
-                    btnRadio="24px">24px
-            </button>
-            <button type="button"
-                    class="btn button-toggle-primary icon-resize-button"
-                    [(ngModel)]="size"
-                    btnRadio="32px">32px
-            </button>
+        <div *ngIf="iconSetClass === 'ux-icon'" class="icon-search-items-container">
+
+            <div class="icon-selector-text">Icon Size</div>
+            <div class="btn-group icon-resize-buttons">
+                <button type="button"
+                        class="btn button-toggle-primary icon-resize-button"
+                        [(ngModel)]="size"
+                        btnRadio="16px">16px
+                </button>
+                <button type="button"
+                        class="btn button-toggle-primary icon-resize-button"
+                        [(ngModel)]="size"
+                        btnRadio="24px">24px
+                </button>
+                <button type="button"
+                        class="btn button-toggle-primary icon-resize-button"
+                        [(ngModel)]="size"
+                        btnRadio="32px">32px
+                </button>
+            </div>
         </div>
 
     </div>

--- a/docs/app/pages/css/css-sections/icons/ux-icons/ux-icons.component.html
+++ b/docs/app/pages/css/css-sections/icons/ux-icons/ux-icons.component.html
@@ -6,16 +6,8 @@
     following names. Click on an icon to view its implementation.</p>
 
 <div class="row m-b-md icon-search-container">
-    <div class="col-xs-5">
 
-        <!-- Show the standard select component in the keppel site -->
-        <ux-select *ngIf="isKeppel" [(value)]="iconset" (valueChange)="updateIconset(iconset); search()" [options]="iconsets" [readonlyInput]="true"></ux-select>
-
-        <!-- Show the combobox variant in the MF site -->
-        <ux-combobox *ngIf="!isKeppel" [(value)]="iconset" (valueChange)="updateIconset(iconset); search()" [options]="iconsets" [readonlyInput]="true"></ux-combobox>
-    </div>
-
-    <div class="col-xs-6">
+    <div class="icon-search-items-container col-xs-6">
         <input #input
                type="text"
                class="form-control"
@@ -24,8 +16,35 @@
                (ngModelChange)="search()">
     </div>
 
-    <div *ngIf="iconSetClass === 'ux-icon'" class="col-xs-6 icon-resize-container">
-        <div class="icon-resize-text">Icon Size</div>
+    <div [class.col-xs-4]="iconSetClass === 'ux-icon'"
+         [class.col-xs-6]="iconSetClass === 'hpe-icon'"
+         [class.icon-set-selector-alignment]="iconSetClass === 'ux-icon'"
+         class="icon-search-items-container">
+
+        <div class="icon-selector-text">Icon Set</div>
+
+        <!-- Show the standard select component in the keppel site -->
+        <ux-select [class.icon-set-dropdown]="iconSetClass === 'ux-icon'"
+                   *ngIf="isKeppel"
+                   [(value)]="iconset"
+                   (valueChange)="updateIconset(iconset); search()"
+                   [options]="iconsets"
+                   [readonlyInput]="true">
+        </ux-select>
+
+        <!-- Show the combobox variant in the MF site -->
+        <ux-combobox *ngIf="!isKeppel"
+                     [(value)]="iconset"
+                     (valueChange)="updateIconset(iconset); search()"
+                     [options]="iconsets"
+                     [readonlyInput]="true">
+        </ux-combobox>
+    </div>
+
+    <div *ngIf="iconSetClass === 'ux-icon'"
+         class="col-xs-4 icon-search-items-container icon-resize-container-alignment">
+
+        <div class="icon-selector-text">Icon Size</div>
         <div class="btn-group icon-resize-buttons">
             <button type="button"
                     class="btn button-toggle-primary icon-resize-button"
@@ -43,6 +62,7 @@
                     btnRadio="32px">32px
             </button>
         </div>
+
     </div>
 
 </div>

--- a/docs/app/pages/css/css-sections/icons/ux-icons/ux-icons.component.html
+++ b/docs/app/pages/css/css-sections/icons/ux-icons/ux-icons.component.html
@@ -29,7 +29,7 @@
 
             <!-- Show the standard select component in the keppel site -->
             <ux-select *ngIf="isKeppel"
-                       [class.icon-set-dropdown]="iconSetClass === 'ux-icon'"
+                       class="icon-set-dropdown"
                        [(value)]="iconset"
                        (valueChange)="updateIconset(iconset); search()"
                        [options]="iconsets"

--- a/docs/app/pages/css/css-sections/icons/ux-icons/ux-icons.component.html
+++ b/docs/app/pages/css/css-sections/icons/ux-icons/ux-icons.component.html
@@ -29,17 +29,17 @@
         <div class="btn-group icon-resize-buttons">
             <button type="button"
                     class="btn button-toggle-primary icon-resize-button"
-                    [(ngModel)]="iconSizeValue"
+                    [(ngModel)]="size"
                     btnRadio="16px">16px
             </button>
             <button type="button"
                     class="btn button-toggle-primary icon-resize-button"
-                    [(ngModel)]="iconSizeValue"
+                    [(ngModel)]="size"
                     btnRadio="24px">24px
             </button>
             <button type="button"
                     class="btn button-toggle-primary icon-resize-button"
-                    [(ngModel)]="iconSizeValue"
+                    [(ngModel)]="size"
                     btnRadio="32px">32px
             </button>
         </div>
@@ -53,7 +53,7 @@
             [name]="icon.name"
             [classname]="icon.classname"
             [iconset]="iconset"
-            [iconSizeValue]="iconSizeValue"
+            [size]="size"
             [iconSetClass]="iconSetClass">
         </uxd-icon-preview>
     </div>

--- a/docs/app/pages/css/css-sections/icons/ux-icons/ux-icons.component.html
+++ b/docs/app/pages/css/css-sections/icons/ux-icons/ux-icons.component.html
@@ -25,11 +25,10 @@
 
         <div class="icon-search-items-container">
 
-            <div class="icon-selector-text">Icon Set</div>
+            <label class="icon-selector-text">Icon Set</label>
 
             <!-- Show the standard select component in the keppel site -->
             <ux-select *ngIf="isKeppel"
-                       class="icon-set-dropdown"
                        [(value)]="iconset"
                        (valueChange)="updateIconset(iconset); search()"
                        [options]="iconsets"
@@ -52,7 +51,7 @@
 
         <div *ngIf="iconSetClass === 'ux-icon'" class="icon-search-items-container">
 
-            <div class="icon-selector-text">Icon Size</div>
+            <label class="icon-selector-text">Icon Size</label>
             <div class="btn-group icon-resize-buttons">
                 <button type="button"
                         class="btn button-toggle-primary icon-resize-button"

--- a/docs/app/pages/css/css-sections/icons/ux-icons/ux-icons.component.less
+++ b/docs/app/pages/css/css-sections/icons/ux-icons/ux-icons.component.less
@@ -4,16 +4,9 @@
     padding: 5px 0;
 
     .icon-selector-text {
-        justify-content: center;
-        flex-direction: column;
+        flex: none;
         margin-right: 8px;
     }
-
-    .icon-set-dropdown {
-        width: 208px;
-        min-width: 120px;
-    }
-
     .icon-resize-button {
         text-transform: none;
         padding: 4px 12px;

--- a/docs/app/pages/css/css-sections/icons/ux-icons/ux-icons.component.less
+++ b/docs/app/pages/css/css-sections/icons/ux-icons/ux-icons.component.less
@@ -1,32 +1,21 @@
-.icon-search-container {
+.icon-search-items-container {
     display: flex;
+    align-items: center;
+    padding: 5px 0;
 
-    .icon-search-items-container {
-        display: inline-flex;
-        align-items: center;
+    .icon-selector-text {
+        justify-content: center;
+        flex-direction: column;
+        margin-right: 8px;
+    }
 
-        &.icon-resize-container-alignment {
-            justify-content: flex-end;
-        }
+    .icon-set-dropdown {
+        width: 208px;
+        min-width: 120px;
+    }
 
-        &.icon-set-selector-alignment {
-            justify-content: center;
-        }
-
-        .icon-set-dropdown {
-            width: 155px;
-            min-width: 120px;
-        }
-
-        .icon-selector-text {
-            justify-content: center;
-            flex-direction: column;
-            margin-right: 8px;
-        }
-
-        .icon-resize-button {
-            text-transform: none;
-            padding: 4px 12px;
-        }
+    .icon-resize-button {
+        text-transform: none;
+        padding: 4px 12px;
     }
 }

--- a/docs/app/pages/css/css-sections/icons/ux-icons/ux-icons.component.less
+++ b/docs/app/pages/css/css-sections/icons/ux-icons/ux-icons.component.less
@@ -7,6 +7,7 @@
         flex: none;
         margin-right: 8px;
     }
+
     .icon-resize-button {
         text-transform: none;
         padding: 4px 12px;

--- a/docs/app/pages/css/css-sections/icons/ux-icons/ux-icons.component.less
+++ b/docs/app/pages/css/css-sections/icons/ux-icons/ux-icons.component.less
@@ -1,21 +1,32 @@
 .icon-search-container {
     display: flex;
 
-    .icon-resize-container {
+    .icon-search-items-container {
         display: inline-flex;
         align-items: center;
 
-        .icon-resize-text {
-            justify-content: center;
-            flex-direction: column;
+        &.icon-resize-container-alignment {
+            justify-content: flex-end;
         }
 
-        .icon-resize-buttons {
-            margin-left: 8px;
+        &.icon-set-selector-alignment {
+            justify-content: center;
+        }
 
-            .icon-resize-button {
-                text-transform: none;
-            }
+        .icon-set-dropdown {
+            width: 155px;
+            min-width: 120px;
+        }
+
+        .icon-selector-text {
+            justify-content: center;
+            flex-direction: column;
+            margin-right: 8px;
+        }
+
+        .icon-resize-button {
+            text-transform: none;
+            padding: 4px 12px;
         }
     }
 }

--- a/docs/app/pages/css/css-sections/icons/ux-icons/ux-icons.component.less
+++ b/docs/app/pages/css/css-sections/icons/ux-icons/ux-icons.component.less
@@ -1,0 +1,25 @@
+.icon-search-container {
+    display: flex;
+
+    .icon-resize-container {
+        display: inline-flex;
+        align-items: center;
+
+        .icon-resize-text {
+            justify-content: center;
+            flex-direction: column;
+        }
+
+        .icon-resize-buttons {
+            margin-left: 8px;
+
+            .icon-resize-button {
+                text-transform: none;
+
+                &:first-child {
+                    margin-left: -1px;
+                }
+            }
+        }
+    }
+}

--- a/docs/app/pages/css/css-sections/icons/ux-icons/ux-icons.component.less
+++ b/docs/app/pages/css/css-sections/icons/ux-icons/ux-icons.component.less
@@ -15,10 +15,6 @@
 
             .icon-resize-button {
                 text-transform: none;
-
-                &:first-child {
-                    margin-left: -1px;
-                }
             }
         }
     }

--- a/docs/app/pages/css/css-sections/icons/ux-icons/ux-icons.component.ts
+++ b/docs/app/pages/css/css-sections/icons/ux-icons/ux-icons.component.ts
@@ -34,6 +34,8 @@ export class CssUxIconsComponent {
 
     uxIconComponentRoute: string;
 
+    iconSizeValue: string = '24px';
+
     get isKeppel(): boolean {
         return this._documentationType === DocumentationType.Keppel;
     }

--- a/docs/app/pages/css/css-sections/icons/ux-icons/ux-icons.component.ts
+++ b/docs/app/pages/css/css-sections/icons/ux-icons/ux-icons.component.ts
@@ -34,7 +34,7 @@ export class CssUxIconsComponent {
 
     uxIconComponentRoute: string;
 
-    iconSizeValue: string = '24px';
+    size: string = '24px';
 
     get isKeppel(): boolean {
         return this._documentationType === DocumentationType.Keppel;

--- a/docs/styles.less
+++ b/docs/styles.less
@@ -1601,6 +1601,6 @@ Spark table documentation styles
 }
 
 .icon-code-snippet-popover {
-    max-width: 500px;
+    max-width: 650px;
     padding: 10px 5px;
 }

--- a/docs/styles.less
+++ b/docs/styles.less
@@ -1601,6 +1601,6 @@ Spark table documentation styles
 }
 
 .icon-code-snippet-popover {
-    max-width: 650px;
+    max-width: 500px;
     padding: 10px 5px;
 }


### PR DESCRIPTION
#### Checklist

* [x] The contents of this PR are mine to submit. No third party code or other material is being committed.
* [x] New third party dependencies (if any) are linked via `package.json`. Third party dependencies are licenced under one of the following: Apache, MIT, BSD, Mozilla Public License, Eclipse Public License, or Oracle Binary Code License.
* [x] The code in this PR does not contain export-restricted encryption algorithms.

#### Ticket / Issue

https://portal.digitalsafe.net/browse/EL-3552

#### Description of Proposed Changes

- Added in size selector for ux-icon for 16px, 24px, 32px
- Default 24px
- Added in <code>size</code> to ux-icon clipboard copy

#### Documentation CI URL

https://pages.github.houston.softwaregrp.net/sepg-docs-qa/UXAspects_CI_UXAspects_EL-3552-add-size-selector-icon-documentation
