### PR TITLE
EL-4010 - Dashboard: cannot move additional widgets after initial move

### DIFF
--- a/e2e/tests/components/dashboard/dashboard.e2e-spec.ts
+++ b/e2e/tests/components/dashboard/dashboard.e2e-spec.ts
@@ -173,6 +173,34 @@ describe('Dashboard Tests', () => {
 
     });
 
+    it('should allow subsequent widgets to be moved', async () => {
+
+        const layoutMock =  [{ id: 'analytics-1-widget', col: 0, row: 2, colSpan: 4, rowSpan: 2},
+                             { id: 'subscription-widget', col: 2, row: 1, colSpan: 2, rowSpan: 1},
+                             { id: 'users-widget', col: 2, row: 0, colSpan: 1, rowSpan: 1},
+                             { id: 'alert-widget', col: 3, row: 0, colSpan: 1, rowSpan: 1}];
+
+        // drag widget1 down
+        await browser.actions().dragAndDrop(widget1, { x: 0, y: 250 }).perform();
+
+        // drag widget2 down and right
+        await browser.actions().dragAndDrop(widget2, { x: 500, y: 250 }).perform();
+
+        expect(await page.getWidgetLocationValue(widget1, 'top')).toBe(440, 'widget1 top');
+        expect(await page.getWidgetLocationValue(widget1, 'left')).toBe(0, 'widget1 left');
+
+        expect(await page.getWidgetLocationValue(widget2, 'top')).toBe(220, 'widget2 top');
+        expect(await page.getWidgetLocationValue(widget2, 'left')).toBe(554, 'widget2 left');
+
+        expect(await page.getWidgetLocationValue(widget3, 'top')).toBe(0, 'widget3 top');
+        expect(await page.getWidgetLocationValue(widget3, 'left')).toBe(554, 'widget3 left');
+
+        expect(await page.getWidgetLocationValue(widget4, 'top')).toBe(0, 'widget4 top');
+        expect(await page.getWidgetLocationValue(widget4, 'left')).toBe(831, 'widget4 left');
+
+        expect(JSON.parse(await page.getLayoutOutput())).toEqual(layoutMock);
+    });
+
     it('should manage focus of the grab handles', async () => {
 
         // Set focus to the element before the dashboard

--- a/src/components/dashboard/dashboard.component.ts
+++ b/src/components/dashboard/dashboard.component.ts
@@ -1,4 +1,4 @@
-import { AfterViewInit, ChangeDetectionStrategy, Component, ContentChildren, ElementRef, EventEmitter, HostBinding, Input, OnDestroy, OnChanges, Output, QueryList, ViewChild, ChangeDetectorRef } from '@angular/core';
+import { AfterContentInit, AfterViewInit, ChangeDetectionStrategy, ChangeDetectorRef, Component, ContentChildren, ElementRef, EventEmitter, HostBinding, Input, OnChanges, OnDestroy, Output, QueryList, ViewChild } from '@angular/core';
 import { Subject } from 'rxjs';
 import { map, takeUntil, tap } from 'rxjs/operators';
 import { ResizeDimensions } from '../../directives/resize/resize.service';
@@ -16,7 +16,7 @@ import { DashboardWidgetComponent } from './widget/dashboard-widget.component';
         DashboardGrabHandleService
     ]
 })
