### PR TITLE
EL-4204 - Dashboard - widgets using autoPositioning should return to original position when another widget's resize is cancelled

### DIFF
--- a/src/components/dashboard/dashboard.service.ts
+++ b/src/components/dashboard/dashboard.service.ts
@@ -281,6 +281,7 @@ export class DashboardService implements OnDestroy {
      * @param action The the widget to resize
      */
     onResizeStart(action: DashboardAction): void {
+        this.cacheWidgets();
 
         // store the mouse event
         this._event = action.event;
@@ -1090,10 +1091,22 @@ export class DashboardService implements OnDestroy {
         // iterate each widget and
         this.widgets.forEach(widget => {
             const widgetIsOnTopRow = widget.getRow() === 0;
-            const widgetIsBeingDragged = this._actionWidget?.widget === widget;
+            const widgetIsBeingResized = this._actionWidget?.widget === widget;
             const widgetShouldBeAutoPositioned = widget.autoPositioning  || this.stacked;
+            const widgetIsBeingMoved = !widgetShouldBeAutoPositioned && this.isDragging$.value?.id === widget.id;
 
-            if (widgetIsOnTopRow || widgetIsBeingDragged || !widgetShouldBeAutoPositioned) {
+            if (widgetIsOnTopRow || widgetIsBeingResized || widgetIsBeingMoved) {
+                return;
+            }
+
+            if (!widgetShouldBeAutoPositioned) {
+                const cachedVersionOfWidget = this._cache.find(cachedWidget => cachedWidget.id === widget.id);
+                const isPreviousPositionAvailable = this.getPositionAvailable(cachedVersionOfWidget.column, cachedVersionOfWidget.row, cachedVersionOfWidget.columnSpan, cachedVersionOfWidget.rowSpan);
+                if (isPreviousPositionAvailable) {
+                    widget.setRow(cachedVersionOfWidget.row);
+                    stable = false;
+                }
+
                 return;
             }
 


### PR DESCRIPTION
#### Checklist
<!-- Use an 'x' to check those which apply. -->
* [x] The contents of this PR are mine to submit. No third party code or other material is being committed.
* [x] New third party dependencies (if any) are linked via `package.json`. Third party dependencies are licensed under one of the following: Apache, MIT, BSD, Mozilla Public License, Eclipse Public License, or Oracle Binary Code License.
* [x] The code in this PR does not contain export-restricted encryption algorithms.

#### Ticket / Issue
<!-- Either a Jira URL or a description of the issue that this PR addresses. -->
https://portal.digitalsafe.net/browse/EL-4204

#### Description of Proposed Changes
<!-- Describe what was changed and how it addresses the original issue. -->
- When a widget with autoPositioning=false is displaced while another widget is being resized, and then that widget's resizing is cancelled (leaving the original position of the autoPositioning widget free), the widget should return to its initial position


#### Documentation CI URL
<!-- Initiate a build at https://jenkins.swinfra.net/job/SEPG/view/Templates/job/New%20SEPG%20Build/build -->
<!-- Append the branch name to the following URL: -->
https://pages.github.houston.softwaregrp.net/sepg-docs-qa/UXAspects_CI_UXAspects_EL-4204-widget-positioning

#### Downstream Build(s)
<!-- Push a branch with the same name in each downstream repository and create a build in Jenkins. -->
<!-- Add the Jenkins build link(s) below: -->
* [caf/ux-aspects-micro-focus](https://jenkins.swinfra.net/job/SEPG/job/caf/job/caf~ux-aspects-micro-focus~EL-4204-widget-positioning~CI/)
