### PR TITLE
EL-4086 - Prevent duplicate breadcrumbs when using routerLink and onClick

### DIFF
--- a/src/components/breadcrumbs/breadcrumbs.component.html
+++ b/src/components/breadcrumbs/breadcrumbs.component.html
@@ -12,7 +12,7 @@
                 (click)="clickCrumb($event, crumb)">
                 {{ crumb.title }}
             </a>
-            <a *ngIf="crumb.onClick"
+            <a *ngIf="crumb.onClick && !crumb.routerLink"
                 uxFocusIndicator
                 tabindex="0"
                 (click)="clickCrumb($event, crumb)">

--- a/src/components/page-header/page-header.component.spec.ts
+++ b/src/components/page-header/page-header.component.spec.ts
@@ -28,6 +28,11 @@ export class PageHeaderTestComponent {
         {
             title: 'Archive',
             onClick: () => {}
+        },
+        {
+            title: 'Page',
+            routerLink: 'page',
+            onClick: () => {}
         }
     ];
 
@@ -110,6 +115,11 @@ describe('Page Header Component', () => {
         const archiveBreadcrumb = nativeElement.querySelectorAll('.breadcrumb a')[1];
         expect(archiveBreadcrumb.textContent.trim()).toBe('Archive');
         expect(archiveBreadcrumb.hasAttribute('href')).toBe(false);
+    });
+
+    it('should only add one <a> for each breadcrumb', () => {
+        const breadcrumbs = nativeElement.querySelectorAll('.breadcrumb a');
+        expect(breadcrumbs.length).toBe(3);
     });
 
 });


### PR DESCRIPTION
#### Checklist
<!-- Use an 'x' to check those which apply. -->
* [x] The contents of this PR are mine to submit. No third party code or other material is being committed.
* [x] New third party dependencies (if any) are linked via `package.json`. Third party dependencies are licensed under one of the following: Apache, MIT, BSD, Mozilla Public License, Eclipse Public License, or Oracle Binary Code License.
* [x] The code in this PR does not contain export-restricted encryption algorithms.

#### Ticket / Issue
<!-- Either a Jira URL or a description of the issue that this PR addresses. -->
https://portal.digitalsafe.net/browse/EL-4086

#### Description of Proposed Changes
<!-- Describe what was changed and how it addresses the original issue. -->
- Prevent duplicate breadcrumbs when using routerLink and onClick

#### Documentation CI URL
<!-- Initiate a build at https://jenkins.swinfra.net/job/SEPG/view/Templates/job/New%20SEPG%20Build/build -->
<!-- Append the branch name to the following URL: -->
https://pages.github.houston.softwaregrp.net/sepg-docs-qa/UXAspects_CI_UXAspects_EL-4086-duplicate-breadcrumbs

#### Downstream Build(s)
<!-- Push a branch with the same name in each downstream repository and create a build in Jenkins. -->
<!-- Add the Jenkins build link(s) below: -->
* [caf/ux-aspects-micro-focus](https://jenkins.swinfra.net/job/SEPG/job/caf/job/caf~ux-aspects-micro-focus~EL-4086-duplicate-breadcrumbs~CI/)
