### PR TITLE
EL-3727: Change docker e2e test execution

### DIFF
--- a/guides/developer-standard.md
+++ b/guides/developer-standard.md
@@ -443,14 +443,11 @@ Follow these steps to run the tests in a CI environment locally:
 1. `npm run docker:ci`
     * This starts a Linux Docker container, and spawns an interactive shell. Enter the subsequent commands at the resulting prompt in order to execute them within the container.
 2. `npm ci`
-    * Note that `npm run docker:ci` will try to backup and restore the Linux platform dependencies; if this was successful, there will be a message informing you that `npm ci` is unnecessary, which can save a lot of time.
+    * Note that `npm run docker:ci` uses `.node_modules__docker` on your host environment to store node modules for the linux platform. Therefore `npm ci` is only required when package updates have been made. 
 3. `npm run build:library`
 4. `npm run test:e2e`
 
-To exit the docker container and restore your developer environment run the following:
-
-1. `exit`
-2. `npm ci`
-    * Note that `npm run docker:ci` will try to backup and restore the Linux platform dependencies; if this was successful, there will be a message informing you that `npm ci` is unnecessary, which can save a lot of time.
+The Docker container can continue to be used for additional test runs. If you wish to exit it simply type `exit` in the linux bash shell.
+Periodic use of `docker ps`, from your host terminal, will show you any running Docker images. These can be terminated using `docker kill CONTAINER ID`.
 
 If there are any differences, the generated screenshots will be found under `target/e2e/screenshots`.

--- a/guides/developer-standard.md
+++ b/guides/developer-standard.md
@@ -447,7 +447,7 @@ Follow these steps to run the tests in a CI environment locally:
 3. `npm run build:library`
 4. `npm run test:e2e`
 
-The Docker container can continue to be used for additional test runs. If you wish to exit it simply type `exit` in the linux bash shell.
-Periodic use of `docker ps`, from your host terminal, will show you any running Docker images. These can be terminated using `docker kill CONTAINER ID`.
+The Docker container can continue to be used for additional test runs. If you wish to exit the container simply type `exit` in the Linux bash shell.
+Periodic use of `docker ps` from your host terminal, will show you any running Docker images. These can be terminated using `docker kill CONTAINER ID`.
 
 If there are any differences, the generated screenshots will be found under `target/e2e/screenshots`.

--- a/guides/developer-standard.md
+++ b/guides/developer-standard.md
@@ -443,7 +443,7 @@ Follow these steps to run the tests in a CI environment locally:
 1. `npm run docker:ci`
     * This starts a Linux Docker container, and spawns an interactive shell. Enter the subsequent commands at the resulting prompt in order to execute them within the container.
 2. `npm ci`
-    * Note that `npm run docker:ci` uses `.node_modules__docker` on your host environment to store node modules for the linux platform. Therefore `npm ci` is only required when package updates have been made. 
+    * Note that `npm run docker:ci` uses `.node_modules__docker` on your host environment to store node modules for the Linux platform. Therefore `npm ci` is only required when package updates have been made. 
 3. `npm run build:library`
 4. `npm run test:e2e`
 

--- a/scripts/run-ci-local.js
+++ b/scripts/run-ci-local.js
@@ -1,12 +1,10 @@
 const { execSync } = require('child_process');
-const { renameSync } = require('fs');
-const { join, basename } = require('path');
 const { mkdirpSync } = require('fs-extra');
+const { join } = require('path');
 
 const cwd = process.cwd();
 
-const nodeModulesDir = join(cwd, 'node_modules');
-const nodeModulesDockerDir = join(cwd, '.node_modules__docker');
+const nodeModulesDocker = join(cwd, '.node_modules__docker');
 //const dockerImage = 'uxaspects/buildenv:latest';
 const dockerImage = 'cafinternal/prereleases:buildenv-1.3.0-EL-3727-SNAPSHOT';
 

--- a/scripts/run-ci-local.js
+++ b/scripts/run-ci-local.js
@@ -16,11 +16,11 @@ const http_proxy = process.env.HTTP_PROXY || process.env.http_proxy;
 const https_proxy = process.env.HTTPS_PROXY || process.env.https_proxy;
 
 if (!http_proxy){
-    console.warn(`An http proxy has not been defined.`);
+    console.warn(`Neither HTTP_PROXY nor http_proxy have been defined in the host environment.`);
 }
 
 if (!https_proxy){
-    console.warn(`An https proxy has not been defined.`);
+    console.warn(`Neither HTTPS_PROXY nor https_proxy have been defined in the host environment.`);
 }
 
 // produce the docker command string

