### PR TITLE
EL-3926 - Select Disabled Options

### DIFF
--- a/docs/app/pages/components/components-sections/input-controls/typeahead/typeahead.component.html
+++ b/docs/app/pages/components/components-sections/input-controls/typeahead/typeahead.component.html
@@ -150,7 +150,7 @@
         <ul>
             <li><code>option: T</code> - the string or custom object representing the option.</li>
             <li><code>api: TypeaheadOptionApi</code> - provides the functions <code>getKey</code>,
-                <code>getDisplay</code> and <code>getDisplayHtml</code>. See the section below for more
+                <code>getDisplay</code>, <code>getDisplayHtml</code> and <code>getDisabled</code>. See the section below for more
                 information.</li>
         </ul>
     </tr>
@@ -202,13 +202,16 @@
     <tr uxd-api-property name="getKey" args="option: T" returns="string">
         Returns the unique key value of the given <code>option</code>.
     </tr>
-    <tr uxd-api-property name="getDisplay" args="option: any" returns="string">
+    <tr uxd-api-property name="getDisplay" args="option: T" returns="string">
         Returns the display value of the given <code>option</code>.
     </tr>
     <tr uxd-api-property name="getDisplayHtml" args="option: T" returns="string">
         Returns the display value of the given <code>option</code> with HTML markup added to highlight
         the part which matches the current <code>filter</code> value. Override the
         <code>ux-filter-match</code> class in CSS to modify the default appearance.
+    </tr>
+    <tr uxd-api-property name="getDisabled" args="option: T" returns="boolean">
+        Returns the disabled state of the given <code>options</code>.
     </tr>
 </uxd-api-properties>
 

--- a/docs/app/pages/components/components-sections/input-controls/typeahead/typeahead.component.html
+++ b/docs/app/pages/components/components-sections/input-controls/typeahead/typeahead.component.html
@@ -211,7 +211,7 @@
         <code>ux-filter-match</code> class in CSS to modify the default appearance.
     </tr>
     <tr uxd-api-property name="getDisabled" args="option: T" returns="boolean">
-        Returns the disabled state of the given <code>options</code>.
+        Returns the disabled state of the given <code>option</code>.
     </tr>
 </uxd-api-properties>
 

--- a/docs/app/pages/components/components-sections/select/select/select.component.html
+++ b/docs/app/pages/components/components-sections/select/select/select.component.html
@@ -219,7 +219,7 @@
             <li><code>option: any</code> - the string or custom object representing the option.</li>
             <li>
                 <code>api: TypeaheadOptionApi</code> - provides the functions <code>getKey</code>,
-                <code>getDisplay</code> and <code>getDisplayHtml</code>.
+                <code>getDisplay</code>, <code>getDisplayHtml</code> and <code>getDisabled</code>.
                 See the <a routerLink="/components/input-controls" fragment="tags">typeahead</a> documentation for
                 details.
             </li>

--- a/e2e/tests/components/custom-facet/custom-facet.e2e-spec.ts
+++ b/e2e/tests/components/custom-facet/custom-facet.e2e-spec.ts
@@ -101,7 +101,7 @@ describe('Custom Facet Tests', () => {
         expect(await page.confirmIsChecked(2)).toBeFalsy();
     });
 
