### PR TITLE
EL-4061 - Tag Input Focus Out

### DIFF
--- a/e2e/pages/app/typeahead/typeahead.testpage.component.ts
+++ b/e2e/pages/app/typeahead/typeahead.testpage.component.ts
@@ -31,8 +31,7 @@ export class TypeaheadTestPageComponent {
         const values = this.values.filter(tag => tag.toLowerCase().indexOf(filter.toLowerCase()) !== -1)
             .slice(pageNum * pageSize, (pageNum + 1) * pageSize);
 
-        // return the values after a delay to simulate server response time
-        return of(values).pipe(delay(1000)).toPromise();
+        return new Promise(resolve => resolve(values));
     }
 
     constructor(public typeaheadKeyService: TypeaheadKeyService<string>) {

--- a/e2e/tests/components/typeahead/typeahead.e2e-spec.ts
+++ b/e2e/tests/components/typeahead/typeahead.e2e-spec.ts
@@ -54,4 +54,21 @@ describe('TypeaheadPage Tests', () => {
         expect(await imageCompare('typeahead-drop-direction-auto-down')).toEqual(0);
     });
 
+    it('should maintain input focus whenever the typeahead is scrolled', async () => {
+        await page.typeaheadInput.click();
+        await page.dragTypeaheadScrollBar(50);
+        expect(await page.isInputFocused()).toBe(true);
+    });
+
+    /**
+     * Test Covering Chrome Bug Workaround: (https://bugs.chromium.org/p/chromium/issues/detail?id=6759)
+     */
+    it('should maintain input focus whenever the typeahead is scrolled inside a tabbable container', async () => {
+        await page.setFormTabIndex(0);
+        expect(await page.form.getAttribute('tabindex')).toBe('0');
+        await page.typeaheadInput.click();
+        await page.dragTypeaheadScrollBar(50);
+        expect(await page.isInputFocused()).toBe(true);
+    });
+
 });

--- a/e2e/tests/components/typeahead/typeahead.po.spec.ts
+++ b/e2e/tests/components/typeahead/typeahead.po.spec.ts
@@ -2,6 +2,7 @@ import { browser, by, element } from 'protractor';
 
 export class TypeaheadPage {
 
+    form = element(by.tagName('form'));
     typeaheadInput = element(by.id('typeahead-input'));
     radioDirection = element(by.id('radio1'));
     maxHeight = element(by.id('max-height'));
@@ -15,27 +16,47 @@ export class TypeaheadPage {
     }
 
     async clickOnDropDirectionUp() {
-        return await this.radioDirection.$('ux-radio-button[option="up"]').$('.ux-radio-button').click();
+        return this.radioDirection.$('ux-radio-button[option="up"]').$('.ux-radio-button').click();
     }
 
     async clickOnDropDirectionDown() {
-        return await this.radioDirection.$('ux-radio-button[option="down"]').$('.ux-radio-button').click();
+        return this.radioDirection.$('ux-radio-button[option="down"]').$('.ux-radio-button').click();
     }
 
     async clickOnMaxHeight() {
-        return await this.maxHeight.click();
+        return this.maxHeight.click();
     }
 
     async clickOnMaxHeightDecrease() {
-        return await this.maxHeightDecrease.click();
+        return this.maxHeightDecrease.click();
     }
 
     async getTypeaheadClass(): Promise<string> {
-        return await this.typeahead.getAttribute('class');
+        return this.typeahead.getAttribute('class');
     }
 
     async getTypeaheadOptionListClass(): Promise<string> {
-        return await this.typeaheadOptions.getAttribute('class');
+        return this.typeaheadOptions.getAttribute('class');
+    }
+
+    async dragTypeaheadScrollBar(delta: number): Promise<void> {
+        const size = await this.typeahead.getSize();
+
+        await browser.actions()
+            .mouseMove(this.typeahead, { x: size.width - 10, y: 30 })
+            .mouseDown()
+            .mouseMove({ x: 0, y: delta })
+            .mouseUp()
+            .perform();
+    }
+
+    async isInputFocused(): Promise<boolean> {
+        const activeElement = await browser.driver.switchTo().activeElement();
+        return this.typeaheadInput.equals(activeElement);
+    }
+
+    async setFormTabIndex(index: number): Promise<void> {
+        await browser.executeScript(`arguments[0].setAttribute('tabindex', '${ index }')`, this.form);
     }
 
 }

