### PR TITLE
fix: improving sanitization of typeaheads

### DIFF
--- a/src/components/facets/facet-typeahead-list/facet-typeahead-list.component.html
+++ b/src/components/facets/facet-typeahead-list/facet-typeahead-list.component.html
@@ -1,58 +1,60 @@
 <ux-facet-header [header]="header" [(expanded)]="expanded"></ux-facet-header>
 
 <div class="facet-typeahead-list-container" role="listbox" *ngIf="expanded">
+  <div
+    class="facet-typeahead-list-selected-container"
+    tabindex="-1"
+    *ngIf="suggestions?.length > 0"
+  >
+    <ux-facet-typeahead-list-item
+      *ngFor="let facet of suggestions; let index = index"
+      [facet]="facet"
+      [tabbable]="activeIndex === index"
+      [selected]="facetService.isSelected(facet)"
+      (selectedChange)="toggleFacet(index, facet)"
+      (keydown)="onKeydown($event)"
+      (itemFocus)="onFocus(index)"
+    >
+    </ux-facet-typeahead-list-item>
+  </div>
 
-    <div class="facet-typeahead-list-selected-container" tabindex="-1" *ngIf="suggestions?.length > 0">
+  <div class="facet-typeahead-list-control">
+    <!-- Create Typeahead Control -->
+    <input
+      type="text"
+      class="form-control"
+      [placeholder]="typeaheadConfig?.placeholder"
+      [attr.aria-activedescendant]="highlightedElement?.id"
+      aria-autocomplete="list"
+      aria-multiline="false"
+      [attr.aria-controls]="typeaheadId"
+      [ngModel]="query$ | async"
+      (ngModelChange)="query$.next($event); updateTypeahead($event)"
+      (keydown)="typeaheadKeyService.handleKey($event, typeahead)"
+      (blur)="typeaheadOpen = false"
+    />
 
-        <ux-facet-typeahead-list-item
-            *ngFor="let facet of suggestions; let index = index"
-            [facet]="facet"
-            [tabbable]="activeIndex === index"
-            [selected]="facetService.isSelected(facet)"
-            (selectedChange)="toggleFacet(index, facet)"
-            (keydown)="onKeydown($event)"
-            (itemFocus)="onFocus(index)">
-        </ux-facet-typeahead-list-item>
-
-    </div>
-
-    <div class="facet-typeahead-list-control">
-
-        <!-- Create Typeahead Control -->
-        <input type="text"
-            class="form-control"
-            [placeholder]="typeaheadConfig?.placeholder"
-            [attr.aria-activedescendant]="highlightedElement?.id"
-            aria-autocomplete="list"
-            aria-multiline="false"
-            [attr.aria-controls]="typeaheadId"
-            [ngModel]="query$ | async"
-            (ngModelChange)="query$.next($event); updateTypeahead($event)"
-            (keydown)="typeaheadKeyService.handleKey($event, typeahead)"
-            (blur)="typeaheadOpen = false">
-
-        <ux-typeahead #typeahead
-            [id]="typeaheadId"
-            [(open)]="typeaheadOpen"
-            [loading]="loading"
-            display="title"
-            [options]="typeaheadOptions"
-            [optionTemplate]="facetOptionTemplate"
-            [selectOnEnter]="true"
-            (optionSelected)="select($event)"
-            (highlightedElementChange)="highlightedElement = $event">
-        </ux-typeahead>
-
-    </div>
-
+    <ux-typeahead
+      #typeahead
+      [id]="typeaheadId"
+      [(open)]="typeaheadOpen"
+      [loading]="loading"
+      display="title"
+      [options]="typeaheadOptions"
+      [optionTemplate]="facetOptionTemplate"
+      [selectOnEnter]="true"
+      (optionSelected)="select($event)"
+      (highlightedElementChange)="highlightedElement = $event"
+    >
+    </ux-typeahead>
+  </div>
 </div>
 
 <ng-template #facetOptionTemplate let-option="option" let-api="api">
-    <p class="facet-typeahead-list-option" [attr.aria-label]="option.title">
-        <span [innerHTML]="option.title | facetTypeaheadHighlight: (query$ | async)"></span>
-        <span class="facet-typeahead-list-option-count"
-            *ngIf="option.count">
-            ({{ option.count }})
-        </span>
-    </p>
+  <p class="facet-typeahead-list-option" [attr.aria-label]="option.title">
+    <span [uxSafeInnerHtml]="option.title | facetTypeaheadHighlight : (query$ | async)"></span>
+    <span class="facet-typeahead-list-option-count" *ngIf="option.count">
+      ({{ option.count }})
+    </span>
+  </p>
 </ng-template>

--- a/src/components/facets/facets.module.ts
+++ b/src/components/facets/facets.module.ts
@@ -1,9 +1,10 @@
 import { A11yModule } from '@angular/cdk/a11y';
+import { DragDropModule } from '@angular/cdk/drag-drop';
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { DragDropModule } from '@angular/cdk/drag-drop';
 import { AccessibilityModule } from '../../directives/accessibility/index';
+import { SafeInnerHtmlDirective } from '../../directives/safe-inner-html/safe-inner-html.directive';
 import { CheckboxModule } from '../checkbox/index';
 import { IconModule } from '../icon/index';
 import { TooltipModule } from '../tooltip/index';
@@ -14,34 +15,38 @@ import { FacetCheckListItemComponent } from './facet-check-list/check-list-item/
 import { FacetCheckListComponent } from './facet-check-list/facet-check-list.component';
 import { FacetClearButtonDirective } from './facet-clear-button/facet-clear-button.directive';
 import { FacetContainerComponent } from './facet-container.component';
-import { FacetTypeaheadHighlight, FacetTypeaheadListComponent } from './facet-typeahead-list/facet-typeahead-list.component';
+import {
+  FacetTypeaheadHighlight,
+  FacetTypeaheadListComponent,
+} from './facet-typeahead-list/facet-typeahead-list.component';
 import { FacetTypeaheadListItemComponent } from './facet-typeahead-list/typeahead-list-item/facet-typeahead-list-item.component';
 
 const DECLARATIONS = [
-    FacetContainerComponent,
-    FacetHeaderComponent,
-    FacetCheckListComponent,
-    FacetCheckListItemComponent,
-    FacetTypeaheadListComponent,
-    FacetTypeaheadListItemComponent,
-    FacetTypeaheadHighlight,
-    FacetClearButtonDirective
+  FacetContainerComponent,
+  FacetHeaderComponent,
+  FacetCheckListComponent,
+  FacetCheckListItemComponent,
+  FacetTypeaheadListComponent,
+  FacetTypeaheadListItemComponent,
+  FacetTypeaheadHighlight,
+  FacetClearButtonDirective,
 ];
 
 @NgModule({
-    imports: [
-        A11yModule,
-        AccessibilityModule,
-        CheckboxModule,
-        CommonModule,
-        FormsModule,
-        IconModule,
-        ReorderableModule,
-        TooltipModule,
-        TypeaheadModule,
-        DragDropModule
-    ],
-    exports: DECLARATIONS,
-    declarations: DECLARATIONS
+  imports: [
+    A11yModule,
+    AccessibilityModule,
+    CheckboxModule,
+    CommonModule,
+    FormsModule,
+    IconModule,
+    ReorderableModule,
+    TooltipModule,
+    TypeaheadModule,
+    DragDropModule,
+    SafeInnerHtmlDirective,
+  ],
+  exports: DECLARATIONS,
+  declarations: DECLARATIONS,
 })
-export class FacetsModule { }
+export class FacetsModule {}

--- a/src/components/filters/filter-dynamic/filter-dynamic.component.html
+++ b/src/components/filters/filter-dynamic/filter-dynamic.component.html
@@ -1,99 +1,99 @@
 <div class="btn-group ux-dynamic-filter">
+  <button
+    type="button"
+    [class.active]="selected !== initial"
+    class="filter-dropdown btn dropdown-toggle"
+    [id]="filterId + '-trigger'"
+    [uxMenuTriggerFor]="menu"
+    [closeOnBlur]="closeOnBlur"
+    (closed)="closed.emit()"
+    #trigger="ux-menu-trigger"
+  >
+    {{ selected?.group }}
+    <span class="filter-header" *ngIf="selected !== initial"> ({{ selected?.name }}) </span>
+    <ux-icon name="down"></ux-icon>
+  </button>
 
