### PR TITLE
464101 - Tag Input - Console error when enforceTagLimits is at maxTag limit when tabbing through tags

### DIFF
--- a/e2e/tests/components/tags/tags.e2e-spec.ts
+++ b/e2e/tests/components/tags/tags.e2e-spec.ts
@@ -1,4 +1,4 @@
-import { Key } from 'protractor';
+import { browser, Key } from 'protractor';
 import { imageCompare } from '../common/image-compare';
 import { TagsPage } from './tags.po.spec';
 
@@ -298,5 +298,13 @@ describe('TagsPage Tests', () => {
         await page.sendCharactersToTagsInput(Key.ENTER);
 
         expect(await imageCompare('tags-typeahead-reopen')).toEqual(0);
+    });
+
+    it('should allow tabbing through the component when enforceTagLimits is true and the tags is at the max', async () => {
+        await page.enforceTagLimits.click();
+        await page.changeMaxTags('3');
+
+        await page.clickOnTagAtIndex(2);
+        await browser.actions().sendKeys(Key.TAB).perform();
     });
 });

--- a/e2e/tests/components/tags/tags.po.spec.ts
+++ b/e2e/tests/components/tags/tags.po.spec.ts
@@ -1,4 +1,4 @@
-import { $, browser, by, element, ElementFinder, Key, protractor } from 'protractor';
+import { $, browser, by, element, ElementFinder, Key, protractor, WebElement } from 'protractor';
 
 export class TagsPage {
 
@@ -19,6 +19,7 @@ export class TagsPage {
     selectFirst = $('#selectFirst');
     showTypeaheadOnClick = $('#showTypeaheadOnClick');
     typeahead = $('ux-typeahead');
+    input = $('input.ux-tag-input');
 
     async getPage(): Promise<void> {
         await browser.get('#/tags');
@@ -120,7 +121,7 @@ export class TagsPage {
     }
 
     confirmTypeaheadClassExists(item: ElementFinder, soughtClass: string) {
-        return item.getAttribute('class').then(function (classes: string) {
+        return item.getAttribute('class').then(function(classes: string) {
             const allClasses = classes.split(' ');
             if (allClasses.indexOf(soughtClass) > -1) {
                 return true;
@@ -159,5 +160,13 @@ export class TagsPage {
 
     getInputPatternErrorMessage() {
         return this.inputPatternErrorMessage.getText();
+    }
+
+    async activeElement(): Promise<WebElement> {
+        return await browser.driver.switchTo().activeElement();
+    };
+
+    async clickOnTagAtIndex(index: number) {
+        return this.tagsInput.$$('li.ux-tag').get(index).click();
     }
 }

--- a/src/components/tag-input/tag-input.component.ts
+++ b/src/components/tag-input/tag-input.component.ts
@@ -209,7 +209,7 @@ export class TagInputComponent<T = any> implements AfterContentInit, OnChanges, 
 
     @ContentChildren(TypeaheadComponent) typeaheadQuery: QueryList<TypeaheadComponent>;
 
-    @ViewChild('tagInput', { static: false }) tagInput: ElementRef;
+    @ViewChild('tagInput', { static: false }) tagInput: ElementRef<HTMLInputElement>;
 
     selectedIndex: number = -1;
 
@@ -336,7 +336,7 @@ export class TagInputComponent<T = any> implements AfterContentInit, OnChanges, 
         }
 
         // Get the input field cursor location
-        const inputCursorPos = this.tagInput?.nativeElement.selectionStart;
+        const inputCursorPos = this.tagInput?.nativeElement.selectionStart ?? 0;
 
         // Determine if the input field has any text selected
         const hasSelection = this.tagInput?.nativeElement.selectionStart !== this.tagInput?.nativeElement.selectionEnd;

--- a/src/components/tag-input/tag-input.component.ts
+++ b/src/components/tag-input/tag-input.component.ts
@@ -336,10 +336,10 @@ export class TagInputComponent<T = any> implements AfterContentInit, OnChanges, 
         }
 
         // Get the input field cursor location
-        const inputCursorPos = this.tagInput.nativeElement.selectionStart;
+        const inputCursorPos = this.tagInput?.nativeElement.selectionStart;
 
         // Determine if the input field has any text selected
-        const hasSelection = this.tagInput.nativeElement.selectionStart !== this.tagInput.nativeElement.selectionEnd;
+        const hasSelection = this.tagInput?.nativeElement.selectionStart !== this.tagInput?.nativeElement.selectionEnd;
 
         // Determine if a tag has focus
         const tagSelected = this.isValidTagIndex(this.selectedIndex);


### PR DESCRIPTION
#### Checklist
<!-- Use an 'x' to check those which apply. -->
* [x] The contents of this PR are mine to submit. No third party code or other material is being committed.
* [x] New third party dependencies (if any) are linked via `package.json`. Third party dependencies are licensed under one of the following: Apache, MIT, BSD, Mozilla Public License, Eclipse Public License, or Oracle Binary Code License.
* [x] The code in this PR does not contain export-restricted encryption algorithms.

#### Ticket / Issue
<!-- Either a Jira URL or a description of the issue that this PR addresses. -->
https://internal.almoctane.com/ui/entity-navigation?p=131002/7002&entityType=work_item&id=464101

#### Description of Proposed Changes
<!-- Describe what was changed and how it addresses the original issue. -->
1. ISSUE: There is a console error when tabbing through the component when there are max tags and enforce tag limits is true. The input is removed when this parameter is met and therefore this.tagInput is undefined in the keyHandler function.
2. FIX: Making problem parameters optional.

#### Documentation CI URL
<!-- Initiate a build at https://jenkins.swinfra.net/job/SEPG/view/Templates/job/New%20SEPG%20Build/build -->
<!-- Append the branch name to the following URL: -->
https://pages.github.houston.softwaregrp.net/sepg-docs-qa/UXAspects_CI_UXAspects_464101-tag-input-console-error

#### Downstream Build(s)
<!-- Push a branch with the same name in each downstream repository and create a build in Jenkins. -->
<!-- Add the Jenkins build link(s) below: -->
* [caf/ux-aspects-micro-focus](https://jenkins.swinfra.net/job/SEPG/job/caf/job/caf~ux-aspects-micro-focus~464101-tag-input-console-error~CI/)
