### PR TITLE
fix: remove stray closing comment tag from menu-divider template

### DIFF
--- a/src/components/menu/menu-divider/menu-divider.component.html
+++ b/src/components/menu/menu-divider/menu-divider.component.html
@@ -15,4 +15,3 @@
     limitations under the License.
 
 -->
--->


### PR DESCRIPTION
## Problem

The license header update in #1759 introduced a duplicate `-->` closing tag in `menu-divider.component.html`:

```html
<- ValueEdge 5668797 ( behavioral regression, separate ) : https://ot-internal.saas.microfocus.com/ui/entity-navigation?p=4001/48001 & entityType=work_item &
    Copyright 2015-2026 Micro Focus or one of its affiliates.
    ...
-->
-->  <- stray text node
```

Angular's template compiler treats the orphaned `-->` as a literal text node, causing it to render visibly as arrow-like text in dropdown menus (e.g. the Search menu) in consuming applications.

## Fix

Remove the duplicate `-->` line. One line deletion.