### PR TITLE
EL-3706 - Added background="white" to Toolbar Search e2e testpage

### DIFF
--- a/e2e/pages/app/toolbar-search/toolbar-search.testpage.component.html
+++ b/e2e/pages/app/toolbar-search/toolbar-search.testpage.component.html
@@ -5,6 +5,7 @@
             [alwaysExpanded]="alwaysExpanded"
             [(expanded)]="expanded"
             direction="right"
+            background="white"
             (search)="onSearch($event)">
 
             <input uxToolbarSearchField
@@ -54,6 +55,7 @@
             id="searchRight"
             [alwaysExpanded]="alwaysExpanded"
             direction="left"
+            background="white"
             (search)="onSearchRight()">
 
             <input uxToolbarSearchField


### PR DESCRIPTION
#### Checklist
<!-- Use an 'x' to check those which apply. -->
* [x] The contents of this PR are mine to submit. No third party code or other material is being committed.
* [x] New third party dependencies (if any) are linked via `package.json`. Third party dependencies are licenced under one of the following: Apache, MIT, BSD, Mozilla Public License, Eclipse Public License, or Oracle Binary Code License.
* [x] The code in this PR does not contain export-restricted encryption algorithms.

#### Ticket / Issue
https://portal.digitalsafe.net/browse/EL-3706

#### Description of Proposed Changes
`background="white"` is needed to prevent the icon overlap seen in the Micro Focus theme.

#### Documentation CI URL
<!-- Initiate a build at https://jenkins.swinfra.net/job/SEPG/view/Templates/job/New%20SEPG%20Build/build -->
<!-- Append the branch name to the following URL: -->
https://pages.github.houston.softwaregrp.net/sepg-docs-qa/UXAspects_CI_UXAspects_EL-3706-Toolbar-Search
