### PR TITLE
EL-4012 - Marquee Wizard: initial step not visible when loading steps after initialization

### DIFF
--- a/src/components/marquee-wizard/marquee-wizard.component.spec.ts
+++ b/src/components/marquee-wizard/marquee-wizard.component.spec.ts
@@ -202,7 +202,7 @@ describe('Marquee wizard with delayed step creation', () => {
         fixture.detectChanges();
     });
 
-    fit('should update steps after delay', fakeAsync(async () => {
+    it('should update steps after delay', fakeAsync(async () => {
         let steps = getSteps();
         expect(steps.length).toBe(0);
 

--- a/src/components/marquee-wizard/marquee-wizard.component.spec.ts
+++ b/src/components/marquee-wizard/marquee-wizard.component.spec.ts
@@ -202,7 +202,7 @@ describe('Marquee wizard with delayed step creation', () => {
         fixture.detectChanges();
     });
 
-    it('should update steps after delay', fakeAsync(async () => {
+    fit('should update steps after delay', fakeAsync(async () => {
         let steps = getSteps();
         expect(steps.length).toBe(0);
 
@@ -220,6 +220,7 @@ describe('Marquee wizard with delayed step creation', () => {
         ).toBe('Second Step');
 
         expect(component.step).toBe(0);
+        expect(getContentText()).toContain('Content of first step');
     }));
 
     it('should navigate to the second step after delay', fakeAsync(async () => {
@@ -247,7 +248,11 @@ describe('Marquee wizard with delayed step creation', () => {
 
     async function whenStepsLoaded(): Promise<void> {
         tick(200);
+        fixture.detectChanges();
         await fixture.whenStable();
+
+        // tick() operator requires a second round of change detection
+        fixture.detectChanges();
     }
 
     function getSteps(): NodeListOf<HTMLUListElement> {

--- a/src/components/wizard/wizard.component.ts
+++ b/src/components/wizard/wizard.component.ts
@@ -1,4 +1,4 @@
-import { Component, ContentChild, ContentChildren, EventEmitter, Input, OnDestroy, OnInit, Output, QueryList, TemplateRef } from '@angular/core';
+import { AfterContentInit, Component, ContentChild, ContentChildren, EventEmitter, Input, OnDestroy, OnInit, Output, QueryList, TemplateRef } from '@angular/core';
 import { Subject } from 'rxjs';
 import { filter, takeUntil } from 'rxjs/operators';
 import { tick } from '../../common/index';
@@ -15,7 +15,7 @@ let uniqueId: number = 0;
         '[class]': 'orientation'
     }
 })
-export class WizardComponent implements OnInit, OnDestroy {
+export class WizardComponent implements OnInit, AfterContentInit, OnDestroy {
 
     /** Defines whether or not the wizard should be displayed in a `horizontal` or `vertical` layout. */
     @Input() orientation: 'horizontal' | 'vertical' = 'horizontal';
@@ -161,9 +161,6 @@ export class WizardComponent implements OnInit, OnDestroy {
         // initially set the correct visibility of the steps
         setTimeout(this.update.bind(this));
 
-        // if the steps change then update the ids
-        this.steps.changes.pipe(tick(), takeUntil(this._onDestroy)).subscribe(() => this.update());
-
         // watch for changes to valid subject
         this._wizardService.validChange$.pipe(
             filter((event: WizardValidEvent<WizardStepComponent>) => !event.valid),
@@ -171,6 +168,9 @@ export class WizardComponent implements OnInit, OnDestroy {
         ).subscribe((event: WizardValidEvent<WizardStepComponent>) => this.setFutureStepsUnvisited(event.step));
     }
 
+    ngAfterContentInit(): void {
+        this.steps.changes.pipe(tick(), takeUntil(this._onDestroy)).subscribe(this.update.bind(this));
+    }
 
     ngOnDestroy(): void {
         this._onDestroy.next();


### PR DESCRIPTION
#### Checklist
<!-- Use an 'x' to check those which apply. -->
* [x] The contents of this PR are mine to submit. No third party code or other material is being committed.
* [x] New third party dependencies (if any) are linked via `package.json`. Third party dependencies are licensed under one of the following: Apache, MIT, BSD, Mozilla Public License, Eclipse Public License, or Oracle Binary Code License.
* [x] The code in this PR does not contain export-restricted encryption algorithms.

#### Ticket / Issue
<!-- Either a Jira URL or a description of the issue that this PR addresses. -->
https://portal.digitalsafe.net/browse/EL-4012

#### Description of Proposed Changes
<!-- Describe what was changed and how it addresses the original issue. -->
Move the subscription to `steps` back into the `ngAfterContentInit` handler. See Jira ticket for the repro plunker example.

#### Documentation CI URL
<!-- Initiate a build at https://jenkins.swinfra.net/job/SEPG/view/Templates/job/New%20SEPG%20Build/build -->
<!-- Append the branch name to the following URL: -->
https://pages.github.houston.softwaregrp.net/sepg-docs-qa/UXAspects_CI_UXAspects_EL-4012-marquee-wizard-fix

#### Downstream Build(s)
<!-- Push a branch with the same name in each downstream repository and create a build in Jenkins. -->
<!-- Add the Jenkins build link(s) below: -->
* [caf/ux-aspects-micro-focus](https://jenkins.swinfra.net/job/SEPG/job/caf/job/caf~ux-aspects-micro-focus~EL-4012-marquee-wizard-fix~CI/)
