### PR TITLE
docs: correct chart.js path

### DIFF
--- a/docs/app/services/playground/utilities/system-helper.ts
+++ b/docs/app/services/playground/utilities/system-helper.ts
@@ -44,7 +44,7 @@ export class SystemJSHelper {
         { name: 'rxjs', path: 'rxjs@6.5.2' },
         { name: 'ngx-bootstrap', path: `ngx-bootstrap@${NGX_BOOTSTRAP_VERSION}/bundles/ngx-bootstrap.umd.min.js` },
         { name: 'chance', path: 'chance' },
-        { name: 'chart.js', path: 'chart.js/dist/chart.min.js' },
+        { name: 'chart.js', path: 'chart.js@2.9.3/dist/Chart.bundle.min.js' },
         { name: 'ng2-charts', path: 'ng2-charts@2.3.0/bundles/ng2-charts.umd.js' },
         { name: 'lodash', path: 'lodash/lodash.js' },
         { name: 'ng2-file-upload', path: 'ng2-file-upload/bundles/ng2-file-upload.umd.js' },

--- a/docs/app/services/playground/utilities/system-helper.ts
+++ b/docs/app/services/playground/utilities/system-helper.ts
@@ -44,7 +44,7 @@ export class SystemJSHelper {
         { name: 'rxjs', path: 'rxjs@6.5.2' },
         { name: 'ngx-bootstrap', path: `ngx-bootstrap@${NGX_BOOTSTRAP_VERSION}/bundles/ngx-bootstrap.umd.min.js` },
         { name: 'chance', path: 'chance' },
-        { name: 'chart.js', path: 'chart.js/dist/Chart.bundle.min.js' },
+        { name: 'chart.js', path: 'chart.js/dist/chart.min.js' },
         { name: 'ng2-charts', path: 'ng2-charts@2.3.0/bundles/ng2-charts.umd.js' },
         { name: 'lodash', path: 'lodash/lodash.js' },
         { name: 'ng2-file-upload', path: 'ng2-file-upload/bundles/ng2-file-upload.umd.js' },


### PR DESCRIPTION
#### Checklist
<!-- Use an 'x' to check those which apply. -->
* [x] The contents of this PR are mine to submit. No third party code or other material is being committed.
* [x] New third party dependencies (if any) are linked via `package.json`. Third party dependencies are licensed under one of the following: Apache, MIT, BSD, Mozilla Public License, Eclipse Public License, or Oracle Binary Code License.
* [x] The code in this PR does not contain export-restricted encryption algorithms.

#### Ticket / Issue
<!-- Either a Jira URL or a description of the issue that this PR addresses. -->
[Dashboard demo link to plunker](https://uxaspects.github.io/UXAspects/#/components/dashboard) doesn't work. It can't load `chart.js` because the path is not correct.

![image](https://user-images.githubusercontent.com/23273077/114165244-d1c11680-995e-11eb-94da-819e5cc061ac.png)

#### Description of Proposed Changes
<!-- Describe what was changed and how it addresses the original issue. -->
Correct `chart.js` path will make the demo work as expected.
#### Documentation CI URL
<!-- Initiate a build at https://jenkins.swinfra.net/job/SEPG/view/Templates/job/New%20SEPG%20Build/build -->
<!-- Append the branch name to the following URL: -->
<!-- https://pages.github.houston.softwaregrp.net/sepg-docs-qa/UXAspects_CI_UXAspects_ -->

#### Downstream Build(s)
<!-- Push a branch with the same name in each downstream repository and create a build in Jenkins. -->
<!-- Add the Jenkins build link(s) below: -->
