### PR TITLE
GitHub Actions build process: CI, per-branch docs previews, gated npm release

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,44 @@
+# GitHub Actions workflows
+
+Operational reference for the CI/CD workflows in this directory. Contributor-facing
+documentation is in [CONTRIBUTING.md](../../CONTRIBUTING.md).
+
+## Workflows
+
+| Workflow | Triggers | Purpose |
+| --- | --- | --- |
+| `ci.yml` | pull requests; pushes to `master` | Lint, Karma unit tests, library production build, documentation build. Uploads `dist-library` and `dist-docs` artifacts. |
+| `docs-preview.yml` | pushes to any branch except `master`/`gh-pages`; branch `delete`; weekly schedule; manual dispatch | Publishes a per-branch documentation preview to the `gh-pages` branch under `ci/previews/<slug>/` and maintains a sticky pull-request comment with the URL. Cleans previews up on branch deletion, plus a weekly sweep for orphaned or stale (>60 days without a push) previews. |
+| `docs-publish.yml` | `workflow_call` (from `release.yml`); manual dispatch | Builds the documentation at the site root base href and deploys it to the `gh-pages` branch **root** with `keep_files` so previews survive. |
+| `release.yml` | `v*` tag push; manual dispatch | Quality gates (lint, tests, builds) from the tag → Verdaccio publish rehearsal with a scratch install of the packed artifact → npm publication (environment-gated) → production documentation deploy. |
+
+## Design notes
+
+-   **Branch slug**: previews are keyed by branch, not pull request. The slug is the branch
+    name with every character outside `[A-Za-z0-9._]` replaced by `-`. The same computation
+    appears in the deploy, cleanup and sweep jobs and must be kept identical.
+-   **The public docs site only changes on release.** `docs-publish.yml` runs as the final
+    release job; nothing else writes to the `gh-pages` root. `ci/previews/master/` provides a
+    live view of unreleased master.
+-   **Publish rehearsal**: the release publishes `@ux-aspects/ux-aspects` under its real name
+    to an in-job Verdaccio using `.verdaccio/config.yml`, then installs it into a scratch
+    package and asserts the artifact's shape. The `@ux-aspects/*` scope must stay
+    unproxied in that config — with the npmjs uplink attached, republishing a version that
+    already exists publicly fails with `E409 Conflict`.
+-   **`npm publish ./dist/library`** — the leading `./` is required; without it npm parses
+    `dist/library` as a GitHub `owner/repo` spec.
+-   **Test publication target**: the publish job pushes to GitHub Packages, rewriting the
+    package name to `@<owner>/ux-aspects` (GitHub Packages requires the scope to match the
+    repository owner, and installs from it always require authentication — it is a staging
+    target, not a distribution channel).
+
+## Operational caveats
+
+-   **`delete` and `schedule` triggers only fire once the workflow files are on the default
+    branch.** Until then, branch-deletion cleanup does not run automatically; run the sweep
+    manually with `gh workflow run docs-preview.yml --ref <branch>`.
+-   **The `npm-publish` environment is created unprotected on first use.** Add required
+    reviewers under *Settings → Environments → npm-publish* to enable the human approval gate
+    before the publish job.
+-   **gh-pages history growth**: preview deploys are additive commits. Squash the `gh-pages`
+    branch history periodically if it grows large.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,178 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  COREPACK_ENABLE_DOWNLOAD_PROMPT: '0'
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Enable corepack
+        run: corepack enable
+
+      - name: Get pnpm store directory
+        id: pnpm-store
+        shell: bash
+        run: echo "path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache pnpm store
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.pnpm-store.outputs.path }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint
+        run: pnpm run lint
+
+  test:
+    name: Test (karma)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Enable corepack
+        run: corepack enable
+
+      - name: Get pnpm store directory
+        id: pnpm-store
+        shell: bash
+        run: echo "path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache pnpm store
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.pnpm-store.outputs.path }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      # src/karma.conf.js resolves the browser via puppeteer.executablePath().
+      # puppeteer 13 downloads Chromium into its own package directory
+      # (.local-chromium) via its install script, which pnpm runs because it is
+      # allowed in pnpm-workspace.yaml onlyBuiltDependencies; pnpm's
+      # side-effects cache keeps that build output in the pnpm store, so the
+      # store cache above avoids repeated downloads.
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run karma tests
+        run: pnpm run test:karma
+
+  build-library:
+    name: Build library
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Enable corepack
+        run: corepack enable
+
+      - name: Get pnpm store directory
+        id: pnpm-store
+        shell: bash
+        run: echo "path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache pnpm store
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.pnpm-store.outputs.path }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build library
+        run: npx grunt build:library
+
+      - name: Upload library artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist-library
+          path: dist/library
+          if-no-files-found: error
+
+  build-docs:
+    name: Build documentation
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Enable corepack
+        run: corepack enable
+
+      - name: Get pnpm store directory
+        id: pnpm-store
+        shell: bash
+        run: echo "path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache pnpm store
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.pnpm-store.outputs.path }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # Same heap headroom the repo's own docs build task uses
+      # (grunt/execute.js passes --max-old-space-size=8192).
+      - name: Build documentation
+        run: npx nx build documentation
+        env:
+          NODE_OPTIONS: --max-old-space-size=8192
+
+      - name: Upload docs artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist-docs
+          path: dist/docs
+          if-no-files-found: error

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,13 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
+      # No step in this job pushes or needs git auth after checkout, so do
+      # not leave the token in .git/config while repo-controlled build and
+      # test code (including fork PR code) runs.
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -55,8 +60,13 @@ jobs:
     name: Test (karma)
     runs-on: ubuntu-latest
     steps:
