### PR TITLE
EL-4224: Dashboard: z-index values on widgets cause overlap issues

### DIFF
--- a/e2e/tests/components/dashboard/dashboard.e2e-spec.ts
+++ b/e2e/tests/components/dashboard/dashboard.e2e-spec.ts
@@ -426,11 +426,11 @@ describe('Dashboard Tests', () => {
         expect(await page.getWidgetLocationValue(widget1, 'width')).toBe(1108, 'should be the same as the initial width');
     });
 
-    it('should have no z-index applied to the widgets in their initial state', async () => {
+    it('should have auto z-index applied to the widget in their initial state', async () => {
         expect(await widget1.getCssValue('z-index')).toBe('auto');
     });
 
-    it('should have no z-index applied to the widget after movement', async () => {
+    it('should have auto z-index applied to the widget after movement', async () => {
         await browser.actions().dragAndDrop(widget1, { x: 0, y: 250 }).perform();
         expect(await widget1.getCssValue('z-index')).toBe('auto');
     });

--- a/e2e/tests/components/dashboard/dashboard.e2e-spec.ts
+++ b/e2e/tests/components/dashboard/dashboard.e2e-spec.ts
@@ -426,6 +426,15 @@ describe('Dashboard Tests', () => {
         expect(await page.getWidgetLocationValue(widget1, 'width')).toBe(1108, 'should be the same as the initial width');
     });
 
+    it('should have no z-index applied to the widgets in their initial state', async () => {
+        expect(await widget1.getCssValue('z-index')).toBe('auto');
+    });
+
+    it('should have no z-index applied to the widget after movement', async () => {
+        await browser.actions().dragAndDrop(widget1, { x: 0, y: 250 }).perform();
+        expect(await widget1.getCssValue('z-index')).toBe('auto');
+    });
+
     describe('Stacked Mode', () => {
 
         beforeEach(async () => {

--- a/src/components/dashboard/dashboard.service.ts
+++ b/src/components/dashboard/dashboard.service.ts
@@ -513,6 +513,8 @@ export class DashboardService implements OnDestroy {
 
         this._widgetOrigin = {};
 
+        this.isDragging$.getValue().sendToBack();
+
         this.isDragging$.next(null);
 
         this.userLayoutChange$.next(this.getLayoutData());

--- a/src/components/dashboard/widget/dashboard-widget.component.ts
+++ b/src/components/dashboard/widget/dashboard-widget.component.ts
@@ -85,7 +85,7 @@ export class DashboardWidgetComponent implements OnInit, AfterViewInit, OnDestro
     @HostBinding('style.width.px') width: number = 100;
     @HostBinding('style.height.px') height: number = 100;
     @HostBinding('style.padding.px') padding: number = 0;
-    @HostBinding('style.z-index') zIndex: number = 0;
+    @HostBinding('style.z-index') zIndex: number = null;
     @HostBinding('attr.aria-label') ariaLabel: string;
     @HostBinding('class.dragging') isDragging: boolean = false;
     @HostBinding('class.grabbing') isGrabbing: boolean = false;
@@ -248,7 +248,7 @@ export class DashboardWidgetComponent implements OnInit, AfterViewInit, OnDestro
     }
 
     sendToBack(): void {
-        this.zIndex = 0;
+        this.zIndex = null;
     }
 
     setBounds(x: number, y: number, width: number, height: number): void {


### PR DESCRIPTION
#### Checklist
<!-- Use an 'x' to check those which apply. -->
* [x] The contents of this PR are mine to submit. No third party code or other material is being committed.
* [x] New third party dependencies (if any) are linked via `package.json`. Third party dependencies are licensed under one of the following: Apache, MIT, BSD, Mozilla Public License, Eclipse Public License, or Oracle Binary Code License.
* [x] The code in this PR does not contain export-restricted encryption algorithms.

#### Ticket / Issue
https://portal.digitalsafe.net/browse/EL-4224

#### Description of Proposed Changes
1. Added call to sendToBack() in the onDragEnd function in the dashboard.service
2. Set initial values of z-index to null from 0
3. 2 protractor tests to check z-index initially and after moving a widget

#### Documentation CI URL
<!-- Initiate a build at https://jenkins.swinfra.net/job/SEPG/view/Templates/job/New%20SEPG%20Build/build -->
<!-- Append the branch name to the following URL: -->
https://pages.github.houston.softwaregrp.net/sepg-docs-qa/UXAspects_CI_UXAspects_EL-4224-dashboard-z-index

#### Downstream Build(s)
<!-- Push a branch with the same name in each downstream repository and create a build in Jenkins. -->
<!-- Add the Jenkins build link(s) below: -->
* [caf/ux-aspects-micro-focus](https://jenkins.swinfra.net/job/SEPG/job/caf/view/Developer/job/caf~ux-aspects-micro-focus~EL-4224-dashboard-z-index~CI/)