--- a/src/components/select/select.component.ts
+++ b/src/components/select/select.component.ts
@@ -6,7 +6,7 @@ import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { BehaviorSubject, Observable, ReplaySubject, Subject } from 'rxjs';
 import { debounceTime, delay, distinctUntilChanged, filter, map, skip, take, takeUntil } from 'rxjs/operators';
 import { InfiniteScrollLoadFunction } from '../../directives/infinite-scroll/index';
-import { TagApi, TagInputComponent } from '../tag-input/index';
+import { TagInputComponent, TagTemplateContext } from '../tag-input/index';
 import { TypeaheadComponent, TypeaheadKeyService, TypeaheadOptionEvent } from '../typeahead/index';
 import { TypeaheadOptionContext } from '../typeahead/typeahead-option-context';
 
@@ -447,8 +447,3 @@ export class SelectComponent<T> implements OnInit, OnChanges, OnDestroy, Control
     }
 }
 
-export interface TagTemplateContext<T = string | any> {
-    tag: T;
-    index: number;
-    api: TagApi;
-}

--- a/src/components/tag-input/tag-input.component.ts
+++ b/src/components/tag-input/tag-input.component.ts
@@ -63,7 +63,7 @@ export class TagInputComponent<T = any> implements AfterContentInit, OnChanges, 
      * the option object as an argument, and should return the appropriate display value.
      * If the name of a property is provided as a string, that property is used as the display value.
      */
-    @Input() display: (option: T) => string | string;
+    @Input() display: TagInputDisplayFn<T> | string;
 
     /** Controls whether pasting text into the text input area automatically converts that text into one or more tags. */
     @Input() addOnPaste: boolean = true;
@@ -126,7 +126,7 @@ export class TagInputComponent<T = any> implements AfterContentInit, OnChanges, 
      * - `index: number` - the zero-based index of the tag as it appears in the tag input.
      * - `api: TagApi` - provides the functions getTagDisplay, removeTagAt and canRemoveTagAt.
      */
-    @Input() tagTemplate: TemplateRef<any>;
+    @Input() tagTemplate: TemplateRef<TagTemplateContext<T>>;
 
     /**
      * A function which returns either a string, string[], or Set<string>, compatible with the NgClass directive. The function receives the following parameters:
@@ -187,7 +187,7 @@ export class TagInputComponent<T = any> implements AfterContentInit, OnChanges, 
     /** Raised when a tag has been clicked. The `tag` property of the event contains the clicked tag. Call `preventDefault()` on the event to prevent the default behaviour of selecting the tag. */
     @Output() tagClick = new EventEmitter<TagInputEvent>();
 
-    // When clicking on the input during mutliple mode it will send a on touched event to the parent component
+    // When clicking on the input during multiple mode it will send a on touched event to the parent component
     @Output() inputFocus = new EventEmitter<FocusEvent>();
 
     @ContentChildren(TypeaheadComponent) typeaheadQuery: QueryList<TypeaheadComponent>;
@@ -388,7 +388,7 @@ export class TagInputComponent<T = any> implements AfterContentInit, OnChanges, 
 
         // If a click on the typeahead is in progress, don't do anything.
         // This works around an issue in IE where clicking a scrollbar drops focus.