+      # No step in this job pushes or needs git auth after checkout, so do
+      # not leave the token in .git/config while repo-controlled build and
+      # test code (including fork PR code) runs.
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -95,8 +105,13 @@ jobs:
     name: Build library
     runs-on: ubuntu-latest
     steps:
+      # No step in this job pushes or needs git auth after checkout, so do
+      # not leave the token in .git/config while repo-controlled build and
+      # test code (including fork PR code) runs.
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -136,8 +151,13 @@ jobs:
     name: Build documentation
     runs-on: ubuntu-latest
     steps:
+      # No step in this job pushes or needs git auth after checkout, so do
+      # not leave the token in .git/config while repo-controlled build and
+      # test code (including fork PR code) runs.
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -1,0 +1,222 @@
+name: Docs Preview
+
+# Per-branch documentation previews published to the gh-pages branch under
+# ci/previews/<slug>/, where <slug> is the branch name with every character
+# outside [A-Za-z0-9._] replaced by '-'. The production site at the gh-pages
+# root is never touched by this workflow.
+
+on:
+  push:
+    branches-ignore:
+      - master
+      - gh-pages
+  delete:
+  schedule:
+    # Weekly sweep of orphaned/stale previews (Monday 04:17 UTC)
+    - cron: '17 4 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  COREPACK_ENABLE_DOWNLOAD_PROMPT: '0'
+
+jobs:
+  deploy:
+    name: Build and deploy preview
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: write
+      pull-requests: write
+    concurrency:
+      group: docs-preview-deploy-${{ github.ref }}
+      cancel-in-progress: true
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Enable corepack
+        run: corepack enable
+
+      - name: Resolve pnpm store directory
+        id: pnpm-store
+        run: echo "path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache pnpm store
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.pnpm-store.outputs.path }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Compute preview slug
+        id: slug
+        env:
+          BRANCH: ${{ github.ref_name }}
+        run: |
+          slug=$(printf '%s' "$BRANCH" | sed 's/[^A-Za-z0-9._]/-/g')
+          echo "slug=$slug" >> "$GITHUB_OUTPUT"
+
+      # NODE_OPTIONS mirrors the heap headroom the repo's own docs build task
+      # uses (grunt/execute.js passes --max-old-space-size=8192).
+      - name: Build documentation
+        run: npx nx build documentation --baseHref=/UXAspects/ci/previews/${{ steps.slug.outputs.slug }}/
+        env:
+          NODE_OPTIONS: --max-old-space-size=8192
+
+      - name: Deploy preview to gh-pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_branch: gh-pages
+          publish_dir: ./dist/docs
+          destination_dir: ci/previews/${{ steps.slug.outputs.slug }}
+          keep_files: true
+          commit_message: 'Publish docs preview for ${{ github.ref_name }}'
+
+      - name: Post preview URL on open PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BRANCH: ${{ github.ref_name }}
+          SLUG: ${{ steps.slug.outputs.slug }}
+        run: |
+          set -euo pipefail
+          pr_number=$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number // empty')
+          if [ -z "$pr_number" ]; then
+            echo "No open PR for branch $BRANCH; skipping comment."
+            exit 0
+          fi
+          repo_name=${GITHUB_REPOSITORY#*/}
+          url="https://${GITHUB_REPOSITORY_OWNER}.github.io/${repo_name}/ci/previews/${SLUG}/"
+          marker='<!-- docs-preview-url -->'
+          body="$marker
+          ### Documentation preview
+
+          $url
+
+          Updated for commit $GITHUB_SHA."
+          comment_id=$(gh api "repos/${GITHUB_REPOSITORY}/issues/${pr_number}/comments" --paginate \
+            --jq '.[] | select(.body | contains("<!-- docs-preview-url -->")) | .id' | sed -n 1p)
+          if [ -n "$comment_id" ]; then
+            gh api --method PATCH "repos/${GITHUB_REPOSITORY}/issues/comments/${comment_id}" -f body="$body" > /dev/null
+            echo "Updated existing preview comment $comment_id on PR #$pr_number"
+          else
+            gh api --method POST "repos/${GITHUB_REPOSITORY}/issues/${pr_number}/comments" -f body="$body" > /dev/null
+            echo "Created preview comment on PR #$pr_number"
+          fi
+
+  cleanup:
+    name: Remove preview for deleted branch
+    if: github.event_name == 'delete' && github.event.ref_type == 'branch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+    concurrency:
+      group: docs-preview-gh-pages
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Remove preview directory from gh-pages
+        env:
+          BRANCH: ${{ github.event.ref }}
+        run: |
+          set -euo pipefail
+          if ! git ls-remote --exit-code origin refs/heads/gh-pages > /dev/null; then
+            echo "gh-pages branch does not exist; nothing to clean up."
+            exit 0
+          fi
+          git fetch --no-tags origin '+refs/heads/gh-pages:refs/remotes/origin/gh-pages'
+          git checkout -B gh-pages origin/gh-pages
+          slug=$(printf '%s' "$BRANCH" | sed 's/[^A-Za-z0-9._]/-/g')
+          if [ ! -d "ci/previews/$slug" ]; then
+            echo "No preview directory for slug $slug; nothing to clean up."
+            exit 0
+          fi
+          git rm -r --quiet "ci/previews/$slug"
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git commit -m "Remove docs preview for deleted branch $BRANCH"
+          git push origin gh-pages
+
+  sweep:
+    name: Sweep orphaned and stale previews
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: write
+    concurrency:
+      group: docs-preview-gh-pages
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Remove previews for deleted or inactive branches
+        shell: bash
+        run: |
+          set -euo pipefail
+          if ! git ls-remote --exit-code origin refs/heads/gh-pages > /dev/null; then
+            echo "gh-pages branch does not exist; nothing to sweep."
+            exit 0
+          fi
+
+          # Tip commits of every branch (shallow) plus the gh-pages tree itself.
+          git fetch --no-tags --depth=1 origin '+refs/heads/*:refs/remotes/origin/*'
+          git checkout -B gh-pages origin/gh-pages
+
+          # Map each preview slug to the newest tip-commit time of any branch
+          # that slugs to it (branch names can collide after slugging).
+          # Slugs never contain whitespace, so "<slug> <epoch>" lines are safe.
+          now=$(date +%s)
+          cutoff=$(( now - 60 * 24 * 60 * 60 ))
+          slug_map=$(mktemp)
+          while IFS= read -r branch; do
+            case "$branch" in
+              HEAD|gh-pages) continue ;;
+            esac
+            slug=$(printf '%s' "$branch" | sed 's/[^A-Za-z0-9._]/-/g')
+            if [ "$branch" = "master" ]; then
+              # master's preview is exempt from the age rule.
+              tip=$now
+            else
+              tip=$(git log -1 --format=%ct "refs/remotes/origin/$branch")
+            fi
+            printf '%s %s\n' "$slug" "$tip" >> "$slug_map"
+          done < <(git for-each-ref --format='%(refname:strip=3)' refs/remotes/origin)
+
+          removed=0
+          shopt -s nullglob
+          for dir in ci/previews/*/; do
+            slug=$(basename "$dir")
+            tip=$(awk -v s="$slug" '$1 == s && $2 > m { m = $2 } END { if (m) print m }' "$slug_map")
+            if [ -z "$tip" ]; then
+              echo "Removing orphaned preview '$slug' (no matching branch)"
+              git rm -r --quiet "$dir"
+              removed=1
+            elif [ "$tip" -lt "$cutoff" ]; then
+              echo "Removing stale preview '$slug' (no branch commit in 60 days)"
+              git rm -r --quiet "$dir"
+              removed=1
+            fi
+          done
+
+          if [ "$removed" -eq 0 ]; then
+            echo "No previews to remove."
+            exit 0
+          fi
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git commit -m 'Remove orphaned and stale docs previews'
+          git push origin gh-pages

--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -74,15 +74,50 @@ jobs:
         env:
           NODE_OPTIONS: --max-old-space-size=8192
 
+      # Publish with plain git plus a fetch/reapply retry loop: gh-pages is
+      # written concurrently by other branches' preview deploys, the cleanup
+      # and sweep jobs and the production docs publish, and a plain push with
+      # no retry fails with a non-fast-forward whenever two of them overlap.
+      # On a rejected push the loop re-fetches gh-pages and re-applies the
+      # preview on top of the new head. The preview directory is replaced
+      # wholesale so stale hashed bundles from earlier builds do not
+      # accumulate; everything outside ci/previews/<slug>/ is left untouched.
       - name: Deploy preview to gh-pages
-        uses: peaceiris/actions-gh-pages@v4
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_branch: gh-pages
-          publish_dir: ./dist/docs
-          destination_dir: ci/previews/${{ steps.slug.outputs.slug }}
-          keep_files: true
-          commit_message: 'Publish docs preview for ${{ github.ref_name }}'
+        env:
+          BRANCH: ${{ github.ref_name }}
+          SLUG: ${{ steps.slug.outputs.slug }}
+        run: |
+          set -euo pipefail
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          for attempt in 1 2 3 4 5; do
+            if git fetch --no-tags --depth=1 origin '+refs/heads/gh-pages:refs/remotes/origin/gh-pages'; then
+              git checkout -q -B gh-pages origin/gh-pages
+            else
+              # First ever deploy: the gh-pages branch does not exist yet.
+              git checkout -q --detach
+              git branch -q -D gh-pages 2> /dev/null || true
+              git checkout -q --orphan gh-pages
+              git rm -r -f -q --ignore-unmatch . || true
+            fi
+            rm -rf "ci/previews/$SLUG"
+            mkdir -p "ci/previews/$SLUG"
+            cp -R dist/docs/. "ci/previews/$SLUG/"
+            git add -A -f -- "ci/previews/$SLUG"
+            if git diff --cached --quiet; then
+              echo "Preview already up to date; nothing to deploy."
+              exit 0
+            fi
+            git commit -q -m "Publish docs preview for branch $BRANCH"
+            if git push origin gh-pages; then
+              echo "Deployed preview to ci/previews/$SLUG/"
+              exit 0
+            fi
+            echo "Push rejected (concurrent gh-pages update); retrying ($attempt/5)"
+            sleep $(( attempt * 5 ))
+          done
+          echo "Failed to push preview after 5 attempts" >&2
+          exit 1
 
       - name: Post preview URL on open PR
         env:
@@ -91,7 +126,10 @@ jobs:
           SLUG: ${{ steps.slug.outputs.slug }}
         run: |
           set -euo pipefail
-          pr_number=$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number // empty')
+          # Filter on the head repository owner: --head matches by branch name
+          # alone, which could also match a fork PR that uses the same name.
+          pr_number=$(gh pr list --head "$BRANCH" --state open --json number,headRepositoryOwner \
+            --jq ".[] | select(.headRepositoryOwner.login == \"$GITHUB_REPOSITORY_OWNER\") | .number" | sed -n 1p)
           if [ -z "$pr_number" ]; then
             echo "No open PR for branch $BRANCH; skipping comment."
             exit 0
@@ -105,8 +143,11 @@ jobs:
           $url
 
           Updated for commit $GITHUB_SHA."
+          # Only ever update a comment this workflow authored: without the
+          # author filter, anyone who pastes the marker into their own comment
+          # could get it overwritten by (or mistaken for) the sticky comment.
           comment_id=$(gh api "repos/${GITHUB_REPOSITORY}/issues/${pr_number}/comments" --paginate \
-            --jq '.[] | select(.body | contains("<!-- docs-preview-url -->")) | .id' | sed -n 1p)
+            --jq '.[] | select(.user.login == "github-actions[bot]") | select(.body | contains("<!-- docs-preview-url -->")) | .id' | sed -n 1p)
           if [ -n "$comment_id" ]; then
             gh api --method PATCH "repos/${GITHUB_REPOSITORY}/issues/comments/${comment_id}" -f body="$body" > /dev/null
             echo "Updated existing preview comment $comment_id on PR #$pr_number"
@@ -137,18 +178,29 @@ jobs:
             echo "gh-pages branch does not exist; nothing to clean up."
             exit 0
           fi
-          git fetch --no-tags origin '+refs/heads/gh-pages:refs/remotes/origin/gh-pages'
-          git checkout -B gh-pages origin/gh-pages
           slug=$(printf '%s' "$BRANCH" | sed 's/[^A-Za-z0-9._]/-/g')
-          if [ ! -d "ci/previews/$slug" ]; then
-            echo "No preview directory for slug $slug; nothing to clean up."
-            exit 0
-          fi
-          git rm -r --quiet "ci/previews/$slug"
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
-          git commit -m "Remove docs preview for deleted branch $BRANCH"
-          git push origin gh-pages
+          # Retry on rejected pushes: preview deploys use a per-branch
+          # concurrency group and can push gh-pages concurrently with this job.
+          for attempt in 1 2 3 4 5; do
+            git fetch --no-tags origin '+refs/heads/gh-pages:refs/remotes/origin/gh-pages'
+            git checkout -q -B gh-pages origin/gh-pages
+            if [ ! -d "ci/previews/$slug" ]; then
+              echo "No preview directory for slug $slug; nothing to clean up."
+              exit 0
+            fi
+            git rm -r --quiet "ci/previews/$slug"
+            git commit -q -m "Remove docs preview for deleted branch $BRANCH"
+            if git push origin gh-pages; then
+              echo "Removed preview ci/previews/$slug/"
+              exit 0
+            fi
+            echo "Push rejected (concurrent gh-pages update); retrying ($attempt/5)"
+            sleep $(( attempt * 5 ))
+          done
+          echo "Failed to push cleanup after 5 attempts" >&2
+          exit 1
 
   sweep:
     name: Sweep orphaned and stale previews
@@ -174,7 +226,6 @@ jobs:
 
           # Tip commits of every branch (shallow) plus the gh-pages tree itself.
           git fetch --no-tags --depth=1 origin '+refs/heads/*:refs/remotes/origin/*'
-          git checkout -B gh-pages origin/gh-pages
 
           # Map each preview slug to the newest tip-commit time of any branch
           # that slugs to it (branch names can collide after slugging).
@@ -196,27 +247,41 @@ jobs:
             printf '%s %s\n' "$slug" "$tip" >> "$slug_map"
           done < <(git for-each-ref --format='%(refname:strip=3)' refs/remotes/origin)
 
-          removed=0
-          shopt -s nullglob
-          for dir in ci/previews/*/; do
-            slug=$(basename "$dir")
-            tip=$(awk -v s="$slug" '$1 == s && $2 > m { m = $2 } END { if (m) print m }' "$slug_map")
-            if [ -z "$tip" ]; then
-              echo "Removing orphaned preview '$slug' (no matching branch)"
-              git rm -r --quiet "$dir"
-              removed=1
-            elif [ "$tip" -lt "$cutoff" ]; then
-              echo "Removing stale preview '$slug' (no branch commit in 60 days)"
-              git rm -r --quiet "$dir"
-              removed=1
-            fi
-          done
-
-          if [ "$removed" -eq 0 ]; then
-            echo "No previews to remove."
-            exit 0
-          fi
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
-          git commit -m 'Remove orphaned and stale docs previews'
-          git push origin gh-pages
+          shopt -s nullglob
+
+          # Retry on rejected pushes: preview deploys use a per-branch
+          # concurrency group and can push gh-pages concurrently with this
+          # job, so re-fetch and re-apply the removals on the new head.
+          for attempt in 1 2 3 4 5; do
+            git fetch --no-tags --depth=1 origin '+refs/heads/gh-pages:refs/remotes/origin/gh-pages'
+            git checkout -q -B gh-pages origin/gh-pages
+            removed=0
+            for dir in ci/previews/*/; do
+              slug=$(basename "$dir")
+              tip=$(awk -v s="$slug" '$1 == s && $2 > m { m = $2 } END { if (m) print m }' "$slug_map")
+              if [ -z "$tip" ]; then
+                echo "Removing orphaned preview '$slug' (no matching branch)"
+                git rm -r --quiet "$dir"
+                removed=1
+              elif [ "$tip" -lt "$cutoff" ]; then
+                echo "Removing stale preview '$slug' (no branch commit in 60 days)"
+                git rm -r --quiet "$dir"
+                removed=1
+              fi
+            done
+
+            if [ "$removed" -eq 0 ]; then
+              echo "No previews to remove."
+              exit 0
+            fi
+            git commit -q -m 'Remove orphaned and stale docs previews'
+            if git push origin gh-pages; then
+              exit 0
+            fi
+            echo "Push rejected (concurrent gh-pages update); retrying ($attempt/5)"
+            sleep $(( attempt * 5 ))
+          done
+          echo "Failed to push sweep after 5 attempts" >&2
+          exit 1

--- a/.github/workflows/docs-publish.yml
+++ b/.github/workflows/docs-publish.yml
@@ -58,13 +58,45 @@ jobs:
         env:
           NODE_OPTIONS: --max-old-space-size=8192
 
-      # keep_files preserves ci/previews/* (per-branch docs previews) while
-      # replacing the site root.
+      # Publish with plain git plus a fetch/reapply retry loop: gh-pages is
+      # also written by per-branch preview deploys, and a plain push with no
+      # retry fails with a non-fast-forward whenever one overlaps with this
+      # job. The build output is overlaid onto the branch root and only those
+      # files are staged, so existing files — notably ci/previews/* (per-branch
+      # docs previews) — are preserved.
       - name: Deploy to gh-pages root
-        uses: peaceiris/actions-gh-pages@v4
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_branch: gh-pages
-          publish_dir: dist/docs
-          keep_files: true
-          full_commit_message: Publish production documentation from ${{ github.ref_name }}
+        env:
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          for attempt in 1 2 3 4 5; do
+            if git fetch --no-tags --depth=1 origin '+refs/heads/gh-pages:refs/remotes/origin/gh-pages'; then
+              git checkout -q -B gh-pages origin/gh-pages
+            else
+              # First ever publish: the gh-pages branch does not exist yet.
+              git checkout -q --detach
+              git branch -q -D gh-pages 2> /dev/null || true
+              git checkout -q --orphan gh-pages
+              git rm -r -f -q --ignore-unmatch . || true
+            fi
+            cp -R dist/docs/. .
+            # Stage exactly the copied files: never workspace build/tooling
+            # output (node_modules, dist, caches), never deletions.
+            (cd dist/docs && find . \( -type f -o -type l \) -print0) \
+              | xargs -0 -r git add -f --
+            if git diff --cached --quiet; then
+              echo "Production docs already up to date; nothing to publish."
+              exit 0
+            fi
+            git commit -q -m "Publish production documentation from $REF_NAME"
+            if git push origin gh-pages; then
+              echo "Published production documentation to the gh-pages root"
+              exit 0
+            fi
+            echo "Push rejected (concurrent gh-pages update); retrying ($attempt/5)"
+            sleep $(( attempt * 5 ))
+          done
+          echo "Failed to push production docs after 5 attempts" >&2
+          exit 1

--- a/.github/workflows/docs-publish.yml
+++ b/.github/workflows/docs-publish.yml
@@ -1,0 +1,70 @@
+name: Docs Publish
+
+# Updates the PRODUCTION documentation site at the root of the gh-pages branch.
+# Runs as the final stage of release.yml (workflow_call) or manually
+# (workflow_dispatch) for out-of-band corrections to the live site.
+on:
+  workflow_dispatch:
+  workflow_call:
+
+permissions:
+  contents: write
+
+env:
+  COREPACK_ENABLE_DOWNLOAD_PROMPT: '0'
+
+jobs:
+  publish:
+    name: Build and deploy production docs
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    # Serialise gh-pages root deployments; never cancel an in-flight publish.
+    # Job-level so it also applies when this workflow runs via workflow_call
+    # (workflow-level concurrency in a called workflow is not honoured).
+    concurrency:
+      group: docs-publish
+      cancel-in-progress: false
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Enable corepack
+        run: corepack enable
+
+      - name: Resolve pnpm store directory
+        id: pnpm-store
+        run: echo "path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache pnpm store
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.pnpm-store.outputs.path }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # NODE_OPTIONS mirrors the heap headroom the repo's own docs build task
+      # uses (grunt/execute.js passes --max-old-space-size=8192).
+      - name: Build documentation
+        run: npx nx build documentation --baseHref=/UXAspects/
+        env:
+          NODE_OPTIONS: --max-old-space-size=8192
+
+      # keep_files preserves ci/previews/* (per-branch docs previews) while
+      # replacing the site root.
+      - name: Deploy to gh-pages root
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_branch: gh-pages
+          publish_dir: dist/docs
+          keep_files: true
+          full_commit_message: Publish production documentation from ${{ github.ref_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,228 @@
+name: Release
+
+# npm publication quality gate: re-validate the tagged commit, rehearse the
+# publish against a local Verdaccio registry, pause for human approval
+# (npm-publish environment), publish to GitHub Packages, then deploy the
+# released documentation to the gh-pages root.
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  COREPACK_ENABLE_DOWNLOAD_PROMPT: '0'
+
+jobs:
+  quality:
+    name: Lint, test and build
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Enable corepack
+        run: corepack enable
+
+      - name: Resolve pnpm store directory
+        id: pnpm-store
+        run: echo "path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache pnpm store
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.pnpm-store.outputs.path }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint
+        run: pnpm run lint
+
+      - name: Test
+        run: pnpm run test:karma
+
+      - name: Build library
+        run: npx grunt build:library
+
+      # Same heap headroom the repo's own docs build task uses
+      # (grunt/execute.js passes --max-old-space-size=8192).
+      - name: Build documentation
+        run: npx nx build documentation
+        env:
+          NODE_OPTIONS: --max-old-space-size=8192
+
+      - name: Upload library artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist-library
+          path: dist/library
+          if-no-files-found: error
+
+  rehearsal:
+    name: Publish rehearsal (Verdaccio)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    needs: quality
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Enable corepack
+        run: corepack enable
+
+      - name: Resolve pnpm store directory
+        id: pnpm-store
+        run: echo "path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache pnpm store
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.pnpm-store.outputs.path }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      # Provides the repo-pinned verdaccio used by the local-registry tooling.
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Download library artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: dist-library
+          path: dist/library
+
+      # Same registry configuration as the repo's `nx local-registry` target
+      # (.verdaccio/config.yml: anonymous access/publish, npmjs uplink proxy),
+      # started in the background instead of nx's foreground runner.
+      - name: Start Verdaccio
+        run: |
+          npx verdaccio --config .verdaccio/config.yml --listen 4873 > verdaccio.log 2>&1 &
+          echo $! > verdaccio.pid
+          for i in $(seq 1 30); do
+            if curl -sf http://localhost:4873/-/ping > /dev/null; then
+              echo "Verdaccio is up"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "Verdaccio did not start" >&2
+          cat verdaccio.log >&2
+          exit 1
+
+      # The npm client insists on an auth token for publish even though the
+      # registry allows anonymous publication; any value satisfies it.
+      - name: Publish to Verdaccio
+        run: |
+          npm config set //localhost:4873/:_authToken "verdaccio-rehearsal"
+          npm publish dist/library --registry http://localhost:4873
+
+      # Install the published package into a scratch package and assert the
+      # artifact is well-formed. The version is pinned to the one just
+      # published so the Verdaccio npmjs uplink (which also knows
+      # @ux-aspects/ux-aspects) cannot satisfy the install with a different
+      # release. --legacy-peer-deps skips installing the Angular peer tree;
+      # this checks packaging, not runtime integration.
+      - name: Install and verify in scratch package
+        run: |
+          version=$(node -p 'require("./dist/library/package.json").version')
+          scratch="$(mktemp -d)"
+          cd "$scratch"
+          npm init -y > /dev/null
+          npm install "@ux-aspects/ux-aspects@$version" --registry http://localhost:4873 --legacy-peer-deps
+          node -e '
+          const fs = require("fs");
+          const path = require("path");
+          const pkgPath = require.resolve("@ux-aspects/ux-aspects/package.json");
+          const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf8"));
+          console.log("Resolved " + pkg.name + "@" + pkg.version);
+          const css = path.join(path.dirname(pkgPath), "styles", "ux-aspects.css");
+          if (!fs.existsSync(css)) {
+            console.error("Missing styles/ux-aspects.css in the installed package");
+            process.exit(1);
+          }
+          console.log("Found styles/ux-aspects.css");
+          '
+
+      - name: Stop Verdaccio
+        if: always()
+        run: |
+          if [ -f verdaccio.pid ]; then
+            kill "$(cat verdaccio.pid)" 2> /dev/null || true
+          fi
+
+  # Pauses until approved in the npm-publish environment (required reviewers
+  # are configured in repository settings; GitHub creates the environment
+  # unprotected on first use).
+  publish:
+    name: Publish to GitHub Packages
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs: rehearsal
+    environment: npm-publish
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Download library artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: dist-library
+          path: dist/library
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: https://npm.pkg.github.com
+
+      # GitHub Packages requires the scope to match the repository owner and
+      # links the package to the repository named in the repository field, so
+      # both are rewritten to the fork. The version is published as-is.
+      - name: Rewrite package name for GitHub Packages
+        run: |
+          node -e '
+          const fs = require("fs");
+          const pkgPath = "dist/library/package.json";
+          const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf8"));
+          pkg.name = "@yuriksan/ux-aspects";
+          pkg.repository = { type: "git", url: "git+https://github.com/yuriksan/UXAspects.git" };
+          fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + "\n");
+          console.log("Publishing as " + pkg.name + "@" + pkg.version);
+          '
+
+      - name: Publish
+        run: npm publish dist/library --registry https://npm.pkg.github.com
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # Deploys the released documentation to the gh-pages root only after a
+  # successful, approved publish.
+  docs:
+    name: Publish documentation
+    needs: publish
+    permissions:
+      contents: write
+    uses: ./.github/workflows/docs-publish.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,7 +137,7 @@ jobs:
       - name: Publish to Verdaccio
         run: |
           npm config set //localhost:4873/:_authToken "verdaccio-rehearsal"
-          npm publish dist/library --registry http://localhost:4873
+          npm publish ./dist/library --registry http://localhost:4873
 
       # Install the published package into a scratch package and assert the
       # artifact is well-formed. The version is pinned to the one just
@@ -214,7 +214,7 @@ jobs:
           '
 
       - name: Publish
-        run: npm publish dist/library --registry https://npm.pkg.github.com
+        run: npm publish ./dist/library --registry https://npm.pkg.github.com
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,8 +26,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
+      # No step in this job pushes or needs git auth after checkout.
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -81,8 +84,11 @@ jobs:
     timeout-minutes: 30
     needs: quality
     steps:
+      # No step in this job pushes or needs git auth after checkout.
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/.verdaccio/config.yml
+++ b/.verdaccio/config.yml
@@ -9,6 +9,14 @@ uplinks:
     maxage: 60m
 
 packages:
+  # our own packages are always served from local storage, never proxied:
+  # with the npmjs proxy, publishing a version that already exists on the
+  # public registry fails with E409 even though local storage is empty
+  '@ux-aspects/*':
+    access: $all
+    publish: $all
+    unpublish: $all
+
   '**':
     # give all users (including non-authenticated users) full access
     # because it is a local registry

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,15 +103,40 @@ npm run test
 
 > Note: The first run of the Protractor tests may take longer than expected, in order to download and deploy the required Docker container.
 
-## Start a Jenkins build
+## Continuous integration (GitHub Actions)
 
-> Note: The Jenkins server is only available on the intranet. If the following link is not accessible, this part can be skipped.
+Pushing a branch and opening a pull request runs the GitHub Actions workflows in
+[`.github/workflows/`](.github/workflows/) automatically — no build needs to be requested
+manually:
+
+-   **CI** (`ci.yml`) runs on every pull request: lint, the Karma unit test suite, a production
+    build of the library, and a build of the documentation site. All checks must pass before a
+    pull request can be merged.
+-   **Documentation preview** (`docs-preview.yml`) runs on every branch push and publishes a
+    live build of the documentation site for your branch at
+    `https://<owner>.github.io/UXAspects/ci/previews/<branch-slug>/`, where `<branch-slug>` is
+    your branch name with any character other than letters, digits, `.` and `_` replaced by
+    `-`. When a pull request is open for the branch, a comment on the pull request carries the
+    link. The preview is removed when the branch is deleted.
+-   **Release** (`release.yml`) runs when a maintainer pushes a `v*` tag: it re-runs all
+    quality checks from the tag, rehearses the npm publication against a local registry,
+    publishes the package (behind an environment approval gate), and deploys the released
+    documentation to the public site. The public documentation site is only updated by a
+    release; between releases, master's documentation is viewable at the
+    `ci/previews/master/` preview.
+
+See [`.github/workflows/README.md`](.github/workflows/README.md) for operational details.
+
+## Start a Jenkins build (legacy)
+
+> Note: The Jenkins server is only available on the intranet, and is superseded by the GitHub
+> Actions workflows above. If the following link is not accessible, this part can be skipped.
 
 See [Using Jenkins](https://github.houston.softwaregrp.net/UXAspects/ux-aspects-micro-focus/blob/master/JENKINS.md) for information on creating a continuous integration (CI) build for your branch.
 
 ## Make a pull request
 
-With all changes pushed and (ideally) a passing Jenkins build, it's time to make a pull request on the upstream repositories.
+With all changes pushed and the CI checks passing, it's time to make a pull request on the upstream repositories.
 
 > See [Creating a pull request from a fork](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request-from-a-fork) on GitHub help.
 
@@ -120,7 +145,7 @@ UX Aspects has a pull request template, and it's important to fill this in as cl
 -   The **Checklist** helps to assert that products can use UX Aspects without legal issues. Check each one with `[x]` if it applies to your submission. If you are unable to check any of the listed items, contact one of the UX Aspects maintainers for advice.
 -   The **Ticket / Issue** field describes the problem that the pull request addresses. If you have access to the UX Aspects Jira board, or are aware of the ticket number, please fill it in here. Otherwise, describe the problem that the pull request intends to solve, and where possible, include a repro case in the form of a Plunker link.
 -   The **Description of Proposed Changes** field describes what you have changed and why.
--   The **Documentation CI URL** field should be filled in after initiating an automated build with Jenkins. If you don't have access to create a build, please note that here instead.
+-   The **Documentation CI URL** field carries the live documentation preview for your branch, published automatically on push: `https://<owner>.github.io/UXAspects/ci/previews/<branch-slug>/` (the same link is posted as a comment on the pull request).
 
 For example, a completed pull request might look like this:
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "Christina Mallon"
   ],
   "license": "Apache-2.0",
+  "packageManager": "pnpm@10.34.5",
   "scripts": {
     "build:documentation": "grunt build:documentation",
     "build:library": "grunt build:library",


### PR DESCRIPTION
#### Checklist
<!-- Use an 'x' to check those which apply. -->
* [x] The contents of this PR are mine to submit. No third party code or other material is being committed.
* [x] New third party dependencies (if any) are linked via `package.json`. Third party dependencies are licensed under one of the following: Apache, MIT, BSD, Mozilla Public License, Eclipse Public License, or Oracle Binary Code License.
* [x] The code in this PR does not contain export-restricted encryption algorithms.

#### Ticket / Issue
Prototype a GitHub-native build process to replace the three responsibilities of the internal Jenkins pipeline: continuous build/test, live per-branch documentation previews (previously published via internal GitLab), and a quality gate in front of npm publication.

#### Description of Proposed Changes
Adds four GitHub Actions workflows (plus `packageManager` pin and documentation):

* **`ci.yml`** — on every PR and master push: lint, Karma unit tests (ChromeHeadless), production library build, documentation build; artifacts uploaded; pnpm store cached; per-ref concurrency.
* **`docs-preview.yml`** — on every branch push: publishes a live docs preview to the `gh-pages` branch under `ci/previews/<branch-slug>/` (base-href set per path), posts/refreshes a sticky PR comment with the URL — restoring the branch-named docs URL workflow the Jenkins "Documentation CI URL" provided. Cleanup on branch delete + weekly sweep for orphaned/stale (>60 days) previews. The production site at the `gh-pages` root is untouched by previews.
* **`docs-publish.yml`** — deploys the site root; invoked only as the final job of a release (or manually), so **the public docs site only changes when a release is made**; `ci/previews/master/` tracks unreleased master.
* **`release.yml`** — on `v*` tag: re-runs all quality gates from the tag → **publish rehearsal** against an in-job Verdaccio (publishes `@ux-aspects/ux-aspects` under its real name using `.verdaccio/config.yml` and installs it into a scratch package to validate the artifact) → npm publication behind an **environment approval gate** (`npm-publish` environment; add required reviewers to activate) → production docs deploy. On this prototype the publish targets GitHub Packages as a staging registry; the production registry decision (public npmjs with provenance vs self-hosted runner vs Jenkins last-mile) is deliberately left open.
* `.verdaccio/config.yml`: the `@ux-aspects/*` scope is now served locally instead of proxied to npmjs (republishing an existing version otherwise fails with E409 — this also affected the local `publish:local-registry` flow).
* `CONTRIBUTING.md` updated (Jenkins section marked legacy; PR-template guidance points at the automatic preview URL) and an operational reference added at `.github/workflows/README.md`, including the caveats: `delete`/`schedule` triggers activate only once these files are on the default branch, and the `npm-publish` environment is created unprotected until reviewers are configured.

Everything was proven with real runs on the fork (`yuriksan/UXAspects`): CI green (all 552 Karma specs pass on ubuntu-latest), preview live at https://yuriksan.github.io/UXAspects/ci/previews/github-actions-ci/ with working sticky comment and sweep cleanup, and a full tag-triggered release run green end-to-end (quality → Verdaccio rehearsal → gated publish → docs root deploy). Design rationale and alternatives are written up in [github-build-plan.md](https://github.com/yuriksan/UXAspects/blob/github-build-plan/github-build-plan.md).

Note: the head branch is on the fork intentionally — pushing it to this repository before merge would let the push-triggered preview workflow write to the production `gh-pages` branch.

#### Documentation CI URL
Superseded by this PR: previews publish automatically per branch. Fork preview for this branch: https://yuriksan.github.io/UXAspects/ci/previews/github-actions-ci/

#### Downstream Build(s)
N/A — no library code changes.
