### PR TITLE
EL-4101 - Wizard-steps-invalid

### DIFF
--- a/src/components/wizard/wizard.component.html
+++ b/src/components/wizard/wizard.component.html
@@ -11,7 +11,7 @@
             class="wizard-step"
             [class.active]="stp._active"
             [class.visited]="stp.visited"
-            [class.invalid]="!stp._valid"
+            [class.invalid]="!stp._valid && stp.visited"
             [attr.aria-posinset]="index + 1"
             [attr.aria-setsize]="steps.length"
             [attr.aria-selected]="stp._active"

--- a/src/components/wizard/wizard.component.spec.ts
+++ b/src/components/wizard/wizard.component.spec.ts
@@ -403,7 +403,7 @@ describe('Wizard with validation', () => {
 });
 
 @Component({
-    selector: 'marquee-wizard-validation-appearance',
+    selector: 'marquee-wizard-validation',
     template: `
         <ux-wizard>
             <ux-wizard-step

--- a/src/components/wizard/wizard.component.spec.ts
+++ b/src/components/wizard/wizard.component.spec.ts
@@ -462,7 +462,6 @@ describe('Wizard with invalid appearance', () => {
         fixture.detectChanges();
 
         expect(isValidAppearance(1)).toBe(true);
-
     });
 
     it('should have an invalid appearance when valid = false and visited = true', () => {

--- a/src/components/wizard/wizard.component.spec.ts
+++ b/src/components/wizard/wizard.component.spec.ts
@@ -391,69 +391,6 @@ describe('Wizard with validation', () => {
         expect(visitedChanged.calls.all().length).toBe(0);
     });
 
-    function isStepVisited(index: number): boolean {
-        const stepElements = nativeElement.querySelectorAll('.wizard-step');
-        return stepElements[index].classList.contains('visited');
-    }
-
-    function isStepValid(index: number): boolean {
-        const stepElements = nativeElement.querySelectorAll('.wizard-step');
-        return !stepElements[index].classList.contains('invalid');
-    }
-});
-
-@Component({
-    selector: 'marquee-wizard-validation-appearance',
-    template: `
-        <ux-wizard>
-            <ux-wizard-step
-                header="Step One"
-                [valid]="step1Valid"
-                [(visited)]="step1Visited">
-                Step One Content
-            </ux-wizard-step>
-            <ux-wizard-step
-                header="Step Two"
-                [valid]="step2Valid"
-                [(visited)]="step2Visited">
-                Step Two Content
-            </ux-wizard-step>
-        </ux-wizard>
-    `
-})
-export class WizardValidationAppearanceComponent {
-
-    // step 1 values
-    step1Valid = true;
-    step1Visited: boolean;
-    step1Completed: boolean;
-
-    // step 2 values
-    step2Valid: boolean = true;
-    step2Visited: boolean;
-    step2Completed: boolean;
-
-}
-
-describe('Wizard with invalid appearance', () => {
-    let component: WizardValidationAppearanceComponent;
-    let fixture: ComponentFixture<WizardValidationAppearanceComponent>;
-    let nativeElement: HTMLElement;
-
-    beforeEach(async(() => {
-        TestBed.configureTestingModule({
-            imports: [WizardModule],
-            declarations: [WizardValidationAppearanceComponent]
-        }).compileComponents();
-    }));
-
-    beforeEach(() => {
-        fixture = TestBed.createComponent(WizardValidationAppearanceComponent);
-        component = fixture.componentInstance;
-        nativeElement = fixture.nativeElement;
-        fixture.detectChanges();
-    });
-
     it('should not have an invalid appearance when valid = false and visited = false', () => {
         component.step1Visited = true;
         component.step2Visited = false;
@@ -461,7 +398,7 @@ describe('Wizard with invalid appearance', () => {
 
         fixture.detectChanges();
 
-        expect(isValidAppearance(1)).toBe(true);
+        expect(isStepValid(1)).toBe(true);
     });
 
     it('should have an invalid appearance when valid = false and visited = true', () => {
@@ -471,10 +408,15 @@ describe('Wizard with invalid appearance', () => {
 
         fixture.detectChanges();
 
-        expect(isValidAppearance(1)).toBe(false);
+        expect(isStepValid(1)).toBe(false);
     });
 
-    function isValidAppearance(index: number): boolean {
+    function isStepVisited(index: number): boolean {
+        const stepElements = nativeElement.querySelectorAll('.wizard-step');
+        return stepElements[index].classList.contains('visited');
+    }
+
+    function isStepValid(index: number): boolean {
         const stepElements = nativeElement.querySelectorAll('.wizard-step');
         return !stepElements[index].classList.contains('invalid');
     }

--- a/src/components/wizard/wizard.component.spec.ts
+++ b/src/components/wizard/wizard.component.spec.ts
@@ -403,7 +403,7 @@ describe('Wizard with validation', () => {
 });
 
 @Component({
-    selector: 'marquee-wizard-validation',
+    selector: 'marquee-wizard-validation-appearance',
     template: `
         <ux-wizard>
             <ux-wizard-step

--- a/src/components/wizard/wizard.component.spec.ts
+++ b/src/components/wizard/wizard.component.spec.ts
@@ -401,3 +401,82 @@ describe('Wizard with validation', () => {
         return !stepElements[index].classList.contains('invalid');
     }
 });
+
+@Component({
+    selector: 'marquee-wizard-validation-appearance',
+    template: `
+        <ux-wizard>
+            <ux-wizard-step
+                header="Step One"
+                [valid]="step1Valid"
+                [(visited)]="step1Visited">
+                Step One Content
+            </ux-wizard-step>
+            <ux-wizard-step
+                header="Step Two"
+                [valid]="step2Valid"
+                [(visited)]="step2Visited">
+                Step Two Content
+            </ux-wizard-step>
+        </ux-wizard>
+    `
+})
+export class WizardValidationAppearanceComponent {
+
+    // step 1 values
+    step1Valid = true;
+    step1Visited: boolean;
+    step1Completed: boolean;
+
+    // step 2 values
+    step2Valid: boolean = true;
+    step2Visited: boolean;
+    step2Completed: boolean;
+
+}
+
+describe('Wizard with invalid appearance', () => {
+    let component: WizardValidationAppearanceComponent;
+    let fixture: ComponentFixture<WizardValidationAppearanceComponent>;
+    let nativeElement: HTMLElement;
+
+    beforeEach(async(() => {
+        TestBed.configureTestingModule({
+            imports: [WizardModule],
+            declarations: [WizardValidationAppearanceComponent]
+        }).compileComponents();
+    }));
+
+    beforeEach(() => {
+        fixture = TestBed.createComponent(WizardValidationAppearanceComponent);
+        component = fixture.componentInstance;
+        nativeElement = fixture.nativeElement;
+        fixture.detectChanges();
+    });
+
+    it('should not have an invalid appearance when valid = false and visited = false', () => {
+        component.step1Visited = true;
+        component.step2Visited = false;
+        component.step2Valid = false;
+
+        fixture.detectChanges();
+
+        expect(isValidAppearance(1)).toBe(true);
+
+    });
+
+    it('should have an invalid appearance when valid = false and visited = true', () => {
+        component.step1Visited = true;
+        component.step2Visited = true;
+        component.step2Valid = false;
+
+        fixture.detectChanges();
+
+        expect(isValidAppearance(1)).toBe(false);
+    });
+
+    function isValidAppearance(index: number): boolean {
+        const stepElements = nativeElement.querySelectorAll('.wizard-step');
+        return !stepElements[index].classList.contains('invalid');
+    }
+});


### PR DESCRIPTION
#### Checklist
<!-- Use an 'x' to check those which apply. -->
* [x] The contents of this PR are mine to submit. No third party code or other material is being committed.
* [x] New third party dependencies (if any) are linked via `package.json`. Third party dependencies are licensed under one of the following: Apache, MIT, BSD, Mozilla Public License, Eclipse Public License, or Oracle Binary Code License.
* [x] The code in this PR does not contain export-restricted encryption algorithms.

#### Ticket / Issue
<!-- Either a Jira URL or a description of the issue that this PR addresses. -->
https://portal.digitalsafe.net/browse/EL-4101

#### Description of Proposed Changes
<!-- Describe what was changed and how it addresses the original issue. -->
Added stp.visited to class.invalid which fixes the regression in the steps having an invalid appearance before being visited
Added a karma test  to verify that: invalid appearance is not shown when valid = false and visited = false &
Invalid appearance should be shown when valid = false and visited = true

#### Documentation CI URL
<!-- Initiate a build at https://jenkins.swinfra.net/job/SEPG/view/Templates/job/New%20SEPG%20Build/build -->
<!-- Append the branch name to the following URL: -->
https://pages.github.houston.softwaregrp.net/sepg-docs-qa/UXAspects_CI_UXAspects_EL-4101-Wizard-steps-invalid

#### Downstream Build(s)
<!-- Push a branch with the same name in each downstream repository and create a build in Jenkins. -->
<!-- Add the Jenkins build link(s) below: -->
* [caf/ux-aspects-micro-focus](https://jenkins.swinfra.net/job/SEPG/job/caf/job/caf~ux-aspects-micro-focus~EL-4101-Wizard-steps-invalid~CI/)
