### PR TITLE
EL-3644 - Menu Visibility Issue

### DIFF
--- a/src/components/menu/menu.spec.ts
+++ b/src/components/menu/menu.spec.ts
@@ -318,6 +318,8 @@ describe('MenuComponent', () => {
         // the menu should now be closed check the internal menu state is correct
         expect(component.trigger.menu._isHovering$.value).toBeFalsy();
         expect(component.trigger.menu._isFocused$.value).toBeFalsy();
+        expect(component.subMenuTrigger.menu._isHovering$.value).toBeFalsy();
+        expect(component.subMenuTrigger.menu._isFocused$.value).toBeFalsy();
 
     });
 });

--- a/src/components/menu/menu.spec.ts
+++ b/src/components/menu/menu.spec.ts
@@ -16,7 +16,7 @@ import { MenuModule } from './menu.module';
   </ux-menu>
 
   <ux-menu #subMenu>
-    <button uxMenuItem>Sub Item One</button>
+    <button uxMenuItem id="submenu-item-1">Sub Item One</button>
     <button uxMenuItem>Sub Item Two</button>
   </ux-menu>
 
@@ -99,7 +99,7 @@ describe('MenuComponent', () => {
         fixture.detectChanges();
 
         // allow noop animation to complete
-        await Promise.resolve();
+        await fixture.whenStable();
 
         // no menus should be visible
         expect(document.querySelectorAll('.ux-menu').length).toBe(0);
@@ -126,7 +126,7 @@ describe('MenuComponent', () => {
         fixture.detectChanges();
 
         // allow noop animation to complete
-        await Promise.resolve();
+        await fixture.whenStable();
 
         // no menus should be visible
         expect(document.querySelectorAll('.ux-menu').length).toBe(0);
@@ -141,22 +141,22 @@ describe('MenuComponent', () => {
     it('should close the menu when the trigger is programmatically called', async () => {
         component.trigger.openMenu();
         fixture.detectChanges();
-        await Promise.resolve();
+        await fixture.whenStable();
         expect(document.querySelectorAll('.ux-menu').length).toBe(1);
         component.trigger.closeMenu();
         fixture.detectChanges();
-        await Promise.resolve();
+        await fixture.whenStable();
         expect(document.querySelectorAll('.ux-menu').length).toBe(0);
     });
 
     it('should toggle the menu when the trigger is programmatically called', async () => {
         component.trigger.toggleMenu();
         fixture.detectChanges();
-        await Promise.resolve();
+        await fixture.whenStable();
         expect(document.querySelectorAll('.ux-menu').length).toBe(1);
         component.trigger.toggleMenu();
         fixture.detectChanges();
-        await Promise.resolve();
+        await fixture.whenStable();
         expect(document.querySelectorAll('.ux-menu').length).toBe(0);
     });
 
@@ -185,7 +185,7 @@ describe('MenuComponent', () => {
     it('should make only the first menu item tabbable', async () => {
         component.trigger.openMenu();
         fixture.detectChanges();
-        await Promise.resolve();
+        await fixture.whenStable();
 
         const items = document.querySelectorAll('button[uxmenuitem]');
 
@@ -199,13 +199,13 @@ describe('MenuComponent', () => {
         // open menu
         component.trigger.openMenu();
         fixture.detectChanges();
-        await Promise.resolve();
+        await fixture.whenStable();
 
         // close menu by clicking on an item
         const items = document.querySelectorAll<HTMLButtonElement>('button[uxmenuitem]');
         items.item(0).click();
         fixture.detectChanges();
-        await Promise.resolve();
+        await fixture.whenStable();
 
         // the trigger element should be focused
         expect(document.activeElement).toBe(triggerElement);
@@ -215,13 +215,13 @@ describe('MenuComponent', () => {
         // open menu
         component.trigger.openMenu();
         fixture.detectChanges();
-        await Promise.resolve();
+        await fixture.whenStable();
 
         // dispatch a mouse enter event
         component.subMenuTrigger._onMouseEnter();
 
         fixture.detectChanges();
-        await Promise.resolve();
+        await fixture.whenStable();
 
         expect(document.querySelectorAll('.ux-menu').length).toBe(2);
     });
@@ -230,13 +230,13 @@ describe('MenuComponent', () => {
         // open menu
         component.trigger.openMenu();
         fixture.detectChanges();
-        await Promise.resolve();
+        await fixture.whenStable();
 
         // dispatch a mouse enter event
         component.subMenuTrigger._onMouseEnter();
 
         fixture.detectChanges();
-        await Promise.resolve();
+        await fixture.whenStable();
 
         // get the backdrop element
         const backdrop = overlayContainerElement.querySelector('.cdk-overlay-backdrop') as HTMLDivElement;
@@ -249,7 +249,7 @@ describe('MenuComponent', () => {
         fixture.detectChanges();
 
         // allow noop animation to complete
-        await Promise.resolve();
+        await fixture.whenStable();
 
         // no menus should be visible
         expect(document.querySelectorAll('.ux-menu').length).toBe(0);
@@ -259,13 +259,13 @@ describe('MenuComponent', () => {
         // open menu
         component.trigger.openMenu();
         fixture.detectChanges();
-        await Promise.resolve();
+        await fixture.whenStable();
 
         // close menu by clicking on an item
         const items = document.querySelectorAll<HTMLButtonElement>('button[uxmenuitem]');
         items.item(0).click();
         fixture.detectChanges();
-        await Promise.resolve();
+        await fixture.whenStable();
         expect(document.querySelectorAll('.ux-menu').length).toBe(0);
     });
 
@@ -273,19 +273,51 @@ describe('MenuComponent', () => {
         // open menu
         component.trigger.openMenu();
         fixture.detectChanges();
-        await Promise.resolve();
+        await fixture.whenStable();
 
         // dispatch a mouse enter event
         component.subMenuTrigger._onMouseEnter();
 
         fixture.detectChanges();
-        await Promise.resolve();
+        await fixture.whenStable();
 
         // close menu by clicking on an item
         const items = document.querySelectorAll<HTMLButtonElement>('button[uxmenuitem]');
         items.item(0).click();
         fixture.detectChanges();
-        await Promise.resolve();
+        await fixture.whenStable();
         expect(document.querySelectorAll('.ux-menu').length).toBe(0);
+    });
+
+    /**
+     * Test case covering issue: https://portal.digitalsafe.net/browse/EL-3644
+     *
+     * Opening a menu, expanding a submenu and selecting an item would close
+     * the menu, hover when the top level menu is re-opened the internal hover
+     * and focus states were not being reset correctly
+     */
+    it('should correctly reset menu state when closed', async () => {
+        component.trigger.openMenu();
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        component.subMenuTrigger.openMenu();
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        // get the child submenu item
+        const submenuItem = document.querySelector<HTMLButtonElement>('#submenu-item-1');
+
+        expect(submenuItem).toBeTruthy();
+
+        // perform a click
+        submenuItem.click();
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        // the menu should now be closed check the internal menu state is correct
+        expect(component.trigger.menu._isHovering$.value).toBeFalsy();
+        expect(component.trigger.menu._isFocused$.value).toBeFalsy();
+
     });
 });

--- a/src/components/menu/menu/menu.component.ts
+++ b/src/components/menu/menu/menu.component.ts
@@ -170,6 +170,12 @@ export class MenuComponent implements AfterContentInit, OnDestroy {
         // store the open state
         this.isMenuOpen = menuOpen;
 
+        // if we are closing the menu reset some values
+        if (!menuOpen) {
+            this._isHovering$.next(false);
+            this._isFocused$.next(false);
+        }
+
         // check for changes - required to show the menu as we are using `*ngIf`
         this._changeDetector.detectChanges();
 


### PR DESCRIPTION
#### Checklist
<!-- Use an 'x' to check those which apply. -->
* [x] The contents of this PR are mine to submit. No third party code or other material is being committed.
* [x] New third party dependencies (if any) are linked via `package.json`. Third party dependencies are licenced under one of the following: Apache, MIT, BSD, Mozilla Public License, Eclipse Public License, or Oracle Binary Code License.
* [x] The code in this PR does not contain export-restricted encryption algorithms.

#### Ticket / Issue
<!-- Either a Jira URL or a description of the issue that this PR addresses. -->
https://portal.digitalsafe.net/browse/EL-3644

#### Description of Proposed Changes
<!-- Describe what was changed and how it addresses the original issue. -->
- When a submenu item was clicked (submenu hover set to `true`), which closed the menu, the internal hover and focus states were not reset, so when you opened the menu a second time and the mouse entered the submenu trigger it showed the submenu but the submenu did not get hidden because it thought the mouse was still over the submenu due to the state it was in when it was first closed.

- Simply resetting the state correctly when a menu is closed fixes the issue.
- Also added test to ensure the menu states get the correct value when they are closed.
- Updated existing tests to use `fixture.whenStable()` instead of `Promise.resolve()`

#### Documentation CI URL
<!-- Initiate a build at https://jenkins.swinfra.net/job/SEPG/view/Templates/job/New%20SEPG%20Build/build -->
<!-- Append the branch name to the following URL: -->
https://pages.github.houston.softwaregrp.net/sepg-docs-qa/UXAspects_CI_UXAspects_EL-3644-Menu-Bug
