### PR TITLE
EL-3636 - Number picker validation fix and tests

### DIFF
--- a/docs/app/pages/components/components-sections/input-controls/number-picker/number-picker.component.html
+++ b/docs/app/pages/components/components-sections/input-controls/number-picker/number-picker.component.html
@@ -41,6 +41,10 @@
         	Defines the maximum value the number picker can set.
     </tr>
     <tr uxd-api-property name="valid" type="boolean">
+        <p><b>Note:</b> This component has been deprecated. We recommend using <a
+            routerLink="https://angular.io/guide/form-validation#reactive-form-validation">reactive form validation</a>
+            instead.
+        </p>
         Can be used to show a red outline around the input to indicate an invalid value. By default the
         error state will appear if the user enters a number below the minimum value or above the maximum value.
     </tr>

--- a/docs/app/pages/components/components-sections/input-controls/number-picker/number-picker.component.html
+++ b/docs/app/pages/components/components-sections/input-controls/number-picker/number-picker.component.html
@@ -41,9 +41,9 @@
         	Defines the maximum value the number picker can set.
     </tr>
     <tr uxd-api-property name="valid" type="boolean">
-        <p><b>Note:</b> This component has been deprecated. We recommend using <a
-            routerLink="https://angular.io/guide/form-validation#reactive-form-validation">reactive form validation</a>
-            instead.
+        <p><b>Note:</b> This property has been deprecated. We recommend using <a
+            href="https://angular.io/guide/form-validation#reactive-form-validation">reactive form
+            validation</a> instead.
         </p>
         Can be used to show a red outline around the input to indicate an invalid value. By default the
         error state will appear if the user enters a number below the minimum value or above the maximum value.

