### PR TITLE
Fixing e2e webpack rebuild issue

### DIFF
--- a/configs/webpack.e2e.config.js
+++ b/configs/webpack.e2e.config.js
@@ -24,7 +24,7 @@ module.exports = {
     },
 
     resolve: {
-        extensions: ['.js', '.ts'],
+        extensions: ['.ts', '.js'],
         alias: rxAlias()
     },
 


### PR DESCRIPTION
#### Checklist
<!-- Use an 'x' to check those which apply. -->
* [x] The contents of this PR are mine to submit. No third party code or other material is being committed.
* [x] New third party dependencies (if any) are linked via `package.json`. Third party dependencies are licenced under one of the following: Apache, MIT, BSD, Mozilla Public License, Eclipse Public License, or Oracle Binary Code License.
* [x] The code in this PR does not contain export-restricted encryption algorithms.

#### Ticket / Issue
<!-- Either a Jira URL or a description of the issue that this PR addresses. -->
N/A

#### Description of Proposed Changes
<!-- Describe what was changed and how it addresses the original issue. -->
There is an issue when modifying any lazy loaded typescript files in our e2e test app, webpack doesn't rebuild the changes. 

Apparently this is a known issue whenever the webpack config resolves javascript files before typescript files (https://github.com/angular/angular-cli/issues/8508). Altering the order fixes the issue.

#### Documentation CI URL
<!-- Initiate a build at https://jenkins.swinfra.net/job/SEPG/view/Templates/job/New%20SEPG%20Build/build -->
<!-- Append the branch name to the following URL: -->
https://pages.github.houston.softwaregrp.net/sepg-docs-qa/UXAspects_CI_UXAspects_e2e-rebuild-issue
