### PR TITLE
EL-3621 - Input Dropdown Styling Fix

### DIFF
--- a/docs/app/pages/components/components-sections/input-controls/input-dropdown/input-dropdown.component.less
+++ b/docs/app/pages/components/components-sections/input-controls/input-dropdown/input-dropdown.component.less
@@ -3,13 +3,11 @@ ux-input-dropdown {
 }
 
 .radio-button-container {
-    padding-top: 16px;
-    padding-bottom: 16px;
+    padding: 16px 4px;
 
     ux-radio-button {
-        padding: 4px 16px;
+        padding: 4px 12px;
         margin-bottom: 0;
-        font-size: 16px;
     }
 }
 

--- a/docs/app/pages/components/components-sections/input-controls/input-dropdown/snippets/app.css
+++ b/docs/app/pages/components/components-sections/input-controls/input-dropdown/snippets/app.css
@@ -3,12 +3,10 @@ ux-input-dropdown {
 }
 
 .radio-button-container {
-    padding-top: 16px;
-    padding-bottom: 16px;
+    padding: 16px 4px;
 }
 
 ux-radio-button {
-    padding: 4px 16px;
+    padding: 4px 12px;
     margin-bottom: 0;
-    font-size: 16px;
 }


### PR DESCRIPTION
#### Checklist
<!-- Use an 'x' to check those which apply. -->
* [x] The contents of this PR are mine to submit. No third party code or other material is being committed.
* [x] New third party dependencies (if any) are linked via `package.json`. Third party dependencies are licenced under one of the following: Apache, MIT, BSD, Mozilla Public License, Eclipse Public License, or Oracle Binary Code License.
* [x] The code in this PR does not contain export-restricted encryption algorithms.

#### Ticket / Issue
<!-- Either a Jira URL or a description of the issue that this PR addresses. -->

#### Description of Proposed Changes
<!-- Describe what was changed and how it addresses the original issue. -->
Updated styling so the focus outline appears inside the dropdown for both Keppel and MF sites.
Also removed `font-size` style rule as it does not appear to have any effect in either Keppel or MF sites.

![image](https://user-images.githubusercontent.com/20795331/63365818-4b625600-c370-11e9-9db6-082c31ee8d7e.png)

#### Documentation CI URL
<!-- Initiate a build at https://jenkins.swinfra.net/job/SEPG/view/Templates/job/New%20SEPG%20Build/build -->
<!-- Append the branch name to the following URL: -->
https://pages.github.houston.softwaregrp.net/sepg-docs-qa/UXAspects_CI_UXAspects_EL-3621-Input-Dropdown-Focus-Styling
