### PR TITLE
Build Fix - Select component e2e test console error

### DIFF
--- a/src/components/tag-input/tag-input.component.ts
+++ b/src/components/tag-input/tag-input.component.ts
@@ -50,7 +50,7 @@ export class TagInputComponent<T = any> implements AfterContentInit, OnChanges, 
         return this._tags;
     }
     set tags(value: ReadonlyArray<T>) {
-        this._tags = value;
+        this._tags = Array.isArray(value) ? value : [];
     }
 
     /** The editable text appearing in the tag input. */

--- a/src/components/typeahead/typeahead.component.ts
+++ b/src/components/typeahead/typeahead.component.ts
@@ -286,7 +286,8 @@ export class TypeaheadComponent<T = any> implements OnChanges, OnDestroy {
      * Returns true if the given option is part of the disabledOptions array.
      */
     isDisabled(option: TypeaheadVisibleOption<T>): boolean {
-        if (this.disabledOptions) {
+
+        if (this.disabledOptions && Array.isArray(this.disabledOptions)) {
             const result = this.disabledOptions.find((selectedOption) => {
                 return this.getKey(selectedOption) === option.key;
             });


### PR DESCRIPTION
#### Checklist
* [x] The contents of this PR are mine to submit. No third party code or other material is being committed.
* [x] New third party dependencies (if any) are linked via `package.json`. Third party dependencies are licenced under one of the following: Apache, MIT, BSD, Mozilla Public License, Eclipse Public License, or Oracle Binary Code License.
* [x] The code in this PR does not contain export-restricted encryption algorithms.

#### Ticket / Issue

https://portal.digitalsafe.net/browse/EL-3653

#### Description of Proposed Changes

- Fixed an issue where select component e2e tests where failing due to having errors in console. This was seen when a single select had a value and multiple was set to true via the customise checkbox.

#### Documentation CI URL

https://pages.github.houston.softwaregrp.net/sepg-docs-qa/UXAspects_CI_UXAspects_Select-e2e-test-error
