### PR TITLE
EL-3639 - Side panel initially open

### DIFF
--- a/src/components/side-panel/side-panel.component.spec.ts
+++ b/src/components/side-panel/side-panel.component.spec.ts
@@ -1,0 +1,114 @@
+import { async, ComponentFixture, TestBed} from '@angular/core/testing';
+import { SidePanelModule } from './side-panel.module';
+import { Component } from '@angular/core';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+@Component({
+    selector: 'app-page-side-panel',
+    template: `<div>
+        <div class="page-content">
+            <div class="wrapper-content">
+                <div class="ebox">
+                    <h2 class="m-t-nil">Side Panel Example</h2>
+                </div>
+            </div>
+        </div>
+
+        <ux-side-panel [(open)]="panelOpen"
+                       [top]="top"
+                       [width]="width"
+                       [animate]="animate"
+                       (openChange)="onToggleChange()">
+
+            <div class="ux-side-panel-header">
+                <h2>Side Panel</h2>
+            </div>
+
+            <div class="ux-side-panel-content">
+                <p> Lorem ipsum dolor sit amet, utinam ornatus ea pro. Vim ad diam velit apeirian, ei has.</p>
+            </div>
+
+            <div class="ux-side-panel-footer btn-container">
+                <button type="button"
+                        class="ux-panel-toggle"
+                        aria-label="Toggle the side panel"
+                        (click)="panelOpen = !panelOpen">
+                    Toggle Side Panel
+                </button>
+            </div>
+
+        </ux-side-panel>
+
+    </div>`
+})
+export class SidePanelTestComponent {
+
+    panelOpen = true;
+    width = '300px';
+    top = '56px';
+    animate = true;
+
+    onToggleChange(): void {}
+}
+
+describe('Side Panel Component', () => {
+    let component: SidePanelTestComponent;
+    let fixture: ComponentFixture<SidePanelTestComponent>;
+    let nativeElement: HTMLElement;
+
+    beforeEach(async( () => {
+        TestBed.configureTestingModule({
+            imports: [SidePanelModule, NoopAnimationsModule],
+            declarations: [SidePanelTestComponent]
+        })
+            .compileComponents();
+    }));
+
+    beforeEach(() => {
+        fixture = TestBed.createComponent(SidePanelTestComponent);
+        component = fixture.componentInstance;
+        nativeElement = fixture.nativeElement;
+        fixture.detectChanges();
+    });
+
+    it ('should open the side panel on load when open is set to true initially', async () => {
+        // set up a spy for the onToggleChange function
+        spyOn(component, 'onToggleChange');
+
+        // find the side panel container
+        const sidePanelContainer: HTMLElement = nativeElement.querySelector('.ux-side-panel-content');
+        expect(sidePanelContainer).toBeTruthy();
+
+        expect(component.onToggleChange).not.toHaveBeenCalled();
+
+    });
+
+    it ('should remain closed initially when open is set to false', async () => {
+        component.panelOpen = false;
+        fixture.detectChanges();
+        await fixture.whenStable();
+        // set up a spy for the onToggleChange function
+        spyOn(component, 'onToggleChange');
+
+        // find the side panel container
+        const sidePanelContainer: HTMLElement = nativeElement.querySelector('.ux-side-panel-content');
+        expect(sidePanelContainer).toBeFalsy();
+
+        expect(component.onToggleChange).not.toHaveBeenCalled();
+
+    });
+
+    it ('should emit event on closing side panel', async () => {
+        // find the toggle button
+        const toggleButton: HTMLElement = nativeElement.querySelector('.ux-panel-toggle');
+        expect(toggleButton).toBeTruthy();
+
+        // set up a spy for the onToggleChange function
+        spyOn(component, 'onToggleChange');
+        toggleButton.click();
+        fixture.detectChanges();
+
+        expect(component.onToggleChange).toHaveBeenCalled();
+    });
+
+});

--- a/src/components/side-panel/side-panel.component.ts
+++ b/src/components/side-panel/side-panel.component.ts
@@ -114,8 +114,6 @@ export class SidePanelComponent implements OnInit, OnDestroy {
                     ? SidePanelAnimationState.Open
                     : SidePanelAnimationState.OpenImmediate
                 : SidePanelAnimationState.Closed;
-
-            this.openChange.emit(isOpen);
         });
     }
 

--- a/src/components/side-panel/side-panel.component.ts
+++ b/src/components/side-panel/side-panel.component.ts
@@ -99,6 +99,9 @@ export class SidePanelComponent implements OnInit, OnDestroy {
     /** Store the current open state */
     private _isOpen: boolean = false;
 
+    /** Store the current open state */
+    private _isInitial: boolean = true;
+
     protected _onDestroy = new Subject<void>();
 
     constructor(
@@ -115,8 +118,11 @@ export class SidePanelComponent implements OnInit, OnDestroy {
                 : SidePanelAnimationState.Closed;
 
             // only if the open state changed should we emit the latest value
-            this.openChange.emit(isOpen);
+            if (!this._isInitial) {
+                this.openChange.emit(isOpen);
+            }
             this._isOpen = isOpen;
+            this._isInitial = false;
         });
     }
 

--- a/src/components/side-panel/side-panel.service.ts
+++ b/src/components/side-panel/side-panel.service.ts
@@ -1,11 +1,11 @@
 import { Injectable } from '@angular/core';
-import { Subject } from 'rxjs';
+import { BehaviorSubject } from 'rxjs';
 
 @Injectable()
 export class SidePanelService {
 
     /** Emit the open state when it changes */
-    open$ = new Subject<boolean>();
+    open$ = new BehaviorSubject<boolean>(false);
 
     open(): void {
         this.open$.next(true);


### PR DESCRIPTION
#### Checklist
* [x] The contents of this PR are mine to submit. No third party code or other material is being committed.
* [x] New third party dependencies (if any) are linked via `package.json`. Third party dependencies are licenced under one of the following: Apache, MIT, BSD, Mozilla Public License, Eclipse Public License, or Oracle Binary Code License.
* [x] The code in this PR does not contain export-restricted encryption algorithms.

#### Ticket / Issue

https://portal.digitalsafe.net/browse/EL-3639

#### Description of Proposed Changes

- Side Panel opens if open initially set to true
- Karma tests added to test initially setting panel open and checking when the openChange event is emitted.

#### Documentation CI URL

https://pages.github.houston.softwaregrp.net/sepg-docs-qa/UXAspects_CI_UXAspects_EL-3639-side-panel-initially-open
