### PR TITLE
Added Padding To Toolbar Search Input Field

### DIFF
--- a/docs/app/pages/components/components-sections/search/toolbar-search/snippets/app.html
+++ b/docs/app/pages/components/components-sections/search/toolbar-search/snippets/app.html
@@ -3,7 +3,8 @@
     <div class="demo-toolbar-left">
         <ux-toolbar-search [(expanded)]="expanded" direction="right" (search)="onSearch($event)">
             <input uxToolbarSearchField #searchField type="text" class="form-control" placeholder="Search"
-                aria-label="Search" [(ngModel)]="searchText">
+                aria-label="Search" [(ngModel)]="searchText"
+                [class.ux-toolbar-search-clear-offset]="searchText">
             <button uxToolbarSearchButton type="button" class="btn btn-link btn-icon button-secondary"
                 aria-label="Toggle Search" uxTooltip="Search">
                 <ux-icon name="search"></ux-icon>

--- a/docs/app/pages/components/components-sections/search/toolbar-search/toolbar-search.component.html
+++ b/docs/app/pages/components/components-sections/search/toolbar-search/toolbar-search.component.html
@@ -3,7 +3,8 @@
     <div class="demo-toolbar-left">
         <ux-toolbar-search [(expanded)]="expanded" direction="right" (search)="onSearch($event)">
             <input uxToolbarSearchField #searchField type="text" class="form-control" placeholder="Search"
-                aria-label="Search" [(ngModel)]="searchText">
+                aria-label="Search" [(ngModel)]="searchText"
+                [class.ux-toolbar-search-clear-offset]="searchText">
             <button uxToolbarSearchButton type="button" class="btn btn-link btn-icon button-secondary"
                 aria-label="Toggle Search" uxTooltip="Search">
                 <ux-icon name="search"></ux-icon>

--- a/src/components/toolbar-search/toolbar-search.component.less
+++ b/src/components/toolbar-search/toolbar-search.component.less
@@ -30,8 +30,14 @@ ux-toolbar-search {
         }
 
         [uxToolbarSearchField] {
+            padding-right: 35px;
+            padding-left: 5px;
             visibility: visible;
             transition: visibility 0s;
+
+            &.ux-toolbar-search-clear-offset {
+                padding-right: 67px;
+            }
         }
 
         [uxToolbarSearchButton] {


### PR DESCRIPTION
-Added padding to the toolbars input field to stop text flowing behind the search button icon in all cases.
-Bound an extra class to the search clear click event, so that if the search clear button is present the extra class will be applied to the input field adding more padding.
-Updated snippet code to reflect changes.

#### Checklist
* [x] The contents of this PR are mine to submit. No third party code or other material is being committed.
* [x] New third party dependencies (if any) are linked via `package.json`. Third party dependencies are licenced under one of the following: Apache, MIT, BSD, Mozilla Public License, Eclipse Public License, or Oracle Binary Code License.
* [x] The code in this PR does not contain export-restricted encryption algorithms.

#### Ticket / Issue
<!-- Either a Jira URL or a description of the issue that this PR addresses. -->
EL-3706 - Toolbar Search - text overlays icons

#### Description of Proposed Changes
<!-- Describe what was changed and how it addresses the original issue. -->

#### Documentation CI URL
<!-- Initiate a build at https://jenkins.swinfra.net/job/SEPG/view/Templates/job/New%20SEPG%20Build/build -->
<!-- Append the branch name to the following URL: -->
https://pages.github.houston.softwaregrp.net/sepg-docs-qa/UXAspects_CI_UXAspects_
