### PR TITLE
Dashboard: Prevent trying to shift widgets before the initial layout has been performed

### DIFF
--- a/src/components/dashboard/widget/dashboard-widget.component.spec.ts
+++ b/src/components/dashboard/widget/dashboard-widget.component.spec.ts
@@ -1,5 +1,5 @@
 import { SimpleChange } from '@angular/core';
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 import { DashboardService } from '../dashboard.service';
 import { DashboardWidgetComponent } from './dashboard-widget.component';
 
@@ -10,7 +10,6 @@ class MockDashboardService extends DashboardService {
 
 describe('Dashboard Widget', () => {
     let component: DashboardWidgetComponent;
-    let fixture: ComponentFixture<DashboardWidgetComponent>;
 
     beforeEach(async () => {
         await TestBed.configureTestingModule({

--- a/src/components/dashboard/widget/dashboard-widget.component.spec.ts
+++ b/src/components/dashboard/widget/dashboard-widget.component.spec.ts
@@ -1,0 +1,31 @@
+import { SimpleChange } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { DashboardService } from '../dashboard.service';
+import { DashboardWidgetComponent } from './dashboard-widget.component';
+
+class MockDashboardService extends DashboardService {
+    resizeWidget = jasmine.createSpy();
+    renderDashboard = jasmine.createSpy();
+}
+
+describe('Dashboard Widget', () => {
+    let component: DashboardWidgetComponent;
+    let fixture: ComponentFixture<DashboardWidgetComponent>;
+
+    beforeEach(async () => {
+        await TestBed.configureTestingModule({
+            providers: [{ provide: DashboardService, useClass: MockDashboardService }],
+            declarations: [DashboardWidgetComponent],
+        }).compileComponents();
+    });
+
+    it('should not attempt to resize a widget before the layout has been set', () => {
+        const dashboardService = TestBed.inject(DashboardService);
+        component.ngOnChanges({
+            colSpan: new SimpleChange(undefined, 1, true),
+        });
+
+        expect(dashboardService.resizeWidget).not.toHaveBeenCalled();
+        expect(dashboardService.renderDashboard).not.toHaveBeenCalled();
+    });
+});

--- a/src/components/dashboard/widget/dashboard-widget.component.spec.ts
+++ b/src/components/dashboard/widget/dashboard-widget.component.spec.ts
@@ -1,5 +1,5 @@
 import { SimpleChange } from '@angular/core';
-import { TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { DashboardService } from '../dashboard.service';
 import { DashboardWidgetComponent } from './dashboard-widget.component';
 
@@ -9,6 +9,7 @@ class MockDashboardService extends DashboardService {
 }
 
 describe('Dashboard Widget', () => {
+    let fixture: ComponentFixture<DashboardWidgetComponent>;
     let component: DashboardWidgetComponent;
 
     beforeEach(async () => {
@@ -16,6 +17,9 @@ describe('Dashboard Widget', () => {
             providers: [{ provide: DashboardService, useClass: MockDashboardService }],
             declarations: [DashboardWidgetComponent],
         }).compileComponents();
+
+        fixture = TestBed.createComponent(DashboardWidgetComponent);
+        component = fixture.componentInstance;
     });
 
     it('should not attempt to resize a widget before the layout has been set', () => {

--- a/src/components/dashboard/widget/dashboard-widget.component.ts
+++ b/src/components/dashboard/widget/dashboard-widget.component.ts
@@ -163,7 +163,7 @@ export class DashboardWidgetComponent implements OnInit, AfterViewInit, OnDestro
     }
 
     ngOnChanges(changes: SimpleChanges): void {
-        if (changes.colSpan || changes.rowSpan) {
+        if (this.hasPosition() && (changes.colSpan || changes.rowSpan)) {
             this.dashboardService.resizeWidget(this);
             this.dashboardService.renderDashboard();
         }
@@ -345,6 +345,11 @@ export class DashboardWidgetComponent implements OnInit, AfterViewInit, OnDestro
      */
     private getStackableValue(property: StackableValue): number {
         return this.dashboardService.stacked ? property.stacked : property.regular;
+    }
+
+    /** Determine if the layout has been performed yet */
+    private hasPosition(): boolean {
+        return this.getColumn() !== undefined && this.getRow() !== undefined;
     }
 
     static ngAcceptInputType_autoPositioning: BooleanInput;

--- a/src/components/marquee-wizard/marquee-wizard.component.spec.ts
+++ b/src/components/marquee-wizard/marquee-wizard.component.spec.ts
@@ -160,7 +160,7 @@ describe('Marquee Wizard', () => {
     it('should only emit stepChange once when "Next" is clicked', async () => {
         spyOn(component, 'onStepChange');
 
-        await wrapper.clickStepButton('Next', false);
+        await wrapper.clickStepButton('Next');
 
         expect(component.onStepChange).toHaveBeenCalledTimes(1);
     });


### PR DESCRIPTION
…has been performed

#### Checklist
<!-- Use an 'x' to check those which apply. -->
* [x] The contents of this PR are mine to submit. No third party code or other material is being committed.
* [x] New third party dependencies (if any) are linked via `package.json`. Third party dependencies are licensed under one of the following: Apache, MIT, BSD, Mozilla Public License, Eclipse Public License, or Oracle Binary Code License.
* [x] The code in this PR does not contain export-restricted encryption algorithms.

#### Ticket / Issue
<!-- Either a Jira URL or a description of the issue that this PR addresses. -->
https://portal.digitalsafe.net/browse/EL-4270

#### Description of Proposed Changes
<!-- Describe what was changed and how it addresses the original issue. -->
- Checking that the widget layout has occurred before attempting to resize widget

#### Documentation CI URL
<!-- Initiate a build at https://jenkins.swinfra.net/job/SEPG/view/Templates/job/New%20SEPG%20Build/build -->
<!-- Append the branch name to the following URL: -->
https://pages.github.houston.softwaregrp.net/sepg-docs-qa/UXAspects_CI_UXAspects_dashboard-fix

#### Downstream Build(s)
<!-- Push a branch with the same name in each downstream repository and create a build in Jenkins. -->
<!-- Add the Jenkins build link(s) below: -->
https://jenkins.swinfra.net/job/SEPG/job/Inner-Source-Incubating/view/Developer/job/Inner-Source-Incubating~ux-aspects-universal~ng-toggle-button~CI/