### PR TITLE
EL-3804 - screenshot failure

### DIFF
--- a/e2e/pages/styles.css
+++ b/e2e/pages/styles.css
@@ -4,3 +4,7 @@
 * {
     caret-color: transparent;
 }
+
+.form-control {
+    transition: none;
+}

--- a/e2e/tests/components/select/forms/select-forms.e2e-spec.ts
+++ b/e2e/tests/components/select/forms/select-forms.e2e-spec.ts
@@ -35,7 +35,7 @@ describe('Select (forms) Tests', () => {
         expect(await page.confirmPageSizeButtonIsDisabled('down')).toBeTruthy();
         expect(await page.confirmPageSizeButtonIsDisabled('up')).toBeTruthy();
 
-        // expect(await imageCompare('select-forms-initial')).toEqual(0);
+        expect(await imageCompare('select-forms-initial')).toEqual(0);
 
     });
 
@@ -56,7 +56,7 @@ describe('Select (forms) Tests', () => {
         await page.clickOnDropdown(false);
         expect(await page.confirmDropdownIsExpanded()).toBeTruthy();
 
-        // expect(await imageCompare('select-forms-dropdown')).toEqual(0);
+        expect(await imageCompare('select-forms-dropdown')).toEqual(0);
 
     });
 
@@ -181,7 +181,7 @@ describe('Select (forms) Tests', () => {
         expect(await page.getFilterText(3)).toBe('Ch');
         expect(await page.getFilterText(4)).toBe('ch');
 
-        // expect(await imageCompare('select-forms-highlight')).toEqual(0);
+        expect(await imageCompare('select-forms-highlight')).toEqual(0);
 
     });
 
@@ -249,7 +249,7 @@ describe('Select (forms) Tests', () => {
         await page.getDropdown(true).sendKeys('ire');
         expect(await page.getCountryText(true, 2)).toBe('Ireland');
 
-        // expect(await imageCompare('select-forms-multiple')).toEqual(0);
+        expect(await imageCompare('select-forms-multiple')).toEqual(0);
 
     });
 
@@ -278,7 +278,7 @@ describe('Select (forms) Tests', () => {
         await page.clickOnCountry(true, 70);
         expect(await page.getSelectedLocationText()).toBe('[ "Cyprus", "Eritrea" ]');
 
-        // expect(await imageCompare('select-forms-multiple-disabled')).toEqual(0);
+        expect(await imageCompare('select-forms-multiple-disabled')).toEqual(0);
 
     });
 

