### PR TITLE
EL-4250 - Menu: trigger is not linked to menu container (accessibility)

### DIFF
--- a/src/components/menu/menu-trigger/menu-trigger.directive.ts
+++ b/src/components/menu/menu-trigger/menu-trigger.directive.ts
@@ -38,7 +38,7 @@ export class MenuTriggerDirective implements OnInit, OnDestroy {
 
     /** Get the aria controls for accessibility */
     get ariaControls(): string | null {
-        return this.menu?.isMenuOpen ? this.menu?.id + '-menu' : null;
+        return this.menu?.isMenuOpen ? this.menu?._ariaControls : null;
     }
 
     /** Store the instance of the focus indicator */

--- a/src/components/menu/menu-trigger/menu-trigger.directive.ts
+++ b/src/components/menu/menu-trigger/menu-trigger.directive.ts
@@ -16,7 +16,7 @@ import { MenuComponent } from '../menu/menu.component';
         '[attr.disabled]': 'disabled ? true : null',
         '[attr.aria-haspopup]': '!!menu',
         '[attr.aria-expanded]': 'menu?.isMenuOpen',
-        '[attr.aria-controls]': 'menu?.isMenuOpen ? this._overlayRef.overlayElement.id : null'
+        '[attr.aria-controls]': 'ariaControls'
     }
 })
 export class MenuTriggerDirective implements OnInit, OnDestroy {
@@ -34,7 +34,12 @@ export class MenuTriggerDirective implements OnInit, OnDestroy {
     private _portal: TemplatePortal;
 
     /** Store the reference to the overlay */
-    _overlayRef: OverlayRef;
+    private _overlayRef: OverlayRef;
+
+    /** Get the aria controls for accessibility */
+    get ariaControls(): string | null {
+        return this.menu?.isMenuOpen ? this._overlayRef?. overlayElement.id : null;
+    }
 
     /** Store the instance of the focus indicator */
     private _focusIndicator: FocusIndicator;

--- a/src/components/menu/menu-trigger/menu-trigger.directive.ts
+++ b/src/components/menu/menu-trigger/menu-trigger.directive.ts
@@ -15,7 +15,8 @@ import { MenuComponent } from '../menu/menu.component';
     host: {
         '[attr.disabled]': 'disabled ? true : null',
         '[attr.aria-haspopup]': '!!menu',
-        '[attr.aria-expanded]': 'menu?.isMenuOpen'
+        '[attr.aria-expanded]': 'menu?.isMenuOpen',
+        '[attr.aria-controls]': 'menu?.isMenuOpen ? this._overlayRef.overlayElement.id : null'
     }
 })
 export class MenuTriggerDirective implements OnInit, OnDestroy {
@@ -33,7 +34,7 @@ export class MenuTriggerDirective implements OnInit, OnDestroy {
     private _portal: TemplatePortal;
 
     /** Store the reference to the overlay */
-    private _overlayRef: OverlayRef;
+    _overlayRef: OverlayRef;
 
     /** Store the instance of the focus indicator */
     private _focusIndicator: FocusIndicator;

--- a/src/components/menu/menu-trigger/menu-trigger.directive.ts
+++ b/src/components/menu/menu-trigger/menu-trigger.directive.ts
@@ -38,7 +38,7 @@ export class MenuTriggerDirective implements OnInit, OnDestroy {
 
     /** Get the aria controls for accessibility */
     get ariaControls(): string | null {
-        return this.menu?.isMenuOpen ? this.menu?.id : null;
+        return this.menu?.isMenuOpen ? this.menu?.id + '-menu' : null;
     }
 
     /** Store the instance of the focus indicator */

--- a/src/components/menu/menu-trigger/menu-trigger.directive.ts
+++ b/src/components/menu/menu-trigger/menu-trigger.directive.ts
@@ -34,11 +34,11 @@ export class MenuTriggerDirective implements OnInit, OnDestroy {
     private _portal: TemplatePortal;
 
     /** Store the reference to the overlay */
-    private _overlayRef: OverlayRef;
+    private _overlayRef?: OverlayRef;
 
     /** Get the aria controls for accessibility */
     get ariaControls(): string | null {
-        return this.menu?.isMenuOpen ? this._overlayRef?. overlayElement.id : null;
+        return this.menu?.isMenuOpen ? this._overlayRef?.overlayElement.id : null;
     }
 
     /** Store the instance of the focus indicator */

--- a/src/components/menu/menu-trigger/menu-trigger.directive.ts
+++ b/src/components/menu/menu-trigger/menu-trigger.directive.ts
@@ -37,8 +37,8 @@ export class MenuTriggerDirective implements OnInit, OnDestroy {
     private _overlayRef?: OverlayRef;
 
     /** Get the aria controls for accessibility */
-    get ariaControls(): string {
-        return this.menu?.id;
+    get ariaControls(): string | null {
+        return this.menu?.isMenuOpen ? this.menu?.id : null;
     }
 
     /** Store the instance of the focus indicator */

--- a/src/components/menu/menu-trigger/menu-trigger.directive.ts
+++ b/src/components/menu/menu-trigger/menu-trigger.directive.ts
@@ -38,7 +38,7 @@ export class MenuTriggerDirective implements OnInit, OnDestroy {
 
     /** Get the aria controls for accessibility */
     get ariaControls(): string | null {
-        return this.menu?.isMenuOpen ? this.menu?._ariaControls : null;
+        return this.menu?.isMenuOpen ? this.menu?.innerId : null;
     }
 
     /** Store the instance of the focus indicator */

--- a/src/components/menu/menu-trigger/menu-trigger.directive.ts
+++ b/src/components/menu/menu-trigger/menu-trigger.directive.ts
@@ -37,8 +37,8 @@ export class MenuTriggerDirective implements OnInit, OnDestroy {
     private _overlayRef?: OverlayRef;
 
     /** Get the aria controls for accessibility */
-    get ariaControls(): string | null {
-        return this.menu?.isMenuOpen ? this._overlayRef?.overlayElement.id : null;
+    get ariaControls(): string {
+        return this.menu?.id;
     }
 
     /** Store the instance of the focus indicator */

--- a/src/components/menu/menu.spec.ts
+++ b/src/components/menu/menu.spec.ts
@@ -551,7 +551,7 @@ describe('MenuTriggerDestroyTestComponent', () => {
     });
 
     it('should contain the aria-controls attribute when the menu is opened', async () => {
-        expect(document.querySelector('.btn').getAttribute('aria-controls')).toBeFalsy();
+        expect(document.querySelector('.btn').getAttribute('aria-controls')).toBe(null);
 
         // open menu
         component.trigger.openMenu();
@@ -560,7 +560,7 @@ describe('MenuTriggerDestroyTestComponent', () => {
         await fixture.whenStable();
 
         // get the aria-controls overlay
-        expect(document.querySelector('.btn').getAttribute('aria-controls')).toBeTruthy();
+        expect(document.querySelector('.btn').getAttribute('aria-controls')).toBe('ux-menu-1');
     });
 
 });

--- a/src/components/menu/menu.spec.ts
+++ b/src/components/menu/menu.spec.ts
@@ -550,7 +550,7 @@ describe('MenuTriggerDestroyTestComponent', () => {
         expect(document.querySelectorAll('.ux-menu').length).toBe(1);
     });
 
-    fit('should contain the aria-controls attribute when the menu is opened', async () => {
+    it('should contain the aria-controls attribute when the menu is opened', async () => {
         expect(document.querySelector('.btn').getAttribute('aria-controls')).toBe(null);
 
         // open menu
@@ -564,7 +564,7 @@ describe('MenuTriggerDestroyTestComponent', () => {
 
     });
 
-    fit('should contain the correct id for the ux-menu and the overlay', async () => {
+    it('should contain the correct id for the ux-menu and the overlay', async () => {
         // open menu
         component.trigger.openMenu();
 
@@ -573,6 +573,6 @@ describe('MenuTriggerDestroyTestComponent', () => {
 
         expect(document.querySelector('.ux-menu').getAttribute('id')).toBe('ux-menu-1-menu');
         expect(document.querySelector('ux-menu').getAttribute('id')).toBe('ux-menu-1');
-    })
+    });
 
 });

--- a/src/components/menu/menu.spec.ts
+++ b/src/components/menu/menu.spec.ts
@@ -427,6 +427,20 @@ describe('MenuComponent', () => {
         expect(subItemMenu).toBeFalsy();
     });
 
+    it('should contain the role menu in the overlay dropdown', async () => {
+        // perform a click on the trigger element
+        triggerElement.click();
+
+        // run change detection
+        fixture.detectChanges();
+
+        // only the root level menu item should be open
+        expect(document.querySelectorAll('.ux-menu').length).toBe(1);
+
+        // expect the ux-menu to contain the role
+        expect(document.querySelector('.ux-menu').getAttribute('role')).toBe('menu');
+    });
+
 });
 
 @Component({
@@ -535,5 +549,23 @@ describe('MenuTriggerDestroyTestComponent', () => {
         await fixture.whenStable();
         expect(document.querySelectorAll('.ux-menu').length).toBe(1);
     });
+
+    it('should contain the aria-controls attribute when the menu is opened', async () => {
+        expect(document.querySelector('.btn').getAttribute('aria-controls')).toBeFalsy();
+
+        // open menu
+        component.trigger.openMenu();
+
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        // expect menu to be open
+        expect(document.querySelectorAll('.ux-menu').length).toBe(1);
+
+        // get the aria-controls overlay
+        expect(document.querySelector('.btn').getAttribute('aria-controls')).toBeTruthy();
+
+
+    })
 
 });

--- a/src/components/menu/menu.spec.ts
+++ b/src/components/menu/menu.spec.ts
@@ -429,10 +429,10 @@ describe('MenuComponent', () => {
 
     it('should contain the role menu in the overlay dropdown', async () => {
         // perform a click on the trigger element
-        triggerElement.click();
+        await triggerElement.click();
 
         // run change detection
-        fixture.detectChanges();
+        await fixture.detectChanges();
 
         // only the root level menu item should be open
         expect(document.querySelectorAll('.ux-menu').length).toBe(1);
@@ -566,6 +566,6 @@ describe('MenuTriggerDestroyTestComponent', () => {
         expect(document.querySelector('.btn').getAttribute('aria-controls')).toBeTruthy();
 
 
-    })
+    });
 
 });

--- a/src/components/menu/menu.spec.ts
+++ b/src/components/menu/menu.spec.ts
@@ -559,13 +559,8 @@ describe('MenuTriggerDestroyTestComponent', () => {
         fixture.detectChanges();
         await fixture.whenStable();
 
-        // expect menu to be open
-        expect(document.querySelectorAll('.ux-menu').length).toBe(1);
-
         // get the aria-controls overlay
         expect(document.querySelector('.btn').getAttribute('aria-controls')).toBeTruthy();
-
-
     });
 
 });

--- a/src/components/menu/menu.spec.ts
+++ b/src/components/menu/menu.spec.ts
@@ -455,7 +455,7 @@ describe('MenuComponent', () => {
             </button>
         </div>
 
-        <ux-menu #menu>
+        <ux-menu id="ux-menu-1" #menu>
             <button type="button" uxMenuItem>
                 <span class="dropdown-menu"></span>
                 <span class="dropdown-menu-text">Export</span>

--- a/src/components/menu/menu.spec.ts
+++ b/src/components/menu/menu.spec.ts
@@ -560,7 +560,7 @@ describe('MenuTriggerDestroyTestComponent', () => {
         await fixture.whenStable();
 
         // get the aria-controls overlay
-        expect(document.querySelector('.btn').getAttribute('aria-controls')).toBe('ux-menu-1');
+        expect(document.querySelector('.btn').getAttribute('aria-controls')).toBe('ux-menu-1-menu');
 
     });
 

--- a/src/components/menu/menu.spec.ts
+++ b/src/components/menu/menu.spec.ts
@@ -550,7 +550,7 @@ describe('MenuTriggerDestroyTestComponent', () => {
         expect(document.querySelectorAll('.ux-menu').length).toBe(1);
     });
 
-    it('should contain the aria-controls attribute when the menu is opened', async () => {
+    fit('should contain the aria-controls attribute when the menu is opened', async () => {
         expect(document.querySelector('.btn').getAttribute('aria-controls')).toBe(null);
 
         // open menu
@@ -561,6 +561,18 @@ describe('MenuTriggerDestroyTestComponent', () => {
 
         // get the aria-controls overlay
         expect(document.querySelector('.btn').getAttribute('aria-controls')).toBe('ux-menu-1');
+
     });
+
+    fit('should contain the correct id for the ux-menu and the overlay', async () => {
+        // open menu
+        component.trigger.openMenu();
+
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        expect(document.querySelector('.ux-menu').getAttribute('id')).toBe('ux-menu-1-menu');
+        expect(document.querySelector('ux-menu').getAttribute('id')).toBe('ux-menu-1');
+    })
 
 });

--- a/src/components/menu/menu/menu.component.html
+++ b/src/components/menu/menu/menu.component.html
@@ -3,7 +3,7 @@
         *ngIf="isMenuOpen"
         class="ux-menu"
         role="menu"
-        [id]="id"
+        [id]="id + '-menu'"
         [class.ux-sub-menu]="_isSubMenu"
         [class.ux-menu-placement-top]="placement === 'top'"
         [ngClass]="menuClass"

--- a/src/components/menu/menu/menu.component.html
+++ b/src/components/menu/menu/menu.component.html
@@ -3,7 +3,7 @@
         *ngIf="isMenuOpen"
         class="ux-menu"
         role="menu"
-        [id]="id + '-menu'"
+        [id]="_ariaControls"
         [class.ux-sub-menu]="_isSubMenu"
         [class.ux-menu-placement-top]="placement === 'top'"
         [ngClass]="menuClass"

--- a/src/components/menu/menu/menu.component.html
+++ b/src/components/menu/menu/menu.component.html
@@ -2,9 +2,9 @@
     <div
         *ngIf="isMenuOpen"
         class="ux-menu"
+        role="menu"
         [class.ux-sub-menu]="_isSubMenu"
         [class.ux-menu-placement-top]="placement === 'top'"
-        [attr.role]="'menu'"
         [ngClass]="menuClass"
         @menuAnimation
         [@.disabled]="!animate"

--- a/src/components/menu/menu/menu.component.html
+++ b/src/components/menu/menu/menu.component.html
@@ -3,7 +3,7 @@
         *ngIf="isMenuOpen"
         class="ux-menu"
         role="menu"
-        [id]="id + '-input'"
+        [id]="id"
         [class.ux-sub-menu]="_isSubMenu"
         [class.ux-menu-placement-top]="placement === 'top'"
         [ngClass]="menuClass"

--- a/src/components/menu/menu/menu.component.html
+++ b/src/components/menu/menu/menu.component.html
@@ -3,6 +3,7 @@
         *ngIf="isMenuOpen"
         class="ux-menu"
         role="menu"
+        [id]="id + '-input'"
         [class.ux-sub-menu]="_isSubMenu"
         [class.ux-menu-placement-top]="placement === 'top'"
         [ngClass]="menuClass"

--- a/src/components/menu/menu/menu.component.html
+++ b/src/components/menu/menu/menu.component.html
@@ -3,7 +3,7 @@
         *ngIf="isMenuOpen"
         class="ux-menu"
         role="menu"
-        [id]="_ariaControls"
+        [id]="innerId"
         [class.ux-sub-menu]="_isSubMenu"
         [class.ux-menu-placement-top]="placement === 'top'"
         [ngClass]="menuClass"

--- a/src/components/menu/menu/menu.component.html
+++ b/src/components/menu/menu/menu.component.html
@@ -4,6 +4,7 @@
         class="ux-menu"
         [class.ux-sub-menu]="_isSubMenu"
         [class.ux-menu-placement-top]="placement === 'top'"
+        [attr.role]="'menu'"
         [ngClass]="menuClass"
         @menuAnimation
         [@.disabled]="!animate"

--- a/src/components/menu/menu/menu.component.ts
+++ b/src/components/menu/menu/menu.component.ts
@@ -99,8 +99,8 @@ export class MenuComponent implements AfterContentInit, OnDestroy, OnChanges {
     /** Automatically unsubscribe when the component is destroyed */
     private readonly _onDestroy$ = new Subject<void>();
 
-    /** Get the aria controls label */
-    get _ariaControls(): string {
+    /** Get innerId for use for accessibility  */
+    get innerId(): string {
        return `${this.id}-menu`;
     }
 
@@ -255,10 +255,6 @@ export class MenuComponent implements AfterContentInit, OnDestroy, OnChanges {
 
     _onBlur(): void {
         this._isFocused$.next(false);
-    }
-
-    _getAriaControls(): void {
-        
     }
 
 }

--- a/src/components/menu/menu/menu.component.ts
+++ b/src/components/menu/menu/menu.component.ts
@@ -16,9 +16,6 @@ let uniqueId = 0;
     selector: 'ux-menu',
     templateUrl: './menu.component.html',
     changeDetection: ChangeDetectionStrategy.OnPush,
-    host: {
-        'role': 'menu'
-    },
     animations: [
         trigger('menuAnimation', [
             transition(':enter', [

--- a/src/components/menu/menu/menu.component.ts
+++ b/src/components/menu/menu/menu.component.ts
@@ -1,7 +1,6 @@
 import { animate, style, transition, trigger } from '@angular/animations';
 import { FocusKeyManager, FocusOrigin } from '@angular/cdk/a11y';
-import { AfterContentInit, ChangeDetectionStrategy, ChangeDetectorRef, Component, EventEmitter, forwardRef, HostBinding, Inject, Input, OnChanges, OnDestroy, Optional, Output, QueryList, SimpleChanges, StaticProvider, TemplateRef, ViewChild, ViewRef } from '@angular/core';
-import { NG_VALUE_ACCESSOR } from '@angular/forms';
+import { AfterContentInit, ChangeDetectionStrategy, ChangeDetectorRef, Component, EventEmitter, HostBinding, Inject, Input, OnChanges, OnDestroy, Optional, Output, QueryList, SimpleChanges, TemplateRef, ViewChild, ViewRef } from '@angular/core';
 import { BehaviorSubject, merge, Observable, Subject } from 'rxjs';
 import { map, switchMap, takeUntil } from 'rxjs/operators';
 import { AnchorAlignment, AnchorPlacement } from '../../tooltip/index';
@@ -13,16 +12,9 @@ import { MenuTabbableItemDirective } from '../menu-tabbable-item/menu-tabbable-i
 
 let uniqueId = 0;
 
-export const MENU_VALUE_ACCESSOR: StaticProvider = {
-    provide: NG_VALUE_ACCESSOR,
-    useExisting: forwardRef(() => MenuComponent),
-    multi: true
-};
-
 @Component({
     selector: 'ux-menu',
     templateUrl: './menu.component.html',
-    providers: [MENU_VALUE_ACCESSOR],
     changeDetection: ChangeDetectionStrategy.OnPush,
     host: {
         'role': 'menu'
@@ -42,7 +34,7 @@ export const MENU_VALUE_ACCESSOR: StaticProvider = {
 export class MenuComponent implements AfterContentInit, OnDestroy, OnChanges {
 
     /** A unique id for the component. */
-    @Input() @HostBinding('attr.id') id: string = `ux-select-${++uniqueId}`;
+    @Input() @HostBinding('attr.id') id: string = `ux-menu-${++uniqueId}`;
 
     /** Define the position of the menu */
     @Input() placement: AnchorPlacement = 'bottom';

--- a/src/components/menu/menu/menu.component.ts
+++ b/src/components/menu/menu/menu.component.ts
@@ -99,6 +99,11 @@ export class MenuComponent implements AfterContentInit, OnDestroy, OnChanges {
     /** Automatically unsubscribe when the component is destroyed */
     private readonly _onDestroy$ = new Subject<void>();
 
+    /** Get the aria controls label */
+    get _ariaControls(): string {
+       return `${this.id}-menu`;
+    }
+
     get _isExpanded(): Observable<boolean> {
         return this._menuItems.pipe(switchMap(items => merge(...items.map(item => item.isExpanded$))), takeUntil(this._onDestroy$));
     }
@@ -250,6 +255,10 @@ export class MenuComponent implements AfterContentInit, OnDestroy, OnChanges {
 
     _onBlur(): void {
         this._isFocused$.next(false);
+    }
+
+    _getAriaControls(): void {
+        
     }
 
 }

--- a/src/components/menu/menu/menu.component.ts
+++ b/src/components/menu/menu/menu.component.ts
@@ -1,6 +1,7 @@
 import { animate, style, transition, trigger } from '@angular/animations';
 import { FocusKeyManager, FocusOrigin } from '@angular/cdk/a11y';
-import { AfterContentInit, ChangeDetectionStrategy, ChangeDetectorRef, Component, EventEmitter, Inject, Input, OnChanges, OnDestroy, Optional, Output, QueryList, SimpleChanges, TemplateRef, ViewChild, ViewRef } from '@angular/core';
+import { AfterContentInit, ChangeDetectionStrategy, ChangeDetectorRef, Component, EventEmitter, forwardRef, HostBinding, Inject, Input, OnChanges, OnDestroy, Optional, Output, QueryList, SimpleChanges, StaticProvider, TemplateRef, ViewChild, ViewRef } from '@angular/core';
+import { NG_VALUE_ACCESSOR } from '@angular/forms';
 import { BehaviorSubject, merge, Observable, Subject } from 'rxjs';
 import { map, switchMap, takeUntil } from 'rxjs/operators';
 import { AnchorAlignment, AnchorPlacement } from '../../tooltip/index';
@@ -10,9 +11,18 @@ import { MenuModuleOptions } from '../menu-options.interface';
 import { MENU_OPTIONS_TOKEN } from '../menu-options.token';
 import { MenuTabbableItemDirective } from '../menu-tabbable-item/menu-tabbable-item.directive';
 
+let uniqueId = 0;
+
+export const MENU_VALUE_ACCESSOR: StaticProvider = {
+    provide: NG_VALUE_ACCESSOR,
+    useExisting: forwardRef(() => MenuComponent),
+    multi: true
+};
+
 @Component({
     selector: 'ux-menu',
     templateUrl: './menu.component.html',
+    providers: [MENU_VALUE_ACCESSOR],
     changeDetection: ChangeDetectionStrategy.OnPush,
     host: {
         'role': 'menu'
@@ -30,6 +40,9 @@ import { MenuTabbableItemDirective } from '../menu-tabbable-item/menu-tabbable-i
     ]
 })
 export class MenuComponent implements AfterContentInit, OnDestroy, OnChanges {
+
+    /** A unique id for the component. */
+    @Input() @HostBinding('attr.id') id: string = `ux-select-${++uniqueId}`;
 
     /** Define the position of the menu */
     @Input() placement: AnchorPlacement = 'bottom';


### PR DESCRIPTION
#### Checklist
<!-- Use an 'x' to check those which apply. -->
* [x] The contents of this PR are mine to submit. No third party code or other material is being committed.
* [x] New third party dependencies (if any) are linked via `package.json`. Third party dependencies are licensed under one of the following: Apache, MIT, BSD, Mozilla Public License, Eclipse Public License, or Oracle Binary Code License.
* [x] The code in this PR does not contain export-restricted encryption algorithms.

#### Ticket / Issue
<!-- Either a Jira URL or a description of the issue that this PR addresses. -->
https://portal.digitalsafe.net/browse/EL-4250

#### Description of Proposed Changes
<!-- Describe what was changed and how it addresses the original issue. -->
- added overlay element id as aria-controls 
- Added role menu to overlay container element
- Updated karma tests to cover this

#### Documentation CI URL
<!-- Initiate a build at https://jenkins.swinfra.net/job/SEPG/view/Templates/job/New%20SEPG%20Build/build -->
<!-- Append the branch name to the following URL: -->
https://pages.github.houston.softwaregrp.net/sepg-docs-qa/UXAspects_CI_UXAspects_EL-4250-menu-accessibility

#### Downstream Build(s)
<!-- Push a branch with the same name in each downstream repository and create a build in Jenkins. -->
<!-- Add the Jenkins build link(s) below: -->
* [caf/ux-aspects-micro-focus](https://jenkins.swinfra.net/job/SEPG/job/caf/job/caf~ux-aspects-micro-focus~EL-4250-menu-accessibility~CI/)