+  <ux-menu #menu menuClass="ux-dynamic-filter-menu" (closed)="onClose()">
+    <!-- Initial Option -->
     <button
-        type="button"
-        [class.active]="selected !== initial"
-        class="filter-dropdown btn dropdown-toggle"
-        [id]="filterId + '-trigger'"
-        [uxMenuTriggerFor]="menu"
-        [closeOnBlur]="closeOnBlur"
-        (closed)="closed.emit()"
-        #trigger="ux-menu-trigger">
-        {{ selected?.group }}
-        <span class="filter-header" *ngIf="selected !== initial">
-                ({{ selected?.name }})
-            </span>
-        <ux-icon name="down"></ux-icon>
+      uxMenuItem
+      *ngIf="showTypeahead"
+      [id]="initial.id || filterId + '-initial-option'"
+      (click)="removeFilter()"
+      (keydown.enter)="removeFilter()"
+    >
+      <ux-icon name="checkmark" [style.visibility]="initial === selected ? 'visible' : 'hidden'">
+      </ux-icon>
+      <span class="filter-dropdown-title">
+        {{ initial.name }}
+      </span>
     </button>
 
-    <ux-menu #menu menuClass="ux-dynamic-filter-menu" (closed)="onClose()">
-        <!-- Initial Option -->
-        <button
-            uxMenuItem
-            *ngIf="showTypeahead"
-            [id]="initial.id || filterId + '-initial-option'"
-            (click)="removeFilter()"
-            (keydown.enter)="removeFilter()">
-            <ux-icon
-                name="checkmark"
-                [style.visibility]="initial === selected ? 'visible' : 'hidden'">
-            </ux-icon>
-            <span class="filter-dropdown-title">
-                {{ initial.name }}
-            </span>
-        </button>
+    <!-- Selected Options -->
+    <button
+      uxMenuItem
+      *ngIf="selected !== initial && showTypeahead"
+      [id]="selected.id || filterId + '-selection'"
+    >
+      <ux-icon name="checkmark"></ux-icon>
+      <span class="filter-dropdown-title">{{ selected.name }}</span>
+    </button>
 
-        <!-- Selected Options -->
-        <button uxMenuItem
-                *ngIf="selected !== initial && showTypeahead"
-                [id]="selected.id || filterId + '-selection'">
-            <ux-icon name="checkmark"></ux-icon>
-            <span class="filter-dropdown-title">{{ selected.name }}</span>
-        </button>
+    <ux-menu-divider *ngIf="showTypeahead"></ux-menu-divider>
 
-        <ux-menu-divider *ngIf="showTypeahead"></ux-menu-divider>
+    <div *ngIf="showTypeahead" class="typeahead-box" role="none">
+      <input
+        type="text"
+        class="form-control"
+        [placeholder]="options?.placeholder"
+        [attr.aria-activedescendant]="highlightedElement?.id"
+        [attr.aria-controls]="typeaheadId"
+        aria-autocomplete="list"
+        aria-multiline="false"
+        [ngModel]="query$ | async"
+        (ngModelChange)="query$.next($event); updateTypeahead($event)"
+        (keydown)="typeaheadKeyService.handleKey($event, typeahead); $event.stopPropagation()"
+        (keydown.enter)="$event.preventDefault()"
+        (blur)="typeaheadOpen = false"
+        (click)="$event.stopPropagation()"
+      />
 
-        <div *ngIf="showTypeahead" class="typeahead-box" role="none">
+      <ux-typeahead
+        #typeahead
+        [id]="typeaheadId"
+        [(open)]="typeaheadOpen"
+        display="title"
+        [selectOnEnter]="true"
+        [options]="typeaheadItems"
+        [optionTemplate]="filterOptionTemplate"
+        (optionSelected)="select($event); trigger.closeMenu($event.origin)"
+        (highlightedElementChange)="highlightedElement = $event"
+      >
+      </ux-typeahead>
+    </div>
 
-            <input type="text"
-                   class="form-control"
-                   [placeholder]="options?.placeholder"
-                   [attr.aria-activedescendant]="highlightedElement?.id"
-                   [attr.aria-controls]="typeaheadId"
-                   aria-autocomplete="list"
-                   aria-multiline="false"
-                   [ngModel]="query$ | async"
-                   (ngModelChange)="query$.next($event); updateTypeahead($event)"
-                   (keydown)="typeaheadKeyService.handleKey($event, typeahead); $event.stopPropagation();"
-                   (keydown.enter)="$event.preventDefault()"
-                   (blur)="typeaheadOpen = false"
-                   (click)="$event.stopPropagation()">
+    <ng-container *ngIf="!showTypeahead">
+      <button
+        *ngFor="let filter of filters; let index = index"
+        type="button"
+        uxMenuItem
+        [id]="filter.id || filterId + '-item-' + index"
+        (click)="selectFilter(filter); trigger.closeMenu('mouse')"
+        (keydown.enter)="selectFilter(filter); trigger.closeMenu('keyboard')"
+      >
+        <ux-icon name="checkmark" [style.visibility]="filter === selected ? 'visible' : 'hidden'">
+        </ux-icon>
 
-            <ux-typeahead #typeahead
-                          [id]="typeaheadId"
-                          [(open)]="typeaheadOpen"
-                          display="title"
-                          [selectOnEnter]="true"
-                          [options]="typeaheadItems"
-                          [optionTemplate]="filterOptionTemplate"
-                          (optionSelected)="select($event); trigger.closeMenu($event.origin)"
-                          (highlightedElementChange)="highlightedElement = $event">
-            </ux-typeahead>
-        </div>
-
-        <ng-container *ngIf="!showTypeahead">
-
-            <button
-                *ngFor="let filter of filters; let index = index"
-                type="button"
-                uxMenuItem
-                [id]="filter.id || filterId + '-item-' + index"
-                (click)="selectFilter(filter); trigger.closeMenu('mouse')"
-                (keydown.enter)="selectFilter(filter); trigger.closeMenu('keyboard')">
-
-                <ux-icon
-                    name="checkmark"
-                    [style.visibility]="filter === selected ? 'visible' : 'hidden'">
-                </ux-icon>
-
-                <span class="filter-dropdown-title">{{ filter.name }}</span>
-            </button>
-
-        </ng-container>
-
-    </ux-menu>
+        <span class="filter-dropdown-title">{{ filter.name }}</span>
+      </button>
+    </ng-container>
+  </ux-menu>
 </div>
 
 <ng-template #filterOptionTemplate let-option="option" let-api="api">
-    <span [attr.aria-label]="option" [innerHTML]="option | filterTypeaheadHighlight: (query$ | async)"></span>
+  <span
+    [attr.aria-label]="option"
+    [uxSafeInnerHtml]="option | filterTypeaheadHighlight : (query$ | async)"
+  ></span>
 </ng-template>

--- a/src/components/filters/filter.module.ts
+++ b/src/components/filters/filter.module.ts
@@ -3,6 +3,7 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { AccessibilityModule } from '../../directives/accessibility/index';
+import { SafeInnerHtmlDirective } from '../../directives/safe-inner-html/safe-inner-html.directive';
 import { IconModule } from '../icon/index';
 import { MenuModule } from '../menu/index';
 import { TooltipModule } from '../tooltip/index';
@@ -13,24 +14,25 @@ import { FilterDynamicComponent } from './filter-dynamic/filter-dynamic.componen
 import { FilterTypeaheadHighlight } from './filter-dynamic/filter-typeahead-highlight.pipe';
 
 const DECLARATIONS = [
-    FilterContainerComponent,
-    FilterDropdownComponent,
-    FilterDynamicComponent,
-    FilterTypeaheadHighlight
+  FilterContainerComponent,
+  FilterDropdownComponent,
+  FilterDynamicComponent,
+  FilterTypeaheadHighlight,
 ];
 
 @NgModule({
-    imports: [
-        A11yModule,
-        AccessibilityModule,
-        CommonModule,
-        FormsModule,
-        IconModule,
-        MenuModule,
-        TooltipModule,
-        TypeaheadModule,
-    ],
-    exports: DECLARATIONS,
-    declarations: DECLARATIONS
+  imports: [
+    A11yModule,
+    AccessibilityModule,
+    CommonModule,
+    FormsModule,
+    IconModule,
+    MenuModule,
+    TooltipModule,
+    TypeaheadModule,
+    SafeInnerHtmlDirective,
+  ],
+  exports: DECLARATIONS,
+  declarations: DECLARATIONS,
 })
