### PR TITLE
EL-3960 - Split Button Dropdown: rework example to use ux-menu

### DIFF
--- a/docs/app/data/components-page.json
+++ b/docs/app/data/components-page.json
@@ -105,7 +105,7 @@
                     "usage": [
                         {
                             "title": "Selector",
-                            "content": "ux-menu, [uxMenuItem], [uxMenuTriggerFor], [uxMenuParent]"
+                            "content": "ux-menu, [uxMenuItem], [uxMenuTriggerFor]"
                         },
                         {
                             "title": "Module",

--- a/docs/app/pages/components/components-sections/buttons/dropdowns/dropdowns.component.html
+++ b/docs/app/pages/components/components-sections/buttons/dropdowns/dropdowns.component.html
@@ -219,6 +219,9 @@
     <tr uxd-api-property name="disabled" type="boolean">
         Define if this trigger is disabled.
     </tr>
+    <tr uxd-api-property name="uxMenuParent" type="ElementRef">
+        Optionally define the menu's parent element. See the <a routerLink="." fragment="split-button-dropdowns">Split Button Dropdown</a> documentation for an example.
+    </tr>
 </uxd-api-properties>
 
 <uxd-api-properties tableTitle="Menu Trigger Directive Methods">

--- a/docs/app/pages/components/components-sections/buttons/split-button-dropdowns/snippets/app.microfocus.html
+++ b/docs/app/pages/components/components-sections/buttons/split-button-dropdowns/snippets/app.microfocus.html
@@ -9,7 +9,7 @@
         [uxMenuTriggerFor]="menu"
         [uxMenuParent]="parent">
 
-        <ux-icon name="down"></ux-icon>
+        <ux-icon name="chevron-down"></ux-icon>
     </button>
 
 </div>

--- a/docs/app/pages/components/components-sections/buttons/split-button-dropdowns/split-button-dropdowns.component.html
+++ b/docs/app/pages/components/components-sections/buttons/split-button-dropdowns/split-button-dropdowns.component.html
@@ -9,7 +9,7 @@
         [uxMenuTriggerFor]="menu"
         [uxMenuParent]="parent">
 
-        <ux-icon name="down"></ux-icon>
+        <ux-icon [name]="toggleIcon"></ux-icon>
     </button>
 
 </div>

--- a/docs/app/pages/components/components-sections/buttons/split-button-dropdowns/split-button-dropdowns.component.ts
+++ b/docs/app/pages/components/components-sections/buttons/split-button-dropdowns/split-button-dropdowns.component.ts
@@ -27,6 +27,8 @@ export class ComponentsSplitButtonDropdownsComponent extends BaseDocumentationSe
         ]
     };
 
+    toggleIcon = this._documentationType === DocumentationType.MicroFocus ? 'chevron-down' : 'down';
+
     constructor(@Inject(DOCUMENTATION_TOKEN) private _documentationType: DocumentationType) {
         super(require.context('./snippets/', false, /\.(html|css|js|ts)$/));
 


### PR DESCRIPTION
#### Checklist
<!-- Use an 'x' to check those which apply. -->
* [x] The contents of this PR are mine to submit. No third party code or other material is being committed.
* [x] New third party dependencies (if any) are linked via `package.json`. Third party dependencies are licensed under one of the following: Apache, MIT, BSD, Mozilla Public License, Eclipse Public License, or Oracle Binary Code License.
* [x] The code in this PR does not contain export-restricted encryption algorithms.

#### Ticket / Issue
<!-- Either a Jira URL or a description of the issue that this PR addresses. -->
https://portal.digitalsafe.net/browse/EL-3960

#### Description of Proposed Changes
<!-- Describe what was changed and how it addresses the original issue. -->
- Document `uxMenuParent` input
- Ensure the appropriate icon is displayed within the documentation

#### Documentation CI URL
<!-- Initiate a build at https://jenkins.swinfra.net/job/SEPG/view/Templates/job/New%20SEPG%20Build/build -->
<!-- Append the branch name to the following URL: -->
https://pages.github.houston.softwaregrp.net/sepg-docs-qa/UXAspects_CI_UXAspects_EL-3960-split-button-dropdown2

#### Downstream Build(s)
<!-- Push a branch with the same name in each downstream repository and create a build in Jenkins. -->
<!-- Add the Jenkins build link(s) below: -->
* [caf/ux-aspects-micro-focus](https://jenkins.swinfra.net/job/SEPG/job/caf/job/caf~ux-aspects-micro-focus~EL-3960-split-button-dropdown2~CI/)
