### PR TITLE
EL-3784 - added $event.stopPropagation() to Today button

### DIFF
--- a/src/components/date-time-picker/date-time-picker.component.html
+++ b/src/components/date-time-picker/date-time-picker.component.html
@@ -26,6 +26,6 @@
     class="now-button"
     [attr.aria-label]="nowBtnAriaLabel"
     [disabled]="_isTodayDisabled"
-    (click)="setToNow()">
+    (click)="setToNow(); $event.stopPropagation()">
     {{ datepicker.nowBtnText$ | async }}
 </button>


### PR DESCRIPTION
#### Checklist
* [x] The contents of this PR are mine to submit. No third party code or other material is being committed.
* [x] New third party dependencies (if any) are linked via `package.json`. Third party dependencies are licensed under one of the following: Apache, MIT, BSD, Mozilla Public License, Eclipse Public License, or Oracle Binary Code License.
* [x] The code in this PR does not contain export-restricted encryption algorithms.

#### Ticket / Issue

https://portal.digitalsafe.net/browse/EL-3784

#### Description of Proposed Changes

- Added $event.stopPropagation() to Today button

#### Documentation CI URL

https://pages.github.houston.softwaregrp.net/sepg-docs-qa/UXAspects_CI_UXAspects_EL-3784-date-time-picker-unexpectedly-closing

#### Downstream Build(s)

https://jenkins.swinfra.net/job/SEPG/job/caf/view/Developer/job/caf~ux-aspects-micro-focus~EL-3784-date-time-picker-unexpectedly-closing~CI/

https://pages.github.houston.softwaregrp.net/sepg-docs-qa/caf_CI_ux-aspects-micro-focus_EL-3784-date-time-picker-unexpectedly-closing


