### PR TITLE
EL-4261 - typeahead previous options not removed

### DIFF
--- a/src/components/typeahead/typeahead.component.ts
+++ b/src/components/typeahead/typeahead.component.ts
@@ -1,10 +1,8 @@
 import { FocusOrigin } from '@angular/cdk/a11y';
-import { ViewportRuler } from '@angular/cdk/scrolling';
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, EventEmitter, HostBinding, HostListener, Input, OnChanges, OnDestroy, Output, Renderer2, SimpleChanges, TemplateRef } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, EventEmitter, HostBinding, HostListener, Input, OnChanges, OnDestroy, Output, SimpleChanges, TemplateRef, ViewChild } from '@angular/core';
 import { BehaviorSubject, combineLatest, Subject } from 'rxjs';
 import { distinctUntilChanged, takeUntil } from 'rxjs/operators';
-import { InfiniteScrollLoadedEvent, InfiniteScrollLoadFunction } from '../../directives/infinite-scroll/index';
-import { ResizeService } from '../../directives/resize/index';
+import { InfiniteScrollDirective, InfiniteScrollLoadedEvent, InfiniteScrollLoadFunction } from '../../directives/infinite-scroll/index';
 import { PopoverOrientation, PopoverOrientationListener, PopoverOrientationService } from '../../services/popover-orientation/popover-orientation.service';
 import { TypeaheadOptionEvent } from './typeahead-event';
 import { TypeaheadOptionApi } from './typeahead-option-api';
@@ -26,6 +24,8 @@ let uniqueId = 0;
     }
 })
 export class TypeaheadComponent<T = any> implements OnChanges, OnDestroy {
+
+    @ViewChild(InfiniteScrollDirective) infiniteScroll:InfiniteScrollDirective;
 
     /** Define a unique id for the typeahead */
     @Input() @HostBinding('attr.id') id: string = `ux-typeahead-${++uniqueId}`;
@@ -169,10 +169,7 @@ export class TypeaheadComponent<T = any> implements OnChanges, OnDestroy {
         public typeaheadElement: ElementRef,
         private _changeDetector: ChangeDetectorRef,
         popoverOrientation: PopoverOrientationService,
-        private _service: TypeaheadService,
-        private _viewportRuler: ViewportRuler,
-        private _renderer: Renderer2,
-        private _resizeService: ResizeService,
+        private _service: TypeaheadService
     ) {
         this.loadOptionsCallback = (pageNum: number, pageSize: number, filter: any) => {
             if (typeof this.options === 'function') {
@@ -274,6 +271,10 @@ export class TypeaheadComponent<T = any> implements OnChanges, OnDestroy {
             } else {
                 this.dropUp = changes.dropDirection.currentValue === 'up';
             }
+        }
+
+        if (changes.options && changes.options.firstChange === false) {
+            this.infiniteScroll.reload();
         }
 
         // Re-filter visibleOptions

--- a/src/components/typeahead/typeahead.component.ts
+++ b/src/components/typeahead/typeahead.component.ts
@@ -25,7 +25,7 @@ let uniqueId = 0;
 })
 export class TypeaheadComponent<T = any> implements OnChanges, OnDestroy {
 
-    @ViewChild(InfiniteScrollDirective) infiniteScroll:InfiniteScrollDirective;
+    @ViewChild(InfiniteScrollDirective) infiniteScroll: InfiniteScrollDirective;
 
     /** Define a unique id for the typeahead */
     @Input() @HostBinding('attr.id') id: string = `ux-typeahead-${++uniqueId}`;


### PR DESCRIPTION
#### Checklist
<!-- Use an 'x' to check those which apply. -->
* [x] The contents of this PR are mine to submit. No third party code or other material is being committed.
* [x] New third party dependencies (if any) are linked via `package.json`. Third party dependencies are licensed under one of the following: Apache, MIT, BSD, Mozilla Public License, Eclipse Public License, or Oracle Binary Code License.
* [x] The code in this PR does not contain export-restricted encryption algorithms.

#### Ticket / Issue
<!-- Either a Jira URL or a description of the issue that this PR addresses. -->
https://portal.digitalsafe.net/browse/EL-4261

#### Description of Proposed Changes
<!-- Describe what was changed and how it addresses the original issue. -->

#### Documentation CI URL
<!-- Initiate a build at https://jenkins.swinfra.net/job/SEPG/view/Templates/job/New%20SEPG%20Build/build -->
<!-- Append the branch name to the following URL: -->
https://pages.github.houston.softwaregrp.net/sepg-docs-qa/UXAspects_CI_UXAspects_EL-4261-typeahead-previous-options-not-removed

#### Downstream Build(s)
<!-- Push a branch with the same name in each downstream repository and create a build in Jenkins. -->
<!-- Add the Jenkins build link(s) below: -->
* [caf/ux-aspects-micro-focus](https://jenkins.swinfra.net/job/SEPG/job/caf/job/caf~ux-aspects-micro-focus~EL-4261-typeahead-previous-options-not-removed~CI/)
