### PR TITLE
EL-4178 - Popover - hovering div edges create event loop

### DIFF
--- a/src/components/hierarchy-bar/hierarchy-bar-standard/hierarchy-bar-standard.component.less
+++ b/src/components/hierarchy-bar/hierarchy-bar-standard/hierarchy-bar-standard.component.less
@@ -22,7 +22,7 @@ ux-hierarchy-bar-standard {
         left: 0;
         bottom: 0;
         width: 47px;
-        z-index: 1;
+        z-index: @tooltip-host-z-index + 1;
         padding: 16px 0 16px 16px;
         text-align: left;
         background-color: @white;

--- a/src/components/popover/popover.directive.ts
+++ b/src/components/popover/popover.directive.ts
@@ -9,7 +9,12 @@ import { PopoverComponent } from './popover.component';
 
 @Directive({
     selector: '[uxPopover]',
-    exportAs: 'ux-popover'
+    exportAs: 'ux-popover',
+    host: {
+        // requires a higher z-index than .cdk-overlay-container to prevent a mouseenter/mouseleave loop
+        // when hovering on the edge that the div and popover share
+        '[style.z-index]': '10102'
+    }
 })
 export class PopoverDirective extends TooltipDirective implements OnInit, OnChanges {
 

--- a/src/components/popover/popover.directive.ts
+++ b/src/components/popover/popover.directive.ts
@@ -11,9 +11,8 @@ import { PopoverComponent } from './popover.component';
     selector: '[uxPopover]',
     exportAs: 'ux-popover',
     host: {
-        // requires a higher z-index than .cdk-overlay-container to prevent a mouseenter/mouseleave loop
-        // when hovering on the edge that the div and popover share
-        '[style.z-index]': '10102'
+        '[class.ux-popover-host]': 'true',
+        '[class.ux-tooltip-host]': 'false'
     }
 })
 export class PopoverDirective extends TooltipDirective implements OnInit, OnChanges {

--- a/src/components/popover/popover.directive.ts
+++ b/src/components/popover/popover.directive.ts
@@ -11,8 +11,7 @@ import { PopoverComponent } from './popover.component';
     selector: '[uxPopover]',
     exportAs: 'ux-popover',
     host: {
-        '[class.ux-popover-host]': 'true',
-        '[class.ux-tooltip-host]': 'false'
+        '[class.ux-tooltip-host]': 'true'
     }
 })
 export class PopoverDirective extends TooltipDirective implements OnInit, OnChanges {

--- a/src/components/tooltip/tooltip.directive.ts
+++ b/src/components/tooltip/tooltip.directive.ts
@@ -11,9 +11,7 @@ import { clearTimeout } from 'timers';
     selector: '[uxTooltip]',
     exportAs: 'ux-tooltip',
     host: {
-        // requires a higher z-index than .cdk-overlay-container to prevent a mouseenter/mouseleave loop
-        // when hovering on the edge that the div and tooltip share
-        '[style.z-index]': '10102'
+        '[class.ux-tooltip-host]': 'true'
     }
 })
 export class TooltipDirective implements OnInit, OnChanges, OnDestroy {

--- a/src/components/tooltip/tooltip.directive.ts
+++ b/src/components/tooltip/tooltip.directive.ts
@@ -9,7 +9,12 @@ import { clearTimeout } from 'timers';
 
 @Directive({
     selector: '[uxTooltip]',
-    exportAs: 'ux-tooltip'
+    exportAs: 'ux-tooltip',
+    host: {
+        // requires a higher z-index than .cdk-overlay-container to prevent a mouseenter/mouseleave loop
+        // when hovering on the edge that the div and tooltip share
+        '[style.z-index]': '10102'
+    }
 })
 export class TooltipDirective implements OnInit, OnChanges, OnDestroy {
 

--- a/src/styles/tooltips.less
+++ b/src/styles/tooltips.less
@@ -110,3 +110,10 @@
     // We need to mark it as important to override inline styles added by the CDK
     pointer-events: none !important;
 }
+
+.ux-tooltip-host,
+.ux-popover-host {
+    // requires a higher z-index than .cdk-overlay-container to prevent a mouseenter/mouseleave loop
+    // when hovering on the edge that the div and tooltip/popover share
+    z-index: @tooltip-host-z-index;
+}

--- a/src/styles/tooltips.less
+++ b/src/styles/tooltips.less
@@ -111,8 +111,7 @@
     pointer-events: none !important;
 }
 
-.ux-tooltip-host,
-.ux-popover-host {
+.ux-tooltip-host {
     // requires a higher z-index than .cdk-overlay-container to prevent a mouseenter/mouseleave loop
     // when hovering on the edge that the div and tooltip/popover share
     z-index: @tooltip-host-z-index;

--- a/src/styles/zindex.less
+++ b/src/styles/zindex.less
@@ -55,3 +55,4 @@
 @notications-z-index: 10100;
 
 @overlay-z-index: 10101;
+@tooltip-host-z-index: @overlay-z-index + 1;


### PR DESCRIPTION
#### Checklist
<!-- Use an 'x' to check those which apply. -->
* [x] The contents of this PR are mine to submit. No third party code or other material is being committed.
* [x] New third party dependencies (if any) are linked via `package.json`. Third party dependencies are licensed under one of the following: Apache, MIT, BSD, Mozilla Public License, Eclipse Public License, or Oracle Binary Code License.
* [x] The code in this PR does not contain export-restricted encryption algorithms.

#### Ticket / Issue
<!-- Either a Jira URL or a description of the issue that this PR addresses. -->
https://portal.digitalsafe.net/browse/EL-4178

#### Description of Proposed Changes
<!-- Describe what was changed and how it addresses the original issue. -->
- div with popover directive requires a higher z-index value than the z-index value of `.cdk-overlay-container` to prevent a mouseenter / mouseleave event loop when hovering the the edge that the div and popover share

#### Documentation CI URL
<!-- Initiate a build at https://jenkins.swinfra.net/job/SEPG/view/Templates/job/New%20SEPG%20Build/build -->
<!-- Append the branch name to the following URL: -->
https://pages.github.houston.softwaregrp.net/sepg-docs-qa/UXAspects_CI_UXAspects_EL-4178-popover-loop

#### Downstream Build(s)
<!-- Push a branch with the same name in each downstream repository and create a build in Jenkins. -->
<!-- Add the Jenkins build link(s) below: -->
* [caf/ux-aspects-micro-focus](https://jenkins.swinfra.net/job/SEPG/job/caf/job/caf~ux-aspects-micro-focus~EL-4178-popover-loop~CI/)