-    it('should allow deletion of all facets', async () => {
+    it('should allow deletion of all facets', () => {
 
         // Add all the facets
         page.getCheckbox(0).click();

--- a/e2e/tests/components/marquee-wizard/marquee-wizard.e2e-spec.ts
+++ b/e2e/tests/components/marquee-wizard/marquee-wizard.e2e-spec.ts
@@ -19,7 +19,7 @@ describe('Marquee Wizard Tests', () => {
         expect(await imageCompare('marquee-wizard-initial')).toEqual(0);
     });
 
-    it('should have steps with the correct titles', async () => {
+    it('should have steps with the correct titles', () => {
         // check that each header contains the correct text
         page.stepHeaders.each(async (step, idx) =>
             expect(await step.getText()).toBe(`Step ${idx + 1}`));

--- a/e2e/tests/components/tabbable-list/tabbable-list.po.spec.ts
+++ b/e2e/tests/components/tabbable-list/tabbable-list.po.spec.ts
@@ -35,23 +35,23 @@ export class TabbableListTestPageComponent {
 
     async clickOnRow(index: number): Promise<void> {
         const row = await this.getTableRow(index);
-        return await row.click();
+        return row.click();
     }
 
     async moveFocusDown(): Promise<void> {
-        browser.actions().sendKeys(Key.ARROW_DOWN).perform();
+        return browser.actions().sendKeys(Key.ARROW_DOWN).perform();
     }
 
     async moveFocusUp(): Promise<void> {
-        browser.actions().sendKeys(Key.ARROW_UP).perform();
+        return browser.actions().sendKeys(Key.ARROW_UP).perform();
     }
 
     async moveFocusHome(): Promise<void> {
-        browser.actions().sendKeys(Key.HOME).perform();
+        return browser.actions().sendKeys(Key.HOME).perform();
     }
 
     async moveFocusEnd(): Promise<void> {
-        browser.actions().sendKeys(Key.END).perform();
+        return browser.actions().sendKeys(Key.END).perform();
     }
 
     async toggleWrap(): Promise<void> {

--- a/src/components/dashboard/dashboard.spec.ts
+++ b/src/components/dashboard/dashboard.spec.ts
@@ -198,7 +198,7 @@ describe('Dashboard with initial layout', () => {
         await fixture.whenStable();
     });
 
-    it('should update the widgets correctly when an initial layout value is given', async () => {
+    it('should update the widgets correctly when an initial layout value is given', () => {
         // check that the underlying widgets receive the correct position and size values
 
         expect(layoutChangeSpy).not.toHaveBeenCalled();

--- a/src/components/facets/facet-check-list.component.spec.ts
+++ b/src/components/facets/facet-check-list.component.spec.ts
@@ -51,7 +51,7 @@ describe('Facet-Check-List', () => {
         expect(component).toBeTruthy();
     });
 
-    it('should propagate ids down to child components', async () => {
+    it('should propagate ids down to child components', () => {
         const checkListItem = nativeElement.querySelectorAll('ux-facet-check-list-item');
         const uxCheckbox = nativeElement.querySelectorAll('ux-facet-check-list-item ux-checkbox input');
 

--- a/src/components/hierarchy-bar/hierarchy-bar.component.spec.ts
+++ b/src/components/hierarchy-bar/hierarchy-bar.component.spec.ts
@@ -42,7 +42,7 @@ describe('Hierarchy Bar in collapsed mode', () => {
     let fixture: ComponentFixture<HierarchyBarCollapsedTestComponent>;
     let nativeElement: HTMLElement;
 
-    beforeEach(async () => {
+    beforeEach(() => {
         TestBed.configureTestingModule({
             imports: [HierarchyBarModule],
             declarations: [HierarchyBarCollapsedTestComponent]

--- a/src/components/marquee-wizard/marquee-wizard.component.spec.ts
+++ b/src/components/marquee-wizard/marquee-wizard.component.spec.ts
@@ -356,7 +356,7 @@ describe('Marquee wizard with validation', () => {
         fixture.detectChanges();
     });
 
-    it('should remove visited state from later steps when valid = false', async () => {
+    it('should remove visited state from later steps when valid = false',  () => {
         // 3 steps and number 2 gets set invalid - 1 should stay the same, 3 should be valid but no longer be visited
         component.step1Visited = true;
         component.step2Visited = true;
@@ -390,7 +390,7 @@ describe('Marquee wizard with validation', () => {
         expect(visitedChanged.calls.all().length).toBe(1);
     });
 
-    it('should not remove visited state from later steps when valid = false and resetVisitedOnValidationError = false', async () => {
+    it('should not remove visited state from later steps when valid = false and resetVisitedOnValidationError = false',  () => {
         component.resetVisitedOnValidationError = false;
         component.step1Visited = true;
         component.step2Visited = true;

--- a/src/components/number-picker/number-picker.component.spec.ts
+++ b/src/components/number-picker/number-picker.component.spec.ts
@@ -360,7 +360,6 @@ describe('Number Picker Component - FormGroup', () => {
             await input1.focus();
             fixture.detectChanges();
             await fixture.whenStable();
-            debugger;
 
             input1.dispatchEvent(new WheelEvent('wheel', { deltaY: 5 }));
             fixture.detectChanges();

--- a/src/components/number-picker/number-picker.component.spec.ts
+++ b/src/components/number-picker/number-picker.component.spec.ts
@@ -678,7 +678,7 @@ describe('Number Picker Component - value', () => {
         expect(numberPicker.classList.contains('ng-invalid')).toBe(false);
     });
 
-    it('should call the event emitter once per change', async () => {
+    it('should call the event emitter once per change', () => {
         const controlUp = nativeElement.querySelector<HTMLElement>('.number-picker-control-up');
 
         spyOn(component, 'onValueChange');

--- a/src/components/select/select.component.spec.ts
+++ b/src/components/select/select.component.spec.ts
@@ -248,27 +248,32 @@ describe('Select Component', () => {
         expect(component.value).toBe('One');
     });
 
-    it('should disable selected items when multiple = true', () => {
+    it('should disable selected options when multiple = true', () => {
         component.multiple = true;
         component.value = ['One'];
         fixture.detectChanges();
 
-        let typeaheadOptions = nativeElement.querySelectorAll<HTMLElement>('.ux-typeahead-options li');
+        const typeaheadOptions = nativeElement.querySelectorAll<HTMLElement>('.ux-typeahead-options li');
         expect(typeaheadOptions.item(0).classList).toContain('disabled');
         expect(typeaheadOptions.item(1).classList).not.toContain('disabled');
         expect(typeaheadOptions.item(2).classList).not.toContain('disabled');
+    });
 
+    it('should re-enabled options when they are deselected when multiple = true', () => {
+        component.multiple = true;
+        component.value = ['One'];
+        fixture.detectChanges();
         // remove the selected item and it should be re-enabled
         component.value = [];
         fixture.detectChanges();
 
-        typeaheadOptions = nativeElement.querySelectorAll<HTMLElement>('.ux-typeahead-options li');
+        const typeaheadOptions = nativeElement.querySelectorAll<HTMLElement>('.ux-typeahead-options li');
         expect(typeaheadOptions.item(0).classList).not.toContain('disabled');
         expect(typeaheadOptions.item(1).classList).not.toContain('disabled');
         expect(typeaheadOptions.item(2).classList).not.toContain('disabled');
     });
 
-    it('should not allow a disabled item to be selected when multiple = true', () => {
+    it('should not allow a disabled option to be selected when multiple = true', () => {
         component.multiple = true;
         component.value = ['One'];
         fixture.detectChanges();
@@ -276,14 +281,15 @@ describe('Select Component', () => {
         let tags = fixture.nativeElement.querySelectorAll('li.ux-tag');
         expect(tags.length).toBe(1);
 
-        const typeaheadOptions = nativeElement.querySelectorAll<HTMLElement>('.ux-typeahead-options li');
-        typeaheadOptions.item(0).click();
+        nativeElement.querySelectorAll<HTMLElement>('.ux-typeahead-options li')
+            .item(0)
+            .click();
 
         tags = fixture.nativeElement.querySelectorAll('li.ux-tag');
         expect(tags.length).toBe(1);
     });
 
-    it('should disable selected items when multiple = true and pagination is enabled', async () => {
+    it('should disable selected options when multiple = true and pagination is enabled', async () => {
         enablePagination();
         component.multiple = true;
         component.value = ['Option 1'];
@@ -291,23 +297,32 @@ describe('Select Component', () => {
         fixture.detectChanges();
         await fixture.whenStable();
 
-        let typeaheadOptions = nativeElement.querySelectorAll<HTMLElement>('.ux-typeahead-options li');
+        const typeaheadOptions = nativeElement.querySelectorAll<HTMLElement>('.ux-typeahead-options li');
 
         expect(typeaheadOptions.item(0).classList).not.toContain('disabled');
         expect(typeaheadOptions.item(1).classList).toContain('disabled');
         expect(typeaheadOptions.item(2).classList).not.toContain('disabled');
+    });
+
+    it('should re-enable options when they are deselected when multiple = true and pagination is enabled', async () => {
+        enablePagination();
+        component.multiple = true;
+        component.value = ['Option 1'];
+        component.dropdownOpen = true;
+        fixture.detectChanges();
+        await fixture.whenStable();
 
         // remove the selected item and it should be re-enabled
         component.value = [];
         fixture.detectChanges();
 
-        typeaheadOptions = nativeElement.querySelectorAll<HTMLElement>('.ux-typeahead-options li');
+        const typeaheadOptions = nativeElement.querySelectorAll<HTMLElement>('.ux-typeahead-options li');
         expect(typeaheadOptions.item(0).classList).not.toContain('disabled');
         expect(typeaheadOptions.item(1).classList).not.toContain('disabled');
         expect(typeaheadOptions.item(2).classList).not.toContain('disabled');
     });
 
-    it('should not allow a disabled item to be selected when multiple = true and pagination is enabled', async () => {
+    it('should not allow a disabled option to be selected when multiple = true and pagination is enabled', async () => {
         enablePagination();
         component.multiple = true;
         component.value = ['Option 1'];
@@ -318,8 +333,10 @@ describe('Select Component', () => {
         let tags = fixture.nativeElement.querySelectorAll('li.ux-tag');
         expect(tags.length).toBe(1);
 
-        const typeaheadOptions = nativeElement.querySelectorAll<HTMLElement>('.ux-typeahead-options li');
-        typeaheadOptions.item(1).click();
+        nativeElement.querySelectorAll<HTMLElement>('.ux-typeahead-options li')
+            .item(1)
+            .click();
+
         fixture.detectChanges();
 
         tags = fixture.nativeElement.querySelectorAll('li.ux-tag');
@@ -846,7 +863,7 @@ describe('Select with recent options', () => {
         expect(component.recentOptions[0]).toBe('One');
     });
 
-    it('should disable selected recent options when multiple = true', async () => {
+    it('should disable selected recent options when multiple = true', () => {
         component.multiple = true;
         component.value = ['One'];
         component.recentOptions = ['One', 'Two'];
@@ -857,7 +874,7 @@ describe('Select with recent options', () => {
         expect(recentOptionListItems.item(1).classList).not.toContain('disabled');
     });
 
-    it('should not be able to select a recent option that is currently selected when multiple = true', async () => {
+    it('should not be able to select a recent option that is currently selected when multiple = true', () => {
         component.multiple = true;
         component.value = ['One'];
         component.recentOptions = ['One', 'Two'];

--- a/src/components/side-panel/side-panel.component.spec.ts
+++ b/src/components/side-panel/side-panel.component.spec.ts
@@ -75,7 +75,7 @@ describe('Side Panel Component', () => {
         fixture.detectChanges();
     });
 
-    it('should open the side panel on load when open is set to true initially', async () => {
+    it('should open the side panel on load when open is set to true initially', () => {
         // set up a spy for the onToggleChange function
         spyOn(component, 'onToggleChange');
 
@@ -102,7 +102,7 @@ describe('Side Panel Component', () => {
 
     });
 
-    it('should emit event on closing side panel', async () => {
+    it('should emit event on closing side panel',  () => {
         // find the toggle button
         const toggleButton: HTMLElement = nativeElement.querySelector('.ux-panel-toggle');
         expect(toggleButton).toBeTruthy();
@@ -140,7 +140,7 @@ describe('Side Panel Component', () => {
 
     });
 
-    it('should not close side panel when [closeOnEscape] is set to false and "esc" key is pressed', async () => {
+    it('should not close side panel when [closeOnEscape] is set to false and "esc" key is pressed',  () => {
         // check closeOnEscape is set to true (as is default)
         expect(component.closeOnEscape).toBeTruthy();
 

--- a/src/components/table/column-picker/column-picker.component.spec.ts
+++ b/src/components/table/column-picker/column-picker.component.spec.ts
@@ -54,7 +54,7 @@ describe('Column Picker Component', () => {
         fixture.detectChanges();
     });
 
-    it('should display the correct number of deselected columns', async () => {
+    it('should display the correct number of deselected columns',  () => {
         expect(component.deselected.length).toEqual(4);
         const deselected = nativeElement.querySelector('.column-picker-list').querySelectorAll('.column-picker-list-item').length;
         expect(deselected).toEqual(4);
@@ -78,7 +78,7 @@ describe('Column Picker Component', () => {
         expect(component.deselected[0]).toEqual({ group: 'Metadata', name: 'Department' });
     });
 
-    it('should display the correct number of selected columns', async () => {
+    it('should display the correct number of selected columns',  () => {
         const numberOfSelectedColumns = nativeElement.querySelectorAll('.column-picker-stats')[1];
         expect(numberOfSelectedColumns.textContent.trim()).toEqual('3 columns added');
     });

--- a/src/components/tabset/tabset.component.spec.ts
+++ b/src/components/tabset/tabset.component.spec.ts
@@ -106,7 +106,7 @@ describe('Tabset Component', () => {
         expect(activeChangeSpy.calls.allArgs()).toEqual([['Schedule', false], ['Solution', true]]);
     });
 
-    it('should change to new tab when tab is programmatically selected by tab index', fakeAsync(async () => {
+    it('should change to new tab when tab is programmatically selected by tab index', fakeAsync(() => {
 
         const tab1 = getTabItem(0);
         const tab3 = getTabItem(2);

--- a/src/components/tooltip/tooltip.directive.spec.ts
+++ b/src/components/tooltip/tooltip.directive.spec.ts
@@ -80,7 +80,7 @@ describe('Tooltip Directive', () => {
         expect((component.showTrigger as any)._showTimeoutId).toBeFalsy();
     }));
 
-    it('should not show tooltip when tooltip is disabled', fakeAsync(async () => {
+    it('should not show tooltip when tooltip is disabled', fakeAsync(() => {
         component.tooltipDirective.disabled = true;
         component.tooltipDirective.show();
         tick(0);
@@ -109,7 +109,7 @@ describe('Tooltip Directive', () => {
         expect(getTooltipContent()).toBe('Tooltip content here');
     }));
 
-    it('should show allow open state to be controlled via the isOpen input', fakeAsync(async () => {
+    it('should show allow open state to be controlled via the isOpen input', fakeAsync(() => {
         component.isOpen = true;
         fixture.detectChanges();
 

--- a/src/components/typeahead/typeahead-option-api.ts
+++ b/src/components/typeahead/typeahead-option-api.ts
@@ -14,4 +14,8 @@ export interface TypeaheadOptionApi<T = any> {
      * Returns the display value of the given option with HTML markup added to highlight the part which matches the current filter value. Override the ux-filter-match class in CSS to modify the default appearance.
      */
     getDisplayHtml(option: T): string;
+    /**
+     * Returns the disabled state of a given option.
+     */
+    getDisabled(option: T): boolean;
 }

--- a/src/components/typeahead/typeahead-options-list.component.html
+++ b/src/components/typeahead/typeahead-options-list.component.html
@@ -1,11 +1,11 @@
 <ol>
 
-    <li *ngFor="let option of options; let i = index"
+    <li *ngFor="let option of options; let i = index; trackBy: trackByFn"
         [attr.id]="id + '-option-' + (i + startIndex)"
-        [class.disabled]="option.isDisabled"
+        [class.disabled]="optionApi.getDisabled(option.value)"
         [class.highlighted]="highlighted?.key === option.key && highlighted?.isRecentOption === option.isRecentOption"
         [class.active]="activeKey === option.key && !option.isRecentOption"
-        [attr.aria-selected]="isMultiselectable ? option.isDisabled : (activeKey === option.key ? true : null)"
+        [attr.aria-selected]="isMultiselectable ? optionApi.getDisabled(option.value) : (activeKey === option.key ? true : null)"
         [uxTypeaheadHighlight]="highlighted?.key === option.key && highlighted?.isRecentOption === option.isRecentOption"
         [uxScrollIntoViewIf]="highlighted?.key === option.key && highlighted?.isRecentOption === option.isRecentOption"
         [scrollParent]="typeaheadElement.nativeElement"

--- a/src/components/typeahead/typeahead-options-list.component.ts
+++ b/src/components/typeahead/typeahead-options-list.component.ts
@@ -38,20 +38,23 @@ export class TypeaheadOptionsListComponent<T> {
     optionApi: TypeaheadOptionApi;
 
     @Input()
-    typeaheadElement: ElementRef<any>;
+    typeaheadElement: ElementRef<HTMLElement>;
 
     @Output()
-    optionMouseover = new EventEmitter<TypeaheadOptionDomEvent<T>>();
+    optionMouseover = new EventEmitter<TypeaheadOptionDomEvent<T, MouseEvent>>();
 
     @Output()
-    optionMousedown = new EventEmitter<TypeaheadOptionDomEvent<T>>();
+    optionMousedown = new EventEmitter<TypeaheadOptionDomEvent<T, MouseEvent>>();
 
     @Output()
-    optionClick = new EventEmitter<TypeaheadOptionDomEvent<T>>();
+    optionClick = new EventEmitter<TypeaheadOptionDomEvent<T, MouseEvent>>();
 
+    trackByFn(_: number, option: TypeaheadVisibleOption<T>): string {
+        return option.key;
+    }
 }
 
-export interface TypeaheadOptionDomEvent<T> {
+export interface TypeaheadOptionDomEvent<T, E extends Event> {
     option: TypeaheadVisibleOption<T>;
-    event: Event;
+    event: E;
 }

--- a/src/components/typeahead/typeahead-visible-option.ts
+++ b/src/components/typeahead/typeahead-visible-option.ts
@@ -1,6 +1,5 @@
 export interface TypeaheadVisibleOption<T = any> {
     value: T;
     key: string;
-    isDisabled: boolean;
     isRecentOption?: boolean;
 }

--- a/src/components/typeahead/typeahead.component.ts
+++ b/src/components/typeahead/typeahead.component.ts
@@ -145,7 +145,8 @@ export class TypeaheadComponent<T = any> implements OnChanges, OnDestroy {
     optionApi: TypeaheadOptionApi<T> = {
         getKey: this.getKey.bind(this),
         getDisplay: this.getDisplay.bind(this),
-        getDisplayHtml: this.getDisplayHtml.bind(this)
+        getDisplayHtml: this.getDisplayHtml.bind(this),
+        getDisabled: this.isDisabled.bind(this)
     };
 
     constructor(
@@ -334,7 +335,7 @@ export class TypeaheadComponent<T = any> implements OnChanges, OnDestroy {
                 .toLowerCase()
                 .indexOf(this.filter.toLowerCase());
             if (matchIndex >= 0) {
-                var highlight = `<span class="ux-filter-match">${displayText.substr(matchIndex, length)}</span>`;
+                const highlight = `<span class="ux-filter-match">${ displayText.substr(matchIndex, length) }</span>`;
                 displayHtml =
                     displayText.substr(0, matchIndex) +
                     highlight +
@@ -355,7 +356,7 @@ export class TypeaheadComponent<T = any> implements OnChanges, OnDestroy {
      * Selects the given option, emitting the optionSelected event and closing the dropdown.
      */
     select(option: TypeaheadVisibleOption<T>, origin?: FocusOrigin): void {
-        if (!option.isDisabled) {
+        if (!this.isDisabled(option.value)) {
             this.optionSelected.emit(
                 new TypeaheadOptionEvent(option.value, origin)
             );
@@ -382,20 +383,14 @@ export class TypeaheadComponent<T = any> implements OnChanges, OnDestroy {
      * Returns true if the given option is part of the disabledOptions array.
      */
     isDisabled(option: T): boolean {
-        if (this.disabledOptions && Array.isArray(this.disabledOptions)) {
-            const result = this.disabledOptions.find(selectedOption => {
-                return this.getKey(selectedOption) === this.getKey(option);
-            });
-            return result !== undefined;
-        }
-        return false;
+        return this.disabledOptions?.some(selectedOption => this.getKey(selectedOption) === this.getKey(option)) ?? false;
     }
 
     /**
      * Set the given option as the current highlighted option, available in the highlightedOption parameter.
      */
     highlight(option: TypeaheadVisibleOption<T>): void {
-        if (!option.isDisabled) {
+        if (!this.isDisabled(option.value)) {
             this.highlighted$.next(option);
             this._changeDetector.detectChanges();
         }
@@ -413,7 +408,7 @@ export class TypeaheadComponent<T = any> implements OnChanges, OnDestroy {
         do {
             newIndex = newIndex + d;
             inBounds = newIndex >= 0 && newIndex < this.allVisibleOptions.length;
-            disabled = inBounds && this.allVisibleOptions[newIndex].isDisabled;
+            disabled = inBounds && this.isDisabled(this.allVisibleOptions[newIndex].value);
         } while (inBounds && disabled);
 
         if (!disabled && inBounds) {
@@ -482,7 +477,6 @@ export class TypeaheadComponent<T = any> implements OnChanges, OnDestroy {
                 .map(value => ({
                     value: value,
                     key: this.getKey(value),
-                    isDisabled: this.isDisabled(value),
                     isRecentOption: isRecentOptions
                 }));
         }

--- a/src/components/typeahead/typeahead.component.ts
+++ b/src/components/typeahead/typeahead.component.ts
@@ -52,7 +52,7 @@ export class TypeaheadComponent<T = any> implements OnChanges, OnDestroy {
     @Input() key: (option: T) => string | string;
 
     /** Specify which options are disabled */
-    @Input() disabledOptions: T[];
+    @Input() disabledOptions: T | T[];
 
     /** Specify the drop direction */
     @Input() dropDirection: 'auto' | 'up' | 'down' = 'down';
@@ -305,7 +305,7 @@ export class TypeaheadComponent<T = any> implements OnChanges, OnDestroy {
     /**
      * Returns the display value of the given option.
      */
-    getDisplay(option: T): string {
+    getDisplay(option: T): string | undefined {
         if (typeof this.display === 'function') {
             return this.display(option);
         }
@@ -324,11 +324,18 @@ export class TypeaheadComponent<T = any> implements OnChanges, OnDestroy {
      * @param option
      */
     getDisplayHtml(option: T): string {
-        const displayText = this.getDisplay(option)
+        const displayText = this.getDisplay(option);
+
+        // getDisplay may return undefined in certain cases
+        if (!displayText) {
+            return '';
+        }
+
+        let displayHtml = displayText
             .replace(/&/g, '&amp;')
             .replace(/</g, '&lt;')
             .replace(/>/g, '&gt;');
-        let displayHtml = displayText;
+
         if (this.filter) {
             const length = this.filter.length;
             const matchIndex = displayText
@@ -383,7 +390,8 @@ export class TypeaheadComponent<T = any> implements OnChanges, OnDestroy {
      * Returns true if the given option is part of the disabledOptions array.
      */
     isDisabled(option: T): boolean {
-        return this.disabledOptions?.some(selectedOption => this.getKey(selectedOption) === this.getKey(option)) ?? false;
+        return Array.isArray(this.disabledOptions) ?
+            this.disabledOptions.some(selectedOption => this.getKey(selectedOption) === this.getKey(option)) : false;
     }
 
     /**

--- a/src/components/wizard/wizard.component.spec.ts
+++ b/src/components/wizard/wizard.component.spec.ts
@@ -320,7 +320,7 @@ describe('Wizard with validation', () => {
         fixture.detectChanges();
     });
 
-    it('should remove visited state from later steps when valid = false', async () => {
+    it('should remove visited state from later steps when valid = false', () => {
         // has to be set manually as false as default
         component.resetVisitedOnValidationError = true;
 
@@ -357,7 +357,7 @@ describe('Wizard with validation', () => {
         expect(visitedChanged.calls.all().length).toBe(1);
     });
 
-    it('should not remove visited state from later steps when valid = false and resetVisitedOnValidationError = false', async () => {
+    it('should not remove visited state from later steps when valid = false and resetVisitedOnValidationError = false', () => {
         component.resetVisitedOnValidationError = false;
         component.step1Visited = true;
         component.step2Visited = true;

--- a/src/directives/badge/badge.spec.ts
+++ b/src/directives/badge/badge.spec.ts
@@ -41,7 +41,7 @@ describe('Badge', () => {
     let fixture: ComponentFixture<BadgeTestComponent>;
     let nativeElement: HTMLElement;
 
-    beforeEach(async () => {
+    beforeEach(() => {
         TestBed.configureTestingModule({
             imports: [BadgeModule],
             providers: [ContrastService, ColorService],

--- a/src/directives/infinite-scroll/infinite-scroll.component.spec.ts
+++ b/src/directives/infinite-scroll/infinite-scroll.component.spec.ts
@@ -41,8 +41,7 @@ describe('Directive - Infinite Scroll', () => {
         fixture.detectChanges();
     });
 
-    it ('should initially call load with filter value of "" if filter input value is undefined', async() => {
-
+    it ('should initially call load with filter value of "" if filter input value is undefined', () => {
         expect(loadSpy).toHaveBeenCalledWith(0, 20, '');
         expect(loadSpy).toHaveBeenCalledTimes(1);
     });

--- a/tslint.json
+++ b/tslint.json
@@ -22,6 +22,7 @@
     "no-bitwise": true,
     "no-shadowed-variable": true,
     "no-unused-expression": true,
+    "no-async-without-await": true,
     "import-blacklist": [
       true,
       "rxjs/Rx"


### PR DESCRIPTION
#### Checklist
<!-- Use an 'x' to check those which apply. -->
* [x] The contents of this PR are mine to submit. No third party code or other material is being committed.
* [x] New third party dependencies (if any) are linked via `package.json`. Third party dependencies are licensed under one of the following: Apache, MIT, BSD, Mozilla Public License, Eclipse Public License, or Oracle Binary Code License.
* [x] The code in this PR does not contain export-restricted encryption algorithms.

#### Ticket / Issue
<!-- Either a Jira URL or a description of the issue that this PR addresses. -->
https://portal.digitalsafe.net/browse/EL-3926

#### Description of Proposed Changes
<!-- Describe what was changed and how it addresses the original issue. -->
Previously the disabled property was added to the item objects in the typeahead themselves, this meant having to update them any time selection changed etc... This was hard when using paging as the infinite scroll directive keeps these items in memory too, so they could further get out of sync. It also meant there was a function on the class to check if it something was disabled and a property on the item to store the disabled state and they could return different results if they are out of sync.

The typeahead also accepted an input called `disabledOptions` which was documented but was never used by the typeahead so was technically broken. I have removed this internal isDisabled property on each item and instead updated to use the `disabledOptions` input. As this is separate from the items this is no longer an issue with the infinite scroll directive and there now is only one way to check the disabled state ensuring they remain in sync.

- Updated documentation
- Added tests
- Fixed some typing issues
- Fixed a case where we assumed an object was defined when it might not be (occurred when switching from `object` types to `string`.
- Updated TSLint config to allow Angular type coercion static properties, e.g. `ngAcceptInputType_disabled`
- Removed `debugger` left in tests
- Removed a lot of unused code in `Typeahead` test

#### Documentation CI URL
<!-- Initiate a build at https://jenkins.swinfra.net/job/SEPG/view/Templates/job/New%20SEPG%20Build/build -->
<!-- Append the branch name to the following URL: -->
https://pages.github.houston.softwaregrp.net/sepg-docs-qa/UXAspects_CI_UXAspects_EL-3926-Select-Disabled-Options

#### Downstream Build(s)
<!-- Push a branch with the same name in each downstream repository and create a build in Jenkins. -->
<!-- Add the Jenkins build link(s) below: -->
* [caf/ux-aspects-micro-focus](https://jenkins.swinfra.net/job/SEPG/job/caf/job/caf~ux-aspects-micro-focus~EL-3926-Select-Disabled-Options~CI/)
