### PR TITLE
EL-3646 - Fix for performance issue

### DIFF
--- a/src/ng1/directives/infiniteScroll/infiniteScroll.controller.js
+++ b/src/ng1/directives/infiniteScroll/infiniteScroll.controller.js
@@ -40,6 +40,7 @@ export class InfiniteScrollController {
         this.$element = $element;
         this.$interval = safeInterval.create($scope);
         this._loading = false;
+        this._ensureScrollableInterval = null;
 
         // private variables
         this._query = this._query || null;
@@ -80,11 +81,13 @@ export class InfiniteScrollController {
      */
     ensureScrollable() {
 
+        if (this._ensureScrollableInterval) return;
+
         //if we are using a load more button this is also not required
         if (this.buttonOptions && this.buttonOptions.show) return;
 
         // repeat until we have enough items
-        this.$interval.interval(() => {
+        this._ensureScrollableInterval = this.$interval.interval(() => {
 
             // if we are currently loading or have loaded all pages then do nothing
             if (this.loading || this.complete || document.hidden) {


### PR DESCRIPTION
#### Checklist
<!-- Use an 'x' to check those which apply. -->
* [x] The contents of this PR are mine to submit. No third party code or other material is being committed.
* [x] New third party dependencies (if any) are linked via `package.json`. Third party dependencies are licenced under one of the following: Apache, MIT, BSD, Mozilla Public License, Eclipse Public License, or Oracle Binary Code License.
* [x] The code in this PR does not contain export-restricted encryption algorithms.

#### Ticket / Issue
https://portal.digitalsafe.net/browse/EL-3646

#### Description of Proposed Changes
The issue is that the interval created within `ensureScrollable` triggers a reinitialize of the jScrollPane plugin, which triggers another call to `ensureScrollable` and so on.

One fix which seems to work is to remove the call to `scrollpane.reinitialise()`. However this was explicitly added to address an issue which cannot now be identified so for safety I have left it in place. This fix instead ensures that the cascade of multiple setIntervals does not occur. Since the interval is never cancelled, the first one created should be sufficient.

Updated plunker - reduce the preview panel to <600px to reproduce:
https://plnkr.co/edit/UNjWhAPQMoTmjOqhdhaj?p=preview

#### Documentation CI URL
<!-- Initiate a build at https://jenkins.swinfra.net/job/SEPG/view/Templates/job/New%20SEPG%20Build/build -->
<!-- Append the branch name to the following URL: -->
https://pages.github.houston.softwaregrp.net/sepg-docs-qa/UXAspects_CI_UXAspects_EL-3646-infinite-scroll-performance
