### PR TITLE
EL-3675 - Colum resizing fix

### DIFF
--- a/src/components/table/table-column-resize/table-column-resize-expanding/resizable-expanding-table.directive.ts
+++ b/src/components/table/table-column-resize/table-column-resize-expanding/resizable-expanding-table.directive.ts
@@ -1,12 +1,12 @@
+import { isPlatformBrowser } from '@angular/common';
 import { AfterViewInit, ContentChildren, Directive, ElementRef, Inject, PLATFORM_ID, QueryList, Renderer2 } from '@angular/core';
+import { fromEvent } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
 import { ResizeService } from '../../../../directives/resize/index';
+import { BaseResizableTableDirective } from '../resizable-table-base.directive';
+import { ResizableTableColumnComponent } from '../resizable-table-column.component';
 import { RESIZABLE_TABLE_SERVICE_TOKEN } from '../resizable-table-service.token';
 import { ResizableExpandingTableService } from './resizable-expanding-table.service';
-import { ResizableTableColumnComponent } from '../resizable-table-column.component';
-import { BaseResizableTableDirective } from '../resizable-table-base.directive';
-import { takeUntil } from 'rxjs/operators';
-import { fromEvent } from 'rxjs';
-import { isPlatformBrowser } from '@angular/common';
 
 @Directive({
     selector: '[uxResizableExpandingTable]',
@@ -65,6 +65,15 @@ export class ResizableExpandingTableDirective extends BaseResizableTableDirectiv
 
         // if we have already initialised or the table width is currently 0 then do nothing
         if (this._initialised || this.getScrollWidth() === 0) {
+
+            // if the table has been initialized but the width is now 0
+            // for example, due to the element being hidden (eg. in a collapsed accordion)
+            // we would need to re-run this logic whenever the width is back over 0
+            // to do this we can mark the table as not having been initialized
+            if (this._initialised && this.getScrollWidth() === 0) {
+                this._initialised = false;
+            }
+
             return;
         }
 


### PR DESCRIPTION
#### Checklist
<!-- Use an 'x' to check those which apply. -->
* [x] The contents of this PR are mine to submit. No third party code or other material is being committed.
* [x] New third party dependencies (if any) are linked via `package.json`. Third party dependencies are licenced under one of the following: Apache, MIT, BSD, Mozilla Public License, Eclipse Public License, or Oracle Binary Code License.
* [x] The code in this PR does not contain export-restricted encryption algorithms.

#### Ticket / Issue
<!-- Either a Jira URL or a description of the issue that this PR addresses. -->
https://portal.digitalsafe.net/browse/EL-3675

#### Description of Proposed Changes
<!-- Describe what was changed and how it addresses the original issue. -->
Issue occurs whenever we switch to expanded mode, then collapse the fixed header table accordion and then expand it again.

Essentially when the table is hidden (but not removed, eg: not using ngIf), it gets a width of 0. Whenever it no longer has a width of 0, e.g. when the accordion gets expanded again, we need to re-run some of the initial column size logic again to ensure columns get the right sizes.

#### Documentation CI URL
<!-- Initiate a build at https://jenkins.swinfra.net/job/SEPG/view/Templates/job/New%20SEPG%20Build/build -->
<!-- Append the branch name to the following URL: -->
https://pages.github.houston.softwaregrp.net/sepg-docs-qa/UXAspects_CI_UXAspects_EL-3675-Resizable-Column-Fix
