### PR TITLE
EL-3649 - Time Picker Invalid Time Entered

### DIFF
--- a/src/components/time-picker/time-picker.component.ts
+++ b/src/components/time-picker/time-picker.component.ts
@@ -235,12 +235,6 @@ export class TimePickerComponent implements ControlValueAccessor {
 
         // convert the string to a number
         let hour = parseInt(value);
-        const currentHour = this.value.getHours();
-
-        // if the value hasn't changed, do nothing
-        if (hour === currentHour) {
-            return;
-        }
 
         // ensure the hours is valid
         if (!isNaN(hour)) {
@@ -251,6 +245,12 @@ export class TimePickerComponent implements ControlValueAccessor {
             if (hour > (this.showMeridian ? 12 : 23)) {
                 hour = this.showMeridian ? 12 : 23;
             }
+        }
+
+        const currentHour = this.value.getHours();
+        // if the value hasn't changed, do nothing
+        if (hour === currentHour) {
+            return;
         }
 
         hour = isNaN(hour) ? currentHour : hour;

--- a/src/components/time-picker/time-picker.component.ts
+++ b/src/components/time-picker/time-picker.component.ts
@@ -248,6 +248,7 @@ export class TimePickerComponent implements ControlValueAccessor {
         }
 
         const currentHour = this.value.getHours();
+        
         // if the value hasn't changed, do nothing
         if (hour === currentHour) {
             return;

--- a/src/components/time-picker/time-picker.spec.ts
+++ b/src/components/time-picker/time-picker.spec.ts
@@ -150,6 +150,22 @@ describe('Time Picker Component', () => {
         expect(hourInput.value).toBe('12');
     });
 
+    it('should not allow 13 in the hour field when meridian is set to true and PM', async () => {
+        component.showMeridian = true;
+        fixture.detectChanges();
+
+        const inputs = nativeElement.querySelectorAll<HTMLInputElement>('input');
+        const hourInput = inputs.item(0);
+
+        hourInput.value = '13';
+        hourInput.dispatchEvent(new Event('input'));
+
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        expect(hourInput.value).toBe('12');
+    });
+
     it('should not allow a number more than 59 to be set in the minute field', async () => {
 
         const inputs = nativeElement.querySelectorAll<HTMLInputElement>('input');


### PR DESCRIPTION
#### Checklist
* [x] The contents of this PR are mine to submit. No third party code or other material is being committed.
* [x] New third party dependencies (if any) are linked via `package.json`. Third party dependencies are licenced under one of the following: Apache, MIT, BSD, Mozilla Public License, Eclipse Public License, or Oracle Binary Code License.
* [x] The code in this PR does not contain export-restricted encryption algorithms.

#### Ticket / Issue

https://portal.digitalsafe.net/browse/EL-3649

#### Description of Proposed Changes

- Moved checking if the <code>hour</code> and <code>currentHour</code> are the same until after the hour entered is checked to be valid. This is because when entering '13' you first enter '1' which would set the <code>currentHour</code> to '13' as '1' is 13 in PM. Once the '3' is added to '13' the <code>currentHour</code> was '13' and the <code>hour</code> is now '13' which would have matched and exited. So I have changed this so that the hour entered is being checked first to see if it is valid so 13 would not be allowed.
- Added a karma test to cover this issue.

#### Documentation CI URL

https://pages.github.houston.softwaregrp.net/sepg-docs-qa/UXAspects_CI_UXAspects_EL-3649-time-picker
