### PR TITLE
EL-3638 - Corrected mistakes in the Wizard documentation

### DIFF
--- a/docs/app/pages/components/components-sections/wizard/wizard/wizard.component.html
+++ b/docs/app/pages/components/components-sections/wizard/wizard/wizard.component.html
@@ -110,10 +110,6 @@
         If set to <code>true</code> the 'Finish' button will be visible on all steps of the wizard.
         By default this button will only be visible on the final step of the wizard.
     </tr>
-    <tr uxd-api-property name="footerTemplate" type="TemplateRef<WizardFooterContext>">
-        Allows customization of the wizard footer by allowing content to be displayed to the right of the
-        buttons. Content can be added to the footer by using: <code>&lt;ng-template #footerTemplate let-step="step"&gt;</code>.
-    </tr>
 </uxd-api-properties>
 
 <uxd-api-properties tableTitle="Outputs">
@@ -143,16 +139,6 @@
     </tr>
 </uxd-api-properties>
 
-<h4>Custom Templates</h4>
-
-<p>
-    Custom content can be added to left of the standard wizard buttons in the footer. Add an <code>ng-template</code>
-    named <code>#footerTemplate</code> as a child of the <code>ux-wizard</code> element. The <code>step</code> context
-    variable can be used to access the current step number (zero-based).
-</p>
-
-<uxd-snippet [content]="snippets.compiled.footerTemplateHtml"></uxd-snippet>
-
 <p>
     The following properties can be used to configure the <code>ux-wizard-step</code>:
 </p>
@@ -174,6 +160,16 @@
         Emits when visited changes.
     </tr>
 </uxd-api-properties>
+
+<h4>Custom Templates</h4>
+
+<p>
+    Custom content can be added to left of the standard wizard buttons in the footer. Add an <code>ng-template</code>
+    named <code>#footerTemplate</code> as a child of the <code>ux-wizard</code> element. The <code>step</code> context
+    variable can be used to access the current step number (zero-based).
+</p>
+
+<uxd-snippet [content]="snippets.compiled.footerTemplateHtml"></uxd-snippet>
 
 <p>
     The following code can be used create the example above:


### PR DESCRIPTION
#### Checklist
<!-- Use an 'x' to check those which apply. -->
* [x] The contents of this PR are mine to submit. No third party code or other material is being committed.
* [x] New third party dependencies (if any) are linked via `package.json`. Third party dependencies are licenced under one of the following: Apache, MIT, BSD, Mozilla Public License, Eclipse Public License, or Oracle Binary Code License.
* [x] The code in this PR does not contain export-restricted encryption algorithms.

#### Ticket / Issue
https://portal.digitalsafe.net/browse/EL-3638

#### Description of Proposed Changes
* Removed `footerTemplate` input documentation.
* Moved the "Custom Templates" section towards the end of the section, matching the Marquee Wizard documentation layout.


#### Documentation CI URL
<!-- Initiate a build at https://jenkins.swinfra.net/job/SEPG/view/Templates/job/New%20SEPG%20Build/build -->
<!-- Append the branch name to the following URL: -->
https://pages.github.houston.softwaregrp.net/sepg-docs-qa/UXAspects_CI_UXAspects_EL-3638-wizard-documentation-corrections