-export class FilterModule { }
+export class FilterModule {}

--- a/src/components/typeahead/typeahead.component.html
+++ b/src/components/typeahead/typeahead.component.html
@@ -1,84 +1,85 @@
-<div class="ux-typeahead-options"
-     [uxInfiniteScroll]="loadOptionsCallback"
-     [collection]="visibleOptions$ | async"
-     (collectionChange)="visibleOptions$.next($event)"
-     [enabled]="hasBeenOpened && isInfiniteScroll()"
-     [filter]="filter"
-     [loadOnScroll]="true"
-     [pageSize]="pageSize"
-     [scrollElement]="typeaheadElement"
-     (loading)="loading = true"
-     (loaded)="loading = false; onLoadedHighlight($event)">
+<div
+  class="ux-typeahead-options"
+  [uxInfiniteScroll]="loadOptionsCallback"
+  [collection]="visibleOptions$ | async"
+  (collectionChange)="visibleOptions$.next($event)"
+  [enabled]="hasBeenOpened && isInfiniteScroll()"
+  [filter]="filter"
+  [loadOnScroll]="true"
+  [pageSize]="pageSize"
+  [scrollElement]="typeaheadElement"
+  (loading)="loading = true"
+  (loaded)="loading = false; onLoadedHighlight($event)"
+>
+  <div *ngIf="(visibleRecentOptions$ | async).length > 0">
+    <ng-container [ngTemplateOutlet]="recentOptionsHeadingTemplate"></ng-container>
+  </div>
 
-    <div *ngIf="(visibleRecentOptions$ | async).length > 0">
-        <ng-container [ngTemplateOutlet]="recentOptionsHeadingTemplate"></ng-container>
-    </div>
+  <!-- Recent options -->
+  <ux-typeahead-options-list
+    *ngIf="(visibleRecentOptions$ | async).length > 0"
+    class="ux-typeahead-recent-options"
+    [id]="id"
+    [options]="visibleRecentOptions$ | async"
+    [highlighted]="highlighted$ | async"
+    [activeKey]="activeKey"
+    [disabledOptions]="_disabledOptions"
+    [isMultiselectable]="multiselectable"
+    [optionTemplate]="optionTemplate || defaultOptionTemplate"
+    [optionApi]="optionApi"
+    [typeaheadElement]="typeaheadElement"
+    (optionMouseover)="highlight($event.option)"
+    (optionMousedown)="optionMousedownHandler($event.event)"
+    (optionClick)="optionClickHandler($event.event, $event.option)"
+  >
+  </ux-typeahead-options-list>
 
-     <!-- Recent options -->
-    <ux-typeahead-options-list
-        *ngIf="(visibleRecentOptions$ | async).length > 0"
-        class="ux-typeahead-recent-options"
-        [id]="id"
-        [options]="visibleRecentOptions$ | async"
-        [highlighted]="highlighted$ | async"
-        [activeKey]="activeKey"
-        [disabledOptions]="_disabledOptions"
-        [isMultiselectable]="multiselectable"
-        [optionTemplate]="optionTemplate || defaultOptionTemplate"
-        [optionApi]="optionApi"
-        [typeaheadElement]="typeaheadElement"
-        (optionMouseover)="highlight($event.option)"
-        (optionMousedown)="optionMousedownHandler($event.event)"
-        (optionClick)="optionClickHandler($event.event, $event.option)">
-    </ux-typeahead-options-list>
+  <ng-container [ngTemplateOutlet]="optionsHeadingTemplate"></ng-container>
 
-    <ng-container [ngTemplateOutlet]="optionsHeadingTemplate"></ng-container>
+  <!-- All options -->
+  <ux-typeahead-options-list
+    *ngIf="(visibleOptions$ | async).length > 0"
+    class="ux-typeahead-all-options"
+    [id]="id"
+    [ariaLabel]="ariaLabel"
+    [startIndex]="(visibleRecentOptions$ | async).length"
+    [options]="visibleOptions$ | async"
+    [highlighted]="highlighted$ | async"
+    [activeKey]="activeKey"
+    [disabledOptions]="_disabledOptions"
+    [isMultiselectable]="multiselectable"
+    [optionTemplate]="optionTemplate || defaultOptionTemplate"
+    [optionApi]="optionApi"
+    [typeaheadElement]="typeaheadElement"
+    (optionMouseover)="highlight($event.option)"
+    (optionMousedown)="optionMousedownHandler($event.event)"
+    (optionClick)="optionClickHandler($event.event, $event.option)"
+  >
+  </ux-typeahead-options-list>
 
-    <!-- All options -->
-    <ux-typeahead-options-list
-        *ngIf="(visibleOptions$ | async).length > 0"
-        class="ux-typeahead-all-options"
-        [id]="id"
-        [ariaLabel]="ariaLabel"
-        [startIndex]="(visibleRecentOptions$ | async).length"
-        [options]="visibleOptions$ | async"
-        [highlighted]="highlighted$ | async"
-        [activeKey]="activeKey"
-        [disabledOptions]="_disabledOptions"
-        [isMultiselectable]="multiselectable"
-        [optionTemplate]="optionTemplate || defaultOptionTemplate"
-        [optionApi]="optionApi"
-        [typeaheadElement]="typeaheadElement"
-        (optionMouseover)="highlight($event.option)"
-        (optionMousedown)="optionMousedownHandler($event.event)"
-        (optionClick)="optionClickHandler($event.event, $event.option)">
-    </ux-typeahead-options-list>
+  <div *uxInfiniteScrollLoading>
+    <ng-container [ngTemplateOutlet]="loadingTemplate || defaultLoadingTemplate"></ng-container>
+  </div>
 
-    <div *uxInfiniteScrollLoading>
-        <ng-container [ngTemplateOutlet]="loadingTemplate || defaultLoadingTemplate"></ng-container>
-    </div>
-
-    <div *ngIf="isInfiniteScroll() === false && (visibleOptions$ | async).length === 0 && loading">
-        <ng-container [ngTemplateOutlet]="loadingTemplate || defaultLoadingTemplate"></ng-container>
-    </div>
-
+  <div *ngIf="isInfiniteScroll() === false && (visibleOptions$ | async).length === 0 && loading">
+    <ng-container [ngTemplateOutlet]="loadingTemplate || defaultLoadingTemplate"></ng-container>
+  </div>
 </div>
 <div *ngIf="(visibleOptions$ | async).length === 0 && !loading">
-    <ng-container [ngTemplateOutlet]="noOptionsTemplate || defaultNoOptionsTemplate">
-    </ng-container>
+  <ng-container [ngTemplateOutlet]="noOptionsTemplate || defaultNoOptionsTemplate"> </ng-container>
 </div>
 
 <ng-template #defaultLoadingTemplate>
-    <div class="ux-typeahead-loading">
-        <div class="spinner spinner-accent spinner-bounce-middle"></div>
-        <div>Loading...</div>
-    </div>
+  <div class="ux-typeahead-loading">
+    <div class="spinner spinner-accent spinner-bounce-middle"></div>
+    <div>Loading...</div>
+  </div>
 </ng-template>
 
 <ng-template #defaultOptionTemplate let-option="option" let-api="api">
-    <span class="ux-typeahead-option" [innerHtml]="api.getDisplayHtml(option)"></span>
+  <span class="ux-typeahead-option" [uxSafeInnerHtml]="api.getDisplayHtml(option)"></span>
 </ng-template>
 
 <ng-template #defaultNoOptionsTemplate>
-    <span class="ux-typeahead-no-options">No results</span>
+  <span class="ux-typeahead-no-options">No results</span>
 </ng-template>

--- a/src/components/typeahead/typeahead.component.ts
+++ b/src/components/typeahead/typeahead.component.ts
@@ -1,10 +1,34 @@
 import { FocusOrigin } from '@angular/cdk/a11y';
 import { coerceArray } from '@angular/cdk/coercion';
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, EventEmitter, HostBinding, HostListener, inject, Input, OnChanges, OnDestroy, Output, SimpleChanges, TemplateRef, ViewChild } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  ElementRef,
+  EventEmitter,
+  HostBinding,
+  HostListener,
+  inject,
+  Input,
+  OnChanges,
+  OnDestroy,
+  Output,
+  SimpleChanges,
+  TemplateRef,
+  ViewChild,
+} from '@angular/core';
 import { BehaviorSubject, combineLatest, Subject } from 'rxjs';
 import { distinctUntilChanged, takeUntil } from 'rxjs/operators';