-export class DashboardComponent implements AfterViewInit, OnDestroy, OnChanges {
+export class DashboardComponent implements AfterViewInit, AfterContentInit, OnDestroy, OnChanges {
 
     isGrabbing: boolean = false;
 
@@ -65,6 +65,10 @@ export class DashboardComponent implements AfterViewInit, OnDestroy, OnChanges {
     ngAfterViewInit(): void {
         // set the initial dimensions
         this.dashboardService.setDimensions(this.dashboardElement.nativeElement.offsetWidth, this.dashboardElement.nativeElement.offsetHeight);
+    }
+
+    ngAfterContentInit(): void {
+        this.dashboardService.initialized$.next(true);
     }
 
     ngOnChanges(): void {

--- a/src/components/dashboard/dashboard.spec.ts
+++ b/src/components/dashboard/dashboard.spec.ts
@@ -203,20 +203,20 @@ describe('Dashboard with initial layout', () => {
 
         expect(layoutChangeSpy).not.toHaveBeenCalled();
 
-        expect(component.widgets.toArray()[0].getColumn()).toBe(0, 'run-widget 0 column');
-        expect(component.widgets.toArray()[0].getRow()).toBe(0, 'run-widget 0 row');
-        expect(component.widgets.toArray()[0].getColumnSpan()).toBe(2, 'run-widget 2 columnSpan');
-        expect(component.widgets.toArray()[0].getRowSpan()).toBe(1, 'run-widget 1 RowSpan');
+        expect(component.widgets.toArray()[0].getColumn()).toBe(0, 'widget 0 column');
+        expect(component.widgets.toArray()[0].getRow()).toBe(0, 'widget 0 row');
+        expect(component.widgets.toArray()[0].getColumnSpan()).toBe(2, 'widget 0 columnSpan');
+        expect(component.widgets.toArray()[0].getRowSpan()).toBe(1, 'widget 0 rowSpan');
 
-        expect(component.widgets.toArray()[1].getColumn()).toBe(0, 'purpose-widget 0 column');
-        expect(component.widgets.toArray()[1].getRow()).toBe(2, 'purpose-widget 2 row');
-        expect(component.widgets.toArray()[1].getColumnSpan()).toBe(1, 'purpose-widget 1 columnSpan');
-        expect(component.widgets.toArray()[1].getRowSpan()).toBe(1, 'purpose-widget 1 RowSpan');
+        expect(component.widgets.toArray()[1].getColumn()).toBe(0, 'widget 1 column');
+        expect(component.widgets.toArray()[1].getRow()).toBe(2, 'widget 1 row');
+        expect(component.widgets.toArray()[1].getColumnSpan()).toBe(1, 'widget 1 columnSpan');
+        expect(component.widgets.toArray()[1].getRowSpan()).toBe(1, 'widget 1 rowSpan');
 
-        expect(component.widgets.toArray()[2].getColumn()).toBe(0, 'host-widget 0 column');
-        expect(component.widgets.toArray()[2].getRow()).toBe(3, 'host-widget 3 row');
-        expect(component.widgets.toArray()[2].getColumnSpan()).toBe(3, 'host-widget 3 columnSpan');
-        expect(component.widgets.toArray()[2].getRowSpan()).toBe(1, 'host-widget 1 RowSpan');
+        expect(component.widgets.toArray()[2].getColumn()).toBe(0, 'widget 2 column');
+        expect(component.widgets.toArray()[2].getRow()).toBe(3, 'widget 2 row');
+        expect(component.widgets.toArray()[2].getColumnSpan()).toBe(3, 'widget 2 columnSpan');
+        expect(component.widgets.toArray()[2].getRowSpan()).toBe(1, 'widget 2 rowSpan');
     });
 
     it('should update the layout when a new value is passed to the input', async () => {
@@ -231,20 +231,20 @@ describe('Dashboard with initial layout', () => {
 
         expect(layoutChangeSpy).not.toHaveBeenCalled();
 
-        expect(component.widgets.toArray()[0].getColumn()).toBe(0, 'run-widget 0 column');
-        expect(component.widgets.toArray()[0].getRow()).toBe(3, 'run-widget 3 row');
-        expect(component.widgets.toArray()[0].getColumnSpan()).toBe(3, 'run-widget 3 columnspan');
-        expect(component.widgets.toArray()[0].getRowSpan()).toBe(1, 'run-widget 1 rowspan');
+        expect(component.widgets.toArray()[0].getColumn()).toBe(0, 'widget 0 column');
+        expect(component.widgets.toArray()[0].getRow()).toBe(3, 'widget 0 row');
+        expect(component.widgets.toArray()[0].getColumnSpan()).toBe(3, 'widget 0 columnSpan');
+        expect(component.widgets.toArray()[0].getRowSpan()).toBe(1, 'widget 0 rowSpan');
 
-        expect(component.widgets.toArray()[1].getColumn()).toBe(0, 'purpose-widget 0 column');
-        expect(component.widgets.toArray()[1].getRow()).toBe(0, 'purpose-widget 0 row');
-        expect(component.widgets.toArray()[1].getColumnSpan()).toBe(2, 'purpose-widget 2 columnSpan');
-        expect(component.widgets.toArray()[1].getRowSpan()).toBe(1, 'purpose-widget 1 rowspan');
+        expect(component.widgets.toArray()[1].getColumn()).toBe(0, 'widget 1 column');
+        expect(component.widgets.toArray()[1].getRow()).toBe(0, 'widget 1 row');
+        expect(component.widgets.toArray()[1].getColumnSpan()).toBe(2, 'widget 1 columnSpan');
+        expect(component.widgets.toArray()[1].getRowSpan()).toBe(1, 'widget 1 rowSpan');
 
-        expect(component.widgets.toArray()[2].getColumn()).toBe(0, 'host-widget 0 column');
-        expect(component.widgets.toArray()[2].getRow()).toBe(2, 'host-widget 2 row');
-        expect(component.widgets.toArray()[2].getColumnSpan()).toBe(1, 'host-widget 1 columnspan');
-        expect(component.widgets.toArray()[2].getRowSpan()).toBe(1, 'host-widget 1 rowspan');
+        expect(component.widgets.toArray()[2].getColumn()).toBe(0, 'widget 2 column');
+        expect(component.widgets.toArray()[2].getRow()).toBe(2, 'widget 2 row');
+        expect(component.widgets.toArray()[2].getColumnSpan()).toBe(1, 'widget 2 columnSpan');
+        expect(component.widgets.toArray()[2].getRowSpan()).toBe(1, 'widget 2 rowSpan');
 
     });
 });


### PR DESCRIPTION
#### Checklist
<!-- Use an 'x' to check those which apply. -->
* [x] The contents of this PR are mine to submit. No third party code or other material is being committed.
* [x] New third party dependencies (if any) are linked via `package.json`. Third party dependencies are licensed under one of the following: Apache, MIT, BSD, Mozilla Public License, Eclipse Public License, or Oracle Binary Code License.
* [x] The code in this PR does not contain export-restricted encryption algorithms.

#### Ticket / Issue
<!-- Either a Jira URL or a description of the issue that this PR addresses. -->
https://portal.digitalsafe.net/browse/EL-4010

#### Description of Proposed Changes
<!-- Describe what was changed and how it addresses the original issue. -->
* Add initialized$ state to replace use of dimensions$ in the setLayoutData subscription.
* Add new e2e test including a second drag operation.
* Fixed some incorrect descriptions in a karma test.

#### Documentation CI URL
<!-- Initiate a build at https://jenkins.swinfra.net/job/SEPG/view/Templates/job/New%20SEPG%20Build/build -->
<!-- Append the branch name to the following URL: -->
https://pages.github.houston.softwaregrp.net/sepg-docs-qa/UXAspects_CI_UXAspects_EL-4010-dashboard-drag

#### Downstream Build(s)
<!-- Push a branch with the same name in each downstream repository and create a build in Jenkins. -->
<!-- Add the Jenkins build link(s) below: -->
* [caf/ux-aspects-micro-focus](https://jenkins.swinfra.net/job/SEPG/job/caf/job/caf~ux-aspects-micro-focus~EL-4010-dashboard-drag~CI/)
