### PR TITLE
976 - Fix date range picker from emitting both onStartChange and onEndChange simultaneously 

### DIFF
--- a/src/components/date-range-picker/date-range-picker.spec.ts
+++ b/src/components/date-range-picker/date-range-picker.spec.ts
@@ -94,8 +94,9 @@ describe('Date Range Picker', () => {
         expect(component).toBeTruthy();
     });
 
-    it('should update start date and call onStartChange when start date is changed ', async () => {
+    it('should update start date and call onStartChange when start date is changed and not call onEndChange', async () => {
         spyOn(component, 'onStartChange');
+        spyOn(component, 'onEndChange');
         component.start = new Date(2020, 0, 7, 0, 0, 0);
 
         fixture.detectChanges();
@@ -103,10 +104,12 @@ describe('Date Range Picker', () => {
 
         expect(getDate().innerHTML).toBe(' 7 January 2020 ');
         expect(component.onStartChange).toHaveBeenCalled();
+        expect(component.onEndChange).not.toHaveBeenCalled();
     });
 
-    it('should update end date and call onEndChange when end date is changed', async () => {
+    it('should update end date and call onEndChange when end date is changed and not call onStartChange', async () => {
         spyOn(component, 'onEndChange');
+        spyOn(component, 'onStartChange');
         component.end = new Date(2020, 0, 23, 23, 59, 59);
 
         fixture.detectChanges();
@@ -114,6 +117,7 @@ describe('Date Range Picker', () => {
 
         expect(getDate(1).innerHTML).toBe(' 23 January 2020 ');
         expect(component.onEndChange).toHaveBeenCalled();
+        expect(component.onStartChange).not.toHaveBeenCalled();
     });
 
     it('should not cause an error when dates set to undefined', async () => {

--- a/src/components/date-time-picker/day-view/day-view.component.ts
+++ b/src/components/date-time-picker/day-view/day-view.component.ts
@@ -121,11 +121,6 @@ export class DayViewComponent implements AfterViewInit, OnDestroy {
      */
     select(date: Date): void {
 
-        // if we are range picking, and have no dates selected clear the range (if we select the current day initially it won't get selected)
-        if (this._isRangeMode && !this._rangeStart && !this._rangeEnd) {
-            this._rangeService.clear();
-        }
-
         // if we are the start range picker and we click the already selected day deselect it
         if (this._isRangeMode && this._isRangeStart && this._rangeStart && compareDays(this._rangeStart, date)) {
             this._rangeService.setStartDate(null);


### PR DESCRIPTION
#### Checklist
<!-- Use an 'x' to check those which apply. -->
* [x] The contents of this PR are mine to submit. No third party code or other material is being committed.
* [x] New third party dependencies (if any) are linked via `package.json`. Third party dependencies are licensed under one of the following: Apache, MIT, BSD, Mozilla Public License, Eclipse Public License, or Oracle Binary Code License.
* [x] The code in this PR does not contain export-restricted encryption algorithms.

#### Ticket / Issue
<!-- Either a Jira URL or a description of the issue that this PR addresses. -->
https://github.houston.softwaregrp.net/caf/ux-aspects-micro-focus/issues/976

#### Description of Proposed Changes
<!-- Describe what was changed and how it addresses the original issue. -->
Remove problem code, update test coverage to cover fix

#### Documentation CI URL
<!-- Initiate a build at https://jenkins.swinfra.net/job/SEPG/view/Templates/job/New%20SEPG%20Build/build -->
<!-- Append the branch name to the following URL: -->
https://pages.github.houston.softwaregrp.net/sepg-docs-qa/UXAspects_CI_UXAspects_range-picker-emit

#### Downstream Build(s)
<!-- Push a branch with the same name in each downstream repository and create a build in Jenkins. -->
<!-- Add the Jenkins build link(s) below: -->
* [caf/ux-aspects-micro-focus](https://jenkins.swinfra.net/job/SEPG/job/caf/job/caf~ux-aspects-micro-focus~range-picker-emit~CI/)
