### PR TITLE
EL-3956 - Marquee wizard resetVisitedOnValidationError setting

### DIFF
--- a/docs/app/pages/components/components-sections/wizard/marquee-wizard/marquee-wizard.component.html
+++ b/docs/app/pages/components/components-sections/wizard/marquee-wizard/marquee-wizard.component.html
@@ -303,6 +303,9 @@
     <tr uxd-api-property name="disableNextWhenInvalid" type="boolean">
         If set to <code>true</code> the 'Next' or 'Finish' button will become disabled when the current step is invalid.
     </tr>
+    <tr uxd-api-property name="resetVisitedOnValidationError" type="boolean" defaultValue="true">
+        Whether to set <code>visited</code> to <code>false</code> on subsequent steps after a validation fault.
+    </tr>
     <tr uxd-api-property name="resizable" type="boolean" defaultValue="false">
         If set to
         <code>true</code> there will be a resizable splitter between the side panel and main content of

--- a/src/components/marquee-wizard/marquee-wizard.component.spec.ts
+++ b/src/components/marquee-wizard/marquee-wizard.component.spec.ts
@@ -64,6 +64,8 @@ export class MarqueeWizardComponent {
         }
     ];
 
+    resetVisitedOnValidationError = true;
+
     /**
      * Close the modal and reset everything
      */
@@ -272,4 +274,107 @@ describe('Marquee wizard with delayed step creation', () => {
         fixture.detectChanges();
         await fixture.whenStable();
     }
+});
+
+@Component({
+    selector: 'marquee-wizard-validation-app',
+    template: `
+        <ux-marquee-wizard
+            [(step)]="currentStep"
+            [resetVisitedOnValidationError]="resetVisitedOnValidationError"
+        >
+            <ux-marquee-wizard-step
+                [(valid)]="step1Valid"
+                [(visited)]="step1Visited"
+                [(completed)]="step1Completed"
+            ></ux-marquee-wizard-step>
+            <ux-marquee-wizard-step
+                [(visited)]="step2Visited"
+                [(completed)]="step2Completed"
+            ></ux-marquee-wizard-step>
+        </ux-marquee-wizard>
+    `
+})
+export class MarqueeWizardValidationComponent {
+    currentStep: number;
+    resetVisitedOnValidationError = true;
+    step1Valid = true;
+    step1Visited: boolean;
+    step1Completed: boolean;
+    step2Visited: boolean;
+    step2Completed: boolean;
+}
+
+describe('Marquee wizard with validation', () => {
+    let component: MarqueeWizardValidationComponent;
+    let fixture: ComponentFixture<MarqueeWizardValidationComponent>;
+    let nativeElement: HTMLElement;
+
+    beforeEach(async () => {
+        TestBed.configureTestingModule({
+            imports: [MarqueeWizardModule],
+            declarations: [MarqueeWizardValidationComponent]
+        }).compileComponents();
+    });
+
+    beforeEach(() => {
+        fixture = TestBed.createComponent(MarqueeWizardValidationComponent);
+        component = fixture.componentInstance;
+        nativeElement = fixture.nativeElement;
+        fixture.detectChanges();
+    });
+
+    it('should remove visited state from later steps when valid = false', async () => {
+        component.step1Visited = true;
+        component.step2Visited = true;
+        fixture.detectChanges();
+
+        expect(isStepValid(0)).toBe(true);
+        expect(isStepValid(1)).toBe(true);
+
+        expect(isStepVisited(0)).toBe(true);
+        expect(isStepVisited(1)).toBe(true);
+
+        component.step1Valid = false;
+        fixture.detectChanges();
+
+        expect(isStepValid(0)).toBe(false);
+        expect(isStepValid(1)).toBe(true);
+
+        expect(isStepVisited(0)).toBe(true);
+        expect(isStepVisited(1)).toBe(false);
+    });
+
+    it('should not remove visited state from later steps when valid = false and resetVisitedOnValidationError = false', async () => {
+        component.resetVisitedOnValidationError = false;
+        component.step1Visited = true;
+        component.step2Visited = true;
+        fixture.detectChanges();
+
+        expect(isStepValid(0)).toBe(true);
+        expect(isStepValid(1)).toBe(true);
+
+        expect(isStepVisited(0)).toBe(true);
+        expect(isStepVisited(1)).toBe(true);
+
+        component.step1Valid = false;
+        fixture.detectChanges();
+
+        expect(isStepValid(0)).toBe(false);
+        expect(isStepValid(1)).toBe(true);
+
+        expect(isStepVisited(0)).toBe(true);
+        expect(isStepVisited(1)).toBe(true);
+    });
+
+    function isStepVisited(index: number): boolean {
+        const stepElements = nativeElement.querySelectorAll('.marquee-wizard-step');
+        return stepElements[index].classList.contains('visited');
+    }
+
+    function isStepValid(index: number): boolean {
+        const stepElements = nativeElement.querySelectorAll('.marquee-wizard-step');
+        return !stepElements[index].classList.contains('invalid');
+    }
+
 });

--- a/src/components/marquee-wizard/marquee-wizard.component.ts
+++ b/src/components/marquee-wizard/marquee-wizard.component.ts
@@ -29,6 +29,9 @@ export class MarqueeWizardComponent extends WizardComponent implements OnDestroy
     /** If set to true the resizable splitter will be enabled and set to the default width **/
     @Input() resizable: boolean = false;
 
+    /** Whether to set `visited` to false on subsequent steps after a validation fault. */
+    @Input() resetVisitedOnValidationError: boolean = true;
+
     /** Emit the current width of the splitter*/
     @Output() sidePanelWidthChange = new EventEmitter<number>();
 
@@ -126,7 +129,7 @@ export class MarqueeWizardComponent extends WizardComponent implements OnDestroy
             step.completed = false;
 
             // if the step is not the current step then also mark it as unvisited
-            if (step !== state.step) {
+            if (this.resetVisitedOnValidationError && step !== state.step) {
                 step.visited = false;
             }
         });


### PR DESCRIPTION
#### Checklist
<!-- Use an 'x' to check those which apply. -->
* [x] The contents of this PR are mine to submit. No third party code or other material is being committed.
* [x] New third party dependencies (if any) are linked via `package.json`. Third party dependencies are licensed under one of the following: Apache, MIT, BSD, Mozilla Public License, Eclipse Public License, or Oracle Binary Code License.
* [x] The code in this PR does not contain export-restricted encryption algorithms.

#### Ticket / Issue
<!-- Either a Jira URL or a description of the issue that this PR addresses. -->
https://portal.digitalsafe.net/browse/EL-3956

#### Description of Proposed Changes
<!-- Describe what was changed and how it addresses the original issue. -->
* Add `resetVisitedOnValidationError` input, which can be used to prevent automatic setting of `visited`.

#### Documentation CI URL
<!-- Initiate a build at https://jenkins.swinfra.net/job/SEPG/view/Templates/job/New%20SEPG%20Build/build -->
<!-- Append the branch name to the following URL: -->
https://pages.github.houston.softwaregrp.net/sepg-docs-qa/UXAspects_CI_UXAspects_EL-3956-prevent-visited-change-on-validation

#### Downstream Build(s)
<!-- Push a branch with the same name in each downstream repository and create a build in Jenkins. -->
<!-- Add the Jenkins build link(s) below: -->
* [caf/ux-aspects-micro-focus](https://jenkins.swinfra.net/job/SEPG/job/caf/job/caf~ux-aspects-micro-focus~EL-3956-prevent-visited-change-on-validation~CI/)
