### PR TITLE
EL-4023 - Fix another tree grid performance issue

### DIFF
--- a/docs/app/pages/components/components-sections/tree-view/tree-grid/snippets/app.html
+++ b/docs/app/pages/components/components-sections/tree-view/tree-grid/snippets/app.html
@@ -5,7 +5,7 @@
             aria-multiselectable="true"
             class="table table-hover"
             [uxTreeGrid]="items"
-            [(rows)]="rows">
+            (rowsChange)="rows = $event">
             <thead>
                 <tr class="treegrid-header table-header-dark">
                     <th>
@@ -96,7 +96,7 @@
             aria-multiselectable="true"
             class="table table-hover"
             [uxTreeGrid]="asyncItems"
-            [(rows)]="asyncRows"
+            (rowsChange)="asyncRows = $event"
             [loadChildren]="loadChildrenFn">
             <thead>
                 <tr class="treegrid-header table-header-dark">

--- a/docs/app/pages/components/components-sections/tree-view/tree-grid/tree-grid.component.html
+++ b/docs/app/pages/components/components-sections/tree-view/tree-grid/tree-grid.component.html
@@ -5,7 +5,7 @@
             aria-multiselectable="true"
             class="table table-hover"
             [uxTreeGrid]="items"
-            [(rows)]="rows">
+            (rowsChange)="rows = $event">
             <thead>
                 <tr class="treegrid-header table-header-dark">
                     <th>
@@ -96,7 +96,7 @@
             aria-multiselectable="true"
             class="table table-hover"
             [uxTreeGrid]="asyncItems"
-            [(rows)]="asyncRows"
+            (rowsChange)="asyncRows = $event"
             [loadChildren]="loadChildrenFn">
             <thead>
                 <tr class="treegrid-header table-header-dark">
@@ -205,11 +205,9 @@
         The items to display in the tree grid.
         See below for details of the <code>TreeGridItem</code> interface.
     </tr>
-    <tr uxd-api-property name="rows" type="TreeGridItem[]" [required]="true">
-        The visible rows to render in the table.
-        This is a two-way binding property which is managed by the directive.
-        Use this array in combination with the <code>ngFor</code> directive to populate the table rows, after applying
-        any required filtering.
+    <tr uxd-api-property name="rows" type="TreeGridItem[]">
+        <strong>Deprecated:</strong> This input will be removed in the next major release.
+        Use <code>(rowsChange)="rows = $event"</code> instead.
     </tr>
     <tr uxd-api-property name="loadChildren" type="(parent: TreeGridItem) => TreeGridItem[] | Promise<TreeGridItem[]> | Observable<TreeGridItem[]>">
         <p>
@@ -226,8 +224,8 @@
 
 <uxd-api-properties tableTitle="Outputs">
     <tr uxd-api-property name="rowsChange" type="TreeGridItem[]">
-        Emitted when the <code>rows</code> array changes.
-        This happens when the <code>uxTreeGrid</code> input array is changed.
+        Provides an array of the currently visible rows, based on the expanded/collapsed states.
+        Bind this array to an <code>ngFor</code> directive to populate the table rows, after applying any required filtering.
     </tr>
 </uxd-api-properties>
 
@@ -238,8 +236,8 @@
 <uxd-api-properties tableTitle="Inputs">
     <tr uxd-api-property name="uxTreeGridRow" type="TreeGridItem" [required]="true">
         The item that the row displays.
-        This should be a member of the <code>rows</code> array emitted by the <code>uxTreeGrid</code> directive, which
-        manages the visible rows and their states.
+        This should be a member of the array emitted by the <code>rowsChange</code> output of the
+        <code>uxTreeGrid</code> directive, which manages the visible rows and their states.
     </tr>
     <tr uxd-api-property name="canExpand" type="boolean">
         Whether the row can expand or not.

--- a/src/directives/tree-grid/tree-grid-row.directive.ts
+++ b/src/directives/tree-grid/tree-grid-row.directive.ts
@@ -1,7 +1,7 @@
+import { coerceBooleanProperty } from '@angular/cdk/coercion';
 import { ChangeDetectorRef, Directive, EventEmitter, HostBinding, HostListener, Input, OnDestroy, OnInit, Output } from '@angular/core';
