### PR TITLE
EL-4170 - Dashboard - allow disabling of widget repositioning

### DIFF
--- a/docs/app/pages/components/components-sections/dashboard/dashboard/dashboard.component.html
+++ b/docs/app/pages/components/components-sections/dashboard/dashboard/dashboard.component.html
@@ -199,6 +199,7 @@
     <tr uxd-api-property name="colSpan" type="number">Defines the number of columns this widget should occupy.</tr>
     <tr uxd-api-property name="rowSpan" type="number">Defines the number of rows this widget should occupy.</tr>
     <tr uxd-api-property name="resizable" type="boolean">Defines whether or not this widget can be resized.</tr>
+    <tr uxd-api-property name="autoPositioning" type="boolean" defaultValue="true">Defines whether or not this widget will be automatically repositioned to fill any vacant space above it.</tr>
 </uxd-api-properties>
 
 <uxd-api-properties tableTitle="Methods">

--- a/e2e/pages/app/dashboard/dashboard.testpage.component.html
+++ b/e2e/pages/app/dashboard/dashboard.testpage.component.html
@@ -67,7 +67,7 @@
 
         </ux-dashboard-widget>
 
-        <ux-dashboard-widget id="alert-widget" name="Alert">
+        <ux-dashboard-widget id="alert-widget" name="Alert" autoPositioning="false">
 
             <div class="widget-content"
                  [class.widget-grabbing]="handle4.isGrabbing"

--- a/e2e/tests/components/dashboard/dashboard.e2e-spec.ts
+++ b/e2e/tests/components/dashboard/dashboard.e2e-spec.ts
@@ -201,6 +201,23 @@ describe('Dashboard Tests', () => {
         expect(JSON.parse(await page.getLayoutOutput())).toEqual(layoutMock);
     });
 
+    it('should not reposition widget when autoPositioning=false', async () => {
+        // drag widget4 down and left
+        await browser.actions().dragAndDrop(widget4, { x: -250, y: 250 }).perform();
+
+        // drag widget3 right (leaving a free space above widget4)
+        await browser.actions().dragAndDrop(widget3, { x: 250, y: 0 }).perform();
+
+        const expectedLayout = [
+            { id: 'analytics-1-widget', col: 0, row: 0, colSpan: 4, rowSpan: 2 },
+            { id: 'subscription-widget', col: 0, row: 2, colSpan: 2, rowSpan: 1 },
+            { id: 'users-widget', col: 3, row: 2, colSpan: 1, rowSpan: 1 },
+            { id: 'alert-widget', col: 2, row: 3, colSpan: 1, rowSpan: 1 }
+        ];
+
+        expect(JSON.parse(await page.getLayoutOutput())).toEqual(expectedLayout);
+    });
+
     it('should manage focus of the grab handles', async () => {
 
         // Set focus to the element before the dashboard
@@ -415,6 +432,22 @@ describe('Dashboard Tests', () => {
             expect(await page.getWidgetLocationValue(widget4, 'left')).toBe(0);
 
             expect(await imageCompareFullPageScreen('dashboard-stacked-mode-rowSpan')).toEqual(0);
+        });
+
+        it('should auto position widgets with autoPositioning=false while in stacked mode', async () => {
+            // move widget 4 to below widget 1
+            await browser.actions().dragAndDrop(widget4, { x: 0, y: -500 }).perform();
+            // move widget 1 below widget 4 (leaving an empty space for widget 4 to move up into)
+            await browser.actions().dragAndDrop(widget1, { x: 0, y: 750 }).perform();
+
+            const expectedLayout = [
+                { id: 'analytics-1-widget', col: 0, row: 1, colSpan: 4, rowSpan: 2 },
+                { id: 'subscription-widget', col: 0, row: 4, colSpan: 4, rowSpan: 1 },
+                { id: 'users-widget', col: 0, row: 3, colSpan: 4, rowSpan: 1 },
+                { id: 'alert-widget', col: 0, row: 0, colSpan: 4, rowSpan: 1 }
+            ];
+
+            expect(JSON.parse(await page.getLayoutOutput())).toEqual(expectedLayout, 'widget 4 should have moved up');
         });
 
     });

