### PR TITLE
EL-3940 - Provide a stylesheet without hpe-icons

### DIFF
--- a/docs/app/pages/css/css-sections/icons/ux-icons/ux-icons.component.html
+++ b/docs/app/pages/css/css-sections/icons/ux-icons/ux-icons.component.html
@@ -1,4 +1,9 @@
-<p *ngIf="iconSetClass === 'hpe-icon'">To use an icon simply apply the <code>{{ iconSetClass }}</code>
+<p *ngIf="iconSetClass === 'hpe-icon'">
+    <span class="label label-critical">Deprecated</span> &mdash; The <code>{{ iconSetClass }}</code> set
+    will be removed in the next major release of UX Aspects.
+</p>
+
+<p *ngIf="iconSetClass === 'hpe-icon'">To use a legacy HPE icon apply the <code>{{ iconSetClass }}</code>
     class along with one of the following classes:</p>
 
 <p *ngIf="iconSetClass === 'ux-icon'">To use an icon apply the <a fragment="icon"


### PR DESCRIPTION
#### Checklist
<!-- Use an 'x' to check those which apply. -->
* [x] The contents of this PR are mine to submit. No third party code or other material is being committed.
* [x] New third party dependencies (if any) are linked via `package.json`. Third party dependencies are licensed under one of the following: Apache, MIT, BSD, Mozilla Public License, Eclipse Public License, or Oracle Binary Code License.
* [x] The code in this PR does not contain export-restricted encryption algorithms.

#### Ticket / Issue
<!-- Either a Jira URL or a description of the issue that this PR addresses. -->
https://portal.digitalsafe.net/browse/EL-3940

#### Description of Proposed Changes
<!-- Describe what was changed and how it addresses the original issue. -->
* Update the less script to create a secondary stylesheet for the distribution named ux-aspects-no-legacy. This is identical to the ux-aspects stylesheet except for the removal of hpe-icons.less.
* Mark hpe-icon set as deprecated.

#### Documentation CI URL
<!-- Initiate a build at https://jenkins.swinfra.net/job/SEPG/view/Templates/job/New%20SEPG%20Build/build -->
<!-- Append the branch name to the following URL: -->
https://pages.github.houston.softwaregrp.net/sepg-docs-qa/UXAspects_CI_UXAspects_EL-3940-remove-hpe-icons

#### Downstream Build(s)
<!-- Push a branch with the same name in each downstream repository and create a build in Jenkins. -->
<!-- Add the Jenkins build link(s) below: -->
* [caf/ux-aspects-micro-focus](https://jenkins.swinfra.net/job/SEPG/job/caf/job/caf~ux-aspects-micro-focus~EL-3940-remove-hpe-icons~CI/)
