### PR TITLE
EL-3645 - Removed some unnecessary font-family rules

### DIFF
--- a/src/styles/buttons.less
+++ b/src/styles/buttons.less
@@ -943,8 +943,6 @@ fieldset[disabled] .btn-toggle.active {
 
 //Hyperlink styles
 .hyperlink {
-    font-family: @font-family;
-
     &:link {
         color: @hyperlink-color;
         border-bottom: 2px dotted @primary;
@@ -1016,7 +1014,6 @@ fieldset[disabled] .btn-toggle.active {
 }
 
 .hyperlink-hover {
-    font-family: @font-family;
     border-bottom: 2px dotted transparent;
 
     &:link {

--- a/src/styles/labels.less
+++ b/src/styles/labels.less
@@ -1,7 +1,6 @@
 .label {
     background-color: @label-bg;
     color: @label-color;
-    font-family: @font-family;
     font-size: @label-size;
     font-weight: @label-weight;
     padding: 3px 8px;


### PR DESCRIPTION
#### Checklist
<!-- Use an 'x' to check those which apply. -->
* [x] The contents of this PR are mine to submit. No third party code or other material is being committed.
* [x] New third party dependencies (if any) are linked via `package.json`. Third party dependencies are licenced under one of the following: Apache, MIT, BSD, Mozilla Public License, Eclipse Public License, or Oracle Binary Code License.
* [x] The code in this PR does not contain export-restricted encryption algorithms.

#### Ticket / Issue
https://portal.digitalsafe.net/browse/EL-3645

#### Description of Proposed Changes
Hyperlinks and labels show up with the incorrect font in the Micro Focus theme. This was not noticed in the documentation since we were building the Less stylesheet with new variables. In this case, these components should be fine with the inherited font.


#### Documentation CI URL
<!-- Initiate a build at https://jenkins.swinfra.net/job/SEPG/view/Templates/job/New%20SEPG%20Build/build -->
<!-- Append the branch name to the following URL: -->
https://pages.github.houston.softwaregrp.net/sepg-docs-qa/UXAspects_CI_UXAspects_EL-3645-label-hyperlink-font
