### PR TITLE
EL-3902 - Column grouping fix focus issue

### DIFF
--- a/src/components/table/column-picker/column-picker.component.html
+++ b/src/components/table/column-picker/column-picker.component.html
@@ -23,10 +23,10 @@
         <cdk-tree-node *cdkTreeNodeDef="let node"
             [attr.aria-hidden]="selected && selected.indexOf(node.name) > -1">
             <div uxTabbableListItem
-                uxFocusIndicator
                 [uxSelectionItem]="node"
                 *ngIf="_shouldRenderNode(node)"
-                class="column-picker-list-item column-picker-tree-node-level-{{ node.level }}">
+                class="column-picker-list-item"
+                [ngClass]="'column-picker-tree-node-level-' + node.level">
 
                 <ng-container *ngIf="!deselectedTemplate">{{ node.name }}</ng-container>
 
@@ -47,7 +47,6 @@
                 class="column-picker-tree-group-node">
 
                 <button uxTabbableListItem
-                    uxFocusIndicator
                     (click)="_setNodeExpanded(node, !node.isExpanded)"
                     (keydown.arrowright)="_setNodeExpanded(node, true)"
                     (keydown.arrowleft)="_setNodeExpanded(node, false)"

--- a/src/components/table/column-picker/column-picker.component.html
+++ b/src/components/table/column-picker/column-picker.component.html
@@ -23,9 +23,10 @@
         <cdk-tree-node *cdkTreeNodeDef="let node"
             [attr.aria-hidden]="selected && selected.indexOf(node.name) > -1">
             <div uxTabbableListItem
-                 [uxSelectionItem]="node"
-                 *ngIf="_shouldRenderNode(node)"
-                 class="column-picker-list-item column-picker-tree-node-level-{{ node.level }}">
+                uxFocusIndicator
+                [uxSelectionItem]="node"
+                *ngIf="_shouldRenderNode(node)"
+                class="column-picker-list-item column-picker-tree-node-level-{{ node.level }}">
 
                 <ng-container *ngIf="!deselectedTemplate">{{ node.name }}</ng-container>
 
@@ -46,12 +47,13 @@
                 class="column-picker-tree-group-node">
 
                 <button uxTabbableListItem
-                        (click)="_setNodeExpanded(node, !node.isExpanded)"
-                        (keydown.arrowright)="_setNodeExpanded(node, true)"
-                        (keydown.arrowleft)="_setNodeExpanded(node, false)"
-                        [style.visibility]="node.expandable ? 'visible' : 'hidden'"
-                        [attr.aria-label]="deselectedGroupAriaLabel(node.name, node.isExpanded)"
-                        class="column-picker-group-toggle-btn">
+                    uxFocusIndicator
+                    (click)="_setNodeExpanded(node, !node.isExpanded)"
+                    (keydown.arrowright)="_setNodeExpanded(node, true)"
+                    (keydown.arrowleft)="_setNodeExpanded(node, false)"
+                    [style.visibility]="node.expandable ? 'visible' : 'hidden'"
+                    [attr.aria-label]="deselectedGroupAriaLabel(node.name, node.isExpanded)"
+                    class="column-picker-group-toggle-btn">
 
                     <ux-icon [name]="node.isExpanded ? 'chevron-down' : 'chevron-right'"></ux-icon>
 

--- a/src/components/table/column-picker/column-picker.component.less
+++ b/src/components/table/column-picker/column-picker.component.less
@@ -2,10 +2,6 @@ ux-column-picker {
     display: flex;
     width: 100%;
 
-    cdk-tree-node:focus {
-        outline: none;
-    }
-
     .column-picker-column {
         display: flex;
         flex-direction: column;

--- a/src/components/table/column-picker/column-picker.component.less
+++ b/src/components/table/column-picker/column-picker.component.less
@@ -2,6 +2,10 @@ ux-column-picker {
     display: flex;
     width: 100%;
 
+    cdk-tree-node:focus {
+        outline: none;
+    }
+
     .column-picker-column {
         display: flex;
         flex-direction: column;
@@ -24,6 +28,10 @@ ux-column-picker {
         border: 1px solid @table-border;
         overflow-y: auto;
         background-color: @table-hover-bg;
+
+        &:focus {
+            outline: none;
+        }
     }
 
     .column-picker-list-item {

--- a/src/components/table/table.module.ts
+++ b/src/components/table/table.module.ts
@@ -1,4 +1,5 @@
 import { A11yModule } from '@angular/cdk/a11y';
+import { CdkTreeModule } from '@angular/cdk/tree';
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { AccessibilityModule } from '../../directives/accessibility/index';
@@ -12,33 +13,32 @@ import { ResizableTableCellDirective } from './table-column-resize/resizable-tab
 import { ResizableTableColumnComponent } from './table-column-resize/resizable-table-column.component';
 import { ResizableExpandingTableDirective } from './table-column-resize/table-column-resize-expanding/resizable-expanding-table.directive';
 import { ResizableTableDirective } from './table-column-resize/table-column-resize-standard/resizable-table.directive';
-import { CdkTreeModule } from '@angular/cdk/tree';
 
 @NgModule({
     imports: [
         A11yModule,
         AccessibilityModule,
+        CdkTreeModule,
         CommonModule,
         DragModule,
         IconModule,
         ResizeModule,
         ReorderableModule,
         SelectionModule,
-        CdkTreeModule
     ],
     declarations: [
+        ColumnPickerComponent,
         ResizableTableDirective,
         ResizableExpandingTableDirective,
         ResizableTableColumnComponent,
         ResizableTableCellDirective,
-        ColumnPickerComponent,
     ],
     exports: [
+        ColumnPickerComponent,
         ResizableTableDirective,
         ResizableExpandingTableDirective,
         ResizableTableColumnComponent,
         ResizableTableCellDirective,
-        ColumnPickerComponent,
     ]
 })
 export class TableModule { }


### PR DESCRIPTION
#### Checklist
<!-- Use an 'x' to check those which apply. -->
* [x] The contents of this PR are mine to submit. No third party code or other material is being committed.
* [x] New third party dependencies (if any) are linked via `package.json`. Third party dependencies are licensed under one of the following: Apache, MIT, BSD, Mozilla Public License, Eclipse Public License, or Oracle Binary Code License.
* [x] The code in this PR does not contain export-restricted encryption algorithms.

#### Ticket / Issue
<!-- Either a Jira URL or a description of the issue that this PR addresses. -->
https://portal.digitalsafe.net/browse/EL-3902

#### Description of Proposed Changes
<!-- Describe what was changed and how it addresses the original issue. -->
This branch fixes two issues:

- When scrolling the deselected items in the column picker the scroll area comes into focus (outline now removed).
- Sometimes the list items within deselected also have a focus state that we do not want to see we have our own custom styling to show this (outline also removed).

#### Documentation CI URL
<!-- Initiate a build at https://jenkins.swinfra.net/job/SEPG/view/Templates/job/New%20SEPG%20Build/build -->
<!-- Append the branch name to the following URL: -->
https://pages.github.houston.softwaregrp.net/sepg-docs-qa/UXAspects_CI_UXAspects_EL-3902-column-picker-grouping-focus-fix

#### Downstream Build(s)
<!-- Push a branch with the same name in each downstream repository and create a build in Jenkins. -->
<!-- Add the Jenkins build link(s) below: -->
* [caf/ux-aspects-micro-focus](https://jenkins.swinfra.net/job/SEPG/job/caf/view/Developer/job/caf~ux-aspects-micro-focus~EL-3902-column-picker-grouping-focus-fix~CI/)