-import { InfiniteScrollDirective, InfiniteScrollLoadedEvent, InfiniteScrollLoadFunction } from '../../directives/infinite-scroll/index';
-import { PopoverOrientation, PopoverOrientationListener, PopoverOrientationService } from '../../services/popover-orientation/popover-orientation.service';
+import {
+  InfiniteScrollDirective,
+  InfiniteScrollLoadedEvent,
+  InfiniteScrollLoadFunction,
+} from '../../directives/infinite-scroll/index';
+import {
+  PopoverOrientation,
+  PopoverOrientationListener,
+  PopoverOrientationService,
+} from '../../services/popover-orientation/popover-orientation.service';
 import { TypeaheadOptionEvent } from './typeahead-event';
 import { TypeaheadOptionApi } from './typeahead-option-api';
 import { TypeaheadOptionContext } from './typeahead-option-context';
@@ -14,546 +38,552 @@ import { TypeaheadService } from './typeahead.service';
 let uniqueId = 0;
 
 @Component({
-    selector: 'ux-typeahead',
-    templateUrl: 'typeahead.component.html',
-    providers: [TypeaheadService, PopoverOrientationService],
-    changeDetection: ChangeDetectionStrategy.OnPush,
-    host: {
-        '[class.open]': 'open',
-        '[style.maxHeight]': 'maxHeight'
-    }
+  selector: 'ux-typeahead',
+  templateUrl: 'typeahead.component.html',
+  providers: [TypeaheadService, PopoverOrientationService],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  host: {
+    '[class.open]': 'open',
+    '[style.maxHeight]': 'maxHeight',
+  },
 })
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export class TypeaheadComponent<T = any> implements OnChanges, OnDestroy {
-    readonly typeaheadElement = inject(ElementRef);
+  readonly typeaheadElement = inject(ElementRef);
 
-    readonly popoverOrientation = inject(PopoverOrientationService);
+  readonly popoverOrientation = inject(PopoverOrientationService);
 
-    private readonly _changeDetector = inject(ChangeDetectorRef);
+  private readonly _changeDetector = inject(ChangeDetectorRef);
 
-    private readonly _service = inject(TypeaheadService);
+  private readonly _service = inject(TypeaheadService);
 
-    @ViewChild(InfiniteScrollDirective) infiniteScroll: InfiniteScrollDirective;
+  @ViewChild(InfiniteScrollDirective) infiniteScroll: InfiniteScrollDirective;
 
-    /** Define a unique id for the typeahead */
-    @Input() @HostBinding('attr.id') id: string = `ux-typeahead-${++uniqueId}`;
+  /** Define a unique id for the typeahead */
+  @Input() @HostBinding('attr.id') id: string = `ux-typeahead-${++uniqueId}`;
 
-    /** Define the options or infinite load function */
-    @Input() options: T[] | InfiniteScrollLoadFunction;
+  /** Define the options or infinite load function */
+  @Input() options: T[] | InfiniteScrollLoadFunction;
 
-    /** Define the filter text */
-    @Input() filter: string;
+  /** Define the filter text */
+  @Input() filter: string;
 
-    /** Specify if the typeahead is open */
-    @Input()
-    get open() {
-        return this._service.open$.getValue();
+  /** Specify if the typeahead is open */
+  @Input()
+  get open() {
+    return this._service.open$.getValue();
+  }
+  set open(value: boolean) {
+    this._service.open$.next(value);
+  }
+
+  /** Extract the test to display from an option */
+  @Input() display: ((option: T) => string) | string;
+
+  /** Extract the key from an option */
+  @Input() key: ((option: T) => string) | string;
+
+  /** Specify which options are disabled */
+  @Input() set disabledOptions(options: T | T[]) {
+    this._disabledOptions = coerceArray(options);
+  }
+
+  get disabledOptions(): T | T[] {
+    return this._disabledOptions;
+  }
+
+  _disabledOptions: T[] = [];
+
+  /** Specify the drop direction */
+  @Input() dropDirection: 'auto' | 'up' | 'down' = 'down';
+
+  /** Specify the max height of the dropdown */
+  @Input()
+  get maxHeight(): string {
+    return this._maxHeight;
+  }
+
+  set maxHeight(maxHeight: string) {
+    this._maxHeight = maxHeight;
+    if (this.maxHeight.endsWith('px')) {
+      this._popoverOrientationListener.maxHeight = Number(this.maxHeight.slice(0, -2));
     }
-    set open(value: boolean) {
-        this._service.open$.next(value);
-    }
+  }
 
-    /** Extract the test to display from an option */
-    @Input() display: ((option: T) => string) | string;
+  /** Specify the aria multi selectable attribute value */
+  @Input()
+  multiselectable: boolean = false;
 
-    /** Extract the key from an option */
-    @Input() key: ((option: T) => string) | string;
+  /** Specify the aria label for the listbox */
+  @Input()
+  ariaLabel: string;
 
-    /** Specify which options are disabled */
-    @Input() set disabledOptions(options: T | T[]) {
-        this._disabledOptions = coerceArray(options);
-    }
+  /** Specify if the dropdown should appear when the filter appears */
+  @Input() openOnFilterChange: boolean = true;
 
-    get disabledOptions(): T | T[] {
-        return this._disabledOptions;
-    }
+  /** Specify the page size */
+  @Input() pageSize: number = 20;
 
-    _disabledOptions: T[] = [];
+  /** Specify if we should select the first item by default */
+  @Input() selectFirst: boolean = true;
 
-    /** Specify the drop direction */
-    @Input() dropDirection: 'auto' | 'up' | 'down' = 'down';
+  /** Specify if we should select an item on enter key press */
+  @Input() selectOnEnter: boolean = false;
 
-    /** Specify the max height of the dropdown */
-    @Input()
-    get maxHeight(): string {
-        return this._maxHeight;
-    }
+  /** Specify the loading state */
+  @Input() loading = false;
 
-    set maxHeight(maxHeight: string) {
-        this._maxHeight = maxHeight;
-        if (this.maxHeight.endsWith('px')) {
-            this._popoverOrientationListener.maxHeight = Number(this.maxHeight.slice(0, -2));
-        }
-    }
+  /** Specify a custom loading template */
+  @Input() loadingTemplate: TemplateRef<void>;
 
-    /** Specify the aria multi selectable attribute value */
-    @Input()
-    multiselectable: boolean = false;
+  /** Specify a custom option template */
+  @Input() optionTemplate: TemplateRef<TypeaheadOptionContext<T>>;
 
-    /** Specify the aria label for the listbox */
-    @Input()
-    ariaLabel: string;
+  /** Specify a custom template to display when there are no options */
+  @Input() noOptionsTemplate: TemplateRef<void>;
 
-    /** Specify if the dropdown should appear when the filter appears */
-    @Input() openOnFilterChange: boolean = true;
+  /** Specify the currently active item */
+  @Input() set active(item: T) {
+    this.activeKey = this.getKey(item);
+  }
 
-    /** Specify the page size */
-    @Input() pageSize: number = 20;
+  /**
+   * An initial list of recently selected options, to be presented above the full list of options.
+   * Bind an empty array to `recentOptions` to enable this feature without providing an initial set.
+   */
+  @Input() recentOptions: ReadonlyArray<T>;
 
-    /** Specify if we should select the first item by default */
-    @Input() selectFirst: boolean = true;
+  /** Maximum number of displayed recently selected options. */
+  @Input() recentOptionsMaxCount: number = 5;
 
-    /** Specify if we should select an item on enter key press */
-    @Input() selectOnEnter: boolean = false;
+  @Input() recentOptionsHeadingTemplate: TemplateRef<void>;
 
-    /** Specify the loading state */
-    @Input() loading = false;
+  @Input() optionsHeadingTemplate: TemplateRef<void>;
 
-    /** Specify a custom loading template */
-    @Input() loadingTemplate: TemplateRef<void>;
+  /** Emit when the open state changes */
+  @Output() openChange = new EventEmitter<boolean>();
 
-    /** Specify a custom option template */
-    @Input() optionTemplate: TemplateRef<TypeaheadOptionContext<T>>;
+  /** Emit when an option is selected */
+  @Output() optionSelected = new EventEmitter<TypeaheadOptionEvent<T>>();
 
-    /** Specify a custom template to display when there are no options */
-    @Input() noOptionsTemplate: TemplateRef<void>;
+  /** Emit whenever a highlighted item changes */
+  @Output() highlightedChange = new EventEmitter<T>();
 
-    /** Specify the currently active item */
-    @Input() set active(item: T) {
-        this.activeKey = this.getKey(item);
-    }
+  /** Emit the highlighted element when it changes */
+  @Output() highlightedElementChange = new EventEmitter<HTMLElement>();
 
-    /**
-     * An initial list of recently selected options, to be presented above the full list of options.
-     * Bind an empty array to `recentOptions` to enable this feature without providing an initial set.
-     */
-    @Input() recentOptions: ReadonlyArray<T>;
+  /** Emits when recently selected options change.*/
+  @Output() recentOptionsChange = new EventEmitter<ReadonlyArray<T>>();
 
-    /** Maximum number of displayed recently selected options. */
-    @Input() recentOptionsMaxCount: number = 5;
+  activeKey: string = null;
+  clicking = false;
+  hasBeenOpened = false;
+  highlighted$ = new BehaviorSubject<TypeaheadVisibleOption<T>>(null);
+  loadOptionsCallback: InfiniteScrollLoadFunction;
+  visibleOptions$ = new BehaviorSubject<TypeaheadVisibleOption<T>[]>([]);
+  visibleRecentOptions$ = new BehaviorSubject<TypeaheadVisibleOption<T>[]>([]);
+  allVisibleOptions: TypeaheadVisibleOption<T>[] = [];
 
-    @Input() recentOptionsHeadingTemplate: TemplateRef<void>;
+  get highlighted(): T {
+    const value = this.highlighted$.getValue();
+    return value ? value.value : null;
+  }
 
-    @Input() optionsHeadingTemplate: TemplateRef<void>;
+  /** Store the list of recent items */
+  private _recentOptions: T[];
 
-    /** Emit when the open state changes */
-    @Output() openChange = new EventEmitter<boolean>();
+  private readonly _onDestroy = new Subject<void>();
 
-    /** Emit when an option is selected */
-    @Output() optionSelected = new EventEmitter<TypeaheadOptionEvent<T>>();
+  private readonly _popoverOrientationListener: PopoverOrientationListener;
 
-    /** Emit whenever a highlighted item changes */
-    @Output() highlightedChange = new EventEmitter<T>();
+  private _maxHeight = '250px';
 
-    /** Emit the highlighted element when it changes */
-    @Output() highlightedElementChange = new EventEmitter<HTMLElement>();
+  @HostBinding('class.drop-up')
+  dropUp: boolean;
 
-    /** Emits when recently selected options change.*/
-    @Output() recentOptionsChange = new EventEmitter<ReadonlyArray<T>>();
+  optionApi: TypeaheadOptionApi<T> = {
+    getKey: this.getKey.bind(this),
+    getDisplay: this.getDisplay.bind(this),
+    getDisplayHtml: this.getDisplayHtml.bind(this),
+    getDisabled: this.isDisabled.bind(this),
+  };
 
-    activeKey: string = null;
-    clicking = false;
-    hasBeenOpened = false;
-    highlighted$ = new BehaviorSubject<TypeaheadVisibleOption<T>>(null);
-    loadOptionsCallback: InfiniteScrollLoadFunction;
-    visibleOptions$ = new BehaviorSubject<TypeaheadVisibleOption<T>[]>([]);
-    visibleRecentOptions$ = new BehaviorSubject<TypeaheadVisibleOption<T>[]>([]);
-    allVisibleOptions: TypeaheadVisibleOption<T>[] = [];
+  constructor() {
+    this.loadOptionsCallback = (pageNum: number, pageSize: number, filter: unknown) => {
+      if (typeof this.options === 'function') {
+        // Invoke the callback which may return an array or a promise.
+        const arrayOrPromise = this.options(pageNum, pageSize, filter);
 
-    get highlighted(): T {
-        const value = this.highlighted$.getValue();
-        return value ? value.value : null;
-    }
+        // Map the results to an array of TypeaheadVisibleOption.
+        return Promise.resolve(arrayOrPromise).then(newOptions => {
+          if (!Array.isArray(newOptions)) {
+            return newOptions;
+          }
 
-    /** Store the list of recent items */
-    private _recentOptions: T[];
-
-    private readonly _onDestroy = new Subject<void>();
-
-    private readonly _popoverOrientationListener: PopoverOrientationListener;
-
-    private _maxHeight = '250px';
-
-    @HostBinding('class.drop-up')
-    dropUp: boolean;
-
-    optionApi: TypeaheadOptionApi<T> = {
-        getKey: this.getKey.bind(this),
-        getDisplay: this.getDisplay.bind(this),
-        getDisplayHtml: this.getDisplayHtml.bind(this),
-        getDisabled: this.isDisabled.bind(this)
+          return this.getVisibleOptions(newOptions, '');
+        });
+      }
+      return null;
     };
 
-    constructor() {
-        this.loadOptionsCallback = (pageNum: number, pageSize: number, filter: unknown) => {
-            if (typeof this.options === 'function') {
-                // Invoke the callback which may return an array or a promise.
-                const arrayOrPromise = this.options(pageNum, pageSize, filter);
+    this._service.open$
+      .pipe(distinctUntilChanged(), takeUntil(this._onDestroy))
+      .subscribe(isOpen => {
+        this.openChange.emit(isOpen);
 
-                // Map the results to an array of TypeaheadVisibleOption.
-                return Promise.resolve(arrayOrPromise).then(newOptions => {
-                    if (!Array.isArray(newOptions)) {
-                        return newOptions;
-                    }
+        if (isOpen) {
+          this.hasBeenOpened = true;
+          this.initOptions();
+        }
+      });
 
-                    return this.getVisibleOptions(newOptions, '');
-                });
-            }
-            return null;
-        };
+    this._popoverOrientationListener = this.popoverOrientation.createPopoverOrientationListener(
+      this.typeaheadElement.nativeElement,
+      this.typeaheadElement.nativeElement.parentElement
+    );
 
-        this._service.open$
-            .pipe(distinctUntilChanged(), takeUntil(this._onDestroy))
-            .subscribe(isOpen => {
-                this.openChange.emit(isOpen);
+    this._popoverOrientationListener.orientation$
+      .pipe(takeUntil(this._onDestroy))
+      .subscribe(direction => {
+        if (this.dropDirection === 'auto') {
+          this.dropUp = direction === PopoverOrientation.Up;
+        }
+      });
 
-                if (isOpen) {
-                    this.hasBeenOpened = true;
-                    this.initOptions();
-                }
-            });
+    this.highlighted$.pipe(takeUntil(this._onDestroy)).subscribe(next => {
+      this.highlightedChange.emit(next ? next.value : null);
+    });
 
-        this._popoverOrientationListener = this.popoverOrientation.createPopoverOrientationListener(this.typeaheadElement.nativeElement, this.typeaheadElement.nativeElement.parentElement);
+    combineLatest([this.visibleOptions$, this.visibleRecentOptions$])
+      .pipe(takeUntil(this._onDestroy))
+      .subscribe(([visibleOptions, visibleRecentOptions]) => {
+        this.allVisibleOptions = [...visibleRecentOptions, ...visibleOptions];
+      });
 
-        this._popoverOrientationListener.orientation$.pipe(takeUntil(this._onDestroy))
-            .subscribe(direction => {
-                if (this.dropDirection === 'auto') {
-                    this.dropUp = direction === PopoverOrientation.Up;
-                }
-            });
+    combineLatest([this._service.open$, this._service.highlightedElement$, this.visibleOptions$])
+      .pipe(takeUntil(this._onDestroy))
+      .subscribe(([open, highlightedElement, visibleOptions]) => {
+        this.highlightedElementChange.emit(
+          open && visibleOptions.length > 0 ? highlightedElement : null
+        );
+      });
+  }
 
-        this.highlighted$.pipe(takeUntil(this._onDestroy)).subscribe(next => {
-            this.highlightedChange.emit(next ? next.value : null);
+  ngOnChanges(changes: SimpleChanges): void {
+    // Open the dropdown if the filter value updates
+    if (changes.filter) {
+      if (
+        this.openOnFilterChange &&
+        changes.filter.currentValue &&
+        changes.filter.currentValue.length > 0
+      ) {
+        // if the dropdown item was just selected, and we set the filter value to match the
+        // selected value then open will have also just been set to `false`, in which case we do
+        // not want to set open to `true`
+        if (
+          changes.open &&
+          changes.open.previousValue === true &&
+          changes.open.currentValue === false
+        ) {
+          return;
+        }
+
+        // show the dropdown
+        this.open = true;
+      }
+    }
+
+    // Cut off recentOptions at recentOptionsMaxCount
+    if (changes.recentOptions || changes.recentOptionsMaxCount) {
+      this._recentOptions = this.recentOptions
+        ? this.recentOptions.slice(0, this.recentOptionsMaxCount)
+        : undefined;
+
+      if (changes.recentOptionsMaxCount) {
+        // Avoid ExpressionChangedAfterChecked error
+        setTimeout(() => {
+          this.recentOptionsChange.emit(this._recentOptions);
         });
-
-        combineLatest([this.visibleOptions$, this.visibleRecentOptions$])
-            .pipe(takeUntil(this._onDestroy))
-            .subscribe(([visibleOptions, visibleRecentOptions]) => {
-                this.allVisibleOptions = [...visibleRecentOptions, ...visibleOptions];
-            });
-
-        combineLatest([
-            this._service.open$,
-            this._service.highlightedElement$,
-            this.visibleOptions$
-        ])
-            .pipe(takeUntil(this._onDestroy))
-            .subscribe(([open, highlightedElement, visibleOptions]) => {
-                this.highlightedElementChange.emit(
-                    open && visibleOptions.length > 0 ? highlightedElement : null
-                );
-            });
+      }
     }
 
-    ngOnChanges(changes: SimpleChanges): void {
-        // Open the dropdown if the filter value updates
-        if (changes.filter) {
-            if (this.openOnFilterChange && changes.filter.currentValue && changes.filter.currentValue.length > 0) {
-                // if the dropdown item was just selected, and we set the filter value to match the
-                // selected value then open will have also just been set to `false`, in which case we do
-                // not want to set open to `true`
-                if (
-                    changes.open &&
-                    changes.open.previousValue === true &&
-                    changes.open.currentValue === false
-                ) {
-                    return;
-                }
-
-                // show the dropdown
-                this.open = true;
-            }
-        }
-
-        // Cut off recentOptions at recentOptionsMaxCount
-        if (changes.recentOptions || changes.recentOptionsMaxCount) {
-            this._recentOptions = this.recentOptions
-                ? this.recentOptions.slice(0, this.recentOptionsMaxCount)
-                : undefined;
-
-            if (changes.recentOptionsMaxCount) {
-                // Avoid ExpressionChangedAfterChecked error
-                setTimeout(() => {
-                    this.recentOptionsChange.emit(this._recentOptions);
-                });
-            }
-        }
-
-        if (changes.dropDirection) {
-            if (changes.dropDirection.currentValue === 'auto') {
-                this.dropUp = this._popoverOrientationListener.orientation$.getValue() === PopoverOrientation.Up;
-            } else {
-                this.dropUp = changes.dropDirection.currentValue === 'up';
-            }
-        }
-
-        if (changes.options && changes.options.firstChange === false) {
-            this.infiniteScroll.reset(false);
-            this.infiniteScroll.reload();
-        }
-
-        // Re-filter visibleOptions
-        this.updateOptions();
+    if (changes.dropDirection) {
+      if (changes.dropDirection.currentValue === 'auto') {
+        this.dropUp =
+          this._popoverOrientationListener.orientation$.getValue() === PopoverOrientation.Up;
+      } else {
+        this.dropUp = changes.dropDirection.currentValue === 'up';
+      }
     }
 
-    ngOnDestroy(): void {
-        this._onDestroy.next();
-        this._onDestroy.complete();
-        this._popoverOrientationListener.destroy();
+    if (changes.options && changes.options.firstChange === false) {
+      this.infiniteScroll.reset(false);
+      this.infiniteScroll.reload();
     }
 
-    @HostListener('mousedown', ['$event', '$event.target'])
-    mousedownHandler(event: MouseEvent, target: HTMLElement): void {
-        this.clicking = true;
+    // Re-filter visibleOptions
+    this.updateOptions();
+  }
 
-        /**
-         * Chrome Bug Workaround: (https://bugs.chromium.org/p/chromium/issues/detail?id=6759)
-         * In Chrome, if the typeahead is within a tabbable element, e.g. it has a parent with
-         * `tabindex="0"` like our side panel has, then clicking on a scrollbar will remove
-         * focus from the input element.
-         *
-         * To avoid this we can determine if the mousedown event occurred within the scrollbar
-         * region of the typeahead and if so preventDefault which will stop the input
-         * from losing focus
-         */
-        if (event.clientX >= target.clientWidth || event.clientY >= target.clientHeight) {
-            event.preventDefault();
-        }
-    }
+  ngOnDestroy(): void {
+    this._onDestroy.next();
+    this._onDestroy.complete();
+    this._popoverOrientationListener.destroy();
+  }
 
-    @HostListener('mouseup')
-    mouseupHandler(): void {
-        this.clicking = false;
-    }
-
-    optionMousedownHandler(event: MouseEvent): void {
-        // Workaround to prevent focus changing when an option is clicked
-        event.preventDefault();
-    }
-
-    optionClickHandler(_event: MouseEvent, option: TypeaheadVisibleOption<T>): void {
-        this.select(option, 'mouse');
-    }
+  @HostListener('mousedown', ['$event', '$event.target'])
+  mousedownHandler(event: MouseEvent, target: HTMLElement): void {
+    this.clicking = true;
 
     /**
-     * Returns the unique key value of the given option.
+     * Chrome Bug Workaround: (https://bugs.chromium.org/p/chromium/issues/detail?id=6759)
+     * In Chrome, if the typeahead is within a tabbable element, e.g. it has a parent with
+     * `tabindex="0"` like our side panel has, then clicking on a scrollbar will remove
+     * focus from the input element.
+     *
+     * To avoid this we can determine if the mousedown event occurred within the scrollbar
+     * region of the typeahead and if so preventDefault which will stop the input
+     * from losing focus
      */
-    getKey(option: T): string {
-        if (typeof this.key === 'function') {
-            return this.key(option);
-        }
-        // eslint-disable-next-line no-prototype-builtins
-        if (typeof this.key === 'string' && option && option.hasOwnProperty(this.key)) {
-            return option[this.key];
-        }
-        return this.getDisplay(option);
+    if (event.clientX >= target.clientWidth || event.clientY >= target.clientHeight) {
+      event.preventDefault();
+    }
+  }
+
+  @HostListener('mouseup')
+  mouseupHandler(): void {
+    this.clicking = false;
+  }
+
+  optionMousedownHandler(event: MouseEvent): void {
+    // Workaround to prevent focus changing when an option is clicked
+    event.preventDefault();
+  }
+
+  optionClickHandler(_event: MouseEvent, option: TypeaheadVisibleOption<T>): void {
+    this.select(option, 'mouse');
+  }
+
+  /**
+   * Returns the unique key value of the given option.
+   */
+  getKey(option: T): string {
+    if (typeof this.key === 'function') {
+      return this.key(option);
+    }
+    // eslint-disable-next-line no-prototype-builtins
+    if (typeof this.key === 'string' && option && option.hasOwnProperty(this.key)) {
+      return option[this.key];
+    }
+    return this.getDisplay(option);
+  }
+
+  /**
+   * Returns the display value of the given option.
+   */
+  getDisplay(option: T): string | undefined {
+    if (typeof this.display === 'function') {
+      return this.display(option);
     }
 
-    /**
-     * Returns the display value of the given option.
-     */
-    getDisplay(option: T): string | undefined {
-        if (typeof this.display === 'function') {
-            return this.display(option);
-        }
-
-        // eslint-disable-next-line no-prototype-builtins
-        if (typeof this.display === 'string' && option && option.hasOwnProperty(this.display)) {
-            return option[this.display];
-        }
-
-        if (typeof option === 'string') {
-            return option;
-        }
+    // eslint-disable-next-line no-prototype-builtins
+    if (typeof this.display === 'string' && option && option.hasOwnProperty(this.display)) {
+      return option[this.display];
     }
 
-    /**
-     * Returns the display value of the given option with HTML markup added to highlight the part which matches the current filter value.
-     * @param option
-     */
-    getDisplayHtml(option: T): string {
-        const displayText = this.getDisplay(option);
+    if (typeof option === 'string') {
+      return option;
+    }
+  }
 
-        // getDisplay may return undefined in certain cases
-        if (!displayText) {
-            return '';
-        }
+  /**
+   * Returns the display value of the given option with HTML markup added to highlight the part which matches the current filter value.
+   * @param option
+   */
+  getDisplayHtml(option: T): string {
+    const displayText = this.getDisplay(option);
 
-        let displayHtml = displayText
-            .replace(/&/g, '&amp;')
-            .replace(/</g, '&lt;')
-            .replace(/>/g, '&gt;');
-
-        if (this.filter) {
-            const length = this.filter.length;
-            const matchIndex = displayText
-                .toLowerCase()
-                .indexOf(this.filter.toLowerCase());
-            if (matchIndex >= 0) {
-                const highlight = `<span class="ux-filter-match">${ displayText.substr(matchIndex, length) }</span>`;
-                displayHtml =
-                    displayText.substr(0, matchIndex) +
-                    highlight +
-                    displayText.substr(matchIndex + length);
-            }
-        }
-        return displayHtml;
+    // getDisplay may return undefined in certain cases
+    if (!displayText) {
+      return '';
     }
 
-    /**
-     * Returns true if the infinite scroll component should load
-     */
-    isInfiniteScroll(): boolean {
-        return typeof this.options === 'function';
+    let displayHtml = displayText
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;');
+
+    if (this.filter) {
+      const length = this.filter.length;
+      const matchIndex = displayText.toLowerCase().indexOf(this.filter.toLowerCase());
+      if (matchIndex >= 0) {
+        const highlight = `<span class="ux-filter-match">${displayText.substr(
+          matchIndex,
+          length
+        )}</span>`;
+        displayHtml =
+          displayText.substr(0, matchIndex) + highlight + displayText.substr(matchIndex + length);
+      }
+    }
+    return displayHtml;
+  }
+
+  /**
+   * Returns true if the infinite scroll component should load
+   */
+  isInfiniteScroll(): boolean {
+    return typeof this.options === 'function';
+  }
+
+  /**
+   * Selects the given option, emitting the optionSelected event and closing the dropdown.
+   */
+  select(option: TypeaheadVisibleOption<T>, origin?: FocusOrigin): void {
+    if (!this.isDisabled(option.value)) {
+      this.optionSelected.emit(new TypeaheadOptionEvent(option.value, origin));
+      this.highlighted$.next(null);
+      this.open = false;
+      this.addToRecentOptions(option.value);
+    }
+  }
+
+  addToRecentOptions(value: T) {
+    if (this._recentOptions) {
+      this._recentOptions = [
+        value,
+        ...this._recentOptions.filter(recentOption => recentOption !== value),
+      ].slice(0, this.recentOptionsMaxCount);
+
+      this.recentOptionsChange.emit(this._recentOptions);
+    }
+  }
+
+  /**
+   * Returns true if the given option is part of the disabledOptions array.
+   */
+  isDisabled(option: T): boolean {
+    return Array.isArray(this.disabledOptions)
+      ? this.disabledOptions.some(
+          selectedOption => this.getKey(selectedOption) === this.getKey(option)
+        )
+      : false;
+  }
+
+  /**
+   * Set the given option as the current highlighted option, available in the highlightedOption parameter.
+   */
+  highlight(option: TypeaheadVisibleOption<T>): void {
+    if (!this.isDisabled(option.value)) {
+      this.highlighted$.next(option);
+      this._changeDetector.detectChanges();
+    }
+  }
+
+  /**
+   * Increment or decrement the highlighted option in the list. Disabled options are skipped.
+   * @param d Value to be added to the index of the highlighted option, i.e. -1 to move backwards, +1 to move forwards.
+   */
+  moveHighlight(d: -1 | 1): T {
+    const highlightIndex = this.indexOfVisibleOption(this.highlighted$.getValue());
+    let newIndex = highlightIndex;
+    let disabled = true;
+    let inBounds = true;
+    do {
+      newIndex = newIndex + d;
+      inBounds = newIndex >= 0 && newIndex < this.allVisibleOptions.length;
+      disabled = inBounds && this.isDisabled(this.allVisibleOptions[newIndex].value);
+    } while (inBounds && disabled);
+
+    if (!disabled && inBounds) {
+      this.highlight(this.allVisibleOptions[newIndex]);
     }
 
-    /**
-     * Selects the given option, emitting the optionSelected event and closing the dropdown.
-     */
-    select(option: TypeaheadVisibleOption<T>, origin?: FocusOrigin): void {
-        if (!this.isDisabled(option.value)) {
-            this.optionSelected.emit(
-                new TypeaheadOptionEvent(option.value, origin)
-            );
-            this.highlighted$.next(null);
-            this.open = false;
-            this.addToRecentOptions(option.value);
-        }
+    return this.highlighted;
+  }
+
+  selectHighlighted(): void {
+    if (this.highlighted$.getValue()) {
+      this.select(this.highlighted$.getValue(), 'keyboard');
+    }
+  }
+
+  /**
+   * Set up the options before the dropdown is displayed.
+   */
+  initOptions(): void {
+    // Clear previous highlight
+    this.highlighted$.next(null);
+    if (this.selectFirst) {
+      // This will highlight the first non-disabled option.
+      this.moveHighlight(1);
+    }
+  }
+
+  /**
+   * Display the first item as highlighted when there are several pages
+   */
+  onLoadedHighlight(event: InfiniteScrollLoadedEvent): void {
+    if (this.selectFirst && this.options && event.pageNumber === 0) {
+      // This will highlight the first non-disabled option.
+      this.moveHighlight(1);
+    }
+  }
+
+  /**
+   * Update the visibleOptions and visibleRecentOptions arrays with the current filter.
+   */
+  updateOptions(): void {
+    const normalisedInput = (this.filter || '').toLowerCase();
+
+    // Create new visibleOptions only if `options` is not a function
+    if (typeof this.options === 'object') {
+      this.visibleOptions$.next(this.getVisibleOptions(this.options, normalisedInput));
     }
 
-    addToRecentOptions(value: T) {
-        if (this._recentOptions) {
-            this._recentOptions = [
-                value,
-                ...this._recentOptions.filter(
-                    recentOption => recentOption !== value
-                )
-            ].slice(0, this.recentOptionsMaxCount);
+    this.visibleRecentOptions$.next(
+      this.getVisibleOptions(this._recentOptions, normalisedInput, true)
+    );
 
-            this.recentOptionsChange.emit(this._recentOptions);
-        }
+    this.initOptions();
+
+    this._changeDetector.detectChanges();
+  }
+
+  /**
+   * Convert a set of raw options into a filtered list of `TypeaheadVisibleOption` objects.
+   * @param options Set of raw options
+   * @param filter The filter expression
+   * @param isRecentOptions Whether `options` is a set of recent options
+   */
+  private getVisibleOptions(
+    options: T[],
+    filter: string = '',
+    isRecentOptions: boolean = false
+  ): TypeaheadVisibleOption<T>[] {
+    if (options) {
+      return options
+        .filter(option => this.getDisplay(option).toLowerCase().indexOf(filter) >= 0)
+        .map(value => ({
+          value,
+          key: this.getKey(value),
+          isRecentOption: isRecentOptions,
+        }));
     }
 
-    /**
-     * Returns true if the given option is part of the disabledOptions array.
-     */
-    isDisabled(option: T): boolean {
-        return Array.isArray(this.disabledOptions) ?
-            this.disabledOptions.some(selectedOption => this.getKey(selectedOption) === this.getKey(option)) : false;
+    return [];
+  }
+
+  /**
+   * Return the index of the given option in the allVisibleOptions array.
+   * Returns -1 if the option is not currently visible.
+   */
+  private indexOfVisibleOption(option: TypeaheadVisibleOption<T>): number {
+    if (option) {
+      return this.allVisibleOptions.findIndex(el => {
+        return el.key === option.key && el.isRecentOption === option.isRecentOption;
+      });
     }
 
-    /**
-     * Set the given option as the current highlighted option, available in the highlightedOption parameter.
-     */
-    highlight(option: TypeaheadVisibleOption<T>): void {
-        if (!this.isDisabled(option.value)) {
-            this.highlighted$.next(option);
-            this._changeDetector.detectChanges();
-        }
-    }
-
-    /**
-     * Increment or decrement the highlighted option in the list. Disabled options are skipped.
-     * @param d Value to be added to the index of the highlighted option, i.e. -1 to move backwards, +1 to move forwards.
-     */
-    moveHighlight(d: -1 | 1): T {
-        const highlightIndex = this.indexOfVisibleOption(this.highlighted$.getValue());
-        let newIndex = highlightIndex;
-        let disabled = true;
-        let inBounds = true;
-        do {
-            newIndex = newIndex + d;
-            inBounds = newIndex >= 0 && newIndex < this.allVisibleOptions.length;
-            disabled = inBounds && this.isDisabled(this.allVisibleOptions[newIndex].value);
-        } while (inBounds && disabled);
-
-        if (!disabled && inBounds) {
-            this.highlight(this.allVisibleOptions[newIndex]);
-        }
-
-        return this.highlighted;
-    }
-
-    selectHighlighted(): void {
-        if (this.highlighted$.getValue()) {
-            this.select(this.highlighted$.getValue(), 'keyboard');
-        }
-    }
-
-    /**
-     * Set up the options before the dropdown is displayed.
-     */
-    initOptions(): void {
-        // Clear previous highlight
-        this.highlighted$.next(null);
-        if (this.selectFirst) {
-            // This will highlight the first non-disabled option.
-            this.moveHighlight(1);
-        }
-    }
-
-    /**
-     * Display the first item as highlighted when there are several pages
-     */
-    onLoadedHighlight(event: InfiniteScrollLoadedEvent): void {
-        if (this.selectFirst && this.options && event.pageNumber === 0) {
-            // This will highlight the first non-disabled option.
-            this.moveHighlight(1);
-        }
-    }
-
-    /**
-     * Update the visibleOptions and visibleRecentOptions arrays with the current filter.
-     */
-    updateOptions(): void {
-        const normalisedInput = (this.filter || '').toLowerCase();
-
-        // Create new visibleOptions only if `options` is not a function
-        if (typeof this.options === 'object') {
-            this.visibleOptions$.next(this.getVisibleOptions(this.options, normalisedInput));
-        }
-
-        this.visibleRecentOptions$.next(this.getVisibleOptions(this._recentOptions, normalisedInput, true));
-
-        this.initOptions();
-
-        this._changeDetector.detectChanges();
-    }
-
-    /**
-     * Convert a set of raw options into a filtered list of `TypeaheadVisibleOption` objects.
-     * @param options Set of raw options
-     * @param filter The filter expression
-     * @param isRecentOptions Whether `options` is a set of recent options
-     */
-    private getVisibleOptions(options: T[], filter: string = '', isRecentOptions: boolean = false): TypeaheadVisibleOption<T>[] {
-        if (options) {
-            return options
-                .filter(option => this.getDisplay(option).toLowerCase().indexOf(filter) >= 0)
-                .map(value => ({
-                    value,
-                    key: this.getKey(value),
-                    isRecentOption: isRecentOptions
-                }));
-        }
-
-        return [];
-    }
-
-    /**
-     * Return the index of the given option in the allVisibleOptions array.
-     * Returns -1 if the option is not currently visible.
-     */
-    private indexOfVisibleOption(option: TypeaheadVisibleOption<T>): number {
-        if (option) {
-            return this.allVisibleOptions.findIndex(el => {
-                return (
-                    el.key === option.key &&
-                    el.isRecentOption === option.isRecentOption
-                );
-            });
-        }
-
-        return -1;
-    }
+    return -1;
+  }
 }

--- a/src/components/typeahead/typeahead.module.ts
+++ b/src/components/typeahead/typeahead.module.ts
@@ -2,6 +2,7 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { InfiniteScrollModule } from '../../directives/infinite-scroll/index';
 import { ResizeModule } from '../../directives/resize/index';
+import { SafeInnerHtmlDirective } from '../../directives/safe-inner-html/safe-inner-html.directive';
 import { ScrollModule } from '../../directives/scroll/index';
 import { PopoverOrientationService } from '../../services/popover-orientation/popover-orientation.service';
 import { TypeaheadHighlightDirective } from './typeahead-highlight.directive';
@@ -9,20 +10,9 @@ import { TypeaheadOptionsListComponent } from './typeahead-options-list.componen
 import { TypeaheadComponent } from './typeahead.component';
 
 @NgModule({
-    imports: [
-        CommonModule,
-        InfiniteScrollModule,
-        ResizeModule,
-        ScrollModule
-    ],
-    exports: [TypeaheadComponent],
-    declarations: [
-        TypeaheadComponent,
-        TypeaheadHighlightDirective,
-        TypeaheadOptionsListComponent
-    ],
-    providers: [
-        PopoverOrientationService
-    ]
+  imports: [CommonModule, InfiniteScrollModule, ResizeModule, ScrollModule, SafeInnerHtmlDirective],
+  exports: [TypeaheadComponent],
+  declarations: [TypeaheadComponent, TypeaheadHighlightDirective, TypeaheadOptionsListComponent],
+  providers: [PopoverOrientationService],
 })
 export class TypeaheadModule {}

--- a/src/directives/safe-inner-html/safe-inner-html.directive.ts
+++ b/src/directives/safe-inner-html/safe-inner-html.directive.ts
@@ -1,0 +1,21 @@
+import { Directive, HostBinding, Input, SecurityContext, inject } from '@angular/core';
+import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
+
+@Directive({
+  standalone: true,
+  selector: '[uxSafeInnerHtml]',
+})
+export class SafeInnerHtmlDirective {
+  private readonly _sanitizer = inject(DomSanitizer);
+
+  @HostBinding('innerHtml')
+  protected safeHtml?: SafeHtml;
+
+  @Input('uxSafeInnerHtml') set safeInnerHtml(value: string) {
+    // Angular's DomSanitizer allows anchor tags, however it does remove any dangerous attributes. That being said
+    // we still want to escape any anchor tags regardless.
+    value = value.replace(/<a/g, '&lt;a').replace(/<\/a>/g, '&lt;/a&gt;');
+
+    this.safeHtml = this._sanitizer.sanitize(SecurityContext.HTML, value);
+  }
+}


### PR DESCRIPTION
#### Checklist
<!-- Use an 'x' to check those which apply. -->
* [x] The contents of this PR are mine to submit. No third party code or other material is being committed.
* [x] New third party dependencies (if any) are linked via `package.json`. Third party dependencies are licensed under one of the following: Apache, MIT, BSD, Mozilla Public License, Eclipse Public License, or Oracle Binary Code License.
* [x] The code in this PR does not contain export-restricted encryption algorithms.

#### Ticket / Issue
<!-- Either a Jira URL or a description of the issue that this PR addresses. -->
Closes https://github.houston.softwaregrp.net/caf/ux-aspects-micro-focus/issues/1018

#### Description of Proposed Changes
<!-- Describe what was changed and how it addresses the original issue. -->

Added improved sanitization. Angular's built in sanitizer does remove dangerous HTML attributes on links, for example script injection etc... however the links are still allowed. In the typeaheads we want to exclude links all together so I have added in some additional escaping.

Note: there is some pre-existing style issues on typeahead items, this issue was not caused by these changes. It only affects the open source theme anyway which is not used, it is fine in the internal theme.

#### Documentation CI URL
<!-- Initiate a build at https://jenkins.swinfra.net/job/SEPG/view/Templates/job/New%20SEPG%20Build/build -->
<!-- Append the branch name to the following URL: -->
https://pages.github.houston.softwaregrp.net/sepg-docs-qa/UXAspects_CI_UXAspects_

#### Downstream Build(s)
<!-- Push a branch with the same name in each downstream repository and create a build in Jenkins. -->
<!-- Add the Jenkins build link(s) below: -->
