### PR TITLE
EL-3599 - Missing type text for input typeahead

### DIFF
--- a/docs/app/pages/components/components-sections/input-controls/typeahead/snippets/app.html
+++ b/docs/app/pages/components/components-sections/input-controls/typeahead/snippets/app.html
@@ -5,6 +5,7 @@
                    [ngModelOptions]="{standalone: true}"
                    placeholder="Enter Text"
                    class="form-control"
+                   type="text"
                    (click)="dropdownOpen = true"
                    (keydown)="typeaheadKeyService.handleKey($event, typeahead)"
                    (keydown.escape)="dropdownOpen = false"

--- a/docs/app/pages/components/components-sections/input-controls/typeahead/typeahead.component.html
+++ b/docs/app/pages/components/components-sections/input-controls/typeahead/typeahead.component.html
@@ -5,6 +5,7 @@
                    [ngModelOptions]="{standalone: true}"
                    placeholder="Enter Text"
                    class="form-control"
+                   type="text"
                    (click)="dropdownOpen = true"
                    (keydown)="typeaheadKeyService.handleKey($event, typeahead)"
                    (keydown.escape)="dropdownOpen = false"


### PR DESCRIPTION
#### Checklist

* [x] The contents of this PR are mine to submit. No third party code or other material is being committed.
* [x] New third party dependencies (if any) are linked via `package.json`. Third party dependencies are licenced under one of the following: Apache, MIT, BSD, Mozilla Public License, Eclipse Public License, or Oracle Binary Code License.
* [x] The code in this PR does not contain export-restricted encryption algorithms.

#### Ticket / Issue

https://portal.digitalsafe.net/browse/EL-3599

#### Description of Proposed Changes
- Missing type of text in Input for typehead causing focus styles to be wrong in MF site

#### Documentation CI URL
https://pages.github.houston.softwaregrp.net/sepg-docs-qa/UXAspects_CI_UXAspects_typeahead-input-type