--- a/scripts/run-ci-local.js
+++ b/scripts/run-ci-local.js
@@ -1,60 +1,36 @@
 const { execSync } = require('child_process');
 const { renameSync } = require('fs');
 const { join, basename } = require('path');
+const { mkdirpSync } = require('fs-extra');
 
 const cwd = process.cwd();
 
 const nodeModulesDir = join(cwd, 'node_modules');
-const nodeModulesDevDir = join(cwd, '.node_modules__dev');
 const nodeModulesDockerDir = join(cwd, '.node_modules__docker');
+//const dockerImage = 'uxaspects/buildenv:latest';
+const dockerImage = 'cafinternal/prereleases:buildenv-1.3.0-EL-3727-SNAPSHOT';
 
-try {
-    // Move existing node_modules to a known location
-    renameSync(nodeModulesDir, nodeModulesDevDir);
-    console.log(`Renamed node_modules to ${basename(nodeModulesDevDir)}. You can use this instead of doing \`npm ci\` again after exiting the shell.`);
-} catch (error) {
-    if (error.code !== 'ENOENT') {
-        console.warn(`Couldn't rename node_modules. (The IDE probably has a handle on it.)`);
-    }
-}
-
-try {
-    // Restore previously saved node_modules
-    renameSync(nodeModulesDockerDir, nodeModulesDir);
-    console.log(`Restored node_modules from ${basename(nodeModulesDockerDir)}. Running \`npm ci\` may not be necessary.`);
-} catch (error) {
-    console.log('Run `npm ci` in the docker shell to obtain Linux 64-bit dependencies.');
-}
+// Ensure the docker node_modules__docker directory exists
+mkdirpSync(nodeModulesDocker);
 
 // access environment
-const http_proxy = process.env.HTTP_PROXY;
-const https_proxy = process.env.HTTPS_PROXY;
+const http_proxy = process.env.HTTP_PROXY || process.env.http_proxy;
+const https_proxy = process.env.HTTPS_PROXY || process.env.https_proxy;
+
+if (!http_proxy){
+    console.warn(`An http proxy has not been defined.`);
+}
+
+if (!https_proxy){
+    console.warn(`An https proxy has not been defined.`);
+}
 
 // produce the docker command string
-const dockerCommand = `docker run --rm -it --memory=4g -e "http_proxy=${http_proxy}" -e "https_proxy=${https_proxy}" -v "${cwd}:/wd" -w /wd --entrypoint /bin/bash uxaspects/buildenv:latest`;
+const dockerCommand = `docker run --rm -it --memory=4g -e "http_proxy=${http_proxy}" -e "https_proxy=${https_proxy}" -v "${cwd}:/wd" -v "${nodeModulesDocker}:/wd/node_modules" -w /wd --entrypoint /bin/bash ${dockerImage}`;
 
 // run the command string with the inherited terminal
 try {
     execSync(dockerCommand, { stdio: 'inherit' });
 } catch (error) {
     console.warn(`Exited: ${error.message || error.signal}`);
-}
-
-try {
-    // Save the linux node_modules for next time
-    renameSync(nodeModulesDir, nodeModulesDockerDir);
-    console.log(`Renamed node_modules to ${basename(nodeModulesDockerDir)}. This can be used next time you use the docker shell.`);
-} catch (error) {
-    if (error.code !== 'ENOENT') {
-        console.warn(`Couldn't rename node_modules. (The IDE probably has a handle on it.)`);
-    }
-}
-
-try {
-    // Restore previously saved node_modules
-    renameSync(nodeModulesDevDir, nodeModulesDir);
-    console.log(`Restored node_modules from ${basename(nodeModulesDevDir)}. Running \`npm ci\` may not be necessary.`);
-}
-catch (error) {
-    console.log('Run `npm ci` again to install dependencies for your normal development environment.');
 }


### PR DESCRIPTION
#### Checklist
<!-- Use an 'x' to check those which apply. -->
* [x] The contents of this PR are mine to submit. No third party code or other material is being committed.
* [x] New third party dependencies (if any) are linked via `package.json`. Third party dependencies are licenced under one of the following: Apache, MIT, BSD, Mozilla Public License, Eclipse Public License, or Oracle Binary Code License.
* [x] The code in this PR does not contain export-restricted encryption algorithms.

#### Ticket / Issue
https://portal.digitalsafe.net/browse/EL-3727

#### Description of Proposed Changes
User a dedicated directory on the docker host environment for Linux node modules.

#### Documentation CI URL
<!-- Initiate a build at https://jenkins.swinfra.net/job/SEPG/view/Templates/job/New%20SEPG%20Build/build -->
<!-- Append the branch name to the following URL: -->
https://pages.github.houston.softwaregrp.net/sepg-docs-qa/UXAspects_CI_UXAspects_