-import { BehaviorSubject, Subject } from 'rxjs';
-import { distinctUntilChanged, takeUntil } from 'rxjs/operators';
-import { tick } from '../../common/operators/tick.operator';
+import { Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
 import { TreeGridItem } from './tree-grid-item.interface';
 import { TreeGridService } from './tree-grid.service';
 
@@ -21,11 +21,15 @@ export class TreeGridRowDirective implements OnInit, OnDestroy {
     canExpand: boolean;
 
     @Input()
-    set expanded(expanded: boolean) {
-        this._expanded$.next(!!expanded);
+    set expanded(value: boolean) {
+        const expanded = coerceBooleanProperty(value);
+        if (expanded !== this._expanded) {
+            this._treeGridService.setExpanded(this.item, expanded);
+            this._expanded = expanded;
+        }
     }
     get expanded(): boolean {
-        return this._expanded$.getValue();
+        return this._expanded;
     }
 
     @Output()
@@ -35,18 +39,18 @@ export class TreeGridRowDirective implements OnInit, OnDestroy {
     loading: boolean = false;
 
     @HostBinding('class.treegrid-row-expanded')
-    isExpanded: boolean = false;
-
-    private _expanded$ = new BehaviorSubject(false);
+    private _expanded = false;
 
     private _onDestroy = new Subject<void>();
 
     constructor(changeDetector: ChangeDetectorRef, private _treeGridService: TreeGridService) {
-        this._expanded$.pipe(distinctUntilChanged(), tick(), takeUntil(this._onDestroy)).subscribe(expanded => {
-            this._treeGridService.setExpanded(this.item, expanded);
-            this.isExpanded = expanded;
-            changeDetector.detectChanges();
-        });
+        // this._expanded$.pipe(distinctUntilChanged(), tick(), takeUntil(this._onDestroy)).subscribe(expanded => {
+        //     if (expanded !== this.isExpanded) {
+        //         this._treeGridService.setExpanded(this.item, expanded);
+        //         this.isExpanded = expanded;
+        //         changeDetector.detectChanges();
+        //     }
+        // });
     }
 
     ngOnInit(): void {

--- a/src/directives/tree-grid/tree-grid-row.directive.ts
+++ b/src/directives/tree-grid/tree-grid-row.directive.ts
@@ -1,5 +1,5 @@
 import { coerceBooleanProperty } from '@angular/cdk/coercion';
-import { ChangeDetectorRef, Directive, EventEmitter, HostBinding, HostListener, Input, OnDestroy, OnInit, Output } from '@angular/core';
+import { Directive, EventEmitter, HostBinding, HostListener, Input, OnDestroy, OnInit, Output } from '@angular/core';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 import { TreeGridItem } from './tree-grid-item.interface';
@@ -21,6 +21,7 @@ export class TreeGridRowDirective implements OnInit, OnDestroy {
     canExpand: boolean;
 
     @Input()
+    @HostBinding('class.treegrid-row-expanded')
     set expanded(value: boolean) {
         const expanded = coerceBooleanProperty(value);
         if (expanded !== this._expanded) {
@@ -38,20 +39,11 @@ export class TreeGridRowDirective implements OnInit, OnDestroy {
     @HostBinding('class.treegrid-row-loading')
     loading: boolean = false;
 
-    @HostBinding('class.treegrid-row-expanded')
     private _expanded = false;
 
     private _onDestroy = new Subject<void>();
 
-    constructor(changeDetector: ChangeDetectorRef, private _treeGridService: TreeGridService) {
-        // this._expanded$.pipe(distinctUntilChanged(), tick(), takeUntil(this._onDestroy)).subscribe(expanded => {
-        //     if (expanded !== this.isExpanded) {
-        //         this._treeGridService.setExpanded(this.item, expanded);
-        //         this.isExpanded = expanded;
-        //         changeDetector.detectChanges();
-        //     }
-        // });
-    }
+    constructor(private _treeGridService: TreeGridService) { }
 
     ngOnInit(): void {
 

--- a/src/directives/tree-grid/tree-grid-row.directive.ts
+++ b/src/directives/tree-grid/tree-grid-row.directive.ts
@@ -25,8 +25,8 @@ export class TreeGridRowDirective implements OnInit, OnDestroy {
     set expanded(value: boolean) {
         const expanded = coerceBooleanProperty(value);
         if (expanded !== this._expanded) {
-            this._treeGridService.setExpanded(this.item, expanded);
             this._expanded = expanded;
+            this._treeGridService.setExpanded(this.item, expanded);
         }
     }
     get expanded(): boolean {

--- a/src/directives/tree-grid/tree-grid.directive.ts
+++ b/src/directives/tree-grid/tree-grid.directive.ts
@@ -1,7 +1,6 @@
 import { Directive, EventEmitter, Input, OnDestroy, OnInit, Output } from '@angular/core';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
-import { tick } from '../../common/index';
 import { TreeGridItem } from './tree-grid-item.interface';
 import { TreeGridLoadFunction } from './tree-grid-load-function.type';
 import { TreeGridService } from './tree-grid.service';
@@ -35,7 +34,7 @@ export class TreeGridDirective implements OnInit, OnDestroy {
     constructor(private _treeGridService: TreeGridService) {}
 
     ngOnInit(): void {
-        this._treeGridService.rows$.pipe(tick(), takeUntil(this._onDestroy)).subscribe(rows => this.rowsChange.emit(rows));
+        this._treeGridService.rows$.pipe(takeUntil(this._onDestroy)).subscribe(rows => this.rowsChange.emit(rows));
     }
 
     ngOnDestroy(): void {

--- a/src/directives/tree-grid/tree-grid.directive.ts
+++ b/src/directives/tree-grid/tree-grid.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, EventEmitter, Input, OnDestroy, OnInit, Output } from '@angular/core';
+import { ChangeDetectorRef, Directive, EventEmitter, Input, OnDestroy, OnInit, Output } from '@angular/core';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 import { TreeGridItem } from './tree-grid-item.interface';
@@ -31,10 +31,18 @@ export class TreeGridDirective implements OnInit, OnDestroy {
 
     private _onDestroy = new Subject<void>();
 
-    constructor(private _treeGridService: TreeGridService) {}
+    constructor(
+        private _changeDetector: ChangeDetectorRef,
+        private _treeGridService: TreeGridService
+    ) {}
 
     ngOnInit(): void {
-        this._treeGridService.rows$.pipe(takeUntil(this._onDestroy)).subscribe(rows => this.rowsChange.emit(rows));
+        this._treeGridService.rows$
+            .pipe(takeUntil(this._onDestroy))
+            .subscribe(rows => {
+                this.rowsChange.emit(rows);
+                this._changeDetector.detectChanges();
+            });
     }
 
     ngOnDestroy(): void {

--- a/src/directives/tree-grid/tree-grid.service.ts
+++ b/src/directives/tree-grid/tree-grid.service.ts
@@ -107,6 +107,8 @@ export class TreeGridService implements OnDestroy {
 
         rows.splice(index + 1, 0, ...childRows);
 
+        console.log(`insertChildren: ${parent['title']}`);
+
         this.rows$.next(rows);
     }
 
@@ -123,6 +125,8 @@ export class TreeGridService implements OnDestroy {
         while (index + 1 < rows.length && rows[index + 1].state.level > parent.state.level) {
             rows.splice(index + 1, 1);
         }
+
+        console.log(`removeChildren: ${parent['title']}`);
 
         this.rows$.next(rows);
     }

--- a/src/directives/tree-grid/tree-grid.service.ts
+++ b/src/directives/tree-grid/tree-grid.service.ts
@@ -107,8 +107,6 @@ export class TreeGridService implements OnDestroy {
 
         rows.splice(index + 1, 0, ...childRows);
 
-        console.log(`insertChildren: ${parent['title']}`);
-
         this.rows$.next(rows);
     }
 
@@ -125,8 +123,6 @@ export class TreeGridService implements OnDestroy {
         while (index + 1 < rows.length && rows[index + 1].state.level > parent.state.level) {
             rows.splice(index + 1, 1);
         }
-
-        console.log(`removeChildren: ${parent['title']}`);
 
         this.rows$.next(rows);
     }

--- a/src/directives/tree-grid/tree-grid.spec.ts
+++ b/src/directives/tree-grid/tree-grid.spec.ts
@@ -1,6 +1,6 @@
-import { Component, QueryList, ViewChildren } from '@angular/core';
-import { async, ComponentFixture, TestBed, fakeAsync, tick, flush } from '@angular/core/testing';
-import { TreeGridItem, TreeGridModule, TreeGridRowDirective } from './index';
+import { Component } from '@angular/core';
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { TreeGridItem, TreeGridModule } from './index';
 
 interface TreeGridTestItem extends TreeGridItem {
     title: string;
@@ -10,7 +10,7 @@ interface TreeGridTestItem extends TreeGridItem {
 @Component({
     selector: 'tree-grid-test',
     template: `
-        <table [uxTreeGrid]="items" [(rows)]="rows">
+        <table [uxTreeGrid]="items" (rowsChange)="rows = $event">
             <tr *ngFor="let row of rows"
                 [uxTreeGridRow]="row"
                 [canExpand]="true"

--- a/src/directives/tree-grid/tree-grid.spec.ts
+++ b/src/directives/tree-grid/tree-grid.spec.ts
@@ -29,7 +29,7 @@ export class TreeGridTestComponent {
     expandedChange(row: TreeGridTestItem, expanded: boolean): void {}
 }
 
-fdescribe('Tree Grid', () => {
+describe('Tree Grid', () => {
     let component: TreeGridTestComponent;
     let fixture: ComponentFixture<TreeGridTestComponent>;
     let nativeElement: HTMLElement;

--- a/src/directives/tree-grid/tree-grid.spec.ts
+++ b/src/directives/tree-grid/tree-grid.spec.ts
@@ -92,6 +92,19 @@ describe('Tree Grid', () => {
             expect(titles[2]).toBe('Root 2');
             expect(component.expandedChange).toHaveBeenCalledTimes(1);
         });
+
+        it('should insert child rows when expanded programmatically', async () => {
+            component.items[0].expanded = true;
+            fixture.detectChanges();
+            await fixture.whenStable();
+
+            const titles = getRowTitles();
+            expect(titles.length).toBe(3);
+            expect(titles[0]).toBe('Root 1');
+            expect(titles[1]).toBe('Node 1');
+            expect(titles[2]).toBe('Root 2');
+            expect(component.expandedChange).toHaveBeenCalledTimes(0);
+        });
     });
 
     describe('with pre-expanded rows', () => {
@@ -135,6 +148,17 @@ describe('Tree Grid', () => {
             expect(titles.length).toBe(1);
             expect(titles[0]).toBe('Root');
             expect(component.expandedChange).toHaveBeenCalledTimes(1);
+        });
+
+        it('should remove child rows when collapsed programmatically', async () => {
+            component.items[0].expanded = false;
+            fixture.detectChanges();
+            await fixture.whenStable();
+
+            const titles = getRowTitles();
+            expect(titles.length).toBe(1);
+            expect(titles[0]).toBe('Root');
+            expect(component.expandedChange).toHaveBeenCalledTimes(0);
         });
     });
 

--- a/src/directives/tree-grid/tree-grid.spec.ts
+++ b/src/directives/tree-grid/tree-grid.spec.ts
@@ -1,7 +1,6 @@
-import { Component, ViewChildren, QueryList } from '@angular/core';
+import { Component, QueryList, ViewChildren } from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { TreeGridItem, TreeGridModule } from './index';
-import { TreeGridRowDirective } from './tree-grid-row.directive';
+import { TreeGridItem, TreeGridModule, TreeGridRowDirective } from './index';
 
 interface TreeGridTestItem extends TreeGridItem {
     title: string;


### PR DESCRIPTION
#### Checklist
<!-- Use an 'x' to check those which apply. -->
* [x] The contents of this PR are mine to submit. No third party code or other material is being committed.
* [x] New third party dependencies (if any) are linked via `package.json`. Third party dependencies are licensed under one of the following: Apache, MIT, BSD, Mozilla Public License, Eclipse Public License, or Oracle Binary Code License.
* [x] The code in this PR does not contain export-restricted encryption algorithms.

#### Ticket / Issue
<!-- Either a Jira URL or a description of the issue that this PR addresses. -->
https://portal.digitalsafe.net/browse/EL-4023

#### Description of Proposed Changes
<!-- Describe what was changed and how it addresses the original issue. -->
This particular problem was caused by the `_expanded$` subscription being invoked for every row, even if the bound value was false. This also caused `rows$` to change as well. Since they both included tick operators, a lot of time was wasted on this.

* Replace `_expanded$` with equivalent code in the setter.
* Remove `tick` from the `rows$` subscription. This is a workaround for an ExpressionChanged error, which can be avoiding by not 2-way binding the `rows` input. (The `rows` input actually does nothing and was probably only implemented to enable the convenient template syntax.)
* Update documentation and example to use `rowsChange` instead of 2-way binding `rows`.
* Mark the `rows` input as deprecated.

#### Documentation CI URL
<!-- Initiate a build at https://jenkins.swinfra.net/job/SEPG/view/Templates/job/New%20SEPG%20Build/build -->
<!-- Append the branch name to the following URL: -->
https://pages.github.houston.softwaregrp.net/sepg-docs-qa/UXAspects_CI_UXAspects_EL-4023-treegrid-performance

#### Downstream Build(s)
<!-- Push a branch with the same name in each downstream repository and create a build in Jenkins. -->
<!-- Add the Jenkins build link(s) below: -->
* [caf/ux-aspects-micro-focus](https://jenkins.swinfra.net/job/SEPG/job/caf/job/caf~ux-aspects-micro-focus~EL-4023-treegrid-performance~CI/)