--- a/src/components/dashboard/dashboard.service.ts
+++ b/src/components/dashboard/dashboard.service.ts
@@ -1082,14 +1082,11 @@ export class DashboardService implements OnDestroy {
 
         // iterate each widget and
         this.widgets.forEach(widget => {
+            const widgetIsOnTopRow = widget.getRow() === 0;
+            const widgetIsBeingDragged = this._actionWidget?.widget === widget;
+            const widgetShouldBeAutoPositioned = widget.autoPositioning  || this.stacked;
 
-            // if widget is already on the top row then do nothing
-            if (widget.getRow() === 0) {
-                return;
-            }
-
-            // if we are currently dragging and this is the dragging widget then skip
-            if (this._actionWidget && this._actionWidget.widget === widget) {
+            if (widgetIsOnTopRow || widgetIsBeingDragged || !widgetShouldBeAutoPositioned) {
                 return;
             }
 

--- a/src/components/dashboard/dashboard.spec.ts
+++ b/src/components/dashboard/dashboard.spec.ts
@@ -381,3 +381,76 @@ describe('Dashboard Widgets layout', () => {
         expect(widgets[2].getRow()).toBe(0, 'host-widget row');
     });
 });
+
+@Component({
+    selector: 'app-ux-dashboard-autopositioning',
+    template: `
+        <ux-dashboard [options]="options" #dashboard>
+            <ux-dashboard-widget *ngFor="let user of users" id="users-widget" name="Users" autoPositioning="false">
+                <div class="widget-content">
+                    <h3 class="widget-title">{{user}}</h3>
+                </div>
+            </ux-dashboard-widget>
+        </ux-dashboard>
+    `
+})
+export class DashboardAutoPositioningTestComponent {
+
+    options: DashboardOptions = {
+        columns: 2,
+        padding: 10,
+        rowHeight: 220,
+        emptyRow: false,
+        minWidth: 187,
+    };
+
+    users: string[] = ['User 1', 'User 2', 'User 3'];
+
+    @ViewChild('dashboard') dashboard: DashboardComponent;
+    @ViewChildren(DashboardWidgetComponent) widgets: QueryList<DashboardWidgetComponent>;
+
+}
+
+describe('Dashboard Auto Positioning', () => {
+    let component: DashboardAutoPositioningTestComponent;
+    let fixture: ComponentFixture<DashboardAutoPositioningTestComponent>;
+    let nativeElement: HTMLElement;
+
+    beforeEach(async(() => {
+        TestBed.configureTestingModule({
+            imports: [DashboardModule],
+            declarations: [DashboardAutoPositioningTestComponent]
+        }).compileComponents();
+    }));
+
+    beforeEach(async () => {
+        fixture = TestBed.createComponent(DashboardAutoPositioningTestComponent);
+        component = fixture.componentInstance;
+        nativeElement = fixture.nativeElement;
+
+        fixture.detectChanges();
+        await fixture.whenStable();
+    });
+
+    it('should not reposition widget when autoPositioning=false', () => {
+        let widgets = component.widgets.toArray();
+
+        expect(widgets[0].getColumn()).toBe(0, 'User 1 - initial col');
+        expect(widgets[0].getRow()).toBe(0, 'User 1 - initial row');
+        expect(widgets[1].getColumn()).toBe(1, 'User 2 - initial col');
+        expect(widgets[1].getRow()).toBe(0, 'User 2 - initial row');
+        expect(widgets[2].getColumn()).toBe(0, 'User 3 - initial col');
+        expect(widgets[2].getRow()).toBe(1, 'User 3 - initial row');
+
+        // remove first widget
+        component.users.splice(0, 1);
+        fixture.detectChanges();
+        component.dashboard.refreshLayout();
+        widgets = component.widgets.toArray();
+
+        expect(widgets[0].getColumn()).toBe(1, 'User 2 col - not affected');
+        expect(widgets[0].getRow()).toBe(0, 'User 2 row - not affected');
+        expect(widgets[1].getColumn()).toBe(0, 'User 3  col - should not be repositioned');
+        expect(widgets[1].getRow()).toBe(1, 'User 3 row - should not be repositioned');
+    });
+});

--- a/src/components/dashboard/widget/dashboard-widget.component.ts
+++ b/src/components/dashboard/widget/dashboard-widget.component.ts
@@ -1,3 +1,4 @@
+import { coerceBooleanProperty } from '@angular/cdk/coercion';
 import { AfterViewInit, Component, HostBinding, Input, OnDestroy, OnInit } from '@angular/core';
 import { map, takeUntil } from 'rxjs/operators';
 import { Subject } from 'rxjs';
@@ -31,6 +32,15 @@ export class DashboardWidgetComponent implements OnInit, AfterViewInit, OnDestro
     /** Defines whether or not this widget can be resized. */
     @Input() resizable: boolean = false;
 
+    /** Defines whether or not this widget will be automatically repositioned */
+    @Input() set autoPositioning(autoPositioning: boolean) {
+        this._autoPositioning = coerceBooleanProperty(autoPositioning);
+    }
+
+    get autoPositioning(): boolean {
+        return this._autoPositioning;
+    }
+
     /** Defines a function that returns an aria label for the widget */
     @Input() widgetAriaLabel: (widgets: DashboardWidgetComponent) => string | string = this.getDefaultAriaLabel;
 
@@ -51,6 +61,7 @@ export class DashboardWidgetComponent implements OnInit, AfterViewInit, OnDestro
     private _row: StackableValue = { regular: undefined, stacked: undefined };
     private _columnSpan: StackableValue = { regular: 1, stacked: 1 };
     private _rowSpan: StackableValue = { regular: 1, stacked: 1 };
+    private _autoPositioning: boolean = true;
     private _onDestroy = new Subject<void>();
 
     constructor(public dashboardService: DashboardService) {
@@ -270,6 +281,8 @@ export class DashboardWidgetComponent implements OnInit, AfterViewInit, OnDestro
     private getStackableValue(property: StackableValue): number {
         return this.dashboardService.stacked ? property.stacked : property.regular;
     }
+
+    static ngAcceptInputType_autoPositioning: boolean | string;
 }
 
 export interface StackableValue {


### PR DESCRIPTION
#### Checklist
<!-- Use an 'x' to check those which apply. -->
* [x] The contents of this PR are mine to submit. No third party code or other material is being committed.
* [x] New third party dependencies (if any) are linked via `package.json`. Third party dependencies are licensed under one of the following: Apache, MIT, BSD, Mozilla Public License, Eclipse Public License, or Oracle Binary Code License.
* [x] The code in this PR does not contain export-restricted encryption algorithms.

#### Ticket / Issue
<!-- Either a Jira URL or a description of the issue that this PR addresses. -->
https://portal.digitalsafe.net/browse/EL-4170

#### Description of Proposed Changes
<!-- Describe what was changed and how it addresses the original issue. -->
- Add new `autoPositioning` input which determines whether or not to move the widget into any free space above it when available

#### Documentation CI URL
<!-- Initiate a build at https://jenkins.swinfra.net/job/SEPG/view/Templates/job/New%20SEPG%20Build/build -->
<!-- Append the branch name to the following URL: -->
https://pages.github.houston.softwaregrp.net/sepg-docs-qa/UXAspects_CI_UXAspects_EL-4170-widget-repositioning

#### Downstream Build(s)
<!-- Push a branch with the same name in each downstream repository and create a build in Jenkins. -->
<!-- Add the Jenkins build link(s) below: -->
* [caf/ux-aspects-micro-focus](https://jenkins.swinfra.net/job/SEPG/job/caf/job/caf~ux-aspects-micro-focus~EL-4170-widget-repositioning~CI/)
