### PR TITLE
EL-3959 - Date & Time Picker: incorrect date selected

### DIFF
--- a/e2e/tests/components/date-time-picker/date-time-picker.e2e-spec.ts
+++ b/e2e/tests/components/date-time-picker/date-time-picker.e2e-spec.ts
@@ -190,8 +190,12 @@ describe('Date Time Picker Tests', () => {
 
         // select 1st February
         date = await page.getDate('1', true);
-        await date.click();
 
-        expect(await page.getCurrentDate()).toBe('February 1, 2019, 12:00:00 PM');
+        if (await page.isClickable(date)) {
+            expect(await page.getCurrentDate()).toBe('February 1, 2019, 12:00:00 PM');
+        } else {
+            expect(await page.getCurrentDate()).toBe('January 31, 2019, 12:00:00 PM');
+        }
+
     });
 });

--- a/e2e/tests/components/date-time-picker/date-time-picker.e2e-spec.ts
+++ b/e2e/tests/components/date-time-picker/date-time-picker.e2e-spec.ts
@@ -182,4 +182,16 @@ describe('Date Time Picker Tests', () => {
         expect(await page.getDisabled(await page.getCalendarItem('2019'))).toBe(false);
 
     });
+
+    it('should correctly set the date when the current day value does not exist in the selected month', async () => {
+        // select 31st January
+        let date = await page.getDate('31');
+        await date.click();
+
+        // select 1st February
+        date = await page.getDate('1', true);
+        await date.click();
+
+        expect(await page.getCurrentDate()).toBe('February 1, 2019, 12:00:00 PM');
+    });
 });

--- a/e2e/tests/components/date-time-picker/date-time-picker.e2e-spec.ts
+++ b/e2e/tests/components/date-time-picker/date-time-picker.e2e-spec.ts
@@ -191,9 +191,11 @@ describe('Date Time Picker Tests', () => {
         // select 1st February
         date = await page.getDate('1', true);
 
-        if (await page.isClickable(date)) {
+        // Dates in the previous and next months are only visible within the open source theme
+        if (await page.attemptClick(date)) {
             expect(await page.getCurrentDate()).toBe('February 1, 2019, 12:00:00 PM');
         } else {
+            // Micro Focus theme does not display dates within the next month, so the 31st should still be selected
             expect(await page.getCurrentDate()).toBe('January 31, 2019, 12:00:00 PM');
         }
 

--- a/e2e/tests/components/date-time-picker/date-time-picker.po.spec.ts
+++ b/e2e/tests/components/date-time-picker/date-time-picker.po.spec.ts
@@ -70,7 +70,7 @@ export class DateTimePickerPage {
         }
     }
 
-    async isClickable(item: ElementFinder): Promise<boolean> {
+    async attemptClick(item: ElementFinder): Promise<boolean> {
         try {
             await item.click();
             return true;

--- a/e2e/tests/components/date-time-picker/date-time-picker.po.spec.ts
+++ b/e2e/tests/components/date-time-picker/date-time-picker.po.spec.ts
@@ -69,4 +69,13 @@ export class DateTimePickerPage {
             }
         }
     }
+
+    async isClickable(item: ElementFinder): Promise<boolean> {
+        try {
+            await item.click();
+            return true;
+        } catch {
+            return false;
+        }
+    }
 }

--- a/src/components/date-time-picker/date-time-picker.service.ts
+++ b/src/components/date-time-picker/date-time-picker.service.ts
@@ -104,8 +104,7 @@ export class DateTimePickerService implements OnDestroy {
         const date = new Date(this.selected$.value);
 
         date.setFullYear(year);
-        date.setMonth(month);
-        date.setDate(day);
+        date.setMonth(month, day);
 
         if (hours !== undefined) {
             date.setHours(hours);


### PR DESCRIPTION
#### Checklist
<!-- Use an 'x' to check those which apply. -->
* [x] The contents of this PR are mine to submit. No third party code or other material is being committed.
* [x] New third party dependencies (if any) are linked via `package.json`. Third party dependencies are licensed under one of the following: Apache, MIT, BSD, Mozilla Public License, Eclipse Public License, or Oracle Binary Code License.
* [x] The code in this PR does not contain export-restricted encryption algorithms.

#### Ticket / Issue
<!-- Either a Jira URL or a description of the issue that this PR addresses. -->
https://portal.digitalsafe.net/browse/EL-3959

#### Description of Proposed Changes
<!-- Describe what was changed and how it addresses the original issue. -->
- `Date`'s set date, month and year methods accept invalid values and will automatically correct them. In this case, setting the month value before the day can cause a month to be incorrectly skipped. Using `setMonth` with both month and day values ensures that the date is correctly set.

#### Documentation CI URL
<!-- Initiate a build at https://jenkins.swinfra.net/job/SEPG/view/Templates/job/New%20SEPG%20Build/build -->
<!-- Append the branch name to the following URL: -->
https://pages.github.houston.softwaregrp.net/sepg-docs-qa/UXAspects_CI_UXAspects_EL-3959-datepicker-incorrectdate

#### Downstream Build(s)
<!-- Push a branch with the same name in each downstream repository and create a build in Jenkins. -->
<!-- Add the Jenkins build link(s) below: -->
* [caf/ux-aspects-micro-focus](https://jenkins.swinfra.net/job/SEPG/job/caf/job/caf~ux-aspects-micro-focus~EL-3959-datepicker-incorrectdate~CI/)
