### PR TITLE
Prevent scrolling though page affecting number pickers

### DIFF
--- a/docs/app/pages/components/components-sections/input-controls/number-picker/number-picker.component.html
+++ b/docs/app/pages/components/components-sections/input-controls/number-picker/number-picker.component.html
@@ -19,7 +19,7 @@
 <p>
     The <code>ux-number-picker</code> component provides a way in which users can easily select a number value from a specified
     range by clicking the up and down buttons, using the up/down arrow keys or by using the mouse wheel while hovering over
-    the control.
+    the control once it has focus.
 </p>
 
 <p>The number picker behavior can be customized by using the following attributes:</p>

--- a/src/components/number-picker/number-picker.component.spec.ts
+++ b/src/components/number-picker/number-picker.component.spec.ts
@@ -319,6 +319,67 @@ describe('Number Picker Component - FormGroup', () => {
             expect(component.form.controls.integer.value).toBe(99999998.9);
         });
     });
+
+    describe('on scroll', () => {
+        it('should not change the value if the picker has not been focused', async () => {
+            component.form.controls.integer.setValue(0);
+            fixture.detectChanges();
+            await fixture.whenStable();
+
+            input1.dispatchEvent(new WheelEvent('wheel', { deltaY: 5 }));
+            fixture.detectChanges();
+            await fixture.whenStable();
+            expect(input1.value).toBe('0');
+
+            input1.dispatchEvent(new WheelEvent('wheel', { deltaY: -5 }));
+            fixture.detectChanges();
+            await fixture.whenStable();
+            expect(input1.value).toBe('0');
+        });
+        it('should change the value if the picker is focused', async () => {
+            component.form.controls.integer.setValue(0);
+            fixture.detectChanges();
+            await fixture.whenStable();
+
+            await input1.focus();
+            fixture.detectChanges();
+            await fixture.whenStable();
+            debugger;
+
+            input1.dispatchEvent(new WheelEvent('wheel', { deltaY: 5 }));
+            fixture.detectChanges();
+            await fixture.whenStable();
+            expect(input1.value).toBe('-1');
+
+            input1.dispatchEvent(new WheelEvent('wheel', { deltaY: -5 }));
+            fixture.detectChanges();
+            await fixture.whenStable();
+            expect(input1.value).toBe('0');
+        });
+        it('should stop changing the value if the picker is blured', async () => {
+            component.form.controls.integer.setValue(0);
+            fixture.detectChanges();
+            await fixture.whenStable();
+
+            input1.focus();
+            fixture.detectChanges();
+            await fixture.whenStable();
+
+            input1.dispatchEvent(new WheelEvent('wheel', { deltaY: 5 }));
+            fixture.detectChanges();
+            await fixture.whenStable();
+            expect(input1.value).toBe('-1');
+
+            input1.blur();
+            fixture.detectChanges();
+            await fixture.whenStable();
+
+            input1.dispatchEvent(new WheelEvent('wheel', { deltaY: -5 }));
+            fixture.detectChanges();
+            await fixture.whenStable();
+            expect(input1.value).toBe('-1');
+        });
+    });
 });
 
 @Component({

--- a/src/components/number-picker/number-picker.component.ts
+++ b/src/components/number-picker/number-picker.component.ts
@@ -1,5 +1,5 @@
 import { coerceBooleanProperty, coerceNumberProperty } from '@angular/cdk/coercion';
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, EventEmitter, forwardRef, Input, OnChanges, OnDestroy, Optional, Output } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, EventEmitter, forwardRef, HostListener, Input, OnChanges, OnDestroy, Optional, Output } from '@angular/core';
 import { ControlValueAccessor, FormGroupDirective, NG_VALUE_ACCESSOR } from '@angular/forms';
 
 let uniqueId = 0;
@@ -26,9 +26,10 @@ export class NumberPickerComponent implements ControlValueAccessor, OnDestroy, O
     private _disabled: boolean = false;
     private _value: number = 0;
     private _lastValue: number;
-    private _propagateChange = (_: number) => {};
-    _touchedChange = () => {};
+    private _focused: boolean = false;
 
+    private _propagateChange = (_: number) => { };
+    _touchedChange = () => { };
 
     /** Sets the id of the number picker. The child input will have this value with a -input suffix as its id. */
     @Input() id: string = `ux-number-picker-${uniqueId++}`;
@@ -164,6 +165,9 @@ export class NumberPickerComponent implements ControlValueAccessor, OnDestroy, O
     }
 
     onScroll(event: WheelEvent): void {
+        if (!this._focused) {
+            return;
+        }
         // get the distance scrolled
         const scrollValue = event.deltaY || (event as any).wheelDelta;
 
@@ -205,6 +209,15 @@ export class NumberPickerComponent implements ControlValueAccessor, OnDestroy, O
         this._lastValue = value;
         this.valueChange.emit(value);
         this._propagateChange(value);
+    }
+
+    @HostListener('focusin')
+    onFocusIn(): void {
+        this._focused = true;
+    }
+    @HostListener('focusout')
+    onFocusOut(): void {
+        this._focused = false;
     }
 }
 


### PR DESCRIPTION
#### Checklist
<!-- Use an 'x' to check those which apply. -->
* [x] The contents of this PR are mine to submit. No third party code or other material is being committed.
* [x] New third party dependencies (if any) are linked via `package.json`. Third party dependencies are licensed under one of the following: Apache, MIT, BSD, Mozilla Public License, Eclipse Public License, or Oracle Binary Code License.
* [x] The code in this PR does not contain export-restricted encryption algorithms.

#### Ticket / Issue
Scrolling though a page can cause accidental changes to the values of number pickers.

#### Description of Proposed Changes
Number pickers now  only change values when scrolled if they have focus

#### Documentation CI URL
Do not have access to Jenkins

#### Downstream Build(s)
Do not have access to Jenkins
