### PR TITLE
Wait for table width before adding header padding

### DIFF
--- a/grunt/jasmine.js
+++ b/grunt/jasmine.js
@@ -17,6 +17,10 @@ module.exports = {
                 path.join(process.cwd(), 'node_modules', 'angular', 'angular.js'),
                 path.join(process.cwd(), 'node_modules', 'angular-mocks', 'angular-mocks.js'),
             ],
+            styles: [
+                path.join(process.cwd(), 'node_modules', 'bootstrap', 'dist', 'css', 'bootstrap.css'),
+                path.join(process.cwd(), 'dist', 'styles', 'ux-aspects.css'),
+            ],
             keepRunner: true,
             display: 'none',
             summary: true

--- a/src/ng1/directives/fixedHeaderTable/fixed-header-table.controller.js
+++ b/src/ng1/directives/fixedHeaderTable/fixed-header-table.controller.js
@@ -18,8 +18,28 @@ export class FixedHeaderTableController {
         // bind to scroll events on the table body
         this._tableBody.addEventListener('scroll', this.onScroll.bind(this));
 
+        // Wait until the table has a width before proceeding
+        const initWatcher = $scope.$watch(() => this._tableBody.offsetWidth, (newValue, oldValue) => {
+
+            // we need to re-run the setLayout function if the table width is greater than 0
+            // and it was 0 when we first run it as it won't have correctly applied the padding to
+            // the table header when there is no table width.
+            if (newValue > 0 && oldValue === 0) {
+                this.setLayout();
+            }
+
+            // remove the watcher after the table has a width as it is no longer needed
+            if (newValue > 0) {
+                initWatcher();
+            }
+        });
+
+        
         // wait until bindings are available
         $scope.$evalAsync(this.onInit.bind(this));
+
+        // ensure we have destroyed all watchers on component destroy
+        $scope.$on('$destroy', () => initWatcher());
     }
 
     /**

--- a/src/ng1/directives/fixedHeaderTable/fixed-header-table.spec.js
+++ b/src/ng1/directives/fixedHeaderTable/fixed-header-table.spec.js
@@ -1,0 +1,80 @@
+describe('filters', function () {
+    var $compile, $rootScope, $document;
+  
+    beforeEach(module("ux-aspects.fixed-header-table"));
+  
+    beforeEach(inject(function (_$compile_, _$rootScope_, _$document_) {
+      $compile = _$compile_;
+      $rootScope = _$rootScope_;
+      $document = _$document_;
+    }));
+  
+  
+    describe("Fixed Header Table", function () {
+
+        var element, $scope;
+
+        beforeEach(function () {
+
+            $scope = $rootScope.$new();
+
+            $scope.people = [
+                {
+                    id: 1,
+                    name: 'John Smith',
+                    address: 'Main Street',
+                    phone: '02890654321',
+                    active: true
+                }
+            ];
+
+            const html = `
+            <table class="table" fixed-header-table table-height="500">
+
+                <thead>
+                    <tr><th class="fixed-header-table-col-id">Id</th>
+                    <th>Name</th>
+                    <th>Address</th>
+                    <th>Phone</th>
+                    <th>Active</th>
+                </tr></thead>
+
+                <tbody>
+
+                    <tr ng-repeat="person in people">
+                        <td class="fixed-header-table-col-id" ng-bind="::person.id"></td>
+                        <td ng-bind="::person.name"></td>
+                        <td ng-bind="::person.address"></td>
+                        <td ng-bind="::person.phone"></td>
+                        <td>
+                            <i class="hpe-icon hpe-checkmark" ng-if="person.active"></i>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+            `;
+
+            element = $compile(html)($scope);
+
+            $document.find('body').append(element);
+            $scope.$apply();
+        });
+
+        afterEach(() => {
+            element.remove();
+        });
+
+        it('should adjust table heading padding for the scrollbar', function () {
+            
+            const tableHead = element.find('thead');
+            const tableBody = element.find('tbody');
+            const theadPadding = parseInt(tableHead.css('padding-right'));
+            const scrollbar = tableBody.get(0).offsetWidth - tableBody.get(0).clientWidth;
+
+			expect(theadPadding).toBe(scrollbar);
+        });
+
+    });
+
+  
+  });


### PR DESCRIPTION
#### Checklist
<!-- Use an 'x' to check those which apply. -->
* [x] The contents of this PR are mine to submit. No third party code or other material is being committed.
* [x] New third party dependencies (if any) are linked via `package.json`. Third party dependencies are licenced under one of the following: Apache, MIT, BSD, Mozilla Public License, Eclipse Public License, or Oracle Binary Code License.
* [x] The code in this PR does not contain export-restricted encryption algorithms.

#### Ticket / Issue
<!-- Either a Jira URL or a description of the issue that this PR addresses. -->
https://portal.digitalsafe.net/browse/EL-3673

#### Description of Proposed Changes
<!-- Describe what was changed and how it addresses the original issue. -->
Table head was being rendered before table body, so was not accounting for the scrollbar. A watcher was added to rerender the layout if the table width is greater than 0.

#### Documentation CI URL
<!-- Initiate a build at https://jenkins.swinfra.net/job/SEPG/view/Templates/job/New%20SEPG%20Build/build -->
<!-- Append the branch name to the following URL: -->
https://pages.github.houston.softwaregrp.net/sepg-docs-qa/UXAspects_CI_UXAspects_EL-3673-Fixed-header-table-alignment