--- a/src/components/number-picker/number-picker.component.less
+++ b/src/components/number-picker/number-picker.component.less
@@ -4,7 +4,7 @@ ux-number-picker-inline {
     flex-direction: row;
     height: 34px;
 
-    &.ux-number-picker-invalid:not([formControlName]) {
+    &.ux-number-picker-invalid:not(.ng-invalid) {
         > .number-picker-input {
             border-color: @critical;
         }

--- a/src/components/number-picker/number-picker.component.less
+++ b/src/components/number-picker/number-picker.component.less
@@ -4,6 +4,10 @@ ux-number-picker-inline {
     flex-direction: row;
     height: 34px;
 
+    &.ng-invalid {
+        border-color: @critical;
+    }
+
     &.has-error {
         > .number-picker-input:focus {
             border-color: @critical;

--- a/src/components/number-picker/number-picker.component.less
+++ b/src/components/number-picker/number-picker.component.less
@@ -4,12 +4,14 @@ ux-number-picker-inline {
     flex-direction: row;
     height: 34px;
 
-    &.ng-invalid {
-        border-color: @critical;
+    &.ux-number-picker-invalid:not([formControlName]) {
+        > .number-picker-input {
+            border-color: @critical;
+        }
     }
 
-    &.has-error {
-        > .number-picker-input:focus {
+    &.ng-invalid {
+        > .number-picker-input {
             border-color: @critical;
         }
     }

--- a/src/components/number-picker/number-picker.component.spec.ts
+++ b/src/components/number-picker/number-picker.component.spec.ts
@@ -81,32 +81,13 @@ describe('Number Picker Component - FormGroup', () => {
         expect(input1.value).toBe('6');
     });
 
-
-    it ('should display has-error class when value above max value', async() => {
-        component.form.controls.integer.setValue(20);
-        fixture.detectChanges();
-        await fixture.whenStable();
-
-        expect(input1.value).toBe('20');
-        expect(numberPicker1.classList.contains('has-error')).toBe(true);
-    });
-
-    it ('should display has-error class when value below min value', async() => {
-        component.form.controls.integer.setValue(-20);
-        fixture.detectChanges();
-        await fixture.whenStable();
-
-        expect(input1.value).toBe('-20');
-        expect(numberPicker1.classList.contains('has-error')).toBe(true);
-    });
-
-    it ('should not display has-error class when value above max value and disabled', async() => {
+    it ('should not display ux-number-picker-invalid class when value above max value and disabled', async() => {
         component.form.controls.integer2.setValue(20);
         fixture.detectChanges();
         await fixture.whenStable();
 
         expect(input2.value).toBe('20');
-        expect(numberPicker2.classList.contains('has-error')).toBe(false);
+        expect(numberPicker2.classList.contains('ux-number-picker-invalid')).toBe(false);
     });
 
     it ('should display ng-invalid class when value above max value', async() => {
@@ -196,27 +177,27 @@ describe('Number Picker Component - ngModel', () => {
         expect(input.value).toBe('9');
     });
 
-    it ('should display has-error class when value above max value', async() => {
+    it ('should display ux-number-picker-invalid class when value above max value', async() => {
         component.value = 90;
         fixture.detectChanges();
         await fixture.whenStable();
         expect(input.value).toBe('90');
 
         fixture.detectChanges();
-        expect(numberPicker.classList.contains('has-error')).toBe(true);
+        expect(numberPicker.classList.contains('ux-number-picker-invalid')).toBe(true);
     });
 
-    it ('should display has-error class when value below min value', async() => {
+    it ('should display ux-number-picker-invalid class when value below min value', async() => {
         component.value = -20;
         fixture.detectChanges();
         await fixture.whenStable();
         expect(input.value).toBe('-20');
 
         fixture.detectChanges();
-        expect(numberPicker.classList.contains('has-error')).toBe(true);
+        expect(numberPicker.classList.contains('ux-number-picker-invalid')).toBe(true);
     });
 
-    it ('should not display has-error class when value above max value and disabled', async() => {
+    it ('should not display ux-number-picker-invalid class when value above max value and disabled', async() => {
         component.disabled = true;
         fixture.detectChanges();
         component.value = 20;
@@ -224,7 +205,7 @@ describe('Number Picker Component - ngModel', () => {
         await fixture.whenStable();
         expect(input.value).toBe('20');
 
-        expect(numberPicker.classList.contains('has-error')).toBe(false);
+        expect(numberPicker.classList.contains('ux-number-picker-invalid')).toBe(false);
     });
 });
 
@@ -287,50 +268,50 @@ describe('Number Picker Component - value', () => {
         expect(input.value).toBe('9');
     });
 
-    it ('should display has-error class when value above max value', async() => {
+    it ('should display ux-number-picker-invalid class when value above max value', async() => {
         component.value = 78;
         fixture.detectChanges();
         await fixture.whenStable();
         expect(input.value).toBe('78');
 
-        expect(numberPicker.classList.contains('has-error')).toBe(true);
+        expect(numberPicker.classList.contains('ux-number-picker-invalid')).toBe(true);
     });
 
-    it ('should display has-error class when value below min value', async() => {
+    it ('should display ux-number-picker-invalid class when value below min value', async() => {
         component.value = -20;
         fixture.detectChanges();
         await fixture.whenStable();
 
         expect(input.value).toBe('-20');
-        expect(numberPicker.classList.contains('has-error')).toBe(true);
+        expect(numberPicker.classList.contains('ux-number-picker-invalid')).toBe(true);
     });
 
-    it ('should not display has-error class when value above max value and disabled', async() => {
+    it ('should not display ux-number-picker-invalid class when value above max value and disabled', async() => {
         component.disabled = true;
         component.value = 20;
         fixture.detectChanges();
         await fixture.whenStable();
 
         expect(input.value).toBe('20');
-        expect(numberPicker.classList.contains('has-error')).toBe(false);
+        expect(numberPicker.classList.contains('ux-number-picker-invalid')).toBe(false);
     });
 
-    it ('should not display ng-valid class when value above max value', async() => {
+    it ('should not display ng-invalid class when value above max value', async() => {
         component.value = 20;
         fixture.detectChanges();
         await fixture.whenStable();
 
         expect(input.value).toBe('20');
-        expect(numberPicker.classList.contains('ng-valid')).toBe(false);
+        expect(numberPicker.classList.contains('ng-invalid')).toBe(false);
     });
 
-    it ('should not display ng-valid class when value below min value', async() => {
+    it ('should not display ng-invalid class when value below min value', async() => {
         component.value = -20;
         fixture.detectChanges();
         await fixture.whenStable();
 
         expect(input.value).toBe('-20');
-        expect(numberPicker.classList.contains('ng-valid')).toBe(false);
+        expect(numberPicker.classList.contains('ng-invalid')).toBe(false);
     });
 
     it ('should not display ng-invalid class when value above max value and disabled', async() => {

--- a/src/components/number-picker/number-picker.component.spec.ts
+++ b/src/components/number-picker/number-picker.component.spec.ts
@@ -1,0 +1,346 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { NumberPickerModule } from './number-picker.module';
+import { Component } from '@angular/core';
+import { FormBuilder, FormGroup, Validators, ReactiveFormsModule, FormsModule } from '@angular/forms';
+
+@Component({
+    selector: 'app-number-picker-form',
+    template: `<ux-number-picker min="-10"
+                                 max="10"
+                                 [valid]="form.controls['integer'].valid" 
+                                 [formControl]="form.controls['integer']">
+                </ux-number-picker>
+                <ux-number-picker min="-10"
+                                  max="10"
+                                  [valid]="form.controls['integer2'].valid"
+                                  [formControl]="form.controls['integer2']">
+                </ux-number-picker>
+    
+    `
+})
+export class NumberPickerTestFormGroupComponent {
+
+    form: FormGroup;
+    disabled = false;
+
+    constructor(formBuilder: FormBuilder) {
+
+        this.form = formBuilder.group({
+            integer: [{value: 0, disabled: false},  Validators.compose([Validators.required, Validators.min(-10), Validators.max(10)])],
+            integer2: [{value: 0, disabled: true}, Validators.compose([Validators.required, Validators.min(-10), Validators.max(10)])]
+        });
+    }
+}
+
+describe('Number Picker Component - FormGroup', () => {
+    let component: NumberPickerTestFormGroupComponent;
+    let fixture: ComponentFixture<NumberPickerTestFormGroupComponent>;
+    let nativeElement: HTMLElement;
+    let numberPickers: NodeListOf<HTMLInputElement>;
+    let numberPicker1: HTMLInputElement;
+    let numberPicker2: HTMLInputElement;
+    let input1: HTMLInputElement;
+    let input2: HTMLInputElement;
+
+
+    beforeEach(async(() => {
+        TestBed.configureTestingModule({
+            imports: [NumberPickerModule, ReactiveFormsModule],
+            declarations: [NumberPickerTestFormGroupComponent],
+        })
+            .compileComponents();
+    }));
+
+    beforeEach(() => {
+        fixture = TestBed.createComponent(NumberPickerTestFormGroupComponent);
+        component = fixture.componentInstance;
+        nativeElement = fixture.nativeElement;
+        numberPickers = nativeElement.querySelectorAll<HTMLInputElement>('ux-number-picker');
+        numberPicker1 = numberPickers.item(0);
+        numberPicker2 = numberPickers.item(1);
+        input1 = numberPicker1.querySelector('input');
+        input2 = numberPicker2.querySelector('input');
+        fixture.detectChanges();
+    });
+
+
+    it ('should initialise correctly', () => {
+
+        expect(component).toBeTruthy();
+
+        expect(component.form.controls.integer.value).toBe(0);
+        expect(component.form.controls.integer2.value).toBe(0);
+    });
+
+    it ('should allow a number to be entered', async() => {
+
+        component.form.controls.integer.setValue(6);
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        expect(input1.value).toBe('6');
+    });
+
+
+    it ('should display has-error class when value above max value', async() => {
+        component.form.controls.integer.setValue(20);
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        expect(input1.value).toBe('20');
+        expect(numberPicker1.classList.contains('has-error')).toBe(true);
+    });
+
+    it ('should display has-error class when value below min value', async() => {
+        component.form.controls.integer.setValue(-20);
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        expect(input1.value).toBe('-20');
+        expect(numberPicker1.classList.contains('has-error')).toBe(true);
+    });
+
+    it ('should not display has-error class when value above max value and disabled', async() => {
+        component.form.controls.integer2.setValue(20);
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        expect(input2.value).toBe('20');
+        expect(numberPicker2.classList.contains('has-error')).toBe(false);
+    });
+
+    it ('should display ng-invalid class when value above max value', async() => {
+        component.form.controls.integer.setValue(20);
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        expect(input1.value).toBe('20');
+        expect(numberPicker1.classList.contains('ng-invalid')).toBe(true);
+    });
+
+    it ('should display ng-invalid class when value below min value', async() => {
+        component.form.controls.integer.setValue(-20);
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        expect(input1.value).toBe('-20');
+        expect(numberPicker1.classList.contains('ng-invalid')).toBe(true);
+    });
+
+    it ('should not display ng-invalid class when value above max value and disabled', async() => {
+        component.form.controls.integer2.setValue(20);
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        expect(input2.value).toBe('20');
+        expect(numberPicker2.classList.contains('ng-invalid')).toBe(false);
+    });
+});
+
+@Component({
+    selector: 'app-number-picker-ngmodel',
+    template: `<ux-number-picker [min]="-10"
+                                 [max]="10"
+                                 [disabled]="disabled"
+                                 [(ngModel)]="value">
+                </ux-number-picker>
+    
+    `
+})
+export class NumberPickerTestNgModelComponent {
+
+    value = 0;
+    disabled = false;
+
+}
+
+describe('Number Picker Component - ngModel', () => {
+    let component: NumberPickerTestNgModelComponent;
+    let fixture: ComponentFixture<NumberPickerTestNgModelComponent>;
+    let nativeElement: HTMLElement;
+    let numberPicker: HTMLElement;
+    let input: HTMLInputElement;
+
+    beforeEach(async(() => {
+        TestBed.configureTestingModule({
+            imports: [
+                NumberPickerModule,
+                FormsModule
+            ],
+            declarations: [NumberPickerTestNgModelComponent],
+        })
+            .compileComponents();
+    }));
+
+    beforeEach(() => {
+        fixture = TestBed.createComponent(NumberPickerTestNgModelComponent);
+        component = fixture.componentInstance;
+        nativeElement = fixture.nativeElement;
+        numberPicker = nativeElement.querySelector('ux-number-picker');
+        input = numberPicker.querySelector('input');
+        fixture.detectChanges();
+    });
+
+
+    it ('should initialise correctly', () => {
+        expect(component).toBeTruthy();
+
+        expect(component.value).toBe(0);
+    });
+
+    it ('should allow a number to be entered', async() => {
+        component.value = 9;
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        expect(input.value).toBe('9');
+    });
+
+    it ('should display has-error class when value above max value', async() => {
+        component.value = 90;
+        fixture.detectChanges();
+        await fixture.whenStable();
+        expect(input.value).toBe('90');
+
+        fixture.detectChanges();
+        expect(numberPicker.classList.contains('has-error')).toBe(true);
+    });
+
+    it ('should display has-error class when value below min value', async() => {
+        component.value = -20;
+        fixture.detectChanges();
+        await fixture.whenStable();
+        expect(input.value).toBe('-20');
+
+        fixture.detectChanges();
+        expect(numberPicker.classList.contains('has-error')).toBe(true);
+    });
+
+    it ('should not display has-error class when value above max value and disabled', async() => {
+        component.disabled = true;
+        fixture.detectChanges();
+        component.value = 20;
+        fixture.detectChanges();
+        await fixture.whenStable();
+        expect(input.value).toBe('20');
+
+        expect(numberPicker.classList.contains('has-error')).toBe(false);
+    });
+});
+
+@Component({
+    selector: 'app-number-picker-value',
+    template: `<ux-number-picker [min]="-10"
+                                 [max]="10"
+                                 [disabled]="disabled"
+                                 [value]="value">
+                </ux-number-picker>
+    
+    `
+})
+export class NumberPickerTestValueComponent {
+
+    value = 0;
+    disabled = false;
+}
+
+describe('Number Picker Component - value', () => {
+    let component: NumberPickerTestValueComponent;
+    let fixture: ComponentFixture<NumberPickerTestValueComponent>;
+    let nativeElement: HTMLElement;
+    let numberPicker: HTMLElement;
+    let input: HTMLInputElement;
+
+    beforeEach(async(() => {
+        TestBed.configureTestingModule({
+            imports: [
+                NumberPickerModule,
+                FormsModule
+            ],
+            declarations: [NumberPickerTestValueComponent],
+        })
+            .compileComponents();
+    }));
+
+    beforeEach(() => {
+        fixture = TestBed.createComponent(NumberPickerTestValueComponent);
+        component = fixture.componentInstance;
+        nativeElement = fixture.nativeElement;
+        numberPicker = nativeElement.querySelector('ux-number-picker');
+        input = numberPicker.querySelector('input');
+        fixture.detectChanges();
+    });
+
+
+    it ('should initialise correctly', () => {
+
+        expect(component).toBeTruthy();
+
+        expect(component.value).toBe(0);
+    });
+
+    it ('should allow a number to be entered', async() => {
+        component.value = 9;
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        expect(input.value).toBe('9');
+    });
+
+    it ('should display has-error class when value above max value', async() => {
+        component.value = 78;
+        fixture.detectChanges();
+        await fixture.whenStable();
+        expect(input.value).toBe('78');
+
+        expect(numberPicker.classList.contains('has-error')).toBe(true);
+    });
+
+    it ('should display has-error class when value below min value', async() => {
+        component.value = -20;
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        expect(input.value).toBe('-20');
+        expect(numberPicker.classList.contains('has-error')).toBe(true);
+    });
+
+    it ('should not display has-error class when value above max value and disabled', async() => {
+        component.disabled = true;
+        component.value = 20;
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        expect(input.value).toBe('20');
+        expect(numberPicker.classList.contains('has-error')).toBe(false);
+    });
+
+    it ('should not display ng-valid class when value above max value', async() => {
+        component.value = 20;
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        expect(input.value).toBe('20');
+        expect(numberPicker.classList.contains('ng-valid')).toBe(false);
+    });
+
+    it ('should not display ng-valid class when value below min value', async() => {
+        component.value = -20;
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        expect(input.value).toBe('-20');
+        expect(numberPicker.classList.contains('ng-valid')).toBe(false);
+    });
+
+    it ('should not display ng-invalid class when value above max value and disabled', async() => {
+        component.disabled = true;
+        component.value = 20;
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        expect(input.value).toBe('20');
+        expect(numberPicker.classList.contains('ng-invalid')).toBe(false);
+    });
+
+});

--- a/src/components/number-picker/number-picker.component.ts
+++ b/src/components/number-picker/number-picker.component.ts
@@ -1,6 +1,6 @@
 import { coerceBooleanProperty, coerceNumberProperty } from '@angular/cdk/coercion';
-import { ChangeDetectorRef, Component, EventEmitter, forwardRef, Input, Output } from '@angular/core';
-import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
+import { ChangeDetectorRef, Component, EventEmitter, forwardRef, Input, Optional, Output } from '@angular/core';
+import { ControlValueAccessor, FormGroupDirective, NG_VALUE_ACCESSOR } from '@angular/forms';
 
 let uniqueId = 0;
 
@@ -15,7 +15,7 @@ export const NUMBER_PICKER_VALUE_ACCESSOR: any = {
     templateUrl: './number-picker.component.html',
     providers: [NUMBER_PICKER_VALUE_ACCESSOR],
     host: {
-        '[class.ux-number-picker-invalid]': '!_valid && !disabled'
+        '[class.ux-number-picker-invalid]': '!_valid && !disabled && !_formGroup'
     }
 })
 export class NumberPickerComponent implements ControlValueAccessor {
@@ -102,7 +102,10 @@ export class NumberPickerComponent implements ControlValueAccessor {
     /** Store the current valid state */
     _valid: boolean = true;
 
-    constructor(private _changeDetector: ChangeDetectorRef) {}
+    constructor(
+        private _changeDetector: ChangeDetectorRef,
+        @Optional() public _formGroup: FormGroupDirective
+    ) { }
 
     increment(event?: MouseEvent | KeyboardEvent): void {
         if (event) {

--- a/src/components/number-picker/number-picker.component.ts
+++ b/src/components/number-picker/number-picker.component.ts
@@ -15,7 +15,7 @@ export const NUMBER_PICKER_VALUE_ACCESSOR: any = {
     templateUrl: './number-picker.component.html',
     providers: [NUMBER_PICKER_VALUE_ACCESSOR],
     host: {
-        '[class.has-error]': '!_valid && !disabled'
+        '[class.ux-number-picker-invalid]': '!_valid && !disabled'
     }
 })
 export class NumberPickerComponent implements ControlValueAccessor {

--- a/src/components/number-picker/number-picker.component.ts
+++ b/src/components/number-picker/number-picker.component.ts
@@ -1,5 +1,5 @@
 import { coerceBooleanProperty, coerceNumberProperty } from '@angular/cdk/coercion';
-import { Component, EventEmitter, forwardRef, Input, Output } from '@angular/core';
+import { ChangeDetectorRef, Component, EventEmitter, forwardRef, Input, Output } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 
 let uniqueId = 0;
@@ -15,7 +15,7 @@ export const NUMBER_PICKER_VALUE_ACCESSOR: any = {
     templateUrl: './number-picker.component.html',
     providers: [NUMBER_PICKER_VALUE_ACCESSOR],
     host: {
-        '[class.has-error]': '!isValid()'
+        '[class.has-error]': '!_valid && !disabled'
     }
 })
 export class NumberPickerComponent implements ControlValueAccessor {
@@ -52,6 +52,7 @@ export class NumberPickerComponent implements ControlValueAccessor {
         this._value = value;
         this.valueChange.emit(value);
         this._propagateChange(value);
+        this._valid = this.isValid();
     }
 
     /** Defines the minimum value the number picker can set. */
@@ -97,6 +98,11 @@ export class NumberPickerComponent implements ControlValueAccessor {
     get inputId(): string {
         return this.id + '-input';
     }
+
+    /** Store the current valid state */
+    _valid: boolean = true;
+
+    constructor(private _changeDetector: ChangeDetectorRef) {}
 
     increment(event?: MouseEvent | KeyboardEvent): void {
         if (event) {
@@ -144,6 +150,8 @@ export class NumberPickerComponent implements ControlValueAccessor {
     writeValue(value: number): void {
         if (value !== undefined) {
             this._value = value;
+            this._valid = this.isValid();
+            this._changeDetector.detectChanges();
         }
     }
 


### PR DESCRIPTION
#### Checklist
* [x] The contents of this PR are mine to submit. No third party code or other material is being committed.
* [x] New third party dependencies (if any) are linked via `package.json`. Third party dependencies are licenced under one of the following: Apache, MIT, BSD, Mozilla Public License, Eclipse Public License, or Oracle Binary Code License.
* [x] The code in this PR does not contain export-restricted encryption algorithms.

#### Ticket / Issue

https://portal.digitalsafe.net/browse/EL-3636

#### Description of Proposed Changes

- removed has-error styling when disabled
- Added styling for ng-invalid
- Added in tests for number picker

#### Documentation CI URL

https://pages.github.houston.softwaregrp.net/sepg-docs-qa/UXAspects_CI_UXAspects_EL-3636-number-picker-validation