-        if (this.typeahead && this.typeahead.clicking) {
+        if (this.typeahead?.clicking) {
             return;
         }
 
@@ -829,3 +829,11 @@ export interface TagApi<T = any> {
  * The function used to return custom class information, for use in `ngClass`.
  */
 export type TagClassFunction<T = any> = (tag: T, index: number, selected: boolean) => (string | string[] | Set<string>);
+
+export type TagInputDisplayFn<T> = (option: T) => string;
+
+export interface TagTemplateContext<T = string | any> {
+    tag: T;
+    index: number;
+    api: TagApi;
+}

--- a/src/components/tag-input/tag-input.component.ts
+++ b/src/components/tag-input/tag-input.component.ts
@@ -63,7 +63,7 @@ export class TagInputComponent<T = any> implements AfterContentInit, OnChanges, 
      * the option object as an argument, and should return the appropriate display value.
      * If the name of a property is provided as a string, that property is used as the display value.
      */
-    @Input() display: TagInputDisplayFn<T> | string;
+    @Input() display: TagInputDisplayFunction<T> | string;
 
     /** Controls whether pasting text into the text input area automatically converts that text into one or more tags. */
     @Input() addOnPaste: boolean = true;
@@ -830,7 +830,7 @@ export interface TagApi<T = any> {
  */
 export type TagClassFunction<T = any> = (tag: T, index: number, selected: boolean) => (string | string[] | Set<string>);
 
-export type TagInputDisplayFn<T> = (option: T) => string;
+export type TagInputDisplayFunction<T> = (option: T) => string;
 
 export interface TagTemplateContext<T = string | any> {
     tag: T;

--- a/src/components/typeahead/typeahead.component.ts
+++ b/src/components/typeahead/typeahead.component.ts
@@ -269,9 +269,23 @@ export class TypeaheadComponent<T = any> implements OnChanges, OnDestroy {
         this._popoverOrientationListener.destroy();
     }
 
-    @HostListener('mousedown')
-    mousedownHandler(): void {
+    @HostListener('mousedown', ['$event', '$event.target'])
+    mousedownHandler(event: MouseEvent, target: HTMLElement): void {
         this.clicking = true;
+
+        /**
+         * Chrome Bug Workaround: (https://bugs.chromium.org/p/chromium/issues/detail?id=6759)
+         * In Chrome, if the typeahead is within a tabbable element, e.g. it has a parent with
+         * `tabindex="0"` like our side panel has, then clicking on a scrollbar will remove
+         * focus from the input element.
+         *
+         * To avoid this we can determine if the mousedown event occurred within the scrollbar
+         * region of the typeahead and if so preventDefault which will stop the input
+         * from losing focus
+         */
+        if (event.clientX >= target.clientWidth || event.clientY >= target.clientHeight) {
+            event.preventDefault();
+        }
     }
 
     @HostListener('mouseup')


### PR DESCRIPTION
#### Checklist
<!-- Use an 'x' to check those which apply. -->
* [x] The contents of this PR are mine to submit. No third party code or other material is being committed.
* [x] New third party dependencies (if any) are linked via `package.json`. Third party dependencies are licensed under one of the following: Apache, MIT, BSD, Mozilla Public License, Eclipse Public License, or Oracle Binary Code License.
* [x] The code in this PR does not contain export-restricted encryption algorithms.

#### Ticket / Issue
<!-- Either a Jira URL or a description of the issue that this PR addresses. -->
https://portal.digitalsafe.net/browse/EL-4061

#### Description of Proposed Changes
<!-- Describe what was changed and how it addresses the original issue. -->
After some investigation the issue was slightly different than I think we initially suspected. Neither stopping propagation or creating a new output was the solution to the issue. 

The issue is caused by a Chrome bug, that will blur an input when a scrollbar is used if a parent element has a tabindex set. So the side panel is one potential cause as it has a tabindex="0", but really it could be any parent element.

The solution is to `preventDefault` if a mousedown event occurs within the scrollbar region of the typeahead.

Due to this, I couldn't find a way to add a test for this, as it requires the scroll to be performed using the mouse, its not standard behaviour that occurs whenever general scrolling happens, but if you have any suggestions I'm glad to try them out.

Additionally I improved some typing:
- The Tag template context was defined in select, but not in tag input, I have now changed this to provide correct context typing for both tag input and select.
- The `display` type was incorrect, it should have been a function that returns a string or a string, however due to slightly confusing typescript semantics it was checking only for a function the returned (string | string). So a string value was not correct. I have split the function into its own type to fix this.

#### Documentation CI URL
<!-- Initiate a build at https://jenkins.swinfra.net/job/SEPG/view/Templates/job/New%20SEPG%20Build/build -->
<!-- Append the branch name to the following URL: -->
https://pages.github.houston.softwaregrp.net/sepg-docs-qa/UXAspects_CI_UXAspects_EL-4061-Tag-Input-Focus-Out

#### Downstream Build(s)
<!-- Push a branch with the same name in each downstream repository and create a build in Jenkins. -->
<!-- Add the Jenkins build link(s) below: -->
* [caf/ux-aspects-micro-focus](https://jenkins.swinfra.net/job/SEPG/job/caf/job/caf~ux-aspects-micro-focus~EL-4061-Tag-Input-Focus-Out~CI/)