--- a/e2e/tests/components/select/standard/select.e2e-spec.ts
+++ b/e2e/tests/components/select/standard/select.e2e-spec.ts
@@ -535,7 +535,7 @@ describe('Select Tests', () => {
         await page.clickOnDropdown(true);
         await page.clickOnCountry(true, 250);
         expect(await page.getSelectedLocationText()).toBe('[ "Daenerys of the House Targaryen, the First of Her Name, The Unburnt, Queen of the Andals, the Rhoynar and the First Men, Queen of Meereen, Khaleesi of the Great Grass Sea, Protector of the Realm, Lady Regent of the Seven Kingdoms, Breaker of Chains and Mother of Dragons" ]');
-        // expect(await imageCompare('select-tag-overflow')).toEqual(0);
+        expect(await imageCompare('select-tag-overflow')).toEqual(0);
     });
 
     it('should allow a custom icon', async () => {

--- a/e2e/tests/components/select/standard/select.e2e-spec.ts
+++ b/e2e/tests/components/select/standard/select.e2e-spec.ts
@@ -22,7 +22,7 @@ describe('Select Tests', () => {
         // selected location(s) - null
         expect(await page.getSelectedLocationText()).toBe('null');
 
-        // expect(await imageCompare('select-initial')).toEqual(0);
+        expect(await imageCompare('select-initial')).toEqual(0);
     });
 
     it('should display correct text', async () => {
@@ -42,7 +42,7 @@ describe('Select Tests', () => {
         await page.clickOnDropdown(false);
         expect(await page.confirmDropdownIsExpanded()).toBeTruthy();
 
-        // expect(await imageCompare('select-dropdown')).toEqual(0);
+        expect(await imageCompare('select-dropdown')).toEqual(0);
 
         await page.clickOnDropdown(false);
         expect(await page.confirmDropdownIsExpanded()).toBeFalsy();
@@ -69,7 +69,7 @@ describe('Select Tests', () => {
         await page.clickOnDropdown(false);
         await page.clickOnCountry(false, 249);
         expect(await page.getSelectedLocationText()).toBe('"MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMM"');
-        // expect(await imageCompare('select-overflow')).toEqual(0);
+        expect(await imageCompare('select-overflow')).toEqual(0);
 
     });
 
@@ -136,7 +136,7 @@ describe('Select Tests', () => {
         expect(await page.getFilterText(3)).toBe('Ch');
         expect(await page.getFilterText(4)).toBe('ch');
 
-        // expect(await imageCompare('select-dropdown-highlight')).toEqual(0);
+        expect(await imageCompare('select-dropdown-highlight')).toEqual(0);
 
     });
 
@@ -204,7 +204,7 @@ describe('Select Tests', () => {
         await page.getDropdown(true).sendKeys('ire');
         expect(await page.getCountryText(true, 2)).toBe('Ireland');
 
-        // expect(await imageCompare('select-multiple')).toEqual(0);
+        expect(await imageCompare('select-multiple')).toEqual(0);
 
     });
 
@@ -520,7 +520,7 @@ describe('Select Tests', () => {
         await page.clickOnCountry(false, 249);
         expect(await page.getSelectedLocationText()).toBe('"MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMM"');
         expect(await clearButton.isPresent()).toBeTruthy();
-        // expect(await imageCompare('select-clear-button-overflow')).toEqual(0);
+        expect(await imageCompare('select-clear-button-overflow')).toEqual(0);
 
         // Clear the control using the clear button
         await clearButton.click();
@@ -545,18 +545,18 @@ describe('Select Tests', () => {
         await page.clickOnDropdown(false);
         await page.clickOnCountry(false, 1);
         expect(await customIcon.isPresent()).toBeTruthy();
-        // expect(await imageCompare('select-custom-icon-single')).toEqual(0);
+        expect(await imageCompare('select-custom-icon-single')).toEqual(0);
         await page.toggleClearButton();
-        // expect(await imageCompare('select-custom-icon-single-clear-btn')).toEqual(0);
+        expect(await imageCompare('select-custom-icon-single-clear-btn')).toEqual(0);
         await page.toggleClearButton();
         await page.clickOnCheckbox(page.checkboxMulti);
         await page.clickOnDropdown(true);
         await page.clickOnCountry(true, 1);
         await page.clickOnCountry(true, 2);
         expect(await customIcon.isPresent()).toBeTruthy();
-        // expect(await imageCompare('select-custom-icon-multiple')).toEqual(0);
+        expect(await imageCompare('select-custom-icon-multiple')).toEqual(0);
         await page.toggleClearButton();
-        // expect(await imageCompare('select-custom-icon-multiple-clear-btn')).toEqual(0);
+        expect(await imageCompare('select-custom-icon-multiple-clear-btn')).toEqual(0);
     });
 
     it('should handle recent options correctly: single selection', async () => {
@@ -564,7 +564,7 @@ describe('Select Tests', () => {
         await page.clickOnDropdown(false);
 
         // Initial state: recent option list is not shown
-        // expect(await imageCompare('select-open-single')).toEqual(0);
+        expect(await imageCompare('select-open-single')).toEqual(0);
 
         await page.clickOnCountry(false, 1);
         await page.checkRecentOptions(false, ['United Kingdom']);
@@ -582,7 +582,7 @@ describe('Select Tests', () => {
         await page.checkRecentOptions(false, ['Aland Islands', 'Albania', 'United Kingdom']);
 
         // Recent options list with three entries
-        // expect(await imageCompare('select-recent-single')).toEqual(0);
+        expect(await imageCompare('select-recent-single')).toEqual(0);
     });
 
     it('should handle recent options correctly: multi selection', async () => {
@@ -591,7 +591,7 @@ describe('Select Tests', () => {
         await page.clickOnDropdown(true);
 
         // Initial state: recent option list is not shown
-        // expect(await imageCompare('select-open-multi')).toEqual(0);
+        expect(await imageCompare('select-open-multi')).toEqual(0);
 
         await page.clickOnCountry(true, 1);
         await page.checkRecentOptions(true, ['United Kingdom']);
@@ -610,7 +610,7 @@ describe('Select Tests', () => {
         await page.checkRecentOptions(true, ['Aland Islands', 'Albania', 'Afghanistan']);
 
         // Recent options list with three entries
-        // expect(await imageCompare('select-recent-multi')).toEqual(0);
+        expect(await imageCompare('select-recent-multi')).toEqual(0);
     });
 
     it('should handle recent options correctly: recent options filled', async () => {
@@ -626,6 +626,6 @@ describe('Select Tests', () => {
         await page.checkRecentOptions(false, ['United Kingdom', 'Algeria', 'Afghanistan']);
 
         // Recent options list with three entries
-        // expect(await imageCompare('select-recent-filled')).toEqual(0);
+        expect(await imageCompare('select-recent-filled')).toEqual(0);
     });
 });


### PR DESCRIPTION
#### Checklist
* [x] The contents of this PR are mine to submit. No third party code or other material is being committed.
* [x] New third party dependencies (if any) are linked via `package.json`. Third party dependencies are licensed under one of the following: Apache, MIT, BSD, Mozilla Public License, Eclipse Public License, or Oracle Binary Code License.
* [x] The code in this PR does not contain export-restricted encryption algorithms.

#### Ticket / Issue

https://portal.digitalsafe.net/browse/EL-3804

#### Description of Proposed Changes

- Uncommented select screenshot tests
- Removed the transition on the form control which causes a delay for the focus state

#### Documentation CI URL

https://pages.github.houston.softwaregrp.net/sepg-docs-qa/UXAspects_CI_UXAspects_EL-3804-screenshot-failure

https://jenkins.swinfra.net/job/SEPG/job/UXAspects/view/Developer/job/UXAspects~UXAspects~EL-3804-screenshot-failure~CI/

#### Downstream Build(s)

https://pages.github.houston.softwaregrp.net/sepg-docs-qa/caf_CI_ux-aspects-micro-focus_EL-3804-screenshot-failure

https://jenkins.swinfra.net/job/SEPG/job/caf/view/Developer/job/caf~ux-aspects-micro-focus~EL-3804-screenshot-failure~CI/
