### PR TITLE
EL-3950 - Select: ExpressionChangedAfterItHasBeenCheckedError

### DIFF
--- a/configs/webpack.docs.dev.config.js
+++ b/configs/webpack.docs.dev.config.js
@@ -200,7 +200,8 @@ module.exports = {
         overlay: true,
         headers: {
             'Access-Control-Allow-Origin': '*'
-        }
+        },
+        disableHostCheck: true // https://github.com/webpack/webpack-dev-server/issues/1604
     },
 
     node: false

--- a/docs/app/pages/components/components-sections/select/select-list/select-list.component.ts
+++ b/docs/app/pages/components/components-sections/select/select-list/select-list.component.ts
@@ -1,8 +1,11 @@
 import { Component } from '@angular/core';
+import { Chance } from 'chance';
 import { BaseDocumentationSection } from '../../../../../components/base-documentation-section/base-documentation-section';
 import { DocumentationSectionComponent } from '../../../../../decorators/documentation-section-component';
 import { IPlayground } from '../../../../../interfaces/IPlayground';
 import { IPlaygroundProvider } from '../../../../../interfaces/IPlaygroundProvider';
+
+const chance = new Chance();
 
 @Component({
     selector: 'uxd-components-select-list',

--- a/src/components/select/select.component.html
+++ b/src/components/select/select.component.html
@@ -57,7 +57,7 @@
         [class.ux-tag-input-clear-inset]="clearButton && allowNull && _hasValue"
         [attr.aria-activedescendant]="highlightedElement?.id"
         aria-autocomplete="list"
-        [attr.aria-controls]="singleTypeahead.id"
+        [attr.aria-controls]="id + '-typeahead'"
         [attr.aria-label]="ariaLabel"
         aria-multiline="false"
         [autocomplete]="autocomplete"


### PR DESCRIPTION
#### Checklist
<!-- Use an 'x' to check those which apply. -->
* [x] The contents of this PR are mine to submit. No third party code or other material is being committed.
* [x] New third party dependencies (if any) are linked via `package.json`. Third party dependencies are licensed under one of the following: Apache, MIT, BSD, Mozilla Public License, Eclipse Public License, or Oracle Binary Code License.
* [x] The code in this PR does not contain export-restricted encryption algorithms.

#### Ticket / Issue
<!-- Either a Jira URL or a description of the issue that this PR addresses. -->
https://portal.digitalsafe.net/browse/EL-3950

#### Description of Proposed Changes
<!-- Describe what was changed and how it addresses the original issue. -->
* Fix ExpressionChanged error for aria-controls.
* There were some other errors in the console which were quite straightforward to fix so I have included those fixes here as well.

Since discussing these errors during storytime I have not been able to reproduce the second occurrence noted in the ticket.

#### Documentation CI URL
<!-- Initiate a build at https://jenkins.swinfra.net/job/SEPG/view/Templates/job/New%20SEPG%20Build/build -->
<!-- Append the branch name to the following URL: -->
https://pages.github.houston.softwaregrp.net/sepg-docs-qa/UXAspects_CI_UXAspects_EL-3950-select-expression-changed

#### Downstream Build(s)
<!-- Push a branch with the same name in each downstream repository and create a build in Jenkins. -->
<!-- Add the Jenkins build link(s) below: -->
* [caf/ux-aspects-micro-focus](https://jenkins.swinfra.net/job/SEPG/job/caf/job/caf~ux-aspects-micro-focus~EL-3950-select-expression-changed~CI/)
