### PR TITLE
Changed facet service to use facet ID for comparisons

### DIFF
--- a/src/components/facets/facet.service.ts
+++ b/src/components/facets/facet.service.ts
@@ -34,7 +34,7 @@ export class FacetService {
         }
 
         // update the list of active facets
-        this.facets$.next(this.facets$.value.filter(_facet => _facet !== facet));
+        this.facets$.next(this.facets$.value.filter(_selectedFacets => _selectedFacets.id !== facet.id));
 
         // emit the event
         this.events$.next(new FacetDeselect(facet));
@@ -54,6 +54,6 @@ export class FacetService {
     }
 
     isSelected(facet: Facet): boolean {
-        return this.facets$.value.indexOf(facet) > -1;
+        return !!this.facets$.value.find((_selectedFacet) => _selectedFacet.id === facet.id);
     }
 }

--- a/src/components/facets/facet.service.ts
+++ b/src/components/facets/facet.service.ts
@@ -34,7 +34,7 @@ export class FacetService {
         }
 
         // update the list of active facets
-        this.facets$.next(this.facets$.value.filter(_selectedFacet => !this.areFacetsMatching(_selectedFacet, facet)));
+        this.facets$.next(this.facets$.value.filter(_selectedFacet => !this.isFacetMatch(_selectedFacet, facet)));
 
         // emit the event
         this.events$.next(new FacetDeselect(facet));
@@ -54,11 +54,11 @@ export class FacetService {
     }
 
     isSelected(facet: Facet): boolean {
-        return !!this.facets$.value.find((_selectedFacet) => this.areFacetsMatching(_selectedFacet, facet));
+        return !!this.facets$.value.find((_selectedFacet) => this.isFacetMatch(_selectedFacet, facet));
     }
 
-    private areFacetsMatching(facet1: Facet, facet2: Facet): boolean {
-        if(facet1.id === undefined || facet2.id === undefined) {
+    private isFacetMatch(facet1: Facet, facet2: Facet): boolean {
+        if (facet1.id === undefined || facet2.id === undefined) {
             return facet1 === facet2;
         }
 

--- a/src/components/facets/facet.service.ts
+++ b/src/components/facets/facet.service.ts
@@ -34,7 +34,7 @@ export class FacetService {
         }
 
         // update the list of active facets
-        this.facets$.next(this.facets$.value.filter(_selectedFacets => _selectedFacets.id !== facet.id));
+        this.facets$.next(this.facets$.value.filter(_selectedFacet => !this.areFacetsMatching(_selectedFacet, facet)));
 
         // emit the event
         this.events$.next(new FacetDeselect(facet));
@@ -54,6 +54,14 @@ export class FacetService {
     }
 
     isSelected(facet: Facet): boolean {
-        return !!this.facets$.value.find((_selectedFacet) => _selectedFacet.id === facet.id);
+        return !!this.facets$.value.find((_selectedFacet) => this.areFacetsMatching(_selectedFacet, facet));
+    }
+
+    private areFacetsMatching(facet1: Facet, facet2: Facet): boolean {
+        if(facet1.id === undefined || facet2.id === undefined) {
+            return facet1 === facet2;
+        }
+
+        return facet1.id === facet2.id;
     }
 }


### PR DESCRIPTION
#### Checklist
<!-- Use an 'x' to check those which apply. -->
* [x] The contents of this PR are mine to submit. No third party code or other material is being committed.
* [x] New third party dependencies (if any) are linked via `package.json`. Third party dependencies are licensed under one of the following: Apache, MIT, BSD, Mozilla Public License, Eclipse Public License, or Oracle Binary Code License.
* [x] The code in this PR does not contain export-restricted encryption algorithms.

#### Ticket / Issue
https://github.houston.softwaregrp.net/caf/ux-aspects-micro-focus/issues/959

#### Description of Proposed Changes
Updated the facet service to use the facet id for comparisons rather than the object.