### PR TITLE
Moved custom icon inside icon div and fixed clear

### DIFF
--- a/src/components/select/select.component.html
+++ b/src/components/select/select.component.html
@@ -44,7 +44,6 @@
     [attr.aria-expanded]="dropdownOpen"
     aria-haspopup="listbox">
 
-    <ng-container *ngIf="icon" [ngTemplateOutlet]="icon"></ng-container>
 
     <input #singleInput type="text"
         [attr.id]="id + '-input'"
@@ -80,6 +79,9 @@
            [class.ux-icon-down]="dropDirection === 'down'"
            (click)="toggle(); $event.stopPropagation()">
         </i>
+
+        <ng-container *ngIf="icon" [ngTemplateOutlet]="icon"></ng-container>
+
     </div>
 
     <ux-typeahead #singleTypeahead

--- a/src/components/select/select.component.less
+++ b/src/components/select/select.component.less
@@ -48,6 +48,7 @@ ux-dropdown {
         }
 
         .ux-select-icons {
+            display: flex;
             position: absolute;
             top: 0;
             right: 0;


### PR DESCRIPTION
#### Checklist
<!-- Use an 'x' to check those which apply. -->
* [x] The contents of this PR are mine to submit. No third party code or other material is being committed.
* [x] New third party dependencies (if any) are linked via `package.json`. Third party dependencies are licenced under one of the following: Apache, MIT, BSD, Mozilla Public License, Eclipse Public License, or Oracle Binary Code License.
* [x] The code in this PR does not contain export-restricted encryption algorithms.

#### Ticket / Issue
<!-- Either a Jira URL or a description of the issue that this PR addresses. -->
https://portal.digitalsafe.net/browse/EL-3668

#### Description of Proposed Changes
<!-- Describe what was changed and how it addresses the original issue. -->
Custom icon was appearing above select field, rather than inline. Moved the div inside the ux-select-icons div, and modified a style to allow the clear and icon to sit inline.

#### Documentation CI URL
<!-- Initiate a build at https://jenkins.swinfra.net/job/SEPG/view/Templates/job/New%20SEPG%20Build/build -->
<!-- Append the branch name to the following URL: -->
https://pages.github.houston.softwaregrp.net/sepg-docs-qa/UXAspects_CI_UXAspects_EL-3668-Custom-icon-on-select-fix
