### PR TITLE
EL-3871 - Fix timezone related karma test failures

### DIFF
--- a/src/components/date-range-picker/date-range-picker.spec.ts
+++ b/src/components/date-range-picker/date-range-picker.spec.ts
@@ -56,6 +56,18 @@ describe('Date Range Picker', () => {
     let nativeElement: HTMLElement;
     let onStartTimezoneChangeSpy: jasmine.Spy;
     let onEndTimezoneChangeSpy: jasmine.Spy;
+    let getTimezoneOffset: () => number;
+
+    beforeAll(() => {
+        getTimezoneOffset = Date.prototype.getTimezoneOffset;
+        Date.prototype.getTimezoneOffset = () => {
+            return 0;
+        };
+    });
+
+    afterAll(() => {
+        Date.prototype.getTimezoneOffset = getTimezoneOffset;
+    });
 
     beforeEach(async(() => {
         TestBed.configureTestingModule({

--- a/src/components/date-range-picker/date-range-picker.spec.ts
+++ b/src/components/date-range-picker/date-range-picker.spec.ts
@@ -92,7 +92,7 @@ describe('Date Range Picker', () => {
 
     it('should update start date and call onStartChange when start date is changed ', async () => {
         spyOn(component, 'onStartChange');
-        component.start = new Date('Tue Jan 07 2020 00:00:00 GMT+0000 (Greenwich Mean Time)');
+        component.start = new Date(2020, 0, 7, 0, 0, 0);
 
         fixture.detectChanges();
         await fixture.whenStable();
@@ -103,7 +103,7 @@ describe('Date Range Picker', () => {
 
     it('should update end date and call onEndChange when end date is changed', async () => {
         spyOn(component, 'onEndChange');
-        component.end = new Date('Thu Jan 23 2020 23:59:59 GMT+0000 (Greenwich Mean Time)');
+        component.end = new Date(2020, 0, 23, 23, 59, 59);
 
         fixture.detectChanges();
         await fixture.whenStable();

--- a/src/components/date-time-picker/date-time-picker.spec.ts
+++ b/src/components/date-time-picker/date-time-picker.spec.ts
@@ -43,6 +43,18 @@ describe('Date Time Picker', () => {
     let fixture: ComponentFixture<DateRangePickerComponent>;
     let nativeElement: HTMLElement;
     let onTimezoneChangeSpy: jasmine.Spy;
+    let getTimezoneOffset: () => number;
+
+    beforeAll(() => {
+        getTimezoneOffset = Date.prototype.getTimezoneOffset;
+        Date.prototype.getTimezoneOffset = () => {
+            return 0;
+        };
+    });
+
+    afterAll(() => {
+        Date.prototype.getTimezoneOffset = getTimezoneOffset;
+    });
 
     beforeEach(async(() => {
         TestBed.configureTestingModule({


### PR DESCRIPTION
#### Checklist
<!-- Use an 'x' to check those which apply. -->
* [x] The contents of this PR are mine to submit. No third party code or other material is being committed.
* [x] New third party dependencies (if any) are linked via `package.json`. Third party dependencies are licensed under one of the following: Apache, MIT, BSD, Mozilla Public License, Eclipse Public License, or Oracle Binary Code License.
* [x] The code in this PR does not contain export-restricted encryption algorithms.

#### Ticket / Issue
<!-- Either a Jira URL or a description of the issue that this PR addresses. -->
https://portal.digitalsafe.net/browse/EL-3871

#### Description of Proposed Changes
<!-- Describe what was changed and how it addresses the original issue. -->
Tests depend on being run on a system in the +0 timezone, which will not always be the case. Stub the `getTimezoneOffset` function to always return 0 when running these tests.

The explicit timezone in these tests causes the date to be adjusted to the local timezone when parsed, and therefore (depending on the system timezone) may no longer match the expected date when displayed in the date range picker.

#### Documentation CI URL
<!-- Initiate a build at https://jenkins.swinfra.net/job/SEPG/view/Templates/job/New%20SEPG%20Build/build -->
<!-- Append the branch name to the following URL: -->
https://pages.github.houston.softwaregrp.net/sepg-docs-qa/UXAspects_CI_UXAspects_EL-3871-timezone-tests

#### Downstream Build(s)
<!-- Push a branch with the same name in each downstream repository and create a build in Jenkins. -->
<!-- Add the Jenkins build link(s) below: -->
* [caf/ux-aspects-micro-focus](https://jenkins.swinfra.net/job/SEPG/job/caf/job/caf~ux-aspects-micro-focus~EL-3871-timezone-tests~CI/)